### PR TITLE
demo-loop: compact Trust & Review card (Kramer #2)

### DIFF
--- a/frontend/src/demo/DemoLoop.test.tsx
+++ b/frontend/src/demo/DemoLoop.test.tsx
@@ -94,6 +94,14 @@ describe("DemoLoop", () => {
     expect(screen.getByTestId("demo-banner")).toHaveTextContent(/stub-echo/);
     const runBtn = await screen.findByTestId("demo-run");
 
+    // Trust & Review card present from the start, with the three facts and one CTA.
+    const card = screen.getByTestId("trust-review-card");
+    expect(card).toHaveTextContent(/Audit trail/);
+    expect(card).toHaveTextContent(/Human review/);
+    expect(card).toHaveTextContent(/Source visibility/);
+    expect(card).not.toHaveTextContent(/verified/i);
+    expect(screen.getByTestId("trust-review-open-trail")).toBeInTheDocument();
+
     // Run → artifact renders via ArtifactPreview skill_response branch.
     fireEvent.click(runBtn);
     await waitFor(() => expect(screen.getByTestId("demo-artifact")).toBeInTheDocument());

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -29,6 +29,7 @@ import {
 } from "../lib/api";
 import { ArtifactPreview } from "../matter/ArtifactPreview";
 import { ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
+import { TrustReviewCard } from "./TrustReviewCard";
 
 type Phase =
   | { step: "ensuring" }
@@ -110,6 +111,15 @@ export function DemoLoop() {
             model <span className="font-mono">{handles.model_id}</span>. Keyless demonstration
             modelled on Khan v Acme. Not legal advice. Bring a key for real providers.
           </div>
+
+          <TrustReviewCard
+            matterSlug={handles.matter_slug}
+            invocationId={
+              phase.step === "ran" || phase.step === "requesting" || phase.step === "reviewed"
+                ? phase.invocationId
+                : undefined
+            }
+          />
 
           {/* Step 1 — run */}
           <Step n={1} title="Run a governed action" done={phase.step !== "ready"}>

--- a/frontend/src/demo/TrustReviewCard.tsx
+++ b/frontend/src/demo/TrustReviewCard.tsx
@@ -1,0 +1,57 @@
+/**
+ * Compact Trust and Review card for the guided demo (`/demo-loop`).
+ *
+ * States the three governance facts that hold for every run on this matter,
+ * with a single CTA into the Activity Trail. Kept narrowly scoped to the
+ * guided exhibit for now — proves the pattern before any matter-shell-wide
+ * rollout.
+ *
+ * Honesty boundary: no "verified" wording, no audit-row count. Claims are
+ * only what the current substrate actually delivers — runs are recorded,
+ * sign-off gates final treatment, artifact contents and source references
+ * are visible per output.
+ */
+
+import { Link } from "@tanstack/react-router";
+
+type TrustReviewCardProps = {
+  matterSlug: string;
+  invocationId?: string;
+};
+
+export function TrustReviewCard({ matterSlug, invocationId }: TrustReviewCardProps) {
+  return (
+    <aside
+      className="rounded-md border border-rule bg-wash p-4"
+      data-testid="trust-review-card"
+      aria-label="Trust and review posture"
+    >
+      <h2 className="text-[11px] uppercase tracking-widest text-muted">Trust &amp; review</h2>
+      <ul className="mt-2 space-y-1.5 text-sm">
+        <li>
+          <span className="font-medium">Audit trail.</span>{" "}
+          Every run is recorded in the matter&rsquo;s Activity Trail.
+        </li>
+        <li>
+          <span className="font-medium">Human review.</span>{" "}
+          A separate reviewer must sign off before output is treated as final.
+        </li>
+        <li>
+          <span className="font-medium">Source visibility.</span>{" "}
+          Artifact contents and source references are viewable per output.
+        </li>
+      </ul>
+      <p className="mt-3">
+        <Link
+          to="/matters/$slug/audit"
+          params={{ slug: matterSlug }}
+          search={invocationId ? { invocation_id: invocationId } : {}}
+          className="inline-flex items-center rounded-md border border-rule px-3 py-1.5 text-xs hover:border-ink"
+          data-testid="trust-review-open-trail"
+        >
+          Open Activity Trail &rarr;
+        </Link>
+      </p>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

Kramer carry-over #2, narrowly scoped to `/demo-loop` per Reviewer call. Adds a compact `TrustReviewCard` between the demo banner and Step 1.

Three governance facts, one CTA. No backend change. No matter-shell-wide rollout.

## What the card says

- **Audit trail.** Every run is recorded in the matter's Activity Trail.
- **Human review.** A separate reviewer must sign off before output is treated as final.
- **Source visibility.** Artifact contents and source references are viewable per output.

CTA: **Open Activity Trail** → links to `/matters/{slug}/audit`, with `invocation_id` deep-link once a run has happened.

## Honesty boundary

Per Reviewer instruction, no "verified" wording, no audit-row count. The card only claims what the current substrate actually delivers — runs are recorded, sign-off gates final treatment, artifact contents and source references are visible per output. Test asserts the absence of "verified".

## Why narrow scope

The Kramer ask is to make trust visible on every matter shell. Doing that today across `/matters/$slug` surfaces is the matter-shell-wide rollout the user explicitly said to defer. Proving the pattern on `/demo-loop` first lets the next call (rollout vs different shape) be made with the component already in hand and the testid already wired.

## Files

| File | Change |
|---|---|
| `frontend/src/demo/TrustReviewCard.tsx` | New, reusable component (~50 lines) |
| `frontend/src/demo/DemoLoop.tsx` | Mount card between banner and Step 1 |
| `frontend/src/demo/DemoLoop.test.tsx` | Assert card present, three facts, CTA, no "verified" |

## Verification

- `tsc --noEmit`: clean.
- `vitest run`: 193/193 across 27 files.

## Test plan

- [ ] CI green.
- [ ] Browser walk over `/demo-loop` (combined with PR #19 changes) — card reads clean below the banner, CTA opens Activity Trail.
- [ ] Decision after browser walk: lift `TrustReviewCard` into matter-shell, or redesign first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Trust & Review" card to the demo displaying governance information, including audit trail access, human review capabilities, and source visibility. The card includes a link to view the matter's activity trail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->