### PR TITLE
Fix Lawve draft schema packaging in backend deploy

### DIFF
--- a/backend/app/core/registry/validator.py
+++ b/backend/app/core/registry/validator.py
@@ -42,20 +42,28 @@ class InvalidManifestError(ValueError):
         super().__init__(message or "manifest invalid")
 
 
-# Locate ``schemas/module.v2.json`` — single source of truth.
+# Locate ``schemas/module.v2.json`` — single source of truth. Local
+# development runs from the repo root, while the Fly image is built from
+# ``backend/`` and only packages ``backend/schemas``.
+_BACKEND_ROOT = Path(__file__).resolve().parents[3]
 _REPO_ROOT = Path(__file__).resolve().parents[4]
-_SCHEMA_PATH = _REPO_ROOT / "schemas" / "module.v2.json"
+_SCHEMA_CANDIDATES = (
+    _REPO_ROOT / "schemas" / "module.v2.json",
+    _BACKEND_ROOT / "schemas" / "module.v2.json",
+)
 
 
 @lru_cache(maxsize=1)
 def _v2_schema() -> dict:
     """Load the v2 schema once per process."""
-    if not _SCHEMA_PATH.exists():
-        raise FileNotFoundError(
-            f"schemas/module.v2.json not found at {_SCHEMA_PATH}; "
-            "Phase 2 cannot validate manifests without it"
-        )
-    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    for candidate in _SCHEMA_CANDIDATES:
+        if candidate.exists():
+            return json.loads(candidate.read_text(encoding="utf-8"))
+    candidates = ", ".join(str(path) for path in _SCHEMA_CANDIDATES)
+    raise FileNotFoundError(
+        f"schemas/module.v2.json not found in any of: {candidates}; "
+        "Phase 2 cannot validate manifests without it"
+    )
 
 
 def _schema_errors(payload: dict) -> list[dict[str, Any]]:

