### PR TITLE
demo-loop: reshape as Khan-modelled keyless exhibit (1.5b)

### DIFF
--- a/backend/app/core/demo_loop.py
+++ b/backend/app/core/demo_loop.py
@@ -197,9 +197,9 @@ async def _ensure_demo_matter(session: AsyncSession, user: User) -> tuple[Matter
     if matter is None:
         matter = Matter(
             slug=DEMO_MATTER_SLUG,
-            title="Guided Demo — Governed Loop (stub model)",
+            title="Guided Demo — Employment Tribunal (keyless)",
             matter_type="employment_tribunal",
-            cause="Demo — not a real matter",
+            cause="Demo — modelled on the Khan v Acme employment dispute. Not a real matter.",
             status=STATUS_OPEN,
             privilege_posture=PRIVILEGE_CLEARED,
             default_model_id="stub-echo",

--- a/frontend/src/app/AppHome.tsx
+++ b/frontend/src/app/AppHome.tsx
@@ -223,7 +223,7 @@ function AuthedHome() {
         data-testid="try-governed-loop"
       >
         <span>
-          <span className="text-sm font-medium">Try the governed loop</span>
+          <span className="text-sm font-medium">Watch the governed loop</span>
           <span className="mt-0.5 block text-xs opacity-80">
             Run a skill → artifact → review → audit trail. No provider key needed.
           </span>

--- a/frontend/src/demo/DemoLoop.test.tsx
+++ b/frontend/src/demo/DemoLoop.test.tsx
@@ -50,7 +50,7 @@ function mountDemo() {
 
 const HANDLES = {
   matter_slug: "guided-demo-loop",
-  matter_title: "Guided Demo — Governed Loop (stub model)",
+  matter_title: "Guided Demo — Employment Tribunal (keyless)",
   module_id: "demo.guided-skill",
   capability_id: "summarise",
   document_id: "doc-1",

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -96,8 +96,8 @@ export function DemoLoop() {
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
       <PageHeader
         eyebrow="Demo"
-        title="Try the governed loop"
-        description="Watch the full supervised-autonomy loop run end to end — no provider key needed. This uses a keyless stub model on a clearly-labelled demo matter. Bring a real provider key (Settings → Keys) to run real models on your own matters."
+        title="Watch the governed loop"
+        description="Watch the full supervised-autonomy loop run end to end — no provider key needed. This is a keyless demonstration matter modelled on the Khan v Acme employment dispute; real Khan remains the full workspace matter. Bring a real provider key (Settings → Keys) to run real models on your own matters."
       />
 
       {error && <ErrorCallout message={error} />}
@@ -107,8 +107,8 @@ export function DemoLoop() {
         <div className="space-y-6">
           <div className="rounded-md border border-seal/40 bg-seal/5 p-3 text-xs text-seal" data-testid="demo-banner">
             Demo · matter <span className="font-mono">{handles.matter_slug}</span> ·
-            model <span className="font-mono">{handles.model_id}</span>. Synthetic content,
-            not legal advice. Outputs come from a toy model — bring a key for real providers.
+            model <span className="font-mono">{handles.model_id}</span>. Keyless demonstration
+            modelled on Khan v Acme. Not legal advice. Bring a key for real providers.
           </div>
 
           {/* Step 1 — run */}


### PR DESCRIPTION
## Summary

Implements Option 1.5(b) from the demo loop disposition (PR #18). Evolves `/demo-loop` content to read as Khan-shaped without touching the real Khan seed or adding a third demo surface.

String-only. No route change. No backend logic change. `backend/app/core/seed.py` untouched. Keyless `stub-echo` property preserved.

## Changes

| File | Change |
|---|---|
| `backend/app/core/demo_loop.py` | Matter title + cause now Khan-modelled |
| `frontend/src/demo/DemoLoop.tsx` | Page title "Watch the governed loop"; description + banner make Khan-modelled disclosure explicit |
| `frontend/src/app/AppHome.tsx` | Dashboard CTA "Watch the governed loop" |
| `frontend/src/demo/DemoLoop.test.tsx` | Test matter_title fixture matches new title |

## Explicit honesty copy

Per the disposition redline: *"This is a keyless demonstration matter modelled on the Khan v Acme employment dispute; real Khan remains the full workspace matter."* That line is in the page description; the in-page banner and the matter `cause` carry the same framing.

## Verification

- Frontend `tsc --noEmit`: clean.
- `DemoLoop.test.tsx`: 2/2 passing.
- Backend `tests/test_demo_loop.py`: not executed locally (Docker daemon down). Backend test assertions inspected before changes — only `matter_slug` is asserted (unchanged), not `matter_title` or `cause`. CI will run the full backend suite on PR open.

## Test plan

- [ ] CI green: backend `tests/test_demo_loop.py`, frontend vitest, e2e.
- [ ] Browser walk: dashboard CTA reads "Watch the governed loop" → page renders with new title + Khan-modelled description → banner shows Khan framing → loop still runs keyless end-to-end.
- [ ] Confirm real Khan matter at `/matters/khan-v-acme-trading-2026` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)