### PR TITLE
demo-loop: drift-correct stale matter title/cause on re-ensure

### DIFF
--- a/backend/app/core/demo_loop.py
+++ b/backend/app/core/demo_loop.py
@@ -52,6 +52,10 @@ from app.models.document_body import BODY_KIND_EXTRACTED, DocumentBody
 from app.models.document_version import VERSION_KIND_UPLOAD, DocumentVersion
 
 DEMO_MATTER_SLUG = "guided-demo-loop"
+DEMO_MATTER_TITLE = "Guided Demo — Employment Tribunal (keyless)"
+DEMO_MATTER_CAUSE = (
+    "Demo — modelled on the Khan v Acme employment dispute. Not a real matter."
+)
 DEMO_MODULE_ID = "demo.guided-skill"
 DEMO_CAPABILITY_ID = "summarise"
 DEMO_DOC_FILENAME = "demo-employment-note.txt"
@@ -197,9 +201,9 @@ async def _ensure_demo_matter(session: AsyncSession, user: User) -> tuple[Matter
     if matter is None:
         matter = Matter(
             slug=DEMO_MATTER_SLUG,
-            title="Guided Demo — Employment Tribunal (keyless)",
+            title=DEMO_MATTER_TITLE,
             matter_type="employment_tribunal",
-            cause="Demo — modelled on the Khan v Acme employment dispute. Not a real matter.",
+            cause=DEMO_MATTER_CAUSE,
             status=STATUS_OPEN,
             privilege_posture=PRIVILEGE_CLEARED,
             default_model_id="stub-echo",
@@ -208,6 +212,16 @@ async def _ensure_demo_matter(session: AsyncSession, user: User) -> tuple[Matter
         )
         session.add(matter)
         await session.flush()
+    else:
+        # Drift-correct copy on pre-existing demo matter rows. PR #19 only
+        # set the new title/cause on first-create, so users whose demo
+        # matter pre-dates that PR still see the old "Governed Loop (stub
+        # model)" wording in matter chrome (sidebar, Approvals, audit
+        # filter). Idempotent — no-op once aligned.
+        if matter.title != DEMO_MATTER_TITLE:
+            matter.title = DEMO_MATTER_TITLE
+        if matter.cause != DEMO_MATTER_CAUSE:
+            matter.cause = DEMO_MATTER_CAUSE
 
     document = await session.scalar(
         select(Document).where(

--- a/backend/tests/test_demo_loop.py
+++ b/backend/tests/test_demo_loop.py
@@ -13,7 +13,13 @@ import uuid
 import pytest
 from sqlalchemy import select
 
-from app.core.demo_loop import DEMO_CAPABILITY_ID, DEMO_MATTER_SLUG, DEMO_MODULE_ID
+from app.core.demo_loop import (
+    DEMO_CAPABILITY_ID,
+    DEMO_MATTER_CAUSE,
+    DEMO_MATTER_SLUG,
+    DEMO_MATTER_TITLE,
+    DEMO_MODULE_ID,
+)
 from app.models import AuditEntry, MatterArtifact, Matter, User
 
 
@@ -155,3 +161,30 @@ async def test_review_requestable_but_author_cannot_self_approve(client) -> None
     )
     assert decided.status_code == 403, decided.text
     assert decided.json()["detail"]["error"] == "reviewer_is_author"
+
+
+@pytest.mark.asyncio
+async def test_ensure_drift_corrects_stale_demo_matter_title(client) -> None:
+    # Pre-existing prod matter rows (seeded before the Khan-modelled copy
+    # landed in PR #19) keep the old title/cause until ensure_guided_demo
+    # rewrites them. Regression for the post-#19 browser walk finding.
+    await _register_login(client)
+    from app.main import app
+
+    # First ensure provisions the matter with the current canonical copy.
+    await client.post("/api/demo/guided-loop")
+
+    # Simulate the pre-#19 row by stamping the old copy back on.
+    async with app.state.session_factory() as session:
+        matter = await session.scalar(select(Matter).where(Matter.slug == DEMO_MATTER_SLUG))
+        matter.title = "Guided Demo — Governed Loop (stub model)"
+        matter.cause = "Demo — not a real matter"
+        await session.commit()
+
+    # Re-ensure — drift-correct branch should rewrite both fields.
+    await client.post("/api/demo/guided-loop")
+
+    async with app.state.session_factory() as session:
+        matter = await session.scalar(select(Matter).where(Matter.slug == DEMO_MATTER_SLUG))
+        assert matter.title == DEMO_MATTER_TITLE
+        assert matter.cause == DEMO_MATTER_CAUSE


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #19. Browser walk found that users whose `guided-demo-loop` matter row predates the Khan-modelled copy still see *"Guided Demo — Governed Loop (stub model)"* in matter chrome (Approvals sidebar, audit filter chip, etc.) — PR #19 only set the new title/cause on first-create.

This PR drift-corrects existing rows idempotently on re-ensure.

## Changes

- Extract `DEMO_MATTER_TITLE` and `DEMO_MATTER_CAUSE` to module-level constants. Canonical wording lives in one place.
- In `_ensure_demo_matter`, add an `else` branch that rewrites `matter.title` / `matter.cause` if they differ from the constants. Idempotent — no-op once aligned.
- Regression test (`test_ensure_drift_corrects_stale_demo_matter_title`) pre-stamps the old wording back on, re-ensures, asserts both fields rewrite.

## Verification

- `python3 -m py_compile`: clean.
- Backend pytest not executed locally (Docker daemon still down). CI will run.

## Test plan

- [ ] CI green: backend pytest including new regression.
- [ ] Browser re-walk: refresh `/demo-loop` (fires ensure), then open Approvals / Activity Trail — sidebar matter title now matches the page copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)