### PR TITLE
Fix vite dev /auth proxy: bypass HTML cold-loads (follow-up to #10)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,44 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// `/auth` is shared between fastapi-users backend endpoints
+// (POST /auth/register, POST /auth/login, GET /auth/users/me, ...) and
+// frontend ROUTES (/auth/signin, /auth/signup, /auth/verify).
+//
+// A blanket `"/auth": http://backend:8000` proxy catches the frontend
+// route GETs too — Vite then forwards them to FastAPI, which has no GET
+// handler at /auth/signin, returns 404, and the SPA never paints.
+//
+// CI works because PR #10's `serve-e2e-preview.mjs` does the right thing
+// for the built bundle. Local `vite dev` needs the same treatment: only
+// proxy requests the backend should actually handle (non-HTML), and let
+// the SPA serve cold-loads of frontend routes.
+//
+// `proxyHtmlBypass` returns the original URL when the request is an HTML
+// navigation; Vite then serves index.html and React Router takes over
+// client-side. Form POSTs, fetch(), and JSON API calls fall through to
+// the proxy as normal.
+export function proxyHtmlBypass(req: {
+  method?: string;
+  url?: string;
+  headers: { accept?: string };
+}): string | undefined {
+  if (
+    req.method === "GET" &&
+    typeof req.headers.accept === "string" &&
+    req.headers.accept.includes("text/html")
+  ) {
+    return req.url;
+  }
+  return undefined;
+}
+
+const spaAwareBackendProxy = {
+  target: "http://backend:8000",
+  changeOrigin: true,
+  bypass: proxyHtmlBypass,
+} as const;
+
 export default defineConfig({
   plugins: [react()],
   server: {
@@ -8,7 +46,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       "/api": "http://backend:8000",
-      "/auth": "http://backend:8000",
+      "/auth": spaAwareBackendProxy,
       "/health": "http://backend:8000",
     },
   },


### PR DESCRIPTION
## Summary

Follow-up to #10. The `/auth` proxy added in #10 fixed the signup POST (`/auth/register` → backend) but inadvertently catches frontend route cold-loads:

```
GET /auth/signin → proxy → FastAPI (no GET handler) → 404
GET /auth/signup → proxy → FastAPI (no GET handler) → 404
```

In-app navigation (clicking "Sign in") works because React Router is client-side. URL-bar entry doesn't.

CI didn't catch it because `serve-e2e-preview.mjs` (also from #10) does the right thing for the built bundle. Local `vite dev` needs the same treatment.

## Fix

One file, one function. Add `proxyHtmlBypass` that returns the original URL when the request is an HTML GET — Vite then serves `index.html`, React Router takes over client-side. POSTs, fetch(), and JSON requests fall through to the proxy unchanged.

## Verification

- ✅ Frontend typecheck clean.
- ⏸ Live re-probe blocked on the local stack being bound to a different checkout right now; once this lands and the running stack restarts with master, the probe sequence is:
  - `GET /auth/signin` should return 200 (SPA HTML).
  - `GET /auth/signup` should return 200 (SPA HTML).
  - `POST /auth/register` should still reach the backend (422 on a malformed payload).

## Walkthrough impact

This unblocks the Phase 17 cold walkthrough at `/auth/signin` and `/auth/signup` cold-loads. The PR #10 review note about "PR #10 introduces a new collision on /auth/signin GET" was not flagged at merge time — picking it up post-merge here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development server configuration to improve single-page application support for authentication routes. The proxy now intelligently manages HTML requests to ensure proper client-side route handling during authentication flows, providing a more reliable development experience while preserving existing API route configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/b1rdmania/legalise/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->