### PR TITLE
Unblock local signup and Phase 17 auth entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
       # path inside the workspace.
       STORAGE_BACKEND: local
       LOCAL_STORAGE_ROOT: ${{ github.workspace }}/_storage
+      # Reference modules live at repo-root examples/modules and are
+      # imported by manifest entrypoint, e.g.
+      # examples.modules.contract_review.capability. The backend job
+      # runs from ./backend, so add the repo root explicitly.
+      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/backend
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,8 +7,9 @@ on:
     branches: [runtime-rewrite, master]
 
 # Phase 15 F — Playwright e2e job. Spins the existing docker-
-# compose stack, runs `npm run e2e` against `npm run preview` for
-# production-parity. Trace + video artifacts uploaded on failure.
+# compose stack, runs `npm run e2e` against the built frontend served
+# by the e2e static preview server. Trace + video artifacts uploaded
+# on failure.
 #
 # Single job; single worker (tests share a DB per the v3 plan).
 
@@ -160,12 +161,17 @@ jobs:
         run: npm run build
 
       - name: Start preview server
-        run: nohup npm run preview -- --host 0.0.0.0 --port 4173 > preview.log 2>&1 &
+        # Use an explicit static SPA server instead of `vite preview`.
+        # CI caught `vite preview` returning a 500 + empty HTML body for
+        # deep links such as /auth/signin, which made the sign-in form
+        # invisible before React could mount. The e2e server serves the
+        # built dist assets and falls back to index.html for every route.
+        run: nohup npm run preview:e2e -- --host 0.0.0.0 --port 4173 > preview.log 2>&1 &
 
       - name: Wait for preview
         run: |
           for i in {1..30}; do
-            if curl -sf http://localhost:4173 >/dev/null; then
+            if curl -sf http://localhost:4173/auth/signin >/dev/null; then
               echo "preview up"
               break
             fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,10 +143,9 @@ jobs:
       - name: Build frontend
         # Vite env vars are baked in at build time.
         #
-        # VITE_HOSTED_ACCESS_MODE=open — the default in lib/access.ts
-        # is "waitlist", which routes /auth/signin to the Waitlist
-        # page (no email input). Without this every signInViaUi
-        # caller timed out waiting for getByLabel(/email/i).
+        # VITE_HOSTED_ACCESS_MODE=open — CI must render the real auth
+        # forms. lib/access.ts also gates waitlist mode to the hosted
+        # domain, but baking "open" keeps the test contract explicit.
         #
         # VITE_API_BASE_URL=http://localhost:8000/api — the preview
         # server (npm run preview) does NOT honour vite.config.ts's

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -231,10 +231,12 @@ you want to invoke a real provider with your own key.
 "Join the waitlist" page with no email/password fields.
 
 **Diagnosis.** The frontend reads `VITE_HOSTED_ACCESS_MODE` at build
-time. Default is `waitlist` (correct for hosted prod). Phase 16 B
-bakes `VITE_HOSTED_ACCESS_MODE=open` into the **compose frontend
-service**, so a fresh `docker compose -f infra/docker-compose.yml up` should render the signup
-form.
+time. Waitlist mode is only honoured on the hosted domain
+(`legalise.dev` by default); localhost and self-hosted forks render the
+real auth forms. Phase 16 B also bakes `VITE_HOSTED_ACCESS_MODE=open`
+into the **compose frontend service**, so a fresh
+`docker compose -f infra/docker-compose.yml up` should render the
+signup form.
 
 If you see the waitlist page locally, something is overriding the
 compose default — most likely a stale `frontend/.env` or a host env
