### PR TITLE
docs: Kramer-to-Legalise baseline and rewrite addendum

### DIFF
--- a/docs/IMPLEMENTATION_PLAN_REWRITE_ADDENDUM_2026_06_01.md
+++ b/docs/IMPLEMENTATION_PLAN_REWRITE_ADDENDUM_2026_06_01.md
@@ -1,0 +1,99 @@
+# Implementation Plan Rewrite — Addendum 2026-06-01
+
+**Status:** factual reconciliation between the locked v2 architecture plan (`docs/IMPLEMENTATION_PLAN_REWRITE.md`, ratified 2026-05-25) and what has shipped on `master` since. Builder-authored. Interpretive calls (does V1 surface X *satisfy* phase Y?) are deferred to Reviewer.
+
+This addendum does not modify the v2 plan. It records that the v2 plan is canonical direction but not start-here-tomorrow build state, and lists what changed underneath it.
+
+## Premise
+
+v2 plan was grounded at `5322e70` (24 May 2026). Plan §0 says *"Build not yet started"* and §0 specifies a dedicated `runtime-rewrite` branch cut from master at the start of Phase 0, with hosted-eval staying on master throughout the rewrite.
+
+As of 2026-06-01:
+
+- `runtime-rewrite` branch is not active. `origin/runtime-rewrite` exists but is an ancestor of `master`.
+- `master` is at `c94d0ca` — 34 commits past `5322e70`.
+- The thirteen Phase 0 architecture docs are present in `docs/architecture/` (one more than the twelve listed in plan §Phase 0: `ADVICE_BOUNDARY.md` is split out from `STATE_MACHINE_PRIMITIVE.md`).
+- A substantial V1 product slice has shipped on `master` outside the rewrite branch.
+
+The canonical V1 state summary lives at `docs/handovers/HANDOVER_V1_PRODUCT_STATE_2026_05_30.md`. This addendum cites it, does not duplicate it.
+
+## V1 surfaces shipped since v2 plan (factual map)
+
+Each row: surface → on-disk location(s) → which v2 phase(s) it may relate to. The *"may relate to"* column is descriptive, not a completion claim. Reviewer ratifies whether each surface is retained, ported, or rewritten during the runtime rewrite.
+
+| V1 surface | Files / routes | May relate to |
+|---|---|---|
+| Professional Sign-Off | `backend/app/api/signoffs.py`, `backend/app/core/signoff.py`, `backend/app/models/matter_signoff.py`, `frontend/src/matter/SignOff.tsx`, `SignOffConfirmation.tsx`, migration `0022_professional_signoff.py` | Phase 1.3 (advice-boundary tier transitions), Phase 5 (audit reconstruction — sign-off events emit audit rows), Phase 12 (frontend gate UX) |
+| Source Anchors | `backend/app/core/source_anchors.py`, `backend/app/core/prompt_runtime.py`, `tests/test_source_anchors.py`, `test_contract_review_source_anchors.py` | Phase 5 (output evidence in audit), Phase 7 (Contract Review reference port — already source-aware) |
+| Export Gating v1.1 | `backend/app/core/exports.py`, `tests/test_export_signoff_gating.py`, `test_export_source_anchors.py` | Phase 5 (audit/evidence pack emission), Phase 16 (pre-launch hardening) |
+| Module v2 manifest schema | `backend/schemas/module.v2.json` (293 lines) | Phase 2 (manifest v2 + capability registry) — schema artefact present; runtime registry/grammar work still to do per plan |
+| Prompt Runtime v1 | `backend/app/core/prompt_runtime.py`, `tests/test_prompt_runtime*.py` | Phase 6 (sync/streaming runtime), Phase 7/8 (reference ports — module dispatch path) |
+| Lawve Skill Importer | `frontend/src/modules-v2/LawveImport.tsx`, related handover | Phase 11 (connector proof set — distinct from first-party-signed reference connectors; importer is a different surface), Phase 12 (catalogue UX) |
+| Guided Demo Loop v1 | `backend/app/api/demo.py` (`POST /api/demo/guided-loop`), `backend/app/core/demo_loop.py`, `frontend/src/demo/DemoLoop.tsx`, handover `HANDOVER_GUIDED_DEMO_LOOP_V1_DONE.md` | Phase 13 (Khan canonical demo) — Guided Demo Loop overlaps with Kramer carry-over #1 (guided exhibit); Reviewer to decide relationship |
+| Document Workspace + Ingress | `frontend/src/matter/tabs/DocumentsTab.tsx`, `ArtifactDetail.tsx`, `ArtifactPreview.tsx`, `ArtifactsList.tsx` | Phase 12 (frontend capability runtime UX) — may reduce Phase 12 scope |
+| Matter Desk UX compression | `frontend/src/matter/MatterNav.tsx`, `MatterPulse.tsx`, `MatterDetail.tsx` | Phase 12 |
+| `legalise doctor` (Phase 16 C) | `backend/app/tools/doctor.py` — 8 checks including `khan.demo_present` | Phase 16 (pre-launch hardening) — partial scope; pen-test + audit-integrity work still per plan |
+| Audit-centered matter UX | `frontend/src/matter/ReconstructionView.tsx`, related handover | Phase 5 (audit reconstruction view), Phase 12 |
+| KISS V1 compression pass | `c94d0ca chore: apply KISS repo cleanup` on master; further partial work on `origin/repo-cleanup-pass` | Not a rewrite phase deliverable; separate hygiene track |
+
+## Architectural primitives from v2 plan §1 — status
+
+| Primitive | Plan location | On master |
+|---|---|---|
+| Generic state-machine primitive | Phase 1.1 | Not present as `backend/app/core/state_machine/`. Sign-off + review machinery uses bespoke state today. |
+| Generic matter-context store | Phase 1.2 | Not present as `backend/app/core/matter_context/`. |
+| Opinion/advice boundary | Phase 1.3 | Doctrine doc at `docs/architecture/ADVICE_BOUNDARY.md`. Runtime enforcement partially present via existing `phase1_runtime/advice_boundary` (predates v2 plan; Reviewer to confirm whether this is the v1.3 primitive or stub). |
+| MCP host | Phase 3.1 | Not present as `backend/app/core/mcp_host/`. |
+| Sandbox | Phase 3.2 | Not present as `backend/app/core/sandbox/`. |
+| Signing (sigstore) | Phase 3.3 | Not present as `backend/app/core/signing.py`. |
+| Trust ceremony | Phase 3.4 | UI shell present at `frontend/src/modules-v2/InstallCeremony.tsx`; backend `trust_ceremony.py` not present. Plan §3.4 specifies state machine + signature gating which is not implemented. |
+| Grants lifecycle | Phase 4 | Not present as `backend/app/core/grants_lifecycle.py`. |
+| Module CLI | Phase 14 | Not present as `cli/legalise.py`. |
+
+## What is untouched relative to v2 plan
+
+- `runtime-rewrite` branch strategy (plan §0).
+- Phase 1 substrate primitives (state-machine, matter-context, advice-boundary as a new package).
+- Phase 2 capability registry + grammar (schema file exists; registry runtime + grammar do not).
+- Phase 3 MCP host + sandbox + signing + trust ceremony state machine.
+- Phase 4 grant lifecycle.
+- Phase 7/8/9 module ports as governed under the new runtime (Contract Review + Pre-Motion + Document Redliner) — existing modules run on the legacy bridge.
+- Phase 10 `MIGRATION.md` files for the six migration-target workflows.
+- Phase 11 first-party signed reference connectors (Companies House, legislation.gov.uk, local document reader, provider modules under v2 manifest).
+- Phase 16 pen test + audit integrity review + cut-over.
+
+## Reviewer to decide
+
+These are the items the builder cannot ratify alone:
+
+1. **Branch decision.** Cut `runtime-rewrite` from current `master` (`c94d0ca`)? If yes, freeze feature work on `master` to security/audit-only per plan §Branch strategy. If no, restate the branch strategy.
+2. **Manifest v2 schema reuse.** `backend/schemas/module.v2.json` exists. Is this the Phase 2 schema, or does Phase 2 supersede it?
+3. **Prompt runtime relationship to Phase 6.** Prompt Runtime v1 ships sync + streaming behaviour. Does Phase 6 still need to land, or is its scope reduced?
+4. **Guided Demo Loop relationship to Phase 13.** Demo loop already produces a guided keyless flow on Khan. Does Phase 13 still need to land as planned, or is its scope reduced?
+5. **`phase1_runtime/advice_boundary` relationship to Phase 1.3.** Is the existing package the Phase 1.3 advice-boundary primitive, or is it superseded?
+6. **KISS cleanup.** `origin/repo-cleanup-pass` carries the partial PR-A redline (~366 phase markers across ~98 files). Merge as partial, finish, or close?
+
+## Kramer carry-overs — scope check
+
+Per `docs/handovers/KRAMER_DEMO_COMPREHENSION.md`, seven carry-overs are proposed. This addendum does not sequence them. It flags only:
+
+- Carry-over #1 (guided exhibit for Khan) overlaps Guided Demo Loop v1 already on master. Any guided-exhibit PR should explicitly state whether it extends `DemoLoop.tsx` or replaces it.
+- Carry-over #2 (Trust + Review card) is the smallest scope and does not appear duplicated by any V1 surface.
+- Carry-overs #3–#7 do not appear duplicated by any V1 surface (verified by file inspection only; Reviewer to confirm).
+
+## What this addendum is not
+
+- Not a rewrite of the v2 plan.
+- Not a phase-completion claim for any V1 surface.
+- Not a build sequence.
+
+Sequence + scope decisions sit with Reviewer.
+
+## References
+
+- v2 plan: `docs/IMPLEMENTATION_PLAN_REWRITE.md`
+- V1 product state: `docs/handovers/HANDOVER_V1_PRODUCT_STATE_2026_05_30.md`
+- Kramer carry-over brief: `docs/handovers/KRAMER_DEMO_COMPREHENSION.md`
+- Khan demo health check: `docs/handovers/KHAN_HEALTH_CHECK.md`
+- Phase 0 architecture docs: `docs/architecture/*.md`
+- KISS cleanup state: branch `origin/repo-cleanup-pass`

