### PR TITLE
frontend: center matter UX on activity trail

### DIFF
--- a/docs/handovers/HANDOVER_AUDIT_CENTERED_MATTER_UX_DONE.md
+++ b/docs/handovers/HANDOVER_AUDIT_CENTERED_MATTER_UX_DONE.md
@@ -1,0 +1,41 @@
+# Audit-Centred Matter UX Pass
+
+Date: 2026-05-29
+Branch: `codex/audit-centered-matter-ux`
+
+## Goal
+
+Correct the visible product drift: the matter workspace had started to expose too much substrate state across too many panels. The thesis is supervised autonomy on a matter, so the matter-level activity/audit record should be the main explanatory surface.
+
+## Shipped
+
+- Matter sidebar label changed from `Audit` to `Activity Trail`.
+- Matter nav now puts `Activity Trail` immediately after `Documents`, ahead of chronology/workflows/approvals.
+- Workspace/global audit label changed to `Workspace audit` so it does not compete with the matter trail.
+- `/matters/{slug}/audit` now leads with `Activity Trail`, not `Reconstruction`.
+- The page copy explains the user story: documents touched, actions run, models called, outputs written, reviews, and blocked attempts.
+- Raw source filters and decision-type chips are collapsed under `Filters and raw sources`.
+- Loaded activity classes render as simple story cards (`Action ran`, `Model used`, `Human review`, etc.) that still facet the loaded page.
+- Matter action panel now says `Actions on this matter`.
+- Technical grants and the grant form are collapsed under `Permissions and setup`, with copy that frames grants as setup/debug detail.
+
+## Boundaries
+
+- Frontend-only.
+- No route changes.
+- No endpoint/schema/substrate changes.
+- No removal of raw audit detail; payloads/refs remain expandable.
+- No hiding of governance facts, only progressive disclosure.
+
+## Verification
+
+- `npm test -- GrantsPanel ReconstructionView` -> 29 passed.
+- `npm run typecheck` -> clean.
+- `npm run build` -> clean.
+
+## Product Direction
+
+This is the intended UX principle going forward:
+
+> The matter trail explains what happened. Module, grant, provider, and review machinery should be visible when needed, but not distributed as competing primary surfaces.
+

