### PR TITLE
frontend: surface run readiness on matters

### DIFF
--- a/docs/handovers/HANDOVER_RUN_READINESS_ACTION_LOOP_DONE.md
+++ b/docs/handovers/HANDOVER_RUN_READINESS_ACTION_LOOP_DONE.md
@@ -1,0 +1,44 @@
+# Run Readiness + Matter Action Loop Pass
+
+Date: 2026-05-29
+Branch: `codex/run-readiness-action-loop`
+
+## Goal
+
+Make the matter action surface explain whether a granted module is actually ready to run before the user clicks `Run`.
+
+This follows the production acceptance finding from the Lawve/imported-skill loop: Khan correctly blocks on a missing Anthropic key, but the old UI only revealed that after the invocation attempt.
+
+## Shipped
+
+- `MatterDetail` now passes `matter.default_model_id` into `GrantsPanel`.
+- `GrantsPanel` loads configured provider-key state via `GET /api/settings/keys`.
+- Runnable actions now render as `Available actions`, with an explicit readiness line per action.
+- Model-backed actions infer the required provider from the matter model:
+  - Claude/Anthropic models -> Anthropic key.
+  - GPT/OpenAI/o-series models -> OpenAI key.
+  - `stub-echo`, local/Ollama, or no keyed provider -> keyless/local ready.
+- Missing provider keys disable the `Run` button up front and link to `/settings/keys`.
+- Configured provider keys show `Key configured, not tested`; the UI does not claim provider validity because no provider test-call endpoint exists.
+- The existing invocation error banners remain in place as backend defence-in-depth.
+
+## Files
+
+- `frontend/src/matter/MatterDetail.tsx`
+- `frontend/src/matter/GrantsPanel.tsx`
+- `frontend/src/matter/InvocationRunner.tsx`
+- `frontend/src/matter/GrantsPanel.test.tsx`
+
+## Verification
+
+- `npm test -- GrantsPanel InvocationRunner` -> 23 passed.
+- `npm run typecheck` -> clean.
+- `npm run build` -> clean.
+
+## Deliberate Boundaries
+
+- Frontend-only. No substrate change.
+- No provider test-call invented.
+- No claim that a configured key is valid before first real provider use.
+- No change to grant/runnable-pair semantics: installed + enabled + strict per-string grants still gate the action list.
+