--- a/docs/handovers/INDEX.md
+++ b/docs/handovers/INDEX.md
@@ -8,6 +8,15 @@ Start here before reading older phase notes.
   product rules.
 - `KISS_REPO_REVIEW_2026_05_30.md` — current hygiene/KISS cleanup review and
   execution plan.
+- `KRAMER_DEMO_COMPREHENSION.md` — what to lift from the Kramer vs Kramer vs AI
+  build (shipped at divorce.broker 1 Jun 2026) into Legalise's demo layer, and
+  what to leave behind. Demo-comprehension scope only — does not modify the
+  locked v2 architecture plan.
+- `../IMPLEMENTATION_PLAN_REWRITE_ADDENDUM_2026_06_01.md` — factual
+  reconciliation between the v2 plan and master at `c94d0ca`. Pairs with
+  `../IMPLEMENTATION_PLAN_REWRITE.md`.
+- `KHAN_HEALTH_CHECK.md` — non-destructive pre-flight runbook (`legalise
+  doctor`) for Khan demo. Required gate before any Kramer carry-over PR.
 
 ## Current Working Rule
 

--- a/docs/handovers/KHAN_HEALTH_CHECK.md
+++ b/docs/handovers/KHAN_HEALTH_CHECK.md
@@ -1,0 +1,58 @@
+# Khan Demo Health Check — Runbook
+
+**Purpose:** non-destructive verification that the Khan v Acme canonical demo matter is in a working state before any Kramer demo-comprehension PR builds on top of it. Use before guided-exhibit work (Kramer carry-over #1), Trust & Review card work (#2), or proof drawer work (#3).
+
+This runbook does not seed, reset, or migrate. It only reads. The `--create-bucket` flag is the one mutation `legalise doctor` supports; do not pass it for a health check.
+
+## The check command
+
+```sh
+docker compose exec backend python -m app.tools.doctor
+```
+
+Exits `0` if every check is `ok` or `note`. Exits `1` if any check is `fail`.
+
+## Checks relevant to Khan demo
+
+The eight checks reported by `legalise doctor`:
+
+- `db.reachable`
+- `db.migrations_current`
+- `db.audit_table_present`
+- `khan.demo_present` — **load-bearing for demo-comprehension work**
+- `manifests.valid`
+- `plugins.root_mounted`
+- `provider.mode`
+- `redis.reachable`
+
+`khan.demo_present` is stateful by design (see doctrine block at the top of `backend/app/tools/doctor.py`):
+
+| Pre-condition | Expected result | Meaning |
+|---|---|---|
+| Zero users registered | `note: no users yet — seed lands on first signup` | Healthy clean install. Seed has not run; will run on first `/auth/signin`. |
+| Users exist, Khan matter present, seed audit row present | `ok: khan-v-acme-trading-2026 + seed audit row present` | Fully seeded; safe to build demo work on top. |
+| Users exist, Khan matter missing | `fail: users exist but Khan matter ({slug}) missing` | Seeder did not run on signup. Recovery: register a fresh user via `/auth/signin` — seeding runs on first signup. |
+| Users exist, Khan matter present, no `SEED_ACTION_MATTER` audit row | `fail: Khan matter present but no seed audit row` | Partial seed. Recovery: delete the matter row and re-register, or inspect manually. |
+
+`KHAN_SLUG` and `SEED_ACTION_MATTER` are defined in `backend/app/core/seed.py`.
+
+## Gate
+
+Treat any `fail` from `khan.demo_present` as a stop. Do not start a Kramer carry-over PR on top of a failed seed.
+
+`note` is acceptable for fresh-install demo-comprehension work that includes a signup step (e.g. guided-exhibit PR2 begins with `/auth/signin`). If the PR assumes Khan is already seeded, register a user first and re-run the check until `ok`.
+
+## What this runbook does not verify
+
+- Document body extraction for every Khan document (covered by Source Anchors tests, not by `doctor`).
+- Activity Trail rendering correctness (UI; out of scope for this check).
+- Sign-off flow on Khan outputs (covered by `tests/test_signoff_api.py`).
+- Module grants on Khan (separate concern; check via the matter UI after `ok`).
+
+If a Kramer carry-over needs any of those guaranteed, add a targeted verification step to that PR, not to this runbook.
+
+## References
+
+- `backend/app/tools/doctor.py` — implementation (Phase 16 C)
+- `backend/app/core/seed.py` — seed function + `KHAN_SLUG`
+- `docs/handovers/PRE_FLIGHT.md` §7 — full browser smoke walk (out of scope here; this runbook is a 30-second pre-flight)

--- a/docs/handovers/KRAMER_DEMO_COMPREHENSION.md
+++ b/docs/handovers/KRAMER_DEMO_COMPREHENSION.md
@@ -1,0 +1,115 @@
+# Kramer → Legalise: demo-comprehension handover
+
+**Written 1 Jun 2026** after Kramer vs Kramer vs AI shipped to divorce.broker as v0.1 public beta. Captures what Legalise should lift from the Kramer rebuild, and what it should explicitly leave behind.
+
+## The load-bearing frame
+
+**Use Kramer learnings to improve Legalise demo comprehension, not to change Legalise's architecture.**
+
+Legalise is a supply-chain-aware capability runtime for legal work (see `docs/IMPLEMENTATION_PLAN_REWRITE.md`). Its architecture is locked. Kramer should not be used to retrofit decisions there.
+
+What Kramer *did* prove is **how to make a supervised-autonomy product legible to a human in 60 seconds** — and Legalise's launch needs exactly that legibility.
+
+Kramer was the narrative demo. Legalise stays the serious infrastructure product.
+
+## Carry over (seven things)
+
+### 1. Guided exhibit mode for Khan v Acme
+
+Kramer's `/api/demo/seed` writes a full matter — case pack, parties, documents, gates, outputs, audit chain — in one SQL transaction with zero live LLM calls. Picker click → working Money Picture in under five seconds.
+
+**For Legalise**: Khan needs the same shape. The developer OKR ("time to first audit row in under five minutes") is the same problem. A `legalise demo seed --case khan` (or web endpoint equivalent) that writes Khan into a runnable state with one reference module already executed against it is the public-repo product surface.
+
+This is a demo-comprehension move, not architecture. The seed only writes data Legalise's own primitives already define. It does not invent runtime semantics.
+
+Reference: `kramer-v-ai-build/backend/app/main.py:post_demo_seed`, `backend/app/demo_packs.py`.
+
+### 2. Compact Trust and Review card
+
+A small sidebar card with two facts: *Audit trail · verified · N steps* and *Human review · required before export*. One button: **View proof**.
+
+**For Legalise**: this card belongs on every matter-shell surface where supervision is in scope. The full Audit tab still exists for serious inspection. The card just keeps trust visible without dominating the workbench.
+
+Reference: `kramer-v-ai-build/frontend/src/components/TrustReview.tsx`.
+
+### 3. Proof drawer answering four questions
+
+Kramer's ProofDrawer is a slide-in modal with a hash-chained audit excerpt. The Legalise version should be tighter, structured around the four questions a regulator, auditor, or solicitor actually asks:
+
+- **What did the module see?** (inputs, scope, document provenance)
+- **Under what protection?** (privilege posture, redaction state, grant scope)
+- **What did it produce?** (outputs, citations, omissions)
+- **Who remained accountable?** (signing reviewer, sign-off type, override notes)
+
+The four-question shape is sharper than Kramer's free-form drawer. Make it the standard.
+
+Reference: `kramer-v-ai-build/frontend/src/components/ProofDrawer.tsx`.
+
+### 4. Supervisor-gate UX from Kramer sign-off
+
+Kramer's Agreement step is a one-button sign-off with a pre-filled reviewer name, pre-filled notes, and three options (Signed / Signed with notes / Rejected). It writes one audit row and auto-advances to the next stage. The user never sees "Export not yet available" — state and UI move together.
+
+**For Legalise**: every gate (`required_signer_role: qualified_solicitor`, etc.) should ship with the same UX shape. One affordance, three decisions, auto-advance on success.
+
+Reference: `kramer-v-ai-build/frontend/src/components/AgreementView.tsx`.
+
+### 5. "Talk this output through" chat for module outputs
+
+Kramer's Settlement Room is the only live LLM beat. Two-column: selected output summary on the left, streaming chat on the right. The user asks plain-English questions about the output. The agent has a character file, refuses to recommend, names the tradeoff, mentions solicitor review for legal mechanics.
+
+**For Legalise**: every consequential module output (R3 reviewer outcome, Contract Review pack, Pre-Motion brief, Letters draft) should support a "Talk this output through" affordance. Scoped to **this output**, with **this matter's** inputs as context. Streams. Writes one audit row on completion.
+
+The character file convention (`*_CHARACTER.md` sitting next to the agent) is the cleanest way to make module voices distinct without burying tone in Python strings.
+
+Reference: `kramer-v-ai-build/frontend/src/components/SettlementRoom.tsx`, `kramer-v-ai-build/backend/app/agents/SETTLEMENT_ROOM_CHARACTER.md`.
+
+### 6. Working-pack export
+
+Kramer's Solicitor Filing Pack pairs the JSON output with a UI **filing checklist** card: *"Your solicitor would still need to review or prepare: draft consent order, D81, conditional/final divorce order, pension sharing annexes, missing disclosure follow-up."* The pack is honestly described as a working pack — not a court filing.
+
+**For Legalise**: every module that produces an end-of-line artefact should generate a working pack containing the module's output, cited sources, deliberate omissions, the reviewer decision + sign-off identity, and the audit proof for that run. Plus a UI checklist of what a human still needs to verify or prepare. Both honest and useful.
+
+Reference: `kramer-v-ai-build/frontend/src/components/ExportView.tsx` (incl. `FilingChecklist`).
+
+### 7. Clearer landing copy focused on supervised autonomy
+
+Kramer's landing rewrite landed *"There is no view from nowhere..."*, *"The AI is a translator, not a judge. A solicitor stays at the gates."*, *"A settlement is not a number. It is the smallest shared reality both people can live inside."*
+
+Legalise's landing leans on the public line *"Any tool. Any model. Any skill. Matter-scoped, permissioned, auditable."* That works for the infrastructure pitch but does not explain *why* supervised autonomy is the right primitive.
+
+The Kramer pattern — short philosophical lines threaded through specific section copy — is the right technique. The lines will be different (legal-infrastructure, not divorce) but the move transfers: state a short principle, show it being honoured one screen later.
+
+Reference: `kramer-v-ai-build/frontend/src/components/Landing.tsx`.
+
+## Do NOT carry over
+
+- **Divorce-specific philosophy.** "Smallest shared reality both people can live inside" / "end the war" / "small patch of shared ground" — Kramer-shaped. Legalise's philosophy is about capability runtime for legal work, not amicable divorce.
+- **Parody styling.** Synthetic celebrity matter, Johnny Cochran, the divorce Telecaster, pet custody schedule. Kramer's recognisability was the point. Legalise stays clinically Khan-shaped.
+- **Tertiary accent palette.** Pink / garden green / warm gold from the Nicole splash. Pure Kramer surface texture. Legalise stays strict Paper Ink + sealing wax per the locked brand seal doctrine.
+- **Synthetic celebrity documents.** Marriage certificate, Oscar display schedule, jewellery loan register. Demo theatre, not infrastructure.
+- **Hackathon shortcuts.** Fake Party B consent, auto-confirming synthetic counter-frame, single-LLM-call demo path. Legalise needs real dual-party flow + real consent + real LLM work across the matter. Don't ship Kramer's shortcuts into Legalise's substrate.
+
+## Why this reframing matters
+
+An earlier draft of this handover proposed lifting Kramer's *SSE streaming convention* and *one-transaction seed* as architectural conventions. That overreached. The corrected framing is sharper:
+
+- **Kramer's job** was to show how a supervised-autonomy product feels in 60 seconds.
+- **Legalise's job** is to be the right substrate for that product class.
+
+The architectural decisions in `docs/IMPLEMENTATION_PLAN_REWRITE.md` (signed modules, sandboxed execution, manifest contract, grant lifecycle, MCP-first) are answers to different questions. They should be made on their own terms, not by importing whatever happened to ship in Kramer.
+
+What Kramer earned the right to suggest is the *demo layer*: how Khan looks, how trust is surfaced, how outputs are explained, how packs are exported, how the landing reads.
+
+## Where the Kramer reference files live
+
+If you want to walk the original code, the Kramer repo is at `~/kramer-v-ai-build/` on Andy's machine. Public mirror at `github.com/b1rdmania/kramer-v-ai-build`.
+
+Read order, when the demo-comprehension work begins:
+
+1. `backend/app/agents/SETTLEMENT_ROOM_CHARACTER.md` — the character-as-doc convention. Lift the convention, not the divorce content.
+2. `backend/app/main.py:post_demo_seed` — one-transaction seed shape. Adapt the technique to Khan, not the data.
+3. `frontend/src/components/TrustReview.tsx` + `ProofDrawer.tsx` — sidebar card + slide-in drawer. Restructure the drawer around the four questions when ported.
+4. `frontend/src/components/AgreementView.tsx` — supervisor-gate UX. Lift the one-button + auto-advance pattern.
+5. `frontend/src/components/SettlementRoom.tsx` — "talk an output through" two-column streaming chat. Lift the shape, drop the divorce framing.
+6. `frontend/src/components/ExportView.tsx` + the `FilingChecklist` inside it — working-pack pattern.
+7. `frontend/src/components/Landing.tsx` — philosophical lines threaded through section copy. Technique only; Legalise needs its own lines.


### PR DESCRIPTION
## Summary

Docs-only baseline PR. No code, no UI, no architecture changes.

- Lifts `KRAMER_DEMO_COMPREHENSION.md` from `repo-cleanup-pass` onto master as canonical demo-comprehension context.
- Adds `IMPLEMENTATION_PLAN_REWRITE_ADDENDUM_2026_06_01.md` — factual reconciliation between the locked v2 architecture plan (grounded `5322e70`) and master at `c94d0ca`. Builder-authored; six items flagged for Reviewer ratification.
- Adds `KHAN_HEALTH_CHECK.md` — runbook around existing `legalise doctor` Phase 16 C tool (`khan.demo_present` check already exists; no new script).
- Updates `docs/handovers/INDEX.md` to point at the three new entries under Current Truth.

## Two discoveries surfaced in the addendum

- **Guided Demo Loop v1 already shipped on master** (`POST /api/demo/guided-loop`, `frontend/src/demo/DemoLoop.tsx`). Kramer carry-over #1 (guided exhibit) overlaps. PR2 must declare extend-vs-replace.
- **`backend/schemas/module.v2.json` (293 lines) is on master** — v2 plan Phase 2 artefact landed outside the rewrite branch. Flagged as a Reviewer call.

## Handover note for the next agent

**PR2 must start by reading the existing `frontend/src/demo/DemoLoop.tsx` and deciding extend vs replace.** Do not invent a third guided-demo surface.

## Test plan

- [ ] Reviewer reads addendum and either ratifies or amends the six open calls in §"Reviewer to decide".
- [ ] Reviewer confirms the V1-surface → v2-phase mapping table uses "may relate to" language consistently and makes no completion claims.
- [ ] Khan health check runbook verified by running `docker compose exec backend python -m app.tools.doctor` against a local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added system health check runbook for diagnostic verification
  * New architecture implementation reference guides added
  * Updated documentation index with latest handover resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->