--- a/backend/schemas/module.v2.json
+++ b/backend/schemas/module.v2.json
@@ -1,0 +1,293 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://legalise.dev/schemas/module.v2.json",
+  "title": "Legalise Module Manifest v2",
+  "description": "Capability declaration manifest. Replaces the v1 `module.json` plugin-style schema for new modules. v1 manifests are still supported via the auto-derivation shim in `app.core.registry.shim`.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "name",
+    "version",
+    "publisher",
+    "visibility",
+    "runtime",
+    "entrypoint",
+    "capabilities"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^2\\.[0-9]+\\.[0-9]+$",
+      "description": "Manifest schema version. Must be 2.x. The runtime rejects anything outside the 2.x line."
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_.-]+$",
+      "description": "Stable lowercase module id."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable display name."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.-]+)?$",
+      "description": "Module version. Semver."
+    },
+    "publisher": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable publisher id."
+    },
+    "visibility": {
+      "type": "string",
+      "enum": [
+        "first_party",
+        "community",
+        "firm_private",
+        "example",
+        "partner_track"
+      ]
+    },
+    "runtime": {
+      "type": "string",
+      "enum": ["native", "mcp", "prompt"]
+    },
+    "entrypoint": {
+      "type": "object",
+      "description": "Runtime-specific launch/binding declaration.",
+      "oneOf": [
+        {
+          "title": "MCP stdio transport",
+          "type": "object",
+          "required": ["transport", "command"],
+          "properties": {
+            "transport": {"const": "stdio"},
+            "command": {"type": "string", "minLength": 1},
+            "args": {
+              "type": "array",
+              "items": {"type": "string"}
+            },
+            "env": {
+              "type": "object",
+              "additionalProperties": {"type": "string"}
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "title": "MCP SSE transport",
+          "type": "object",
+          "required": ["transport", "url"],
+          "properties": {
+            "transport": {"const": "sse"},
+            "url": {"type": "string", "format": "uri"},
+            "headers": {
+              "type": "object",
+              "additionalProperties": {"type": "string"}
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "title": "Native python entrypoint",
+          "type": "object",
+          "required": ["python_module"],
+          "properties": {
+            "python_module": {
+              "type": "string",
+              "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$"
+            },
+            "entry": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        {
+          "title": "Prompt skill entrypoint",
+          "description": "Manifest-contained prompt runtime. The skill's instructions (and optional non-script reference text) live inline in the manifest; the prompt runtime builds a model prompt from them under the capability's existing grants/posture/audit. No external file store in v1.",
+          "type": "object",
+          "required": ["prompt_source", "instructions"],
+          "properties": {
+            "prompt_source": {"const": "manifest"},
+            "instructions": {"type": "string", "minLength": 1},
+            "references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["path", "content"],
+                "properties": {
+                  "path": {"type": "string"},
+                  "content": {"type": "string"}
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/capability"}
+    },
+    "description": {"type": "string"},
+    "source_url": {"type": "string", "format": "uri"},
+    "license": {"type": "string", "description": "SPDX identifier."},
+    "jurisdictions": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "requires": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/dependency"}
+    },
+    "host_version": {
+      "type": "string",
+      "description": "Minimum Legalise host API version this module supports."
+    },
+    "matter_schema_version": {
+      "type": "string",
+      "description": "Minimum Matter OS schema version this module supports."
+    },
+    "signed_by": {"type": "string"},
+    "signature": {"type": "string"}
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "capability": {
+      "type": "object",
+      "required": [
+        "id",
+        "kind",
+        "scope",
+        "reads",
+        "writes",
+        "model_access",
+        "external_network",
+        "data_movement",
+        "gates",
+        "ui",
+        "streaming_mode",
+        "advice_tier_max",
+        "audit_events"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9_-]+$",
+          "description": "Stable id within the module."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["skill", "tool", "workflow", "provider", "gate"]
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["matter", "workspace", "global"]
+        },
+        "reads": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Capability grammar strings the runtime checks before allowing read."
+        },
+        "writes": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Capability grammar strings the runtime checks before allowing write."
+        },
+        "model_access": {
+          "type": "string",
+          "enum": ["none", "optional", "required", "delegated"]
+        },
+        "external_network": {"type": "boolean"},
+        "data_movement": {"$ref": "#/$defs/data_movement"},
+        "gates": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "ui": {
+          "type": "object",
+          "required": ["slot"],
+          "properties": {
+            "slot": {"type": "string"},
+            "label": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "streaming_mode": {
+          "type": "string",
+          "enum": ["sync", "streaming", "async"]
+        },
+        "advice_tier_max": {
+          "type": "string",
+          "enum": [
+            "factual_extraction",
+            "legal_information",
+            "draft_advice",
+            "supervised_legal_advice",
+            "approved_final_advice"
+          ]
+        },
+        "audit_events": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Expected audit action names this capability will emit."
+        },
+        "output_lifecycle_target": {
+          "anyOf": [
+            {"type": "null"},
+            {
+              "type": "string",
+              "enum": [
+                "draft",
+                "reviewed",
+                "cleared",
+                "sent",
+                "signed",
+                "superseded",
+                "withdrawn"
+              ]
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "data_movement": {
+      "type": "object",
+      "description": "Explicit declaration of where matter data flows. The permission card renders directly from this object.",
+      "properties": {
+        "sends_document_body": {"type": "boolean"},
+        "sends_document_binary": {"type": "boolean"},
+        "sends_matter_metadata": {"type": "boolean"},
+        "external_destinations": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "retention_by_external_service": {"type": "string"},
+        "local_only": {"type": "boolean"}
+      },
+      "additionalProperties": false
+    },
+    "dependency": {
+      "type": "object",
+      "required": ["module_id"],
+      "properties": {
+        "module_id": {"type": "string"},
+        "version": {
+          "type": "string",
+          "description": "Semver range, e.g. '>=1.0.0,<2.0.0'."
+        },
+        "capability": {
+          "type": "string",
+          "description": "Specific capability id this dependency provides."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/backend/tests/test_phase2_schema.py
+++ b/backend/tests/test_phase2_schema.py
@@ -11,6 +11,8 @@ Pure-unit tests — no DB.
 from __future__ import annotations
 
 import copy
+import json
+from pathlib import Path
 
 import pytest
 
@@ -65,6 +67,20 @@ def _base_manifest() -> dict:
 def test_base_manifest_is_valid() -> None:
     is_valid, errors = validate_manifest_v2(_base_manifest())
     assert is_valid, f"base manifest must validate; got errors: {errors}"
+
+
+def test_backend_packaged_schema_matches_repo_root_schema() -> None:
+    """Fly builds from backend/, so the v2 schema must also be packaged
+    there. Pin equality so the deploy fallback cannot drift from the
+    repo-root canonical schema."""
+    repo_root = Path(__file__).resolve().parents[2]
+    root_schema = repo_root / "schemas" / "module.v2.json"
+    backend_schema = repo_root / "backend" / "schemas" / "module.v2.json"
+
+    assert backend_schema.exists()
+    assert json.loads(backend_schema.read_text(encoding="utf-8")) == json.loads(
+        root_schema.read_text(encoding="utf-8")
+    )
 
 
 def test_missing_capabilities_array_rejected() -> None:

--- a/docs/handovers/V1_ACCEPTANCE_WALK_2026_05_29.md
+++ b/docs/handovers/V1_ACCEPTANCE_WALK_2026_05_29.md
@@ -1,10 +1,12 @@
 # V1 Acceptance Walk — 2026-05-29
 
-Status: partial acceptance record against production head `b8aa500`.
+Status: partial acceptance record against production head `b8aa500`, with one
+credentialed production blocker found and patched on
+`codex/fix-lawve-schema-packaging`.
 
-This is not a substitute for a credentialed browser walkthrough. It is the
-current verified state from production HTTP checks, deployed bundle checks,
-CI status, and repo inspection.
+This is not yet the full end-to-end v1 walk. It records the current verified
+state from production HTTP checks, deployed bundle checks, CI status, repo
+inspection, and the first credentialed Lawve import step.
 
 ## Production Head
 
@@ -79,10 +81,11 @@ This closes the main product loop:
 
 ## Not Fully Walked In This Pass
 
-The full credentialed browser path was not exercised from this session because
-no production admin/user credentials or provider key were available.
+The credentialed browser path started and reached the Lawve import conversion
+step. It cannot proceed to install/grant/run until the blocker below is
+deployed and re-tested.
 
-Still requiring a human/credentialed pass:
+Still requiring a credentialed pass after the patch deploys:
 
 1. Sign in as admin.
 2. Open `/modules/lawve`.
@@ -101,11 +104,42 @@ Still requiring a human/credentialed pass:
 
 ## Findings
 
-No production blocker found from unauthenticated/live-bundle checks.
+### P1 — Lawve draft conversion 500s in production
 
-The main remaining v1 risk is UX, not substrate: the pieces now connect, but the
-credentialed flow still needs a real operator pass to catch copy, state,
-permission, and navigation friction.
+Evidence:
+
+- Signed in successfully and opened `/modules/lawve`.
+- Selected `contract-review-anthropic`; the detail panel rendered provenance
+  and the `Convert to module draft` action.
+- Clicking `Convert to module draft` rendered a frontend `TypeError: Failed to
+  fetch`.
+- Direct authenticated API reproduction:
+  `POST https://api.legalise.dev/api/modules/external/lawve/skills/contract-review-anthropic/draft`
+  returned `500 Internal Server Error`.
+- CORS preflight returned `200`; unauthenticated POST returned `401`. This is
+  not a CORS/auth routing issue.
+
+Root cause from Fly logs:
+
+```text
+FileNotFoundError: schemas/module.v2.json not found at /schemas/module.v2.json
+```
+
+The Fly image is built from `backend/`, so repo-root `schemas/module.v2.json`
+is not packaged into the production container. Local development finds it via
+the repo-root path; production resolves the old path to `/schemas/...`.
+
+Patch on `codex/fix-lawve-schema-packaging`:
+
+- package `backend/schemas/module.v2.json`;
+- make the v2 validator check repo-root schema first, then backend-packaged
+  schema;
+- add a drift test proving the packaged schema matches the repo-root canonical
+  schema.
+
+The remaining v1 risk after this fix is UX, not substrate: the pieces now
+connect in code, but the credentialed flow still needs a real operator pass to
+catch copy, state, permission, and navigation friction.
 
 ## Recommended Next Work
 
@@ -118,4 +152,3 @@ permission, and navigation friction.
    id, invocation, artifact, and review decision.
 4. **Module marketplace polish.** Make `/modules` explain available/imported/
    installed/disabled states and licence/script warnings calmly.
-

--- a/docs/handovers/V1_ACCEPTANCE_WALK_2026_05_29.md
+++ b/docs/handovers/V1_ACCEPTANCE_WALK_2026_05_29.md
@@ -1,0 +1,121 @@
+# V1 Acceptance Walk — 2026-05-29
+
+Status: partial acceptance record against production head `b8aa500`.
+
+This is not a substitute for a credentialed browser walkthrough. It is the
+current verified state from production HTTP checks, deployed bundle checks,
+CI status, and repo inspection.
+
+## Production Head
+
+- `master`: `b8aa500c7105e3a3b6e491950f86de18fb2815e7`
+- `phase-17-crm-pass`: `b8aa500c7105e3a3b6e491950f86de18fb2815e7`
+- GitHub Actions for `b8aa500`: CI, e2e, frontend deploy, backend deploy all
+  completed successfully.
+
+## Live Checks Performed
+
+### Frontend
+
+All three SPA entry points returned `200`:
+
+- `https://legalise.dev/`
+- `https://legalise.dev/modules`
+- `https://legalise.dev/modules/lawve`
+
+The deployed frontend bundle contains the new External Skills Product Loop
+strings:
+
+- `Install this draft`
+- `Ready to sign`
+- `Ask an administrator`
+- `skill_response`
+- `Request review`
+- `Lawve`
+
+This confirms the post-`b8aa500` bundle is the one Cloudflare is serving.
+
+### Backend
+
+`GET https://api.legalise.dev/api/system/bootstrap-state` returned:
+
+```json
+{"user_count":3,"has_superuser":true,"firm_role_gates_enabled":false}
+```
+
+This confirms:
+
+- production has users;
+- production has a bootstrapped superuser;
+- firm-role gates are dormant in production, as intended for v1 evaluation.
+
+Unauthenticated endpoint behaviour:
+
+- `GET /api/modules/public` returns public skill catalogue data.
+- `GET /api/modules/v2` returns `401`, as expected.
+- `GET /api/modules/external/lawve/skills` returns `401`, as expected.
+
+## Code-Level Acceptance For The New Loop
+
+The live `b8aa500` code now supports:
+
+1. Lawve skill browsing/import.
+2. Prompt-only Lawve skills converting to valid `runtime: "prompt"` manifests.
+3. Prompt manifests declaring `model_access: "required"` plus an internal
+   provider capability.
+4. One-click `Install this draft` from a valid Lawve draft into the existing
+   trust ceremony.
+5. Matter-scoped grant/run through the existing invocation endpoint.
+6. Prompt runtime producing `skill_response` artifacts.
+7. `skill_response` rendering as a first-class artifact view rather than raw
+   JSON.
+8. `skill_response` eligibility for Supervisor Review.
+9. Typed `AdviceBoundaryDenied` handling for structured 403 translation.
+
+This closes the main product loop:
+
+> Lawve skill -> prompt module -> install -> grant -> run -> skill_response
+> artifact -> request supervisor review -> decision -> audit chain.
+
+## Not Fully Walked In This Pass
+
+The full credentialed browser path was not exercised from this session because
+no production admin/user credentials or provider key were available.
+
+Still requiring a human/credentialed pass:
+
+1. Sign in as admin.
+2. Open `/modules/lawve`.
+3. Import a simple Lawve prompt skill.
+4. Confirm `Install this draft` starts the trust ceremony.
+5. Complete the ceremony.
+6. Open a matter.
+7. Grant the imported module on that matter.
+8. Invoke it.
+9. Open the resulting `skill_response` artifact.
+10. Request supervisor review.
+11. Decide the review.
+12. Open audit reconstruction and confirm the chain is legible.
+13. Export the matter and confirm the bundle includes the artifact, review,
+    reconstruction, and README.
+
+## Findings
+
+No production blocker found from unauthenticated/live-bundle checks.
+
+The main remaining v1 risk is UX, not substrate: the pieces now connect, but the
+credentialed flow still needs a real operator pass to catch copy, state,
+permission, and navigation friction.
+
+## Recommended Next Work
+
+1. **Credentialed V1 acceptance walk.** Use the checklist above and record any
+   P1/P2 issues. This should happen before adding another feature.
+2. **Docs/demo update.** Make the Lawve -> prompt module -> review loop a
+   headline path in `README.md` and `docs/DEMO.md`.
+3. **Audit/evidence polish.** Ensure audit reconstruction and export make
+   external-skill provenance obvious: source repo, pinned SHA, licence, module
+   id, invocation, artifact, and review decision.
+4. **Module marketplace polish.** Make `/modules` explain available/imported/
+   installed/disabled states and licence/script warnings calmly.
+


### PR DESCRIPTION
## Summary
- package module.v2.json inside the backend image context
- make the v2 manifest validator fall back to the packaged backend schema in production
- add a drift test so the packaged copy cannot diverge from the repo-root schema
- update the v1 acceptance walk with the credentialed production blocker and root cause

## Verification
- python -m py_compile backend/app/core/registry/validator.py backend/tests/test_phase2_schema.py
- schema JSON equality check between schemas/module.v2.json and backend/schemas/module.v2.json

## Production finding
Credentialed Lawve draft conversion hit a production 500 because the Fly image is built from backend/ and did not include repo-root schemas/module.v2.json. Fly logs showed FileNotFoundError for /schemas/module.v2.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module manifest schema resolution to work reliably across different deployment environments and execution contexts.

* **Tests**
  * Added validation to verify schema consistency across different package configurations.

* **Documentation**
  * Added acceptance test documentation capturing walkthrough results and identified issues with remediation details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/b1rdmania/legalise/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->