--- a/frontend/src/matter/GrantsPanel.test.tsx
+++ b/frontend/src/matter/GrantsPanel.test.tsx
@@ -15,6 +15,7 @@ beforeEach(() => {
   // they expect. Tests that assert Run is ABSENT can rely on this
   // default — no installed row → no runnable pair.
   vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+  vi.spyOn(api, "listApiKeys").mockResolvedValue([]);
 });
 afterEach(() => {
   cleanup();
@@ -509,6 +510,105 @@ describe("GrantsPanel — runnable-pairs derivation (Phase 14 D)", () => {
         screen.getByTestId("run-contract-review-review"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("blocks Run up front when the matter model needs a missing provider key", async () => {
+    const MODEL_CAP_MANIFEST = {
+      ...MULTI_CAP_MANIFEST,
+      manifest: {
+        ...MULTI_CAP_MANIFEST.manifest,
+        capabilities: [
+          {
+            id: "review",
+            scope: "matter",
+            model_access: "required",
+            reads: ["matter.document.read"],
+            writes: ["matter.artifact.write"],
+          },
+          {
+            id: "default-provider",
+            kind: "provider",
+            scope: "workspace",
+            model_access: "none",
+            reads: [],
+            writes: [],
+          },
+        ],
+      },
+    };
+    vi.spyOn(api, "listGrants").mockResolvedValue({
+      matter_id: "m-1",
+      grants: [
+        grant("contract-review", "review", "matter.document.read"),
+        grant("contract-review", "review", "matter.artifact.write"),
+      ],
+    });
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({
+      modules: [MODEL_CAP_MANIFEST],
+      ui_slots: [],
+    });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([{
+      module_id: "contract-review",
+      version: "0.1.0",
+      publisher: "legalise",
+      visibility: "first_party",
+      signature_status: "verified",
+      enabled: true,
+      installed_at: "2026-01-01T00:00:00",
+      installed_by_user_id: null,
+    }]);
+
+    render(<GrantsPanel slug="khan" defaultModelId="claude-opus-4-7" />);
+    const run = await screen.findByTestId("run-contract-review-review");
+
+    expect(run).toBeDisabled();
+    expect(screen.getByText(/anthropic key needed/i)).toBeInTheDocument();
+    expect(screen.getByText(/configure provider keys/i)).toBeInTheDocument();
+  });
+
+  it("shows a ready keyless status for stub-model matter actions", async () => {
+    const MODEL_CAP_MANIFEST = {
+      ...MULTI_CAP_MANIFEST,
+      manifest: {
+        ...MULTI_CAP_MANIFEST.manifest,
+        capabilities: [
+          {
+            id: "review",
+            scope: "matter",
+            model_access: "required",
+            reads: ["matter.document.read"],
+            writes: ["matter.artifact.write"],
+          },
+        ],
+      },
+    };
+    vi.spyOn(api, "listGrants").mockResolvedValue({
+      matter_id: "m-1",
+      grants: [
+        grant("contract-review", "review", "matter.document.read"),
+        grant("contract-review", "review", "matter.artifact.write"),
+      ],
+    });
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({
+      modules: [MODEL_CAP_MANIFEST],
+      ui_slots: [],
+    });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([{
+      module_id: "contract-review",
+      version: "0.1.0",
+      publisher: "legalise",
+      visibility: "first_party",
+      signature_status: "verified",
+      enabled: true,
+      installed_at: "2026-01-01T00:00:00",
+      installed_by_user_id: null,
+    }]);
+
+    render(<GrantsPanel slug="khan" defaultModelId="stub-echo" />);
+    const run = await screen.findByTestId("run-contract-review-review");
+
+    expect(run).not.toBeDisabled();
+    expect(screen.getByText(/ready: keyless\/local model/i)).toBeInTheDocument();
   });
 
   it("does NOT show Run when the module is installed but disabled", async () => {

--- a/frontend/src/matter/GrantsPanel.tsx
+++ b/frontend/src/matter/GrantsPanel.tsx
@@ -26,6 +26,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   createGrant,
   getModulesV2,
+  listApiKeys,
   listGrants,
   listInstalledModules,
   ModuleDisabledError,
@@ -33,6 +34,7 @@ import {
   revokeGrant,
   type GrantRow,
   type InstalledModule,
+  type UserApiKeyRead,
   type V2ManifestEntry,
 } from "../lib/api";
 import { InvocationRunner } from "./InvocationRunner";
@@ -65,6 +67,7 @@ interface ManifestCapability {
   id: string;
   scope?: string;
   kind?: string;
+  modelAccess?: string;
   // Substrate-truth: when a capability is granted via
   // create_grants_for_capability (grants_lifecycle.py:355-389), it
   // creates one WorkspaceSkillCapabilityGrant row per string in
@@ -98,6 +101,7 @@ function capabilitiesOf(entry: V2ManifestEntry): ManifestCapability[] {
         id,
         scope: typeof c.scope === "string" ? c.scope : undefined,
         kind: typeof c.kind === "string" ? c.kind : undefined,
+        modelAccess: typeof c.model_access === "string" ? c.model_access : undefined,
         reads: stringArray(c.reads),
         writes: stringArray(c.writes),
       };
@@ -123,7 +127,105 @@ function installedModuleEntry(row: InstalledModule): V2ManifestEntry {
   };
 }
 
-export function GrantsPanel({ slug }: { slug: string }) {
+function providerForModel(modelId: string | null | undefined): string | null {
+  const value = (modelId ?? "").trim().toLowerCase();
+  if (!value || value === "stub-echo" || value.includes("ollama")) return null;
+  if (value.includes("claude") || value.includes("anthropic")) return "anthropic";
+  if (
+    value.includes("openai") ||
+    value.includes("gpt") ||
+    /^o[134](?:-|$)/.test(value)
+  ) {
+    return "openai";
+  }
+  return null;
+}
+
+function moduleRequiresModel(entry: V2ManifestEntry, cap: ManifestCapability): boolean {
+  if (cap.modelAccess === "required") return true;
+  return capabilitiesOf(entry).some(
+    (c) => c.kind === "provider" || c.modelAccess === "required",
+  );
+}
+
+type KeyQuery =
+  | { status: "loading" }
+  | { status: "ready"; keys: UserApiKeyRead[] }
+  | { status: "error" };
+
+type RunReadiness = {
+  disabled: boolean;
+  title: string;
+  body: string;
+  provider?: string | null;
+};
+
+function readinessFor(opts: {
+  defaultModelId?: string | null;
+  requiresModel: boolean;
+  keyQuery: KeyQuery;
+}): RunReadiness {
+  if (!opts.requiresModel) {
+    return {
+      disabled: false,
+      title: "Ready to run",
+      body: "This capability does not declare model access.",
+    };
+  }
+
+  const provider = providerForModel(opts.defaultModelId);
+  if (provider === null) {
+    return {
+      disabled: false,
+      title: "Ready: keyless/local model",
+      body: `Matter model ${opts.defaultModelId || "stub-echo"} does not need a BYO provider key.`,
+      provider,
+    };
+  }
+
+  const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
+  if (opts.keyQuery.status === "loading") {
+    return {
+      disabled: true,
+      title: `Checking ${providerLabel} key`,
+      body: "Legalise is checking whether your account has the provider key this matter needs.",
+      provider,
+    };
+  }
+  if (opts.keyQuery.status === "error") {
+    return {
+      disabled: false,
+      title: "Provider key status unavailable",
+      body: `This action uses ${providerLabel}. Run may fail if no key is configured.`,
+      provider,
+    };
+  }
+
+  const hasKey = opts.keyQuery.keys.some((k) => k.provider === provider);
+  if (!hasKey) {
+    return {
+      disabled: true,
+      title: `${providerLabel} key needed`,
+      body: `This matter uses ${opts.defaultModelId}. Add your ${providerLabel} key before running this action.`,
+      provider,
+    };
+  }
+
+  return {
+    disabled: false,
+    title: `${providerLabel} key configured, not tested`,
+    body: "A key is on file. Legalise has not validated it against the provider until the run starts.",
+    provider,
+  };
+}
+
+export function GrantsPanel({
+  slug,
+  defaultModelId,
+}: {
+  slug: string;
+  defaultModelId?: string | null;
+}) {
   const [grants, setGrants] = useState<GrantsQuery>({ status: "loading" });
   const [catalog, setCatalog] = useState<CatalogQuery>({ status: "loading" });
   // Phase 14.5 B — installed-module state. ONE extra AND clause for
@@ -133,6 +235,7 @@ export function GrantsPanel({ slug }: { slug: string }) {
   const [installed, setInstalled] = useState<Map<string, InstalledModule> | null>(
     null,
   );
+  const [keys, setKeys] = useState<KeyQuery>({ status: "loading" });
   const [createState, setCreateState] = useState<CreateState>({ kind: "idle" });
   const [revokeState, setRevokeState] = useState<RevokeState>({ kind: "idle" });
 
@@ -178,6 +281,13 @@ export function GrantsPanel({ slug }: { slug: string }) {
         // looks installed → no runnable pairs render. Safer than
         // assuming everything is installed.
         if (!cancelled) setInstalled(new Map());
+      });
+    listApiKeys()
+      .then((rows) => {
+        if (!cancelled) setKeys({ status: "ready", keys: rows });
+      })
+      .catch(() => {
+        if (!cancelled) setKeys({ status: "error" });
       });
     return () => {
       cancelled = true;
@@ -288,7 +398,12 @@ export function GrantsPanel({ slug }: { slug: string }) {
   //   the substrate would 403 at dispatch, potentially after a
   //   provider call.
   const runnablePairs = useMemo<
-    Array<{ moduleId: string; capabilityId: string; moduleName: string }>
+    Array<{
+      moduleId: string;
+      capabilityId: string;
+      moduleName: string;
+      readiness: RunReadiness;
+    }>
   >(() => {
     // Wait until installed state has resolved before deriving. Pre-
     // resolution we don't know if a module is installed/enabled,
@@ -316,6 +431,7 @@ export function GrantsPanel({ slug }: { slug: string }) {
       moduleId: string;
       capabilityId: string;
       moduleName: string;
+      readiness: RunReadiness;
     }> = [];
     const byId = new Map<string, V2ManifestEntry>();
     for (const m of catalog.modules) byId.set(m.module_id, m);
@@ -345,11 +461,16 @@ export function GrantsPanel({ slug }: { slug: string }) {
           moduleId: m.module_id,
           capabilityId: c.id,
           moduleName: name,
+          readiness: readinessFor({
+            defaultModelId,
+            requiresModel: moduleRequiresModel(m, c),
+            keyQuery: keys,
+          }),
         });
       }
     }
     return out;
-  }, [catalog, grants, installed]);
+  }, [catalog, defaultModelId, grants, installed, keys]);
 
   return (
     <section className="mt-10 rounded-md border border-line bg-paper p-4">
@@ -369,27 +490,42 @@ export function GrantsPanel({ slug }: { slug: string }) {
           data-testid="runnable-capabilities"
         >
           <h3 className="text-xs uppercase tracking-widest text-muted">
-            Run a capability
+            Available actions
           </h3>
+          <p className="mt-2 text-xs text-muted">
+            These actions are installed, enabled, and fully granted on this
+            matter. Readiness shows the provider-key boundary before a run
+            starts.
+          </p>
           <ul className="mt-3 space-y-3">
             {runnablePairs.map((p) => (
               <li
                 key={`${p.moduleId}::${p.capabilityId}`}
                 className="border-t border-line pt-3 first:border-t-0 first:pt-0"
               >
-                <div className="flex items-baseline justify-between gap-3">
+                <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <p className="text-sm">{p.moduleName}</p>
                     <p className="text-xs font-mono text-muted">
                       {p.moduleId} · {p.capabilityId}
                     </p>
                   </div>
+                  <span
+                    className={`rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-widest ${
+                      p.readiness.disabled
+                        ? "border-amber-500/40 bg-amber-50 text-amber-900"
+                        : "border-line bg-paper-sunken text-muted"
+                    }`}
+                  >
+                    {p.readiness.disabled ? "Needs setup" : "Ready"}
+                  </span>
                 </div>
                 <div className="mt-2">
                   <InvocationRunner
                     slug={slug}
                     moduleId={p.moduleId}
                     capabilityId={p.capabilityId}
+                    readiness={p.readiness}
                   />
                 </div>
               </li>

--- a/frontend/src/matter/InvocationRunner.tsx
+++ b/frontend/src/matter/InvocationRunner.tsx
@@ -55,14 +55,21 @@ interface Props {
   slug: string;
   moduleId: string;
   capabilityId: string;
+  readiness?: {
+    disabled: boolean;
+    title: string;
+    body: string;
+    provider?: string | null;
+  };
 }
 
-export function InvocationRunner({ slug, moduleId, capabilityId }: Props) {
+export function InvocationRunner({ slug, moduleId, capabilityId, readiness }: Props) {
   const [state, setState] = useState<RunnerState>({ kind: "idle" });
   const [argsOpen, setArgsOpen] = useState(false);
   const [argsJson, setArgsJson] = useState("{}");
 
   const onRun = async () => {
+    if (readiness?.disabled) return;
     let parsedArgs: Record<string, unknown> = {};
     if (argsOpen) {
       try {
@@ -118,7 +125,7 @@ export function InvocationRunner({ slug, moduleId, capabilityId }: Props) {
         <button
           type="button"
           onClick={onRun}
-          disabled={state.kind === "running"}
+          disabled={state.kind === "running" || readiness?.disabled}
           className="inline-flex items-center rounded-md bg-ink px-3 py-1 text-xs text-paper hover:opacity-90 disabled:opacity-50"
           data-testid={`run-${moduleId}-${capabilityId}`}
         >
@@ -132,6 +139,29 @@ export function InvocationRunner({ slug, moduleId, capabilityId }: Props) {
           {argsOpen ? "Hide args" : "Args"}
         </button>
       </div>
+      {readiness && (
+        <div
+          className={`mt-2 rounded-md border px-3 py-2 text-xs ${
+            readiness.disabled
+              ? "border-amber-500/40 bg-amber-50 text-ink"
+              : "border-line bg-paper-sunken text-muted"
+          }`}
+          data-testid={`run-readiness-${moduleId}-${capabilityId}`}
+        >
+          <p className="font-medium text-ink">{readiness.title}</p>
+          <p className="mt-1">{readiness.body}</p>
+          {readiness.disabled && (
+            <p className="mt-2">
+              <a
+                href="/settings/keys"
+                className="underline underline-offset-4 hover:text-ink"
+              >
+                Configure provider keys →
+              </a>
+            </p>
+          )}
+        </div>
+      )}
       {argsOpen && (
         <div className="mt-2">
           <textarea

--- a/frontend/src/matter/MatterDetail.tsx
+++ b/frontend/src/matter/MatterDetail.tsx
@@ -443,7 +443,12 @@ export function MatterDetail({ slug }: { slug: string }) {
           )}
           {tab === "reviews" && matter && <ReviewsTab matter={matter} />}
           {tab === "research" && matter && <ResearchTab matter={matter} />}
-          {matter && <GrantsPanel slug={matter.slug} />}
+          {matter && (
+            <GrantsPanel
+              slug={matter.slug}
+              defaultModelId={matter.default_model_id}
+            />
+          )}
         </main>
         {tab !== "assistant" && tab !== "workflows" && tab !== "audit" && (
           <RightRailAssistant


### PR DESCRIPTION
## Summary
- show matter action readiness before Run, including missing Anthropic/OpenAI key state
- pass matter.default_model_id into the action panel and use configured provider keys for honest status
- keep invocation error banners as backend defence-in-depth

## Verification
- npm test -- GrantsPanel InvocationRunner
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actions now display readiness status ("Needs setup" or "Ready") indicating whether required provider API keys are configured.
  * Run button automatically disables when required provider keys are missing, with a direct link to settings for key configuration.
  * Added readiness messaging above action parameters to clarify setup requirements.

* **Documentation**
  * Added documentation for the Run Readiness feature, including affected components and verification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/b1rdmania/legalise/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->