### PR TITLE
Fix install ceremony action flow

### DIFF
--- a/backend/app/core/api.py
+++ b/backend/app/core/api.py
@@ -34,7 +34,12 @@ import uuid
 from dataclasses import dataclass
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+)
 
 from app.adapters import plugin_bridge as _plugin_bridge_module
 from app.core.model_gateway import gateway as _gateway
@@ -175,14 +180,19 @@ async def audit_failure(
         # In production, sessions always have a bind.
         return
 
-    # If the session is bound to a Connection (the conftest pattern
+    # If the session is bound to an AsyncConnection (the conftest pattern
     # wraps each test in an outer transaction on a specific connection),
-    # walk up to the engine so the new sessionmaker checks out a fresh
-    # connection from the pool. Otherwise the new session joins the
-    # outer transaction and the "independent commit" would be rolled
-    # back at test teardown.
-    if hasattr(bind, "engine"):
+    # walk up to the AsyncEngine so the new sessionmaker checks out a
+    # fresh connection from the pool. Do not use a generic `.engine`
+    # attribute check here: AsyncEngine exposes a sync `.engine` alias,
+    # and handing that sync Engine to async_sessionmaker crashes the
+    # failure path in production.
+    if isinstance(bind, AsyncConnection):
         bind = bind.engine
+    elif not isinstance(bind, AsyncEngine):
+        # Unexpected/test-only bind shape. Best-effort: do not let a
+        # failure-audit attempt turn the original API error into a 500.
+        return
 
     factory = async_sessionmaker(bind, expire_on_commit=False)
     async with factory() as audit_session:

--- a/frontend/src/modules-v2/InstallCeremony.test.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.test.tsx
@@ -102,7 +102,7 @@ describe("InstallCeremony — stepper", () => {
 });
 
 describe("InstallCeremony — advance actions", () => {
-  it("trust + grant call advanceCeremony with the right action", async () => {
+  it("continues review before the granted boundary", async () => {
     vi.spyOn(api, "getCeremony").mockResolvedValue(makeCeremony());
     const advance = vi
       .spyOn(api, "advanceCeremony")
@@ -110,15 +110,33 @@ describe("InstallCeremony — advance actions", () => {
 
     mountAt("/modules/install/cer-1");
     await waitFor(() => {
-      expect(screen.getByText("Trust + continue")).toBeInTheDocument();
+      expect(screen.getByText("Continue review")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Trust + continue"));
+    expect(screen.queryByText("Enable module")).toBeNull();
+
+    fireEvent.click(screen.getByText("Continue review"));
     await waitFor(() => {
       expect(advance).toHaveBeenCalledWith("cer-1", "trust");
     });
+  });
 
-    fireEvent.click(screen.getByText("Grant + enable"));
+  it("renders the enable action only at the granted boundary", async () => {
+    vi.spyOn(api, "getCeremony").mockResolvedValue(
+      makeCeremony({ state: "granted" }),
+    );
+    const advance = vi
+      .spyOn(api, "advanceCeremony")
+      .mockResolvedValue(makeCeremony({ state: "enabled", is_terminal: true }));
+
+    mountAt("/modules/install/cer-1");
+    await waitFor(() => {
+      expect(screen.getByText("Enable module")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Continue review")).toBeNull();
+
+    fireEvent.click(screen.getByText("Enable module"));
     await waitFor(() => {
       expect(advance).toHaveBeenCalledWith("cer-1", "grant");
     });
@@ -150,7 +168,9 @@ describe("InstallCeremony — advance actions", () => {
 
 describe("InstallCeremony — 409 invalid-transition", () => {
   it("renders a structured banner naming the substrate audit row", async () => {
-    vi.spyOn(api, "getCeremony").mockResolvedValue(makeCeremony());
+    vi.spyOn(api, "getCeremony").mockResolvedValue(
+      makeCeremony({ state: "granted" }),
+    );
     vi.spyOn(api, "advanceCeremony").mockRejectedValueOnce(
       new api.InvalidCeremonyTransitionError(
         "cannot grant before permissions_reviewed",
@@ -161,9 +181,9 @@ describe("InstallCeremony — 409 invalid-transition", () => {
 
     mountAt("/modules/install/cer-1");
     await waitFor(() => {
-      expect(screen.getByText("Grant + enable")).toBeInTheDocument();
+      expect(screen.getByText("Enable module")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText("Grant + enable"));
+    fireEvent.click(screen.getByText("Enable module"));
 
     await waitFor(() => {
       expect(
@@ -195,8 +215,8 @@ describe("InstallCeremony — terminal failures", () => {
         screen.getByText(/ceremony terminated/i),
       ).toBeInTheDocument();
     });
-    expect(screen.queryByText("Trust + continue")).toBeNull();
-    expect(screen.queryByText("Grant + enable")).toBeNull();
+    expect(screen.queryByText("Continue review")).toBeNull();
+    expect(screen.queryByText("Enable module")).toBeNull();
     expect(screen.queryByText("Reject")).toBeNull();
   });
 });

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -12,8 +12,8 @@
  *             sandbox_profile_missing
  *
  * Action policy (mirrors substrate):
- *   - "trust"  — non-terminal, non-granted: advance one step
- *   - "grant"  — only valid at the granted-ready boundary; persists
+ *   - "trust"  — non-terminal, non-granted: advance one review step
+ *   - "grant"  — only rendered at the granted-ready boundary; persists
  *                InstalledModule and emits module.enabled
  *   - "reject" — any non-terminal: emits module.denied + returns to /modules
  *
@@ -147,6 +147,7 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
   const c = q.ceremony;
   const isTerminal = c.is_terminal;
   const isFailure = TERMINAL_FAILURE_STATES.has(c.state);
+  const canEnable = c.state === "granted";
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
@@ -185,28 +186,30 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
       {/* Controls */}
       {!isTerminal && (
         <div className="mt-8 flex flex-wrap items-center gap-3">
-          <button
-            type="button"
-            onClick={() => onAdvance("trust")}
-            disabled={adv.kind === "running"}
-            className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-paper hover:opacity-90 disabled:opacity-50"
-          >
-            {adv.kind === "running" && adv.action === "trust"
-              ? "Advancing…"
-              : c.state === "granted"
-                ? "Trust (already granted)"
-                : "Trust + continue"}
-          </button>
-          <button
-            type="button"
-            onClick={() => onAdvance("grant")}
-            disabled={adv.kind === "running"}
-            className="inline-flex items-center rounded-md border border-ink px-4 py-2 text-ink hover:bg-ink hover:text-paper disabled:opacity-50"
-          >
-            {adv.kind === "running" && adv.action === "grant"
-              ? "Enabling…"
-              : "Grant + enable"}
-          </button>
+          {!canEnable && (
+            <button
+              type="button"
+              onClick={() => onAdvance("trust")}
+              disabled={adv.kind === "running"}
+              className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-paper hover:opacity-90 disabled:opacity-50"
+            >
+              {adv.kind === "running" && adv.action === "trust"
+                ? "Advancing…"
+                : "Continue review"}
+            </button>
+          )}
+          {canEnable && (
+            <button
+              type="button"
+              onClick={() => onAdvance("grant")}
+              disabled={adv.kind === "running"}
+              className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-paper hover:opacity-90 disabled:opacity-50"
+            >
+              {adv.kind === "running" && adv.action === "grant"
+                ? "Enabling…"
+                : "Enable module"}
+            </button>
+          )}
           <button
             type="button"
             onClick={() => onAdvance("reject")}


### PR DESCRIPTION
## Summary
- make audit_failure keep an AsyncEngine bind instead of accidentally converting it to a sync Engine
- render the install ceremony action that is valid for the current substrate state
- show Continue review until the ceremony reaches granted, then show Enable module
- update InstallCeremony tests for the state-specific action policy

## Production finding
During the live v1 acceptance walk, Lawve draft conversion reached the trust ceremony, but clicking Grant + enable while the ceremony was only inspected caused a 500. Logs showed the substrate correctly raised InvalidCeremonyTransition, then the failure-audit helper crashed because it passed a sync Engine into async_sessionmaker.

## Verification
- python -m py_compile backend/app/core/api.py
- frontend focused tests/typecheck could not run locally because this checkout has no installed node_modules; CI is the gate.