### PR TITLE
demo-loop: four-question Proof drawer (Kramer #3)

### DIFF
--- a/frontend/src/demo/DemoLoop.test.tsx
+++ b/frontend/src/demo/DemoLoop.test.tsx
@@ -94,13 +94,29 @@ describe("DemoLoop", () => {
     expect(screen.getByTestId("demo-banner")).toHaveTextContent(/stub-echo/);
     const runBtn = await screen.findByTestId("demo-run");
 
-    // Trust & Review card present from the start, with the three facts and one CTA.
+    // Trust & Review card present from the start, with the three facts and View proof CTA.
     const card = screen.getByTestId("trust-review-card");
     expect(card).toHaveTextContent(/Audit trail/);
     expect(card).toHaveTextContent(/Human review/);
     expect(card).toHaveTextContent(/Source visibility/);
     expect(card).not.toHaveTextContent(/verified/i);
-    expect(screen.getByTestId("trust-review-open-trail")).toBeInTheDocument();
+    const viewProof = screen.getByTestId("trust-review-view-proof");
+    expect(viewProof).toBeInTheDocument();
+
+    // Clicking View proof opens the four-question Proof drawer (pre-run shape).
+    fireEvent.click(viewProof);
+    const drawer = screen.getByTestId("proof-drawer");
+    expect(drawer).toHaveTextContent(/Proof record/);
+    expect(drawer).not.toHaveTextContent(/Verified proof/i);
+    expect(drawer).toHaveTextContent(/What did it see\?/);
+    expect(drawer).toHaveTextContent(/Under what protection\?/);
+    expect(drawer).toHaveTextContent(/What did it produce\?/);
+    expect(drawer).toHaveTextContent(/Who remains accountable\?/);
+    expect(drawer).toHaveTextContent(/Run not yet executed/);
+    // Pre-run: no invocation id yet, so the Activity Trail link is absent.
+    expect(screen.queryByTestId("proof-drawer-open-trail")).toBeNull();
+    fireEvent.click(screen.getByTestId("proof-drawer-close"));
+    expect(screen.queryByTestId("proof-drawer")).toBeNull();
 
     // Run → artifact renders via ArtifactPreview skill_response branch.
     fireEvent.click(runBtn);
@@ -114,6 +130,18 @@ describe("DemoLoop", () => {
     expect(screen.getByTestId("demo-review-note")).toHaveTextContent(/cannot approve their own/i);
     expect(screen.getByTestId("demo-open-trail")).toBeInTheDocument();
     expect(api.requestReview).toHaveBeenCalledWith("guided-demo-loop", "art-1");
+
+    // Post-review: re-open the Proof drawer. The artifact + invocation id
+    // are now in scope, so What did it produce? renders the kind + output
+    // preview, Who remains accountable? notes review requested, and the
+    // deeper "Open full Activity Trail" link is present.
+    fireEvent.click(screen.getByTestId("trust-review-view-proof"));
+    const postRunDrawer = screen.getByTestId("proof-drawer");
+    expect(postRunDrawer).toHaveTextContent(/skill_response/);
+    expect(postRunDrawer).toHaveTextContent(/Three bullet summary/);
+    expect(postRunDrawer).toHaveTextContent(/Review/);
+    expect(postRunDrawer).toHaveTextContent(/separate reviewer/i);
+    expect(screen.getByTestId("proof-drawer-open-trail")).toBeInTheDocument();
   });
 
   it("surfaces an error if the run fails", async () => {

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -29,6 +29,7 @@ import {
 } from "../lib/api";
 import { ArtifactPreview } from "../matter/ArtifactPreview";
 import { ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
+import { ProofDrawer } from "./ProofDrawer";
 import { TrustReviewCard } from "./TrustReviewCard";
 
 type Phase =
@@ -43,6 +44,7 @@ export function DemoLoop() {
   const [handles, setHandles] = useState<GuidedDemoHandles | null>(null);
   const [phase, setPhase] = useState<Phase>({ step: "ensuring" });
   const [error, setError] = useState<string | null>(null);
+  const [proofOpen, setProofOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -112,13 +114,23 @@ export function DemoLoop() {
             modelled on Khan v Acme. Not legal advice. Bring a key for real providers.
           </div>
 
-          <TrustReviewCard
-            matterSlug={handles.matter_slug}
+          <TrustReviewCard onViewProof={() => setProofOpen(true)} />
+
+          <ProofDrawer
+            open={proofOpen}
+            onClose={() => setProofOpen(false)}
+            handles={handles}
+            artifact={
+              phase.step === "ran" || phase.step === "requesting" || phase.step === "reviewed"
+                ? phase.artifact
+                : undefined
+            }
             invocationId={
               phase.step === "ran" || phase.step === "requesting" || phase.step === "reviewed"
                 ? phase.invocationId
                 : undefined
             }
+            reviewRequested={phase.step === "reviewed"}
           />
 
           {/* Step 1 — run */}

--- a/frontend/src/demo/ProofDrawer.tsx
+++ b/frontend/src/demo/ProofDrawer.tsx
@@ -1,0 +1,208 @@
+/**
+ * Four-question proof drawer for the guided demo (`/demo-loop`).
+ *
+ * Opens from TrustReviewCard. The four-question shape is the regulator's
+ * lens: What did it see? Under what protection? What did it produce? Who
+ * remains accountable? — sharper than dumping audit rows.
+ *
+ * Honesty boundary: header is "Proof record" not "Verified proof". Where
+ * a fact is not available client-side (input text pre-run, source anchors,
+ * etc.), the drawer says "Recorded in Activity Trail" rather than
+ * fabricating data. The deeper substrate path stays a click away via
+ * "Open full Activity Trail".
+ *
+ * Scoped narrowly to /demo-loop. Matter-shell rollout is a separate later
+ * call — when that lands, watch out for the supervisor-review vs
+ * professional-sign-off distinction (see memory).
+ */
+
+import { Link } from "@tanstack/react-router";
+import type { ArtifactRead, GuidedDemoHandles } from "../lib/api";
+
+type ProofDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  handles: GuidedDemoHandles;
+  artifact?: ArtifactRead;
+  invocationId?: string;
+  reviewRequested?: boolean;
+};
+
+export function ProofDrawer({
+  open,
+  onClose,
+  handles,
+  artifact,
+  invocationId,
+  reviewRequested,
+}: ProofDrawerProps) {
+  if (!open) return null;
+
+  const payload = (artifact?.payload ?? {}) as Record<string, unknown>;
+  const inputText = typeof payload.input === "string" ? (payload.input as string) : null;
+  const outputText = typeof payload.output === "string" ? (payload.output as string) : null;
+  const outputPreview = outputText
+    ? outputText.length > 280
+      ? outputText.slice(0, 280).trimEnd() + "…"
+      : outputText
+    : null;
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        className="fixed inset-0 z-40 bg-ink/40"
+        aria-hidden="true"
+        data-testid="proof-drawer-backdrop"
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Proof record"
+        className="fixed top-0 right-0 z-50 h-screen w-[460px] max-w-full bg-paper border-l border-rule p-6 overflow-y-auto"
+        data-testid="proof-drawer"
+      >
+        <div className="flex items-start justify-between gap-4 mb-6">
+          <div>
+            <div className="text-[11px] uppercase tracking-widest text-muted mb-1">
+              Proof record
+            </div>
+            <h3 className="text-lg font-bold text-ink leading-tight">{handles.matter_title}</h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-muted hover:text-ink min-h-[44px] min-w-[44px] flex items-center justify-center -mr-2 -mt-2"
+            data-testid="proof-drawer-close"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.5" />
+            </svg>
+          </button>
+        </div>
+
+        <Section title="What did it see?">
+          <Fact label="Document" value={handles.document_filename} mono />
+          {inputText ? (
+            <Fact label="Input" value={inputText} />
+          ) : (
+            <Fact
+              label="Input"
+              value="Recorded in Activity Trail once the skill has been run."
+              muted
+            />
+          )}
+          <Fact label="Source anchors" value="Recorded in Activity Trail." muted />
+        </Section>
+
+        <Section title="Under what protection?">
+          <Fact
+            label="Model"
+            value={`${handles.model_id} — keyless demo provider; no API key in scope.`}
+          />
+          <Fact
+            label="Grant"
+            value="Matter-scoped. Capability is granted only on this demo matter."
+          />
+          <Fact
+            label="Privilege posture"
+            value="Cleared. Synthetic content; no real party data."
+          />
+          <Fact
+            label="Audit"
+            value="Every read, model call, and write is recorded in Activity Trail."
+          />
+        </Section>
+
+        <Section title="What did it produce?">
+          {artifact ? (
+            <>
+              <Fact label="Artifact kind" value={artifact.kind} mono />
+              <Fact
+                label="Output"
+                value={outputPreview ?? "Recorded in Activity Trail."}
+              />
+              <Fact
+                label="Source visibility"
+                value="Rendered above in the page; full payload available via the Activity Trail."
+              />
+            </>
+          ) : (
+            <Fact label="Status" value="Run not yet executed." muted />
+          )}
+        </Section>
+
+        <Section title="Who remains accountable?">
+          <Fact label="Author" value="The signed-in user who triggered the run." />
+          <Fact
+            label="Self-approval"
+            value="Forbidden by the substrate. Authors cannot decide their own review."
+          />
+          {reviewRequested ? (
+            <Fact
+              label="Review"
+              value="Requested. A separate reviewer must decide before output is treated as final."
+            />
+          ) : (
+            <Fact label="Review" value="Not yet requested." muted />
+          )}
+          <Fact
+            label="Sign-off"
+            value="Output remains draft until a reviewer signs off."
+          />
+        </Section>
+
+        {invocationId && (
+          <p className="mt-6 border-t border-rule pt-4">
+            <Link
+              to="/matters/$slug/audit"
+              params={{ slug: handles.matter_slug }}
+              search={{ invocation_id: invocationId }}
+              className="inline-flex items-center text-sm underline underline-offset-4 hover:text-ink"
+              data-testid="proof-drawer-open-trail"
+            >
+              Open full Activity Trail &rarr;
+            </Link>
+          </p>
+        )}
+      </aside>
+    </>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-6">
+      <h4 className="text-sm font-semibold text-ink mb-2">{title}</h4>
+      <dl className="space-y-2">{children}</dl>
+    </section>
+  );
+}
+
+function Fact({
+  label,
+  value,
+  mono,
+  muted,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  muted?: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-[120px_1fr] gap-3 text-xs">
+      <dt className="text-muted">{label}</dt>
+      <dd
+        className={
+          (mono ? "font-mono " : "") +
+          (muted ? "text-muted" : "text-ink") +
+          " break-words"
+        }
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/frontend/src/demo/TrustReviewCard.tsx
+++ b/frontend/src/demo/TrustReviewCard.tsx
@@ -2,24 +2,24 @@
  * Compact Trust and Review card for the guided demo (`/demo-loop`).
  *
  * States the three governance facts that hold for every run on this matter,
- * with a single CTA into the Activity Trail. Kept narrowly scoped to the
- * guided exhibit for now — proves the pattern before any matter-shell-wide
- * rollout.
+ * with a single CTA that opens the four-question Proof drawer. The drawer
+ * itself carries the deeper link into Activity Trail; the card is the
+ * first humane proof layer.
  *
  * Honesty boundary: no "verified" wording, no audit-row count. Claims are
  * only what the current substrate actually delivers — runs are recorded,
  * sign-off gates final treatment, artifact contents and source references
  * are visible per output.
+ *
+ * Scoped narrowly to /demo-loop. Matter-shell rollout is a separate later
+ * call (see memory: legalise-trust-card-rollout-caveat).
  */
 
-import { Link } from "@tanstack/react-router";
-
 type TrustReviewCardProps = {
-  matterSlug: string;
-  invocationId?: string;
+  onViewProof: () => void;
 };
 
-export function TrustReviewCard({ matterSlug, invocationId }: TrustReviewCardProps) {
+export function TrustReviewCard({ onViewProof }: TrustReviewCardProps) {
   return (
     <aside
       className="rounded-md border border-rule bg-wash p-4"
@@ -42,15 +42,14 @@ export function TrustReviewCard({ matterSlug, invocationId }: TrustReviewCardPro
         </li>
       </ul>
       <p className="mt-3">
-        <Link
-          to="/matters/$slug/audit"
-          params={{ slug: matterSlug }}
-          search={invocationId ? { invocation_id: invocationId } : {}}
+        <button
+          type="button"
+          onClick={onViewProof}
           className="inline-flex items-center rounded-md border border-rule px-3 py-1.5 text-xs hover:border-ink"
-          data-testid="trust-review-open-trail"
+          data-testid="trust-review-view-proof"
         >
-          Open Activity Trail &rarr;
-        </Link>
+          View proof &rarr;
+        </button>
       </p>
     </aside>
   );


### PR DESCRIPTION
## Summary

Kramer carry-over #3. New `ProofDrawer` opens from the `TrustReviewCard` **View proof** CTA. Four sections matching the regulator's lens:

- **What did it see?** — document filename, input text, source anchors
- **Under what protection?** — model (keyless), grant scope, privilege posture, audit
- **What did it produce?** — artifact kind, output preview (first 280 chars), source visibility
- **Who remains accountable?** — author, self-approval boundary, review status, sign-off boundary

The deeper **Open full Activity Trail** link lives *inside* the drawer (not as a card CTA replacement) — preserving the serious substrate path while giving the demo a humane first proof layer. The link is present only post-run (deep-linked to `invocation_id`).

## Honesty boundary

- Header reads **Proof record**, not "Verified proof". Test asserts absence of "Verified proof".
- Where a fact is not available client-side, drawer says *"Recorded in Activity Trail"* rather than fabricating.
- Pre-run: section 3 ("What did it produce?") shows *"Run not yet executed"*; activity trail link is hidden because there's no invocation id yet.
- No new "verified" claims; reads existing component state only.

## Scope

- Frontend-only.
- New component at `frontend/src/demo/ProofDrawer.tsx`.
- `TrustReviewCard` CTA changed from Link → button + `onViewProof` callback.
- `DemoLoop` owns drawer open state.
- Matter-shell rollout still deferred — when that's considered, the supervisor-review vs professional-sign-off caveat in memory applies.

## Files

| File | Change |
|---|---|
| `frontend/src/demo/ProofDrawer.tsx` | New, ~200 lines |
| `frontend/src/demo/TrustReviewCard.tsx` | CTA: Link → button + `onViewProof` prop |
| `frontend/src/demo/DemoLoop.tsx` | Drawer state, mount drawer, pass phase data |
| `frontend/src/demo/DemoLoop.test.tsx` | Assert pre-run drawer shape, post-run output preview, no "Verified proof" wording, Activity Trail link only post-run |

## Verification

- `tsc --noEmit`: clean.
- `vitest run`: 193/193 across 27 files.

## Test plan

- [ ] CI green.
- [ ] Browser walk over `/demo-loop`: card → View proof → drawer renders four sections pre-run → close → run → re-open → drawer shows artifact kind + output preview + review status → Open full Activity Trail link present, deep-linked to invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)