--- a/frontend/src/matter/GrantsPanel.tsx
+++ b/frontend/src/matter/GrantsPanel.tsx
@@ -475,12 +475,12 @@ export function GrantsPanel({
   return (
     <section className="mt-10 rounded-md border border-line bg-paper p-4">
       <h2 className="text-sm uppercase tracking-widest text-muted">
-        Matter actions
+        Actions on this matter
       </h2>
       <p className="mt-2 text-sm text-muted">
-        Modules you can run on this matter appear first. The permissions
-        you have granted stay listed below, so you can see exactly what
-        each module may touch here.
+        Run governed actions from installed modules. The Activity Trail
+        records what each action touched, which model ran, what output
+        was written, and how it was reviewed.
       </p>
 
       {/* Phase 14 D — runnable capabilities */}
@@ -534,78 +534,88 @@ export function GrantsPanel({
         </div>
       )}
 
-      {/* Permissions on this matter */}
-      <h3 className="mt-6 text-xs uppercase tracking-widest text-muted">
-        Permissions on this matter
-      </h3>
-      {grants.status === "loading" && (
-        <p className="mt-4 text-sm text-muted">Loading grants…</p>
-      )}
-      {grants.status === "error" && (
-        <p className="mt-4 text-sm text-seal">
-          Could not load grants: {grants.message}
+      <details className="mt-6 rounded-md border border-line bg-paper-sunken p-4">
+        <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">
+          Permissions and setup
+        </summary>
+        <p className="mt-2 text-sm text-muted">
+          Technical grants are hidden by default. Open this when an
+          action needs setup or you need to inspect/revoke exactly what
+          a module may touch.
         </p>
-      )}
-      {grants.status === "ready" && grants.grants.length === 0 && (
-        <p className="mt-4 text-sm text-muted">
-          No capabilities granted on this matter yet. Use the form below
-          to grant from an installed module.
-        </p>
-      )}
-      {grants.status === "ready" && grants.grants.length > 0 && (
-        <div className="mt-4 overflow-x-auto rounded-md border border-line">
-          <table className="min-w-full text-sm">
-            <thead className="bg-paper-sunken text-xs uppercase tracking-widest text-muted">
-              <tr>
-                <th className="px-3 py-2 text-left">Module</th>
-                <th className="px-3 py-2 text-left">Skill</th>
-                <th className="px-3 py-2 text-left">Permission</th>
-                <th className="px-3 py-2 text-left">Granted</th>
-                <th className="px-3 py-2 text-right"> </th>
-              </tr>
-            </thead>
-            <tbody>
-              {grants.grants.map((g) => (
-                <tr key={g.id} className="border-t border-line">
-                  <td className="px-3 py-2 font-mono text-xs">{g.plugin}</td>
-                  <td className="px-3 py-2 font-mono text-xs">{g.skill}</td>
-                  <td className="px-3 py-2 font-mono text-xs">{g.capability}</td>
-                  <td className="px-3 py-2 text-xs text-muted">
-                    {g.granted_at ? g.granted_at.slice(0, 19).replace("T", " ") : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right">
-                    <button
-                      type="button"
-                      onClick={() => onRevoke(g.id)}
-                      disabled={
-                        revokeState.kind === "revoking" &&
-                        revokeState.grantId === g.id
-                      }
-                      className="text-xs text-muted underline underline-offset-4 hover:text-seal disabled:opacity-50"
-                    >
-                      {revokeState.kind === "revoking" &&
-                      revokeState.grantId === g.id
-                        ? "Revoking…"
-                        : "Revoke"}
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-      {revokeState.kind === "error" && (
-        <p className="mt-3 text-sm text-seal">
-          Revoke failed: {revokeState.message}
-        </p>
-      )}
 
-      {/* Add-grant control */}
-      <div className="mt-6 rounded-md border border-line bg-paper-sunken p-4">
-        <h3 className="text-xs uppercase tracking-widest text-muted">
-          Grant a capability
+        {/* Permissions on this matter */}
+        <h3 className="mt-5 text-xs uppercase tracking-widest text-muted">
+          Permissions on this matter
         </h3>
+        {grants.status === "loading" && (
+          <p className="mt-4 text-sm text-muted">Loading grants…</p>
+        )}
+        {grants.status === "error" && (
+          <p className="mt-4 text-sm text-seal">
+            Could not load grants: {grants.message}
+          </p>
+        )}
+        {grants.status === "ready" && grants.grants.length === 0 && (
+          <p className="mt-4 text-sm text-muted">
+            No capabilities granted on this matter yet. Use the form below
+            to grant from an installed module.
+          </p>
+        )}
+        {grants.status === "ready" && grants.grants.length > 0 && (
+          <div className="mt-4 overflow-x-auto rounded-md border border-line bg-paper">
+            <table className="min-w-full text-sm">
+              <thead className="bg-paper-sunken text-xs uppercase tracking-widest text-muted">
+                <tr>
+                  <th className="px-3 py-2 text-left">Module</th>
+                  <th className="px-3 py-2 text-left">Skill</th>
+                  <th className="px-3 py-2 text-left">Permission</th>
+                  <th className="px-3 py-2 text-left">Granted</th>
+                  <th className="px-3 py-2 text-right"> </th>
+                </tr>
+              </thead>
+              <tbody>
+                {grants.grants.map((g) => (
+                  <tr key={g.id} className="border-t border-line">
+                    <td className="px-3 py-2 font-mono text-xs">{g.plugin}</td>
+                    <td className="px-3 py-2 font-mono text-xs">{g.skill}</td>
+                    <td className="px-3 py-2 font-mono text-xs">{g.capability}</td>
+                    <td className="px-3 py-2 text-xs text-muted">
+                      {g.granted_at ? g.granted_at.slice(0, 19).replace("T", " ") : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => onRevoke(g.id)}
+                        disabled={
+                          revokeState.kind === "revoking" &&
+                          revokeState.grantId === g.id
+                        }
+                        className="text-xs text-muted underline underline-offset-4 hover:text-seal disabled:opacity-50"
+                      >
+                        {revokeState.kind === "revoking" &&
+                        revokeState.grantId === g.id
+                          ? "Revoking…"
+                          : "Revoke"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {revokeState.kind === "error" && (
+          <p className="mt-3 text-sm text-seal">
+            Revoke failed: {revokeState.message}
+          </p>
+        )}
+
+        {/* Add-grant control */}
+        <div className="mt-6 rounded-md border border-line bg-paper p-4">
+          <h3 className="text-xs uppercase tracking-widest text-muted">
+            Grant a capability
+          </h3>
         {catalog.status === "loading" && (
           <p className="mt-3 text-sm text-muted">Loading module catalog…</p>
         )}
@@ -705,7 +715,8 @@ export function GrantsPanel({
         {createState.kind === "error" && (
           <p className="mt-3 text-sm text-seal">{createState.message}</p>
         )}
-      </div>
+        </div>
+      </details>
     </section>
   );
 }

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -69,6 +69,17 @@ const CLASS_LABEL: Record<RowClass, string> = {
   system: "System",
 };
 
+const STORY_LABEL: Record<RowClass, string> = {
+  error: "Error raised",
+  review: "Human review",
+  blocked_denied: "Blocked or denied",
+  grant_role: "Permission changed",
+  advice: "Advice boundary checked",
+  model: "Model used",
+  module: "Action ran",
+  system: "System activity",
+};
+
 type FetchState =
   | { status: "loading" }
   | { status: "ready"; entries: TimelineEntry[]; nextCursor: string | null; totalEstimate: number; loadingMore: boolean }
@@ -223,17 +234,25 @@ export function ReconstructionView({ slug }: { slug: string }) {
   }, [visibleEntries, classFilter]);
 
   const foregroundCount = lanes.chains.length + lanes.standaloneDecisions.length;
+  const storyCounts = useMemo(() => {
+    const counts = new Map<RowClass, number>();
+    for (const entry of visibleEntries) {
+      const key = classifyEntry(entry);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+  }, [visibleEntries]);
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <p className="text-xs uppercase tracking-widest text-muted">Matter</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Reconstruction</h1>
+      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Activity Trail</h1>
       <p className="mt-1 text-xs font-mono text-muted">{slug}</p>
       <p className="mt-3 text-sm text-muted">
-        Canonical timeline of every audited event on this matter. Rows
-        are union-ed from three substrate tables — audit entries,
-        state-machine transitions, and advice-boundary decisions — and
-        ordered by occurrence.
+        The main record of what happened on this matter: documents
+        touched, actions run, models called, outputs written, human
+        reviews, and blocked attempts. Raw substrate rows stay
+        expandable; the first view is the story.
       </p>
 
       {/* Active query-param filters */}
@@ -267,65 +286,70 @@ export function ReconstructionView({ slug }: { slug: string }) {
         </div>
       )}
 
-      {/* Source chips */}
-      <div className="mt-4 flex flex-wrap items-center gap-2">
-        <span className="text-xs uppercase tracking-widest text-muted">
-          Sources
-        </span>
-        {ALL_RECONSTRUCTION_SOURCES.map((s) => {
-          const active = sources.includes(s);
-          return (
-            <button
-              key={s}
-              type="button"
-              onClick={() => toggleSource(s)}
-              className={
-                "rounded-full border px-3 py-1 text-xs transition-colors " +
-                (active
-                  ? "border-ink bg-ink text-paper"
-                  : "border-line text-muted hover:border-ink")
-              }
-              data-testid={`source-chip-${s}`}
-              aria-pressed={active}
-            >
-              {SOURCE_LABEL[s]}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Class facet chips (AT-2) — loaded page only, hidden when a
-          precise deep-link filter is active. */}
-      {!deepLinked && (
-        <div className="mt-3 flex flex-wrap items-center gap-2">
+      <details className="mt-5 rounded-md border border-line bg-paper-sunken p-3">
+        <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">
+          Filters and raw sources
+        </summary>
+        {/* Source chips */}
+        <div className="mt-4 flex flex-wrap items-center gap-2">
           <span className="text-xs uppercase tracking-widest text-muted">
-            Decision type
+            Sources
           </span>
-          {CLASS_CHIPS.map((c) => {
-            const active = classFilter === c.key;
+          {ALL_RECONSTRUCTION_SOURCES.map((s) => {
+            const active = sources.includes(s);
             return (
               <button
-                key={c.key}
+                key={s}
                 type="button"
-                onClick={() => setClassFilter(active ? null : c.key)}
+                onClick={() => toggleSource(s)}
                 className={
                   "rounded-full border px-3 py-1 text-xs transition-colors " +
                   (active
                     ? "border-ink bg-ink text-paper"
                     : "border-line text-muted hover:border-ink")
                 }
-                data-testid={`class-chip-${c.key}`}
+                data-testid={`source-chip-${s}`}
                 aria-pressed={active}
               >
-                {c.label}
+                {SOURCE_LABEL[s]}
               </button>
             );
           })}
-          {classFilter && (
-            <span className="text-[11px] text-muted">filters the loaded page only</span>
-          )}
         </div>
-      )}
+
+        {/* Class facet chips (AT-2) — loaded page only, hidden when a
+            precise deep-link filter is active. */}
+        {!deepLinked && (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs uppercase tracking-widest text-muted">
+              Decision type
+            </span>
+            {CLASS_CHIPS.map((c) => {
+              const active = classFilter === c.key;
+              return (
+                <button
+                  key={c.key}
+                  type="button"
+                  onClick={() => setClassFilter(active ? null : c.key)}
+                  className={
+                    "rounded-full border px-3 py-1 text-xs transition-colors " +
+                    (active
+                      ? "border-ink bg-ink text-paper"
+                      : "border-line text-muted hover:border-ink")
+                  }
+                  data-testid={`class-chip-${c.key}`}
+                  aria-pressed={active}
+                >
+                  {c.label}
+                </button>
+              );
+            })}
+            {classFilter && (
+              <span className="text-[11px] text-muted">filters the loaded page only</span>
+            )}
+          </div>
+        )}
+      </details>
 
       {/* Timeline */}
       {fetchState.status === "loading" && (
@@ -344,6 +368,29 @@ export function ReconstructionView({ slug }: { slug: string }) {
               ? ` · ~${fetchState.totalEstimate} in window`
               : ""}
           </p>
+          {visibleEntries.length > 0 && !deepLinked && (
+            <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {Array.from(storyCounts.entries())
+                .filter(([key]) => key !== "system")
+                .map(([key, count]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setClassFilter(classFilter === key ? null : key)}
+                    className={
+                      "rounded-md border px-3 py-2 text-left text-xs transition-colors " +
+                      (classFilter === key
+                        ? "border-ink bg-ink text-paper"
+                        : "border-line bg-paper hover:border-ink")
+                    }
+                    aria-pressed={classFilter === key}
+                  >
+                    <span className="block font-medium">{STORY_LABEL[key]}</span>
+                    <span className="mt-1 block text-muted">{count} event{count === 1 ? "" : "s"}</span>
+                  </button>
+                ))}
+            </div>
+          )}
 
           {/* Phase 14.5 A — substrate now applies filters before
               pagination. The partial-page advisory the Phase 14 E
@@ -647,4 +694,3 @@ function ExpandedBlock({
     </div>
   );
 }
-

--- a/frontend/src/matter/tabs/types.ts
+++ b/frontend/src/matter/tabs/types.ts
@@ -26,10 +26,10 @@ export type TabKey =
 export const SIDEBAR_NAV: ReadonlyArray<{ key: TabKey; label: string }> = [
   { key: "assistant", label: "Assistant" },
   { key: "documents", label: "Documents" },
+  { key: "audit", label: "Activity Trail" },
   { key: "chronology", label: "Chronology" },
   { key: "workflows", label: "Workflows" },
   { key: "approvals", label: "Approvals" },
-  { key: "audit", label: "Audit" },
 ];
 
 // Frontend workflow taxonomy. Used by TopBar + MatterBreadcrumb to

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -241,7 +241,7 @@ export function Sidebar({
               route.name === "createModule"
             }
           />
-          <NavLink href="/admin/audit" label="Audit" active={onAudit} />
+          <NavLink href="/admin/audit" label="Workspace audit" active={onAudit} />
 
           <SectionLabel>Account</SectionLabel>
           <NavLink


### PR DESCRIPTION
## Summary
- rename the matter audit surface to Activity Trail and move it earlier in matter nav
- collapse raw source/filter controls and technical grant setup behind progressive detail sections
- make the matter action panel point users back to the activity trail as the main explanation of what was touched

## Verification
- npm test -- GrantsPanel ReconstructionView
- npm run typecheck
- npm run build