### PR TITLE
Make imported modules grantable from matter UI

### DIFF
--- a/backend/app/api/modules.py
+++ b/backend/app/api/modules.py
@@ -589,6 +589,7 @@ class InstalledModuleOut(BaseModel):
     publisher: str
     visibility: str
     signature_status: str
+    capabilities: list[dict[str, Any]] = []
     enabled: bool
     installed_at: str  # ISO-8601
     installed_by_user_id: str | None
@@ -636,6 +637,7 @@ async def list_installed_modules(
             sub.c.publisher,
             sub.c.visibility,
             sub.c.signature_status,
+            sub.c.permissions_snapshot,
             sub.c.enabled,
             sub.c.installed_at,
             sub.c.installed_by_user_id,
@@ -651,6 +653,11 @@ async def list_installed_modules(
             publisher=r.publisher,
             visibility=r.visibility,
             signature_status=r.signature_status,
+            capabilities=(
+                r.permissions_snapshot.get("capabilities", [])
+                if isinstance(r.permissions_snapshot, dict)
+                else []
+            ),
             enabled=r.enabled,
             installed_at=r.installed_at.isoformat(),
             installed_by_user_id=(
@@ -1262,5 +1269,4 @@ async def get_skill_body(
         raise HTTPException(404, f"skill not found: {plugin}/{skill}")
     manifest = _parse_skill_md(path.read_text(encoding="utf-8"))
     return PlainTextResponse(manifest.body.strip())
-
 

--- a/backend/tests/test_phase14_5_b_installed_modules.py
+++ b/backend/tests/test_phase14_5_b_installed_modules.py
@@ -50,6 +50,7 @@ def _make_installed_row(
     visibility: str = "first_party",
     signature_status: str = "verified",
     installed_by_user_id: uuid.UUID | None = None,
+    capabilities: list[dict] | None = None,
 ) -> InstalledModule:
     return InstalledModule(
         id=uuid.uuid4(),
@@ -62,7 +63,7 @@ def _make_installed_row(
         verified_at=installed_at,
         install_path="<inline>",
         manifest_snapshot={"id": module_id, "version": version},
-        permissions_snapshot={},
+        permissions_snapshot={"capabilities": capabilities or []},
         installed_at=installed_at,
         installed_by_user_id=installed_by_user_id,
         enabled=enabled,
@@ -230,6 +231,7 @@ async def test_response_shape_excludes_secrets_and_internals(client, db_session)
         "publisher",
         "visibility",
         "signature_status",
+        "capabilities",
         "enabled",
         "installed_at",
         "installed_by_user_id",
@@ -240,6 +242,48 @@ async def test_response_shape_excludes_secrets_and_internals(client, db_session)
     assert "permissions_snapshot" not in matching
     assert "install_path" not in matching
     assert "signed_by" not in matching
+
+
+@pytest.mark.asyncio
+async def test_capability_summaries_surface_without_full_manifest(
+    client, db_session
+):
+    """Imported inline modules are not in the registry catalogue, so
+    the grants UI needs capability summaries from the installed row.
+    Surface just that grantable shape, not the full manifest snapshot."""
+    await _register_and_login(client)
+    module_id = f"phase145b-caps-{uuid.uuid4().hex[:6]}"
+    db_session.add(_make_installed_row(
+        module_id=module_id,
+        version="0.1.0",
+        installed_at=datetime(2026, 3, 2, tzinfo=UTC),
+        capabilities=[
+            {
+                "id": "default",
+                "kind": "skill",
+                "scope": "matter",
+                "reads": ["matter.document.read"],
+                "writes": ["matter.artifact.write"],
+            }
+        ],
+    ))
+    await db_session.flush()
+
+    resp = await client.get("/api/modules/installed")
+    rows = resp.json()
+    matching = next((r for r in rows if r["module_id"] == module_id), None)
+    assert matching is not None
+    assert matching["capabilities"] == [
+        {
+            "id": "default",
+            "kind": "skill",
+            "scope": "matter",
+            "reads": ["matter.document.read"],
+            "writes": ["matter.artifact.write"],
+        }
+    ]
+    assert "manifest_snapshot" not in matching
+    assert "permissions_snapshot" not in matching
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -318,6 +318,7 @@ export interface InstalledModule {
   publisher: string;
   visibility: string;
   signature_status: string;
+  capabilities?: unknown[];
   enabled: boolean;
   installed_at: string;
   installed_by_user_id: string | null;

--- a/frontend/src/matter/GrantsPanel.test.tsx
+++ b/frontend/src/matter/GrantsPanel.test.tsx
@@ -150,6 +150,67 @@ describe("GrantsPanel — create", () => {
     });
   });
 
+  it("offers installed inline modules that are not in the v2 registry catalog", async () => {
+    vi.spyOn(api, "listGrants").mockResolvedValue({
+      matter_id: "m-1",
+      grants: [],
+    });
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({
+      modules: [],
+      ui_slots: [],
+    });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([
+      {
+        module_id: "contract-review-anthropic",
+        version: "2026.01.30",
+        publisher: "Anthropic",
+        visibility: "community",
+        signature_status: "unsigned",
+        enabled: true,
+        installed_at: "2026-01-01T00:00:00",
+        installed_by_user_id: null,
+        capabilities: [
+          {
+            id: "default",
+            kind: "skill",
+            scope: "matter",
+            reads: ["matter.document.read"],
+            writes: ["matter.artifact.write"],
+          },
+        ],
+      },
+    ]);
+    const create = vi.spyOn(api, "createGrant").mockResolvedValue({
+      matter_id: "m-1",
+      parent_capability_id: "default",
+      module_id: "contract-review-anthropic",
+      grants: [],
+      was_idempotent_noop: false,
+    });
+
+    render(<GrantsPanel slug="khan" />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/contract-review-anthropic/i),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Module/i), {
+      target: { value: "contract-review-anthropic" },
+    });
+    fireEvent.change(screen.getByLabelText(/Capability/i), {
+      target: { value: "default" },
+    });
+    fireEvent.click(screen.getByText("Grant"));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith("khan", {
+        module_id: "contract-review-anthropic",
+        capability_id: "default",
+      });
+    });
+  });
+
   it("surfaces 404 module_not_installed inline", async () => {
     vi.spyOn(api, "listGrants").mockResolvedValue({ matter_id: "m-1", grants: [] });
     vi.spyOn(api, "getModulesV2").mockResolvedValue({

--- a/frontend/src/matter/GrantsPanel.tsx
+++ b/frontend/src/matter/GrantsPanel.tsx
@@ -110,6 +110,19 @@ function manifestName(entry: V2ManifestEntry): string {
   return typeof n === "string" ? n : entry.module_id;
 }
 
+function installedModuleEntry(row: InstalledModule): V2ManifestEntry {
+  return {
+    module_id: row.module_id,
+    source_kind: "installed",
+    manifest: {
+      name: row.module_id,
+      capabilities: Array.isArray(row.capabilities) ? row.capabilities : [],
+    },
+    is_valid: true,
+    validation_errors: [],
+  };
+}
+
 export function GrantsPanel({ slug }: { slug: string }) {
   const [grants, setGrants] = useState<GrantsQuery>({ status: "loading" });
   const [catalog, setCatalog] = useState<CatalogQuery>({ status: "loading" });
@@ -179,12 +192,21 @@ export function GrantsPanel({ slug }: { slug: string }) {
   // retained server-side as defence-in-depth.
   const moduleOptions = useMemo(() => {
     if (catalog.status !== "ready") return [];
-    return catalog.modules.filter(
+    const byId = new Map<string, V2ManifestEntry>();
+    for (const m of catalog.modules) byId.set(m.module_id, m);
+    if (installed !== null) {
+      for (const row of installed.values()) {
+        if (!byId.has(row.module_id)) {
+          byId.set(row.module_id, installedModuleEntry(row));
+        }
+      }
+    }
+    return Array.from(byId.values()).filter(
       (m) =>
         m.is_valid &&
         capabilitiesOf(m).some((c) => c.scope === "matter"),
     );
-  }, [catalog]);
+  }, [catalog, installed]);
 
   const selectedManifest = useMemo(
     () => moduleOptions.find((m) => m.module_id === selectedModule) ?? null,
@@ -295,7 +317,14 @@ export function GrantsPanel({ slug }: { slug: string }) {
       capabilityId: string;
       moduleName: string;
     }> = [];
-    for (const m of catalog.modules) {
+    const byId = new Map<string, V2ManifestEntry>();
+    for (const m of catalog.modules) byId.set(m.module_id, m);
+    for (const row of installed.values()) {
+      if (!byId.has(row.module_id)) {
+        byId.set(row.module_id, installedModuleEntry(row));
+      }
+    }
+    for (const m of byId.values()) {
       if (!m.is_valid) continue;
       // Phase 14.5 B — extra AND clause: module must be installed
       // AND enabled. Strictly an addition to the Phase 14 D


### PR DESCRIPTION
## Summary
- include installed module capability summaries on GET /api/modules/installed without leaking full manifest snapshots
- merge installed inline modules into GrantsPanel module options when they are not present in the registry catalog
- keep the strict Phase 14D runnable derivation: installed + enabled + all reads/writes granted
- add backend/frontend regressions for imported inline module grantability

## Production finding
During the live v1 acceptance walk, a Lawve prompt module installed successfully but did not appear in the matter grant picker. The grant UI only used /modules/v2 catalog entries for capability shape, while inline-installed Lawve modules live only in installed_modules.

## Verification
- python -m py_compile backend/app/api/modules.py backend/tests/test_phase14_5_b_installed_modules.py
- frontend focused tests/typecheck could not run locally because this checkout has no installed node_modules; CI is the gate.