@@ -246,5 +248,5 @@ export of `VITE_HOSTED_ACCESS_MODE=waitlist`.
 docker compose -f infra/docker-compose.yml config | grep VITE_HOSTED_ACCESS_MODE
 ```
 
-Should print `open`. If it prints `waitlist`, find and unset the
-override.
+Should print `open`. If it prints `waitlist`, localhost should still
+render the auth form, but the override is stale and should be removed.

--- a/docs/handovers/HANDOVER_PHASE_17_WALKTHROUGH_UNBLOCKERS.md
+++ b/docs/handovers/HANDOVER_PHASE_17_WALKTHROUGH_UNBLOCKERS.md
@@ -9,8 +9,9 @@ Phase 17A/B/C starts. This is not the CRM redesign pass.
 1. Local Vite dev now proxies `/auth` to the backend, matching `/api`
    and `/health`. This closes the signup 404 caused by the browser
    posting to the frontend dev server instead of FastAPI.
-2. Self-host/dev frontend access now defaults to `open`. Hosted prod
-   can still set `VITE_HOSTED_ACCESS_MODE=waitlist`.
+2. Self-host/dev frontend access now defaults to `open`. Waitlist mode
+   is also gated to the hosted domain, so localhost / CI preview cannot
+   accidentally hide the auth forms if an env layer drifts.
 3. Landing page now exposes explicit unauthenticated actions:
    `Sign in` and `Create account`. This closes L-1 from the
    walkthrough attempt.

--- a/docs/handovers/HANDOVER_PHASE_17_WALKTHROUGH_UNBLOCKERS.md
+++ b/docs/handovers/HANDOVER_PHASE_17_WALKTHROUGH_UNBLOCKERS.md
@@ -1,0 +1,39 @@
+# Phase 17 Walkthrough Unblockers
+
+**Branch:** `codex/fix-signup-ci`
+**Purpose:** close the two pre-walkthrough blockers surfaced before
+Phase 17A/B/C starts. This is not the CRM redesign pass.
+
+## What Changed
+
+1. Local Vite dev now proxies `/auth` to the backend, matching `/api`
+   and `/health`. This closes the signup 404 caused by the browser
+   posting to the frontend dev server instead of FastAPI.
+2. Self-host/dev frontend access now defaults to `open`. Hosted prod
+   can still set `VITE_HOSTED_ACCESS_MODE=waitlist`.
+3. Landing page now exposes explicit unauthenticated actions:
+   `Sign in` and `Create account`. This closes L-1 from the
+   walkthrough attempt.
+
+## Why It Is Safe
+
+- No backend files touched.
+- No substrate files touched.
+- No Phase 17 target-screen redesign started.
+- The changes only make existing auth surfaces reachable from a fresh
+  local fork.
+
+## Verification
+
+- `docker compose -f infra/docker-compose.yml exec -T frontend npm run typecheck`
+- `docker compose -f infra/docker-compose.yml exec -T frontend npm test`
+- `docker compose -f infra/docker-compose.yml exec -T frontend npm run build`
+- `docker compose -f infra/docker-compose.yml exec -T backend python -m pytest tests/test_phase10_invocations_api.py -q`
+- Manual: POST `/auth/register` through the frontend dev server reached
+  FastAPI and returned `201`.
+
+## Next
+
+Resume the Phase 17 operator-proxy walkthrough from `/`. Do not begin
+Matter / Modules / Audit redesign until the walkthrough artifact is
+filled and reviewed.

--- a/docs/handovers/HANDOVER_PHASE_17_WALKTHROUGH_UNBLOCKERS.md
+++ b/docs/handovers/HANDOVER_PHASE_17_WALKTHROUGH_UNBLOCKERS.md
@@ -15,6 +15,13 @@ Phase 17A/B/C starts. This is not the CRM redesign pass.
 3. Landing page now exposes explicit unauthenticated actions:
    `Sign in` and `Create account`. This closes L-1 from the
    walkthrough attempt.
+4. Phase 15 e2e preview now uses a tiny explicit static SPA server
+   instead of `vite preview`. CI showed `vite preview` returning
+   `500` plus empty HTML for `/auth/signin`; the e2e server serves
+   `dist` assets and falls back to `index.html` for deep links.
+5. The e2e workflow now smokes `/auth/signin`, not just `/`, before
+   Playwright starts. A broken auth deep link fails at setup instead
+   of wasting the full suite.
 
 ## Why It Is Safe
 
@@ -29,6 +36,7 @@ Phase 17A/B/C starts. This is not the CRM redesign pass.
 - `docker compose -f infra/docker-compose.yml exec -T frontend npm run typecheck`
 - `docker compose -f infra/docker-compose.yml exec -T frontend npm test`
 - `docker compose -f infra/docker-compose.yml exec -T frontend npm run build`
+- `docker compose -f infra/docker-compose.yml exec -T frontend npm run preview:e2e -- --host 0.0.0.0 --port 4173`
 - `docker compose -f infra/docker-compose.yml exec -T backend python -m pytest tests/test_phase10_invocations_api.py -q`
 - Manual: POST `/auth/register` through the frontend dev server reached
   FastAPI and returned `201`.

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -126,6 +126,20 @@ export async function signIn(
  * browser context (not the API context).
  */
 export async function signInViaUi(page: Page, user: RegisteredUser): Promise<void> {
+  const diagnostics: string[] = [];
+  page.on("console", (message) => {
+    if (["error", "warning"].includes(message.type())) {
+      diagnostics.push(`console.${message.type()}: ${message.text()}`);
+    }
+  });
+  page.on("pageerror", (error) => {
+    diagnostics.push(`pageerror: ${error.message}`);
+  });
+  page.on("requestfailed", (request) => {
+    diagnostics.push(
+      `requestfailed: ${request.method()} ${request.url()} ${request.failure()?.errorText ?? ""}`,
+    );
+  });
   await page.goto("/auth/signin");
   const email = page.locator('input[name="email"]');
   try {
@@ -134,8 +148,11 @@ export async function signInViaUi(page: Page, user: RegisteredUser): Promise<voi
     const bodyText = ((await page.locator("body").innerText().catch(() => "")) || "")
       .replace(/\s+/g, " ")
       .slice(0, 1000);
+    const html = ((await page.content().catch(() => "")) || "")
+      .replace(/\s+/g, " ")
+      .slice(0, 1000);
     throw new Error(
-      `Sign-in form did not render at ${page.url()}; body="${bodyText}"`,
+      `Sign-in form did not render at ${page.url()}; body="${bodyText}"; html="${html}"; diagnostics="${diagnostics.join(" | ")}"`,
       { cause: err },
     );
   }

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -127,8 +127,8 @@ export async function signIn(
  */
 export async function signInViaUi(page: Page, user: RegisteredUser): Promise<void> {
   await page.goto("/auth/signin");
-  await page.getByLabel(/email/i).fill(user.email);
-  await page.getByLabel(/password/i).fill(user.password);
+  await page.locator('input[name="email"]').fill(user.email);
+  await page.locator('input[name="password"]').fill(user.password);
   await page.getByRole("button", { name: /sign in/i }).click();
   // SignIn navigates to /app on success. The chain is 3 async hops:
   //   1. POST /auth/login (cookie set)

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -127,7 +127,19 @@ export async function signIn(
  */
 export async function signInViaUi(page: Page, user: RegisteredUser): Promise<void> {
   await page.goto("/auth/signin");
-  await page.locator('input[name="email"]').fill(user.email);
+  const email = page.locator('input[name="email"]');
+  try {
+    await email.waitFor({ state: "visible", timeout: 5_000 });
+  } catch (err) {
+    const bodyText = ((await page.locator("body").innerText().catch(() => "")) || "")
+      .replace(/\s+/g, " ")
+      .slice(0, 1000);
+    throw new Error(
+      `Sign-in form did not render at ${page.url()}; body="${bodyText}"`,
+      { cause: err },
+    );
+  }
+  await email.fill(user.email);
   await page.locator('input[name="password"]').fill(user.password);
   await page.getByRole("button", { name: /sign in/i }).click();
   // SignIn navigates to /app on success. The chain is 3 async hops:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "preview:e2e": "node scripts/serve-e2e-preview.mjs",
     "lint": "eslint . --ext ts,tsx",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,8 +1,9 @@
 /**
  * Phase 15 A — Playwright scaffolding.
  *
- * Chromium-only default. Retries on CI; none locally. Trace +
- * video on failure for fast bisection. e2e dir lives at
+ * Chromium-only default. No retries: these flows are deterministic
+ * against a reset DB, and retrying broken setup triples feedback time.
+ * Trace + video on failure for fast bisection. e2e dir lives at
  * `frontend/e2e/`; vitest is unchanged and continues to own
  * `frontend/src/**\/*.test.{ts,tsx}`.
  *
@@ -30,7 +31,7 @@ export default defineConfig({
   testMatch: /.*\.spec\.ts$/,
   fullyParallel: false, // tests share a DB; serial keeps reset semantics simple
   forbidOnly: CI,
-  retries: CI ? 2 : 0,
+  retries: 0,
   workers: 1, // single worker — shared backend + shared DB
   reporter: CI ? [["github"], ["list"]] : "list",
   use: {

--- a/frontend/scripts/serve-e2e-preview.mjs
+++ b/frontend/scripts/serve-e2e-preview.mjs
@@ -1,0 +1,82 @@
+import { createServer } from "node:http";
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const dist = path.join(root, "dist");
+
+function arg(name, fallback) {
+  const prefix = `--${name}=`;
+  const inline = process.argv.find((item) => item.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = process.argv.indexOf(`--${name}`);
+  if (index >= 0 && process.argv[index + 1]) return process.argv[index + 1];
+  return fallback;
+}
+
+const host = arg("host", "127.0.0.1");
+const port = Number(arg("port", "4173"));
+
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".webp", "image/webp"],
+  [".woff", "font/woff"],
+  [".woff2", "font/woff2"],
+]);
+
+function assetPath(requestPath) {
+  const decoded = decodeURIComponent(requestPath);
+  const withoutSlash = decoded.replace(/^\/+/, "");
+  const candidate = path.resolve(dist, withoutSlash || "index.html");
+  if (!candidate.startsWith(dist)) return null;
+  if (!existsSync(candidate)) return null;
+  if (!statSync(candidate).isFile()) return null;
+  return candidate;
+}
+
+async function serveIndex(res) {
+  const html = await readFile(path.join(dist, "index.html"));
+  res.writeHead(200, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  res.end(html);
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    if (!req.url) {
+      res.writeHead(400);
+      res.end("Bad request");
+      return;
+    }
+
+    const url = new URL(req.url, `http://${host}:${port}`);
+    const file = assetPath(url.pathname);
+    if (!file) {
+      await serveIndex(res);
+      return;
+    }
+
+    res.writeHead(200, {
+      "Content-Type": contentTypes.get(path.extname(file)) || "application/octet-stream",
+      "Cache-Control": "no-store",
+    });
+    createReadStream(file).pipe(res);
+  } catch (error) {
+    res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end(error instanceof Error ? error.stack : String(error));
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`e2e preview serving ${dist} at http://${host}:${port}`);
+});

--- a/frontend/src/app/AppHome.test.tsx
+++ b/frontend/src/app/AppHome.test.tsx
@@ -175,7 +175,7 @@ describe("AppHome — State 3: has_superuser, viewer unauthed", () => {
     mountAt("/app");
 
     // The redirect happens in a useEffect. Where it lands depends on
-    // HOSTED_ACCESS_WAITLIST (defaults to true in this build), but the
+    // HOSTED_ACCESS_WAITLIST (defaults to false in self-host/dev), but the
     // invariant is the same: AppHome must NOT render the authed home
     // for an unauthed viewer. Either stub is fine.
     await waitFor(() => {

--- a/frontend/src/auth/SignIn.tsx
+++ b/frontend/src/auth/SignIn.tsx
@@ -34,8 +34,10 @@ export function SignIn() {
   return (
     <AuthCard eyebrow="AUTH - SIGN IN" heading="Sign in" intro="Bring your own Anthropic or OpenAI key after signing in.">
       <form className="flex flex-col gap-6" onSubmit={submit}>
-        <Field label="Email">
+        <Field label="Email" htmlFor="signin-email">
           <input
+            id="signin-email"
+            name="email"
             type="email"
             autoComplete="email"
             required
@@ -44,8 +46,10 @@ export function SignIn() {
             className={inputCls}
           />
         </Field>
-        <Field label="Password">
+        <Field label="Password" htmlFor="signin-password">
           <input
+            id="signin-password"
+            name="password"
             type="password"
             autoComplete="current-password"
             required

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -44,6 +44,31 @@ export function Landing() {
           flourish ambient behind the text (animation by Olga Zamaraeva
           on LottieFiles, recoloured toward seal via CSS filter). */}
       <section className="relative overflow-hidden border-b border-rule">
+        <div className="relative z-20 flex justify-end gap-3 px-4 pt-4 sm:px-6 md:px-16 lg:px-24">
+          {auth.user ? (
+            <a
+              href="/app"
+              className="border border-rule px-3 py-2 text-sm font-medium text-ink transition-colors hover:border-ink hover:bg-wash"
+            >
+              Open app
+            </a>
+          ) : (
+            <>
+              <a
+                href="/auth/signin"
+                className="px-3 py-2 text-sm font-medium text-muted transition-colors hover:text-ink"
+              >
+                Sign in
+              </a>
+              <a
+                href="/auth/signup"
+                className="border border-rule px-3 py-2 text-sm font-medium text-ink transition-colors hover:border-ink hover:bg-wash"
+              >
+                Create account
+              </a>
+            </>
+          )}
+        </div>
         <div
           className="pointer-events-none absolute inset-0 z-0 hidden md:block"
           aria-hidden="true"

--- a/frontend/src/lib/access.test.ts
+++ b/frontend/src/lib/access.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function loadAccessFor(host: string, mode: "open" | "waitlist" | undefined) {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  if (mode) vi.stubEnv("VITE_HOSTED_ACCESS_MODE", mode);
+  vi.stubGlobal("location", { hostname: host });
+  return import("./access");
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("HOSTED_ACCESS_WAITLIST", () => {
+  it("stays open by default on self-hosted domains", async () => {
+    const access = await loadAccessFor("localhost", undefined);
+    expect(access.HOSTED_ACCESS_WAITLIST).toBe(false);
+  });
+
+  it("does not waitlist localhost even when waitlist mode is baked in", async () => {
+    const access = await loadAccessFor("localhost", "waitlist");
+    expect(access.HOSTED_ACCESS_WAITLIST).toBe(false);
+  });
+
+  it("waitlists legalise.dev when waitlist mode is baked in", async () => {
+    const access = await loadAccessFor("legalise.dev", "waitlist");
+    expect(access.HOSTED_ACCESS_WAITLIST).toBe(true);
+  });
+
+  it("keeps legalise.dev open when open mode is baked in", async () => {
+    const access = await loadAccessFor("legalise.dev", "open");
+    expect(access.HOSTED_ACCESS_WAITLIST).toBe(false);
+  });
+});

--- a/frontend/src/lib/access.ts
+++ b/frontend/src/lib/access.ts
@@ -1,6 +1,6 @@
 export const HOSTED_ACCESS_MODE =
   (import.meta.env.VITE_HOSTED_ACCESS_MODE as "waitlist" | "open" | undefined) ??
-  "waitlist";
+  "open";
 
 export const HOSTED_ACCESS_WAITLIST = HOSTED_ACCESS_MODE === "waitlist";
 

--- a/frontend/src/lib/access.ts
+++ b/frontend/src/lib/access.ts
@@ -2,7 +2,14 @@ export const HOSTED_ACCESS_MODE =
   (import.meta.env.VITE_HOSTED_ACCESS_MODE as "waitlist" | "open" | undefined) ??
   "open";
 
-export const HOSTED_ACCESS_WAITLIST = HOSTED_ACCESS_MODE === "waitlist";
+const HOSTED_ACCESS_HOST =
+  (import.meta.env.VITE_HOSTED_ACCESS_HOST as string | undefined) ?? "legalise.dev";
+
+const CURRENT_HOST =
+  typeof globalThis.location === "undefined" ? "" : globalThis.location.hostname;
+
+export const HOSTED_ACCESS_WAITLIST =
+  HOSTED_ACCESS_MODE === "waitlist" && CURRENT_HOST === HOSTED_ACCESS_HOST;
 
 export const WAITLIST_HREF = "/waitlist";
 

--- a/frontend/src/ui/primitives.tsx
+++ b/frontend/src/ui/primitives.tsx
@@ -106,14 +106,16 @@ export function InlineSpinner() {
 export function Field({
   label,
   hint,
+  htmlFor,
   children,
 }: {
   label: string;
   hint?: string;
+  htmlFor?: string;
   children: ReactNode;
 }) {
   return (
-    <label className="flex flex-col gap-2">
+    <label htmlFor={htmlFor} className="flex flex-col gap-2">
       <span className="eyebrow-sm">
         {label}
         {hint && <span className="text-muted text-xs normal-case tracking-normal ml-2">({hint})</span>}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       "/api": "http://backend:8000",
+      "/auth": "http://backend:8000",
       "/health": "http://backend:8000",
     },
   },


### PR DESCRIPTION
## Summary
- proxy `/auth` through the Vite dev server to the backend, matching `/api` and `/health`
- default self-host/dev frontend access to `open`; hosted prod can still set `VITE_HOSTED_ACCESS_MODE=waitlist`
- add explicit `Sign in` / `Create account` landing-page affordances to close the L-1 walkthrough blocker
- add repo-root `PYTHONPATH` in backend CI so reference module entrypoints under `examples.modules...` import when tests run from `backend/`
- add a short handover note for the Phase 17 walkthrough unblockers

## Verification
- `docker compose -f infra/docker-compose.yml exec -T frontend npm run typecheck`
- `docker compose -f infra/docker-compose.yml exec -T frontend npm test`
- `docker compose -f infra/docker-compose.yml exec -T frontend npm run build`
- `docker compose -f infra/docker-compose.yml exec -T backend python -m pytest tests/test_phase10_invocations_api.py -q`
- manual proxy check: POST `/auth/register` through the frontend dev server reached FastAPI and returned `201`

## Notes
This is not Phase 17A/B/C redesign work. It only closes pre-walkthrough auth entry blockers so the operator-proxy walkthrough can resume from `/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Landing page now displays "Sign in" and "Create account" buttons for unauthenticated users.
  * Development environment now proxies authentication requests to the backend.

* **Bug Fixes**
  * Fixed sign-in form field identification for improved test reliability.
  * Self-hosted instances now default to open access mode instead of waitlist.

* **Tests**
  * Enhanced sign-in flow diagnostics with better error reporting.
  * Added access mode validation tests for different deployment environments.
  * Updated e2e test infrastructure with improved preview server and readiness checks.

* **Chores**
  * Updated CI workflows for improved test configuration and environment setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/b1rdmania/legalise/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->