### PR TITLE
PR 1: IA reset vocabulary + /skills route shim

### DIFF
--- a/frontend/e2e/first-run.spec.ts
+++ b/frontend/e2e/first-run.spec.ts
@@ -140,8 +140,10 @@ test("first-run journey: register → bootstrap CLI → auth refresh → install
   const me = await whoami(request);
   expect(me.is_superuser).toBe(true);
   await page.goto("/app");
-  // Phase 17-IA-D renamed the authed home heading "Home" → "Dashboard".
-  await expect(page.getByRole("heading", { name: /^Dashboard$/ })).toBeVisible();
+  // PR 1 IA reset (blueprint §3) renamed the authed home heading
+  // "Dashboard" → "Home" — substrate-flavoured noun replaced with a
+  // user-facing one.
+  await expect(page.getByRole("heading", { name: /^Home$/ })).toBeVisible();
 
   // ---------------------------------------------------------------
   // 6. Keyless invocation path. PATCH the user default to

--- a/frontend/e2e/first-run.spec.ts
+++ b/frontend/e2e/first-run.spec.ts
@@ -140,10 +140,7 @@ test("first-run journey: register → bootstrap CLI → auth refresh → install
   const me = await whoami(request);
   expect(me.is_superuser).toBe(true);
   await page.goto("/app");
-  // PR 1 IA reset (blueprint §3) renamed the authed home heading
-  // "Dashboard" → "Home" — substrate-flavoured noun replaced with a
-  // user-facing one.
-  await expect(page.getByRole("heading", { name: /^Home$/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /^Matters$/ })).toBeVisible();
 
   // ---------------------------------------------------------------
   // 6. Keyless invocation path. PATCH the user default to

--- a/frontend/src/app/AppHome.test.tsx
+++ b/frontend/src/app/AppHome.test.tsx
@@ -184,8 +184,7 @@ describe("AppHome — State 3: has_superuser, viewer unauthed", () => {
       expect(onSignin || onWaitlist).not.toBeNull();
     });
     // Critical invariant: the authed home content is NOT mounted.
-    // (PR 1 IA reset, blueprint §3: "Dashboard" → "Home" rename.)
-    expect(screen.queryByText("Home")).toBeNull();
+    expect(screen.queryByText("Matters")).toBeNull();
   });
 });
 
@@ -209,15 +208,14 @@ describe("AppHome — State 3: has_superuser, viewer authed", () => {
         privilege_posture: "B_mixed",
       } as never,
     ]);
-    // Home pulls the primary matter's recent audit for the
-    // "Recent activity" panel (Phase 17-IA-D).
+    // AppHome pulls the primary matter's recent audit for the
+    // "Recent activity" panel.
     vi.spyOn(api, "listAudit").mockResolvedValue([]);
 
     mountAt("/app");
 
     await waitFor(() => {
-      // PR 1 IA reset, blueprint §3: "Dashboard" → "Home".
-      expect(screen.getByText("Home")).toBeInTheDocument();
+      expect(screen.getByText("Matters")).toBeInTheDocument();
     });
     // listMatters is a second fetch behind the bootstrap+auth gates;
     // wait for the row before asserting on the content alongside.

--- a/frontend/src/app/AppHome.test.tsx
+++ b/frontend/src/app/AppHome.test.tsx
@@ -184,7 +184,8 @@ describe("AppHome — State 3: has_superuser, viewer unauthed", () => {
       expect(onSignin || onWaitlist).not.toBeNull();
     });
     // Critical invariant: the authed home content is NOT mounted.
-    expect(screen.queryByText("Dashboard")).toBeNull();
+    // (PR 1 IA reset, blueprint §3: "Dashboard" → "Home" rename.)
+    expect(screen.queryByText("Home")).toBeNull();
   });
 });
 
@@ -208,14 +209,15 @@ describe("AppHome — State 3: has_superuser, viewer authed", () => {
         privilege_posture: "B_mixed",
       } as never,
     ]);
-    // Dashboard pulls the primary matter's recent audit for the
+    // Home pulls the primary matter's recent audit for the
     // "Recent activity" panel (Phase 17-IA-D).
     vi.spyOn(api, "listAudit").mockResolvedValue([]);
 
     mountAt("/app");
 
     await waitFor(() => {
-      expect(screen.getByText("Dashboard")).toBeInTheDocument();
+      // PR 1 IA reset, blueprint §3: "Dashboard" → "Home".
+      expect(screen.getByText("Home")).toBeInTheDocument();
     });
     // listMatters is a second fetch behind the bootstrap+auth gates;
     // wait for the row before asserting on the content alongside.

--- a/frontend/src/app/AppHome.tsx
+++ b/frontend/src/app/AppHome.tsx
@@ -214,7 +214,7 @@ function AuthedHome() {
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <p className="text-[11px] uppercase tracking-widest text-muted">Workspace</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Home</h1>
+      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Matters</h1>
 
       {/* Guided demo: see the governed loop run end-to-end with no key. */}
       <Link

--- a/frontend/src/app/AppHome.tsx
+++ b/frontend/src/app/AppHome.tsx
@@ -214,7 +214,7 @@ function AuthedHome() {
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <p className="text-[11px] uppercase tracking-widest text-muted">Workspace</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Dashboard</h1>
+      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Home</h1>
 
       {/* Guided demo: see the governed loop run end-to-end with no key. */}
       <Link

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -531,7 +531,7 @@ function SettingsPreferences() {
         <div className="eyebrow-sm mb-2">ROADMAP - v0.2</div>
         <p className="prose-p mb-0">
           Per-user defaults (timezone, locale, retention reminders) land in v0.2 alongside the
-          Module Lifecycle work. v0.1 ships with system defaults applied uniformly.
+          Skill lifecycle work. v0.1 ships with system defaults applied uniformly.
         </p>
       </div>
     </div>

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -267,7 +267,7 @@ function SettingsProfile({
       </div>
 
       <div>
-        <label className="eyebrow mb-2 block">Default privilege posture</label>
+        <label className="eyebrow mb-2 block">Default privilege control</label>
         <div className="flex gap-3">
           <select
             value={defaultPosture}

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -134,11 +134,11 @@ export function DemoLoop() {
           />
 
           {/* Step 1 — run */}
-          <Step n={1} title="Run a governed action" done={phase.step !== "ready"}>
+          <Step n={1} title="Run a skill" done={phase.step !== "ready"}>
             <p className="text-sm text-muted">
               The demo skill <span className="font-mono">{handles.module_id}</span> reads{" "}
               <span className="font-mono">{handles.document_filename}</span> and writes a
-              matter artifact — under the same posture, per-matter grants, and audit as any
+              matter artifact — under the same privilege control, per-matter permissions, and audit as any
               real run.
             </p>
             <button

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -200,7 +200,7 @@ export function DemoLoop() {
           {phase.step === "reviewed" && (
             <Step n={4} title="See the whole chain" done>
               <p className="text-sm text-muted">
-                The Record reconstructs everything that just happened: action invoked,
+                The Record reconstructs everything that just happened: skill run,
                 model called, artifact written, review requested.
               </p>
               <p className="mt-3">

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -4,7 +4,7 @@
  * A fresh visitor watches the full supervised-autonomy loop run WITHOUT a
  * provider key: a seeded stub-echo matter → run an installed prompt skill →
  * a skill_response artifact appears → request supervisor review → open the
- * Activity Trail and see the chain.
+ * Record and see the chain.
  *
  * Every step calls the real endpoints (ensure / invoke / request-review).
  * Nothing is faked — stub-echo is a genuine keyless provider. The page is
@@ -200,7 +200,7 @@ export function DemoLoop() {
           {phase.step === "reviewed" && (
             <Step n={4} title="See the whole chain" done>
               <p className="text-sm text-muted">
-                The Activity Trail reconstructs everything that just happened: action invoked,
+                The Record reconstructs everything that just happened: action invoked,
                 model called, artifact written, review requested.
               </p>
               <p className="mt-3">
@@ -211,7 +211,7 @@ export function DemoLoop() {
                   className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
                   data-testid="demo-open-trail"
                 >
-                  Open Activity Trail →
+                  Open Record →
                 </Link>
               </p>
             </Step>

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -278,7 +278,7 @@ function DemoWorkflowsTab({
     <div className="max-w-5xl">
       <div className="mb-8 border border-rule bg-paper-sunken p-5">
         <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
-          Governed actions
+          Governed skills
         </p>
         <h2 className="mt-1 text-2xl font-semibold tracking-tight2 text-ink">
           Pick the work you want the AI to prepare.

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -284,7 +284,7 @@ function DemoWorkflowsTab({
           Pick the work you want the AI to prepare.
         </h2>
         <p className="mt-2 text-sm text-prose max-w-2xl leading-relaxed">
-          Each action declares the material it reads, the output it writes, and
+          Each skill declares the material it reads, the output it writes, and
           the record it leaves behind. The demo previews the loop; your own
           workspace can run it.
         </p>
@@ -337,7 +337,7 @@ function DemoWorkflowsTab({
       </div>
 
       <p className="mt-8 border-t border-rule pt-4 text-xs text-muted">
-        Module installation and permission setup are hidden in this public
+        Skill installation and permission setup are hidden in this public
         snapshot. They appear when you work inside your own matter.
       </p>
     </div>
@@ -363,7 +363,7 @@ function DemoDocumentsTab({
           The demo matter is already loaded.
         </h2>
         <p className="mt-2 text-sm text-prose max-w-2xl leading-relaxed">
-          These are the documents the assistant and actions can cite. In your
+          These are the documents the assistant and skills can cite. In your
           own workspace, uploaded material is hashed, stored, and recorded.
         </p>
       </div>
@@ -375,7 +375,7 @@ function DemoDocumentsTab({
             <span>Type</span>
             <span>Size</span>
             <span>Source</span>
-            <span className="text-right">Action</span>
+            <span className="text-right">Status</span>
           </div>
           {docs.map((d) => (
             <div key={d.id} className="border-b border-rule">

--- a/frontend/src/demo/ProofDrawer.tsx
+++ b/frontend/src/demo/ProofDrawer.tsx
@@ -7,9 +7,9 @@
  *
  * Honesty boundary: header is "Proof record" not "Verified proof". Where
  * a fact is not available client-side (input text pre-run, source anchors,
- * etc.), the drawer says "Recorded in Activity Trail" rather than
+ * etc.), the drawer says "Recorded in Record" rather than
  * fabricating data. The deeper substrate path stays a click away via
- * "Open full Activity Trail".
+ * "Open full Record".
  *
  * Scoped narrowly to /demo-loop. Matter-shell rollout is a separate later
  * call — when that lands, watch out for the supervisor-review vs
@@ -89,11 +89,11 @@ export function ProofDrawer({
           ) : (
             <Fact
               label="Input"
-              value="Recorded in Activity Trail once the skill has been run."
+              value="Recorded in Record once the skill has been run."
               muted
             />
           )}
-          <Fact label="Source anchors" value="Recorded in Activity Trail." muted />
+          <Fact label="Source anchors" value="Recorded in Record." muted />
         </Section>
 
         <Section title="Under what protection?">
@@ -106,12 +106,12 @@ export function ProofDrawer({
             value="Matter-scoped. Capability is granted only on this demo matter."
           />
           <Fact
-            label="Privilege posture"
+            label="Privilege control"
             value="Cleared. Synthetic content; no real party data."
           />
           <Fact
             label="Audit"
-            value="Every read, model call, and write is recorded in Activity Trail."
+            value="Every read, model call, and write is recorded in Record."
           />
         </Section>
 
@@ -121,11 +121,11 @@ export function ProofDrawer({
               <Fact label="Artifact kind" value={artifact.kind} mono />
               <Fact
                 label="Output"
-                value={outputPreview ?? "Recorded in Activity Trail."}
+                value={outputPreview ?? "Recorded in Record."}
               />
               <Fact
                 label="Source visibility"
-                value="Rendered above in the page; full payload available via the Activity Trail."
+                value="Rendered above in the page; full payload available via the Record."
               />
             </>
           ) : (
@@ -137,7 +137,7 @@ export function ProofDrawer({
           <Fact label="Author" value="The signed-in user who triggered the run." />
           <Fact
             label="Self-approval"
-            value="Forbidden by the substrate. Authors cannot decide their own review."
+            value="Forbidden by the runtime. Authors cannot decide their own review."
           />
           {reviewRequested ? (
             <Fact
@@ -162,7 +162,7 @@ export function ProofDrawer({
               className="inline-flex items-center text-sm underline underline-offset-4 hover:text-ink"
               data-testid="proof-drawer-open-trail"
             >
-              Open full Activity Trail &rarr;
+              Open full Record &rarr;
             </Link>
           </p>
         )}

--- a/frontend/src/demo/ProofDrawer.tsx
+++ b/frontend/src/demo/ProofDrawer.tsx
@@ -102,8 +102,8 @@ export function ProofDrawer({
             value={`${handles.model_id} — keyless demo provider; no API key in scope.`}
           />
           <Fact
-            label="Grant"
-            value="Matter-scoped. Capability is granted only on this demo matter."
+            label="Permission"
+            value="Matter-scoped. The skill is enabled only on this demo matter."
           />
           <Fact
             label="Privilege control"

--- a/frontend/src/demo/TrustReviewCard.tsx
+++ b/frontend/src/demo/TrustReviewCard.tsx
@@ -3,7 +3,7 @@
  *
  * States the three governance facts that hold for every run on this matter,
  * with a single CTA that opens the four-question Proof drawer. The drawer
- * itself carries the deeper link into Activity Trail; the card is the
+ * itself carries the deeper link into Record; the card is the
  * first humane proof layer.
  *
  * Honesty boundary: no "verified" wording, no audit-row count. Claims are
@@ -30,7 +30,7 @@ export function TrustReviewCard({ onViewProof }: TrustReviewCardProps) {
       <ul className="mt-2 space-y-1.5 text-sm">
         <li>
           <span className="font-medium">Audit trail.</span>{" "}
-          Every run is recorded in the matter&rsquo;s Activity Trail.
+          Every run is recorded in the matter&rsquo;s Record.
         </li>
         <li>
           <span className="font-medium">Human review.</span>{" "}

--- a/frontend/src/demo/TrustReviewCard.tsx
+++ b/frontend/src/demo/TrustReviewCard.tsx
@@ -24,7 +24,7 @@ export function TrustReviewCard({ onViewProof }: TrustReviewCardProps) {
     <aside
       className="rounded-md border border-rule bg-wash p-4"
       data-testid="trust-review-card"
-      aria-label="Trust and review posture"
+      aria-label="Trust and review state"
     >
       <h2 className="text-[11px] uppercase tracking-widest text-muted">Trust &amp; review</h2>
       <ul className="mt-2 space-y-1.5 text-sm">

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -18,7 +18,7 @@ const SURFACES: { title: string; body: string }[] = [
   },
   {
     title: "Permission gates",
-    body: "Skills declare what they need. The workspace grants. The runtime enforces, every call.",
+    body: "Skills declare what they need. The workspace enables. The runtime enforces, every call.",
   },
   {
     title: "Skills",

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -13,15 +13,15 @@ const SURFACES: { title: string; body: string }[] = [
     body: "Every model call lives inside a matter. Documents, chronology, posture, audit.",
   },
   {
-    title: "Privilege posture",
-    body: "A_cleared, B_mixed, C_paused. The gateway reads the posture before every model call and refuses what isn't permitted.",
+    title: "Privilege control",
+    body: "A_cleared, B_mixed, C_paused. The gateway reads the privilege state before every model call and refuses what isn't permitted.",
   },
   {
-    title: "Capability gates",
-    body: "Modules declare what they need. The workspace grants. The runtime enforces, every call.",
+    title: "Permission gates",
+    body: "Skills declare what they need. The workspace grants. The runtime enforces, every call.",
   },
   {
-    title: "Modules",
+    title: "Skills",
     body: "Legal skills installed as plugins. Open catalogue. No vendor lock to ours.",
   },
   {
@@ -119,10 +119,10 @@ export function Landing() {
                 All matters
               </a>
               <a
-                href="/modules"
+                href="/skills"
                 className="text-sm text-muted hover:text-ink transition-colors"
               >
-                Modules
+                Skills
               </a>
             </div>
           ) : (

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -10,7 +10,7 @@ const DEMO_SLUG = "khan-v-acme-trading-2026";
 const SURFACES: { title: string; body: string }[] = [
   {
     title: "Matter workspace",
-    body: "Every model call lives inside a matter. Documents, chronology, posture, audit.",
+    body: "Every model call lives inside a matter. Documents, chronology, privilege control, audit.",
   },
   {
     title: "Privilege control",
@@ -197,7 +197,7 @@ export function Landing() {
             </p>
             <p>
               The unit is not a prompt. It is a matter. The control points are
-              permissions, privilege posture, source evidence, review gates, and
+              permissions, privilege control, source evidence, review gates, and
               audit rows. Audit is not the product. Audit is the receipt.
             </p>
           </div>

--- a/frontend/src/landing/Manifesto.tsx
+++ b/frontend/src/landing/Manifesto.tsx
@@ -36,7 +36,7 @@ const SECTIONS: Section[] = [
           frame it as a workspace problem. The matter is the unit of work.
           Every model call, every document mutation, every chronology
           entry exists inside one matter, owned by one user, governed by
-          one privilege posture, written into one audit log.
+          one privilege control, written into one audit log.
         </p>
         <p className="prose-p">
           Outside that frame, the legal use case stops being legal. It is
@@ -62,7 +62,7 @@ const SECTIONS: Section[] = [
         </p>
         <p className="prose-p">
           The unit is not a prompt. It is a matter. The control points are
-          not vibes. They are permissions, privilege posture, source
+          not vibes. They are permissions, privilege control, source
           evidence, review gates, and audit rows. Audit is not the
           product. Audit is the receipt.
         </p>
@@ -77,7 +77,7 @@ const SECTIONS: Section[] = [
         <p className="prose-p">
           The workspace organises around the matter. Documents, prompts,
           outputs, audit rows. All hang off a slug, a title, a parties
-          record, a privilege posture, a retention clock.
+          record, a privilege control, a retention clock.
         </p>
         <p className="prose-p">
           AI tooling that operates outside the matter frame is fine for
@@ -170,8 +170,8 @@ const SECTIONS: Section[] = [
           Three states. <code className="text-sm">A_cleared</code>,{" "}
           <code className="text-sm">B_mixed</code>,{" "}
           <code className="text-sm">C_paused</code>. Each matter carries
-          one. The gateway reads the posture before every model call and
-          decides which providers can serve it.
+          one. The gateway reads the privilege state before every model call
+          and decides which providers can serve it.
         </p>
         <p className="prose-p">
           Cloud providers are commodities behind the gateway, not direct
@@ -179,7 +179,7 @@ const SECTIONS: Section[] = [
           one for <code className="text-sm">C_paused</code> matters.
         </p>
         <p className="prose-p">
-          If the posture rules and the providers configured for a matter
+          If the privilege rules and the providers configured for a matter
           cannot serve a call, the gateway refuses it. The refusal is
           audited. Privilege is not a soft setting.
         </p>
@@ -253,7 +253,7 @@ const SECTIONS: Section[] = [
         </p>
         <p className="prose-p">
           The current release proves the matter workspace, modules, privilege
-          posture, capability gates, BYO keys, and audit trail. Firm-specific
+          privilege control, permission gates, BYO keys, and audit trail. Firm-specific
           seniority gates are staged for real deployments, not required for the
           evaluator path.
         </p>
@@ -327,7 +327,7 @@ const SECTIONS: Section[] = [
             <span className="font-bold text-ink">-</span>
             <span>
               Ship a feature that breaks audit-row contract or
-              privilege-posture dispatch.
+              privilege-control dispatch.
             </span>
           </li>
         </ul>

--- a/frontend/src/landing/Manifesto.tsx
+++ b/frontend/src/landing/Manifesto.tsx
@@ -81,7 +81,7 @@ const SECTIONS: Section[] = [
         </p>
         <p className="prose-p">
           AI tooling that operates outside the matter frame is fine for
-          research. Not acceptable as the substrate for regulated
+          research. Not acceptable as the runtime for regulated
           practice.
         </p>
       </>
@@ -93,8 +93,8 @@ const SECTIONS: Section[] = [
     body: (
       <>
         <p className="prose-p">
-          Open a matter. Ask the assistant. Install a legal module. Run it.
-          See what it touched. See the audit trail.
+          Open a matter. Ask the assistant. Install a legal skill. Run it.
+          See what it touched. See the record.
         </p>
         <p className="prose-p">
           The product mechanic is intentionally plain. A matter carries the
@@ -103,7 +103,7 @@ const SECTIONS: Section[] = [
           The AI does not float outside the file.
         </p>
         <p className="prose-p">
-          Skills declare what they need. The workspace grants it. Runtime
+          Skills declare what they need. The workspace enables it. Runtime
           checks it. Denials are structured and audited. That is the trust
           model in one line.
         </p>

--- a/frontend/src/landing/Manifesto.tsx
+++ b/frontend/src/landing/Manifesto.tsx
@@ -28,7 +28,7 @@ const SECTIONS: Section[] = [
         </p>
         <p className="prose-p">
           The audit log is not a nice-to-have. It is the canonical record.
-          Privilege posture is not a preference. It is a constraint on
+          Privilege control is not a preference. It is a constraint on
           dispatch.
         </p>
         <p className="prose-p">
@@ -98,12 +98,12 @@ const SECTIONS: Section[] = [
         </p>
         <p className="prose-p">
           The product mechanic is intentionally plain. A matter carries the
-          parties, documents, chronology, privilege posture, retention clock,
-          module installs, capability grants, model calls, and audit rows.
+          parties, documents, chronology, privilege control, retention clock,
+          skill installs, permission grants, model calls, and audit rows.
           The AI does not float outside the file.
         </p>
         <p className="prose-p">
-          Modules declare what they need. The workspace grants it. Runtime
+          Skills declare what they need. The workspace grants it. Runtime
           checks it. Denials are structured and audited. That is the trust
           model in one line.
         </p>
@@ -163,7 +163,7 @@ const SECTIONS: Section[] = [
   },
   {
     id: "privilege-posture",
-    title: "Privilege posture is a dispatch constraint",
+    title: "Privilege control is a dispatch constraint",
     body: (
       <>
         <p className="prose-p">

--- a/frontend/src/landing/SubmitModule.tsx
+++ b/frontend/src/landing/SubmitModule.tsx
@@ -372,7 +372,7 @@ export function SubmitModule() {
       <p className="prose-p mb-8">
         Propose a new skill for the{" "}
         <code className="font-mono text-sm">claude-for-uk-legal</code>{" "}
-        catalogue. The form opens a draft pull request. Declared capabilities
+        catalogue. The form opens a draft pull request. Declared permission sets
         are surfaced for review; v0.1 does not enforce them at the call site.
       </p>
 
@@ -439,7 +439,7 @@ export function SubmitModule() {
             />
           </Field>
 
-          <Field label="Declared capabilities" hint="Closed set; for review, not enforced.">
+          <Field label="Declared permission sets" hint="Closed set; for review, not enforced.">
             <div className="grid grid-cols-2 gap-2">
               {SUBMISSION_CAPABILITIES.map((c) => (
                 <label key={c} className="flex items-center gap-2 text-sm font-mono">

--- a/frontend/src/landing/SubmitModule.tsx
+++ b/frontend/src/landing/SubmitModule.tsx
@@ -455,7 +455,7 @@ export function SubmitModule() {
             </div>
           </Field>
 
-          <Field label="Trust posture" hint="Declarative only in v0.1.">
+          <Field label="Trust state" hint="Declarative only in v0.1.">
             <div className="flex flex-wrap gap-4">
               {SUBMISSION_TRUST_POSTURES.map((p) => (
                 <label key={p} className="flex items-center gap-2 text-sm font-mono">

--- a/frontend/src/landing/SubmitModule.tsx
+++ b/frontend/src/landing/SubmitModule.tsx
@@ -261,7 +261,7 @@ export function SubmitModule() {
       if (e.status === 503) {
         setErrorState({
           kind: "disabled",
-          message: detail?.message || "Module submissions are currently closed.",
+          message: detail?.message || "Skill submissions are currently closed.",
         });
       } else if (e.status === 403) {
         setErrorState({
@@ -320,7 +320,7 @@ export function SubmitModule() {
       <SubmitShell>
         <div className="bg-wash p-8 border-l-4 border-ink my-4">
           <p className="text-sm font-medium m-0">
-            Module submissions are currently closed.
+            Skill submissions are currently closed.
           </p>
           <p className="text-sm text-muted mt-2 mb-0">
             Visit the catalogue of installed skills, or fork{" "}

--- a/frontend/src/lib/route.ts
+++ b/frontend/src/lib/route.ts
@@ -71,14 +71,14 @@ export function routeFromPath(pathname: string, search: string): Route {
   if (path === "/auth/verify-pending") return { name: "verifyPending" };
   if (path === "/auth/verify") return { name: "verify", token: query.get("token") };
 
-  // PR 1 (IA reset, blueprint §8): canonical path is /skills; /modules
-  // is preserved as a 302 redirect in the router. Both paths resolve
-  // to the same route name so active-state logic continues to work
-  // for legacy deep links arriving via the redirect.
+  // Canonical paths are /skills/*. The legacy /modules/* paths
+  // resolve to the same route names via router-level redirect shims
+  // so active-state logic keeps working for old deep links and
+  // bookmarks.
   if (path === "/skills" || path === "/modules") return { name: "modules" };
-  if (path === "/modules/submit") return { name: "submitModule" };
-  if (path === "/modules/create") return { name: "createModule" };
-  if (path === "/modules/lawve") return { name: "lawveImport" };
+  if (path === "/skills/submit" || path === "/modules/submit") return { name: "submitModule" };
+  if (path === "/skills/create" || path === "/modules/create") return { name: "createModule" };
+  if (path === "/skills/lawve" || path === "/modules/lawve") return { name: "lawveImport" };
 
   if (path === "/demo-loop") return { name: "demoLoop" };
   if (path === "/demo") return { name: "demo" };

--- a/frontend/src/lib/route.ts
+++ b/frontend/src/lib/route.ts
@@ -71,7 +71,11 @@ export function routeFromPath(pathname: string, search: string): Route {
   if (path === "/auth/verify-pending") return { name: "verifyPending" };
   if (path === "/auth/verify") return { name: "verify", token: query.get("token") };
 
-  if (path === "/modules") return { name: "modules" };
+  // PR 1 (IA reset, blueprint §8): canonical path is /skills; /modules
+  // is preserved as a 302 redirect in the router. Both paths resolve
+  // to the same route name so active-state logic continues to work
+  // for legacy deep links arriving via the redirect.
+  if (path === "/skills" || path === "/modules") return { name: "modules" };
   if (path === "/modules/submit") return { name: "submitModule" };
   if (path === "/modules/create") return { name: "createModule" };
   if (path === "/modules/lawve") return { name: "lawveImport" };

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -99,7 +99,7 @@ export function ArtifactDetail({
             params={{ slug }}
             className="underline underline-offset-4 hover:text-ink"
           >
-            ← All outputs
+            ← All signed outputs
           </Link>
         </p>
       </div>
@@ -230,13 +230,13 @@ export function ArtifactDetail({
           <DT label="Kind">
             <code className="font-mono text-xs">{a.kind}</code>
           </DT>
-          <DT label="Module">
+          <DT label="Skill source">
             <code className="font-mono text-xs">{a.module_id}</code>
           </DT>
-          <DT label="Capability">
+          <DT label="Permission">
             <code className="font-mono text-xs">{a.capability_id}</code>
           </DT>
-          <DT label="Invocation">
+          <DT label="Run id">
             <code className="font-mono text-xs">{a.invocation_id}</code>
           </DT>
           <DT label="Size">
@@ -254,7 +254,7 @@ export function ArtifactDetail({
           params={{ slug }}
           className="text-muted underline underline-offset-4 hover:text-ink"
         >
-          ← All outputs
+          ← All signed outputs
         </Link>
         <a
           href={auditHref}

--- a/frontend/src/matter/ArtifactsList.test.tsx
+++ b/frontend/src/matter/ArtifactsList.test.tsx
@@ -128,7 +128,7 @@ describe("ArtifactsList", () => {
     vi.spyOn(api, "listArtifacts").mockResolvedValue([]);
     mountAt();
     await waitFor(() => {
-      expect(screen.getByText(/No outputs yet/i)).toBeInTheDocument();
+      expect(screen.getByText(/No signed outputs yet/i)).toBeInTheDocument();
     });
   });
 
@@ -136,7 +136,7 @@ describe("ArtifactsList", () => {
     vi.spyOn(api, "listArtifacts").mockRejectedValue(new Error("boom"));
     mountAt();
     await waitFor(() => {
-      expect(screen.getByText(/Could not load outputs/i)).toBeInTheDocument();
+      expect(screen.getByText(/Could not load signed outputs/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -92,22 +92,22 @@ export function ArtifactsList({ slug }: { slug: string }) {
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <PageHeader
         eyebrow="Matter"
-        title="Outputs"
+        title="Signed outputs"
         subId={slug}
         description="Drafts and signed material produced on this matter. Open an output to review sources, sign it, or trace how it was made."
       />
 
       {q.status === "loading" && (
-        <p className="mt-8 text-sm text-muted">Loading outputs…</p>
+        <p className="mt-8 text-sm text-muted">Loading signed outputs…</p>
       )}
       {q.status === "error" && (
         <p className="mt-8 text-sm text-seal">
-          Could not load outputs: {q.message}
+          Could not load signed outputs: {q.message}
         </p>
       )}
       {q.status === "ready" && q.rows.length === 0 && (
         <p className="mt-8 text-sm text-muted">
-          No outputs yet on this matter. Run an action to produce one.
+          No signed outputs yet on this matter. Run a skill to produce one.
         </p>
       )}
       {q.status === "ready" && q.rows.length > 0 && (

--- a/frontend/src/matter/CprGateBanner.tsx
+++ b/frontend/src/matter/CprGateBanner.tsx
@@ -3,7 +3,7 @@ export function CprGateBanner({ count, onConfirm }: { count: number; onConfirm: 
     <div className="bg-paper border border-rule border-l-[3px] border-l-seal p-4 text-ink text-sm mb-6">
       <div className="font-semibold mb-2">
         <span className="text-seal mr-2" aria-hidden="true">▌</span>
-        CPR 31.22 - implied undertaking · action required
+        CPR 31.22 - implied undertaking · step required
       </div>
       <p className="leading-relaxed mb-3">
         {count} chronology {count === 1 ? "entry traces" : "entries trace"} to documents obtained
@@ -13,7 +13,7 @@ export function CprGateBanner({ count, onConfirm }: { count: number; onConfirm: 
         as redacted.
       </p>
       <p className="text-prose leading-relaxed mb-4">
-        Acknowledgement is recorded in the audit trail (action:{" "}
+        Acknowledgement is recorded in the Record (audit action:{" "}
         <span className="font-mono text-xs text-ink">chronology.gate.confirmed</span>) and scoped
         to this matter and user.
       </p>

--- a/frontend/src/matter/GrantsPanel.test.tsx
+++ b/frontend/src/matter/GrantsPanel.test.tsx
@@ -77,7 +77,7 @@ describe("GrantsPanel — list", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/no capabilities granted/i)).toBeInTheDocument();
+      expect(screen.getByText(/no permissions are enabled/i)).toBeInTheDocument();
     });
   });
 });
@@ -125,15 +125,15 @@ describe("GrantsPanel — create", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
-    fireEvent.change(screen.getByLabelText(/Module/i), {
+    fireEvent.change(screen.getByLabelText(/Skill/i), {
       target: { value: "contract-review" },
     });
-    fireEvent.change(screen.getByLabelText(/Capability/i), {
+    fireEvent.change(screen.getByLabelText(/Permission/i), {
       target: { value: "review" },
     });
-    fireEvent.click(screen.getByText("Grant"));
+    fireEvent.click(screen.getByText("Enable"));
 
     await waitFor(() => {
       expect(create).toHaveBeenCalledWith("khan", {
@@ -146,7 +146,7 @@ describe("GrantsPanel — create", () => {
     expect(listGrants).toHaveBeenCalledTimes(2);
     await waitFor(() => {
       expect(
-        screen.getByText(/Granted\. This module may now use that permission/i),
+        screen.getByText(/Enabled\. This skill may now use that permission/i),
       ).toBeInTheDocument();
     });
   });
@@ -196,13 +196,13 @@ describe("GrantsPanel — create", () => {
       ).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByLabelText(/Module/i), {
+    fireEvent.change(screen.getByLabelText(/Skill/i), {
       target: { value: "contract-review-anthropic" },
     });
-    fireEvent.change(screen.getByLabelText(/Capability/i), {
+    fireEvent.change(screen.getByLabelText(/Permission/i), {
       target: { value: "default" },
     });
-    fireEvent.click(screen.getByText("Grant"));
+    fireEvent.click(screen.getByText("Enable"));
 
     await waitFor(() => {
       expect(create).toHaveBeenCalledWith("khan", {
@@ -227,21 +227,21 @@ describe("GrantsPanel — create", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
-    fireEvent.change(screen.getByLabelText(/Module/i), {
+    fireEvent.change(screen.getByLabelText(/Skill/i), {
       target: { value: "contract-review" },
     });
-    fireEvent.change(screen.getByLabelText(/Capability/i), {
+    fireEvent.change(screen.getByLabelText(/Permission/i), {
       target: { value: "review" },
     });
-    fireEvent.click(screen.getByText("Grant"));
+    fireEvent.click(screen.getByText("Enable"));
 
     await waitFor(() => {
       expect(screen.getByText(/not installed/i)).toBeInTheDocument();
     });
-    // Substrate-truth: instruct the user to install via /modules.
-    expect(screen.getByText(/\/modules/)).toBeInTheDocument();
+    // User-facing route points to the canonical skills home.
+    expect(screen.getByText(/\/skills/)).toBeInTheDocument();
   });
 
   it("surfaces 409 module_disabled inline", async () => {
@@ -259,15 +259,15 @@ describe("GrantsPanel — create", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
-    fireEvent.change(screen.getByLabelText(/Module/i), {
+    fireEvent.change(screen.getByLabelText(/Skill/i), {
       target: { value: "contract-review" },
     });
-    fireEvent.change(screen.getByLabelText(/Capability/i), {
+    fireEvent.change(screen.getByLabelText(/Permission/i), {
       target: { value: "review" },
     });
-    fireEvent.click(screen.getByText("Grant"));
+    fireEvent.click(screen.getByText("Enable"));
 
     await waitFor(() => {
       expect(
@@ -292,21 +292,21 @@ describe("GrantsPanel — create", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
-    fireEvent.change(screen.getByLabelText(/Module/i), {
+    fireEvent.change(screen.getByLabelText(/Skill/i), {
       target: { value: "contract-review" },
     });
-    fireEvent.change(screen.getByLabelText(/Capability/i), {
+    fireEvent.change(screen.getByLabelText(/Permission/i), {
       target: { value: "review" },
     });
-    fireEvent.click(screen.getByText("Grant"));
+    fireEvent.click(screen.getByText("Enable"));
 
     await waitFor(() => {
-      expect(screen.getByText(/already granted/i)).toBeInTheDocument();
+      expect(screen.getByText(/already enabled/i)).toBeInTheDocument();
     });
-    // The user is reminded that idempotent grants do NOT emit audit
-    // rows — load-bearing per Phase 7 Decision #4.
+    // The user is reminded that idempotent permission changes do NOT emit audit
+    // rows.
     expect(screen.getByText(/do not emit audit rows/i)).toBeInTheDocument();
   });
 });
@@ -351,18 +351,18 @@ describe("GrantsPanel — capability filtering (matter-scope only)", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByLabelText(/Module/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Skill/i)).toBeInTheDocument();
     });
 
     // Module-B is filtered out entirely.
-    const moduleSelect = screen.getByLabelText(/Module/i) as HTMLSelectElement;
+    const moduleSelect = screen.getByLabelText(/Skill/i) as HTMLSelectElement;
     const moduleValues = Array.from(moduleSelect.options).map((o) => o.value);
     expect(moduleValues).toContain("module-a");
     expect(moduleValues).not.toContain("module-b");
 
     // Pick Module-A and inspect the capability select.
     fireEvent.change(moduleSelect, { target: { value: "module-a" } });
-    const capSelect = screen.getByLabelText(/Capability/i) as HTMLSelectElement;
+    const capSelect = screen.getByLabelText(/Permission/i) as HTMLSelectElement;
     const capValues = Array.from(capSelect.options).map((o) => o.value);
     expect(capValues).toContain("matter-cap");
     // The workspace cap is hidden — the matter endpoint would reject
@@ -473,7 +473,7 @@ describe("GrantsPanel — runnable-pairs derivation (Phase 14 D)", () => {
     // Wait for the panel to settle (the catalog + grants both
     // resolve, but no runnable-capabilities block should render).
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
     expect(screen.queryByTestId("runnable-capabilities")).toBeNull();
     expect(
@@ -649,7 +649,7 @@ describe("GrantsPanel — runnable-pairs derivation (Phase 14 D)", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
     expect(screen.queryByTestId("runnable-capabilities")).toBeNull();
     expect(
@@ -679,7 +679,7 @@ describe("GrantsPanel — runnable-pairs derivation (Phase 14 D)", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
     expect(screen.queryByTestId("runnable-capabilities")).toBeNull();
   });
@@ -701,7 +701,7 @@ describe("GrantsPanel — runnable-pairs derivation (Phase 14 D)", () => {
 
     render(<GrantsPanel slug="khan" />);
     await waitFor(() => {
-      expect(screen.getByText(/Grant a capability/i)).toBeInTheDocument();
+      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
     });
     expect(screen.queryByTestId("runnable-capabilities")).toBeNull();
   });
@@ -740,7 +740,7 @@ describe("GrantsPanel — revoke", () => {
       expect(revoke).toHaveBeenCalledWith("khan", "g-1");
     });
     await waitFor(() => {
-      expect(screen.getByText(/no capabilities granted/i)).toBeInTheDocument();
+      expect(screen.getByText(/no permissions are enabled/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/matter/GrantsPanel.tsx
+++ b/frontend/src/matter/GrantsPanel.tsx
@@ -545,7 +545,7 @@ export function GrantsPanel({
                   <p className="text-sm font-medium text-ink">{item.capabilityId}</p>
                   <p className="mt-0.5 font-mono text-[11px] text-muted">
                     {item.moduleName === item.moduleId
-                      ? "Installed module"
+                      ? "Installed skill"
                       : item.moduleName}
                   </p>
                 </div>
@@ -556,11 +556,11 @@ export function GrantsPanel({
                       : "border-amber-500/40 bg-amber-50 text-amber-900"
                   }`}
                 >
-                  {item.status === "ready" ? "Runnable" : "Needs grant"}
+                  {item.status === "ready" ? "Runnable" : "Needs permission"}
                 </span>
               </div>
               <p className="mt-2 text-xs text-muted">
-                {item.granted}/{item.required} permissions granted on this matter.
+                {item.granted}/{item.required} permissions enabled on this matter.
               </p>
               {item.status === "needs_permissions" && (
                 <button
@@ -572,7 +572,7 @@ export function GrantsPanel({
                   }}
                   className="mt-3 text-xs underline underline-offset-4 hover:text-seal"
                 >
-                  Grant permissions
+                  Enable permissions
                 </button>
               )}
             </div>
@@ -587,10 +587,10 @@ export function GrantsPanel({
           data-testid="runnable-capabilities"
         >
           <h3 className="text-xs uppercase tracking-widest text-muted">
-            Available actions
+            Available skills
           </h3>
           <p className="mt-2 text-xs text-muted">
-            These actions are installed, enabled, and fully granted on this
+            These skills are installed, enabled, and fully permitted on this
             matter. Readiness shows the provider-key boundary before a run
             starts.
           </p>
@@ -640,9 +640,9 @@ export function GrantsPanel({
           Permissions and setup
         </summary>
         <p className="mt-2 text-sm text-muted">
-          Technical grants are hidden by default. Open this when an
-          action needs setup or you need to inspect/revoke exactly what
-          a module may touch.
+          Technical permissions are hidden by default. Open this when a
+          skill needs setup or you need to inspect/revoke exactly what
+          it may touch.
         </p>
 
         {/* Permissions on this matter */}
@@ -650,17 +650,17 @@ export function GrantsPanel({
           Permissions on this matter
         </h3>
         {grants.status === "loading" && (
-          <p className="mt-4 text-sm text-muted">Loading grants…</p>
+          <p className="mt-4 text-sm text-muted">Loading permissions…</p>
         )}
         {grants.status === "error" && (
           <p className="mt-4 text-sm text-seal">
-            Could not load grants: {grants.message}
+            Could not load permissions: {grants.message}
           </p>
         )}
         {grants.status === "ready" && grants.grants.length === 0 && (
           <p className="mt-4 text-sm text-muted">
-            No capabilities granted on this matter yet. Use the form below
-            to grant from an installed module.
+            No permissions are enabled on this matter yet. Use the form below
+            to enable one from an installed skill.
           </p>
         )}
         {grants.status === "ready" && grants.grants.length > 0 && (
@@ -668,10 +668,10 @@ export function GrantsPanel({
             <table className="min-w-full text-sm">
               <thead className="bg-paper-sunken text-xs uppercase tracking-widest text-muted">
                 <tr>
-                  <th className="px-3 py-2 text-left">Module</th>
+                  <th className="px-3 py-2 text-left">Skill source</th>
                   <th className="px-3 py-2 text-left">Skill</th>
                   <th className="px-3 py-2 text-left">Permission</th>
-                  <th className="px-3 py-2 text-left">Granted</th>
+                  <th className="px-3 py-2 text-left">Enabled</th>
                   <th className="px-3 py-2 text-right"> </th>
                 </tr>
               </thead>
@@ -715,24 +715,24 @@ export function GrantsPanel({
         {/* Add-grant control */}
         <div className="mt-6 rounded-md border border-line bg-paper p-4">
           <h3 className="text-xs uppercase tracking-widest text-muted">
-            Grant a capability
+            Enable a permission
           </h3>
         {catalog.status === "loading" && (
-          <p className="mt-3 text-sm text-muted">Loading module catalog…</p>
+          <p className="mt-3 text-sm text-muted">Loading skill catalog…</p>
         )}
         {catalog.status === "error" && (
           <p className="mt-3 text-sm text-seal">{catalog.message}</p>
         )}
         {catalog.status === "ready" && moduleOptions.length === 0 && (
           <p className="mt-3 text-sm text-muted">
-            No modules with declared capabilities are discoverable. Ask
-            an administrator to install a module from the catalog first.
+            No skills with declared permissions are discoverable. Ask
+            an administrator to install a skill from the catalog first.
           </p>
         )}
         {catalog.status === "ready" && moduleOptions.length > 0 && (
           <div className="mt-3 flex flex-wrap items-end gap-3">
             <label className="flex flex-col text-xs text-muted">
-              <span className="mb-1">Module</span>
+              <span className="mb-1">Skill</span>
               <select
                 value={selectedModule}
                 onChange={(e) => {
@@ -751,7 +751,7 @@ export function GrantsPanel({
               </select>
             </label>
             <label className="flex flex-col text-xs text-muted">
-              <span className="mb-1">Capability</span>
+              <span className="mb-1">Permission</span>
               <select
                 value={selectedCap}
                 onChange={(e) => {
@@ -780,35 +780,35 @@ export function GrantsPanel({
               }
               className="inline-flex items-center rounded-md bg-ink px-4 py-1.5 text-sm text-paper hover:opacity-90 disabled:opacity-50"
             >
-              {createState.kind === "submitting" ? "Granting…" : "Grant"}
+              {createState.kind === "submitting" ? "Enabling…" : "Enable"}
             </button>
           </div>
         )}
 
         {createState.kind === "ok" && (
           <p className="mt-3 text-sm text-muted">
-            Granted. This module may now use that permission on this
+            Enabled. This skill may now use that permission on this
             matter.
           </p>
         )}
         {createState.kind === "noop" && (
           <p className="mt-3 text-sm text-muted">
-            Already granted — no change. Idempotent grants do not emit
+            Already enabled — no change. Idempotent permission changes do not emit
             audit rows.
           </p>
         )}
         {createState.kind === "not_installed" && (
           <p className="mt-3 text-sm text-seal">
-            Module{" "}
+            Skill{" "}
             <span className="font-mono">{createState.moduleId}</span> is
             not installed on this workspace. Ask an administrator to
             install it from{" "}
-            <code className="font-mono text-xs">/modules</code> first.
+            <code className="font-mono text-xs">/skills</code> first.
           </p>
         )}
         {createState.kind === "disabled" && (
           <p className="mt-3 text-sm text-seal">
-            Module{" "}
+            Skill{" "}
             <span className="font-mono">{createState.moduleId}</span> is
             installed but currently disabled. {createState.message}
           </p>

--- a/frontend/src/matter/GrantsPanel.tsx
+++ b/frontend/src/matter/GrantsPanel.tsx
@@ -528,12 +528,12 @@ export function GrantsPanel({
   return (
     <section className="mt-10 rounded-md border border-line bg-paper p-4">
       <h2 className="text-sm uppercase tracking-widest text-muted">
-        Actions on this matter
+        Skills on this matter
       </h2>
       <p className="mt-2 text-sm text-muted">
-        Run governed actions from installed modules. The Activity Trail
-        records what each action touched, which model ran, what output
-        was written, and how it was reviewed.
+        Run governed skills installed on this matter. The Record captures
+        what each skill touched, which model ran, what output was
+        written, and how it was reviewed.
       </p>
 
       {setupSuggestions.length > 0 && (

--- a/frontend/src/matter/InvocationRunner.test.tsx
+++ b/frontend/src/matter/InvocationRunner.test.tsx
@@ -77,13 +77,13 @@ describe("InvocationRunner — happy path", () => {
     fireEvent.click(runBtn);
 
     await waitFor(() => {
-      expect(screen.getByText(/Invocation complete/i)).toBeInTheDocument();
+      expect(screen.getByText(/Run complete/i)).toBeInTheDocument();
     });
     expect(screen.getByText("inv-1")).toBeInTheDocument();
     expect(screen.getByTestId("motion-draft-view")).toBeInTheDocument();
-    // Deep-link to Phase 14 E target carries invocation_id.
+    // Deep-link to the Record carries invocation_id.
     const auditLink = screen.getByRole("link", {
-      name: /see audit trail/i,
+      name: /see record/i,
     });
     expect(auditLink.getAttribute("href")).toMatch(
       /\/matters\/khan\/audit\?invocation_id=inv-1/,
@@ -141,7 +141,7 @@ describe("InvocationRunner — structured failure paths", () => {
     expect(link.getAttribute("href")).toMatch(/\/settings\/keys/);
   });
 
-  it("renders capability-denied banner referencing module.capability.denied", async () => {
+  it("renders permission-denied banner referencing module.capability.denied", async () => {
     vi.spyOn(api, "invokeCapability").mockRejectedValue(
       new api.CapabilityDeniedError(
         "denied",
@@ -156,7 +156,7 @@ describe("InvocationRunner — structured failure paths", () => {
     fireEvent.click(runBtn);
 
     await waitFor(() => {
-      expect(screen.getByText(/Capability denied/)).toBeInTheDocument();
+      expect(screen.getByText(/Permission denied/)).toBeInTheDocument();
     });
     expect(
       screen.getByText(/module\.capability\.denied/),

--- a/frontend/src/matter/InvocationRunner.test.tsx
+++ b/frontend/src/matter/InvocationRunner.test.tsx
@@ -108,7 +108,7 @@ describe("InvocationRunner — structured failure paths", () => {
     fireEvent.click(runBtn);
 
     await waitFor(() => {
-      expect(screen.getByText(/Posture gate blocked/)).toBeInTheDocument();
+      expect(screen.getByText(/Privilege gate blocked/)).toBeInTheDocument();
     });
     expect(screen.getByText(/B_mixed/)).toBeInTheDocument();
     expect(screen.getByText(/qualified_solicitor/)).toBeInTheDocument();

--- a/frontend/src/matter/InvocationRunner.tsx
+++ b/frontend/src/matter/InvocationRunner.tsx
@@ -204,7 +204,7 @@ function ResultPanel({
           className="mr-2 inline-block h-2 w-2 rounded-full border border-muted border-t-transparent animate-spin align-middle"
           aria-hidden="true"
         />
-        Invocation in flight…
+        Run in flight…
       </div>
     );
   }
@@ -215,7 +215,7 @@ function ResultPanel({
       <div className="mt-3 rounded-md border border-line p-3">
         <div className="flex items-baseline justify-between gap-3">
           <p className="text-xs uppercase tracking-widest text-muted">
-            Invocation complete
+            Run complete
           </p>
           <p className="text-xs font-mono text-muted">{r.invocation_id}</p>
         </div>
@@ -226,13 +226,13 @@ function ResultPanel({
             params={{ slug }}
             className="text-muted underline underline-offset-4 hover:text-ink"
           >
-            See all artifacts on this matter
+            See all signed outputs on this matter
           </Link>
           <a
             href={`/matters/${encodeURIComponent(slug)}/audit?invocation_id=${encodeURIComponent(r.invocation_id)}`}
             className="text-muted underline underline-offset-4 hover:text-ink"
           >
-            See audit trail for this invocation
+            See Record for this run
           </a>
         </div>
       </div>
@@ -260,13 +260,13 @@ function ResultPanel({
 
   if (state.kind === "capability_denied") {
     return (
-      <Banner tone="seal" title="Capability denied">
+      <Banner tone="seal" title="Permission denied">
         <p>
-          The substrate denied{" "}
+          The runtime denied{" "}
           <code className="font-mono text-xs">{state.err.plugin}</code>/
           <code className="font-mono text-xs">{state.err.skill}</code>/
           <code className="font-mono text-xs">{state.err.capability}</code>.
-          A grant exists in policy but `require_capability` rejected at
+          A permission exists in policy but `require_capability` rejected at
           dispatch time.
         </p>
         <p className="mt-1 text-xs">
@@ -355,9 +355,9 @@ function ResultPanel({
     );
   }
 
-  // Unknown substrate envelope.
+  // Unknown runtime envelope.
   return (
-    <Banner tone="seal" title="Invocation failed">
+    <Banner tone="seal" title="Run failed">
       <p>{state.message}</p>
     </Banner>
   );

--- a/frontend/src/matter/InvocationRunner.tsx
+++ b/frontend/src/matter/InvocationRunner.tsx
@@ -241,9 +241,9 @@ function ResultPanel({
 
   if (state.kind === "posture_blocked") {
     return (
-      <Banner tone="amber" title="Posture gate blocked invocation">
+      <Banner tone="amber" title="Privilege gate blocked invocation">
         <p>
-          This matter's posture (
+          This matter's privilege state (
           <code className="font-mono text-xs">{state.err.posture}</code>)
           requires role{" "}
           <code className="font-mono text-xs">{state.err.requiredRole}</code>.
@@ -251,7 +251,7 @@ function ResultPanel({
           <code className="font-mono text-xs">{state.err.actorRole}</code>.
         </p>
         <p className="mt-1 text-xs">
-          Substrate audit row:{" "}
+          Audit row:{" "}
           <code className="font-mono">posture_gate.check.blocked</code>.
         </p>
       </Banner>
@@ -270,7 +270,7 @@ function ResultPanel({
           dispatch time.
         </p>
         <p className="mt-1 text-xs">
-          Substrate audit row:{" "}
+          Audit row:{" "}
           <code className="font-mono">module.capability.denied</code>.
         </p>
       </Banner>
@@ -288,7 +288,7 @@ function ResultPanel({
           .
         </p>
         <p className="mt-1 text-xs">
-          Substrate audit row:{" "}
+          Audit row:{" "}
           <code className="font-mono">advice_boundary.check.blocked</code>.
         </p>
       </Banner>
@@ -337,7 +337,7 @@ function ResultPanel({
           ) : null}
         </p>
         <p className="mt-1 text-xs">
-          Substrate audit row:{" "}
+          Audit row:{" "}
           <code className="font-mono">model.call.error</code>.
         </p>
       </Banner>

--- a/frontend/src/matter/MatterBreadcrumb.tsx
+++ b/frontend/src/matter/MatterBreadcrumb.tsx
@@ -59,7 +59,7 @@ export function MatterBreadcrumb({
                   href={`/matters/${matter.slug}/workflows`}
                   className="text-muted hover:text-ink transition-colors shrink-0"
                 >
-                  Actions
+                  Skills
                 </a>
                 <span className="text-muted mx-2 shrink-0">/</span>
               </>

--- a/frontend/src/matter/MatterLifecycle.tsx
+++ b/frontend/src/matter/MatterLifecycle.tsx
@@ -213,7 +213,7 @@ function ExportPanel({ slug }: { slug: string }) {
         href={`/matters/${encodeURIComponent(slug)}/audit?action=module.export.job.completed`}
         className="mt-3 inline-block text-xs text-muted underline underline-offset-4 hover:text-ink"
       >
-        View export activity in the Activity Trail
+        View export activity in the Record
       </a>
     </section>
   );

--- a/frontend/src/matter/MatterLifecycle.tsx
+++ b/frontend/src/matter/MatterLifecycle.tsx
@@ -59,9 +59,9 @@ export function MatterLifecycle({ slug }: { slug: string }) {
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
       <PageHeader
         eyebrow="Matter"
-        title="Export matter"
+        title="Working pack"
         subId={matter.slug}
-        description="Download the governed matter record, then close or delete only if needed. Export is the normal final step."
+        description="Download the governed matter record, then close or delete only if needed. Exporting the working pack is the normal final step."
       >
         <p className="mt-3 text-xs text-muted">
           Status: <span className="text-ink">{matter.status}</span>
@@ -142,14 +142,14 @@ function ExportPanel({ slug }: { slug: string }) {
 
   return (
     <section className="mt-8 border border-rule p-5">
-      <h2 className="text-sm uppercase tracking-widest text-muted">Export record</h2>
+      <h2 className="text-sm uppercase tracking-widest text-muted">Export working pack</h2>
       <div className="mt-3 grid grid-cols-1 gap-4 text-xs sm:grid-cols-2">
         <div>
           <p className="uppercase tracking-widest text-muted">Includes</p>
           <ul className="mt-1 list-disc pl-4 text-muted">
             <li>matter metadata</li>
             <li>uploaded documents + original files</li>
-            <li>artefacts (outputs) + bytes</li>
+            <li>signed outputs + bytes</li>
             <li>review decisions</li>
             <li>audit reconstruction + raw audit</li>
             <li>README / manifest</li>

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -71,7 +71,7 @@ export function MatterList() {
               <span>Matter</span>
               <span>Type</span>
               <span>Status</span>
-              <span>Posture</span>
+              <span>Privilege</span>
               <span>Opened</span>
               <span>Retention</span>
             </div>

--- a/frontend/src/matter/MatterNav.tsx
+++ b/frontend/src/matter/MatterNav.tsx
@@ -188,7 +188,7 @@ function PrivilegeControlInline({
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      aria-label="Privilege posture"
+      aria-label="Privilege control"
       title={POSTURE_BLURB[value] ?? value}
       className="bg-transparent text-[10px] font-mono font-bold uppercase tracking-track2 text-ink border-none outline-none cursor-pointer p-0 focus-visible:underline focus-visible:underline-offset-4"
     >

--- a/frontend/src/matter/MatterNav.tsx
+++ b/frontend/src/matter/MatterNav.tsx
@@ -1,8 +1,8 @@
 // MatterNav - compact left rail for the matter workspace.
 // Pattern reference: Mike, Claude.ai, Sana AI, Mistral, Fibery.
-// Core V1 loop (Matter desk / Documents / Actions / Activity Trail);
-// secondary review/chronology surfaces stay routable without dominating
-// the first-run matter experience.
+// Core V1 loop (Chat / Documents / Skills / Record); secondary
+// review/chronology surfaces stay routable without dominating the
+// first-run matter experience.
 //
 // Mobile: at < md the static rail is hidden. When `mobileOpen` is true
 // the same content renders as a left-anchored 280px sheet with a
@@ -127,7 +127,7 @@ function NavBody({
         </div>
         {showPosture && (
           <div className="mt-3 flex items-center gap-2">
-            <span className="eyebrow">Posture</span>
+            <span className="eyebrow">Privilege</span>
             <span className="inline-flex items-center border border-rule px-1.5 py-0.5">
               <PrivilegeControlInline value={matter.privilege_posture} onChange={onPostureChange} />
             </span>

--- a/frontend/src/matter/MatterPulse.tsx
+++ b/frontend/src/matter/MatterPulse.tsx
@@ -73,8 +73,8 @@ export function MatterPulse({
   const hasActions = workflowsGranted !== 0;
   const actionLabel =
     workflowsGranted === null
-      ? "Actions checked on sign-in"
-      : `${workflowsGranted} governed action${workflowsGranted === 1 ? "" : "s"} ready`;
+      ? "Skills checked on sign-in"
+      : `${workflowsGranted} skill${workflowsGranted === 1 ? "" : "s"} ready`;
 
   return (
     <section
@@ -103,8 +103,8 @@ export function MatterPulse({
       </div>
       {showPosture ? (
         <p className="mt-4 border-t border-rule pt-3 text-xs text-muted">
-          {postureLabel} posture. This demo is safe to inspect; create an account
-          to run the same loop on your own matter.
+          {postureLabel} privilege control. This demo is safe to inspect;
+          create an account to run the same loop on your own matter.
         </p>
       ) : (
         <p className="mt-4 border-t border-rule pt-3 text-xs text-muted">

--- a/frontend/src/matter/MatterPulse.tsx
+++ b/frontend/src/matter/MatterPulse.tsx
@@ -91,14 +91,14 @@ export function MatterPulse({
             {matter.title} is loaded for supervised AI work.
           </p>
           <p className="mt-2 text-sm leading-relaxed text-prose">
-            The workspace has the documents, a chronology, and governed actions.
-            Every AI step is recorded in the Activity Trail.
+            The workspace has the documents, a chronology, and governed AI work.
+            Every AI step is recorded.
           </p>
         </div>
         <div className="grid min-w-[280px] grid-cols-1 gap-2 text-xs sm:grid-cols-3 lg:grid-cols-1">
           <StatusLine label="Documents" value={hasDocuments ? `${documentsCount} loaded` : "Add documents"} />
           <StatusLine label="Timeline" value={hasChronology ? `${chronologyCount} events` : "Not started"} />
-          <StatusLine label="Actions" value={hasActions ? actionLabel : "Setup needed"} />
+          <StatusLine label="Skills" value={hasActions ? actionLabel : "Setup needed"} />
         </div>
       </div>
       {showPosture ? (

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -89,7 +89,7 @@ function AssistantMessageView({
           {!compact && sourceCount > 0
             ? ` · ${sourceCount} source${sourceCount === 1 ? "" : "s"}`
             : ""}
-          {" · recorded in Activity Trail"}
+          {" · recorded in Record"}
         </div>
         <div className={`${proseSizing} text-ink leading-relaxed whitespace-pre-wrap`}>
           {text}

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -86,7 +86,7 @@ export function NewMatter() {
           />
         </Field>
 
-        <Field label="Privilege posture">
+        <Field label="Privilege control">
           <select
             value={form.privilege_posture}
             onChange={(e) => setForm({ ...form, privilege_posture: e.target.value })}

--- a/frontend/src/matter/PostureBanner.test.tsx
+++ b/frontend/src/matter/PostureBanner.test.tsx
@@ -127,7 +127,7 @@ describe("PostureBanner — unknown posture (fail closed)", () => {
       />,
     );
     expect(screen.getByTestId("posture-banner")).toBeInTheDocument();
-    expect(screen.getByText(/unknown posture/i)).toBeInTheDocument();
+    expect(screen.getByText(/unknown privilege/i)).toBeInTheDocument();
     expect(screen.getByText(/Z_experimental/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/matter/PostureBanner.tsx
+++ b/frontend/src/matter/PostureBanner.tsx
@@ -130,8 +130,8 @@ export function PostureBanner({
   return (
     <BannerShell tone="mixed" badge={posture} badgeLabel="Unknown">
       <p className="font-medium text-ink">
-        Unknown posture <code className="font-mono text-xs">{posture}</code>.
-        Module invocation will fail until the matter posture is
+        Unknown privilege <code className="font-mono text-xs">{posture}</code>.
+        Skill runs will fail until the matter privilege state is
         recognised.
       </p>
     </BannerShell>
@@ -173,7 +173,7 @@ function ChangePostureControl({
   return (
     <div className="mt-3 flex flex-wrap items-end gap-2" data-testid="change-posture-control">
       <label className="flex flex-col text-xs text-muted">
-        <span className="mb-1">Change posture</span>
+        <span className="mb-1">Change privilege</span>
         <select
           data-testid="change-posture-select"
           value={next}

--- a/frontend/src/matter/PostureBanner.tsx
+++ b/frontend/src/matter/PostureBanner.tsx
@@ -73,7 +73,7 @@ export function PostureBanner({
     return (
       <BannerShell tone="paused" badge="C_paused" badgeLabel="Paused">
         <p className="font-medium text-ink">
-          This matter is paused. No modules can run regardless of role.
+          This matter is paused. No skills can run regardless of role.
         </p>
         <p className="mt-1 text-sm text-muted">
           Requires <code className="font-mono text-xs">matter_paused</code>{" "}
@@ -102,7 +102,7 @@ export function PostureBanner({
       <BannerShell tone="mixed" badge="B_mixed" badgeLabel="Mixed">
         <p className="font-medium text-ink">
           This matter is marked <code className="font-mono text-xs">B_mixed</code>.
-          Only qualified solicitors can run modules.
+          Only qualified solicitors can run skills.
         </p>
         <p className="mt-1 text-sm text-muted">
           Requires{" "}

--- a/frontend/src/matter/PrivilegeControl.tsx
+++ b/frontend/src/matter/PrivilegeControl.tsx
@@ -19,7 +19,7 @@ export function PrivilegeControl({
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      aria-label="Privilege posture"
+      aria-label="Privilege control"
       className={
         "bg-transparent text-sm font-semibold font-mono border-none outline-none cursor-pointer p-0 -ml-0.5 focus-visible:underline focus-visible:underline-offset-4 " +
         (isPaused ? "text-seal" : "text-ink")

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -249,12 +249,12 @@ export function ReconstructionView({ slug }: { slug: string }) {
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <p className="text-xs uppercase tracking-widest text-muted">Matter</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Activity Trail</h1>
+      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Record</h1>
       <p className="mt-1 text-xs font-mono text-muted">{slug}</p>
       <p className="mt-3 text-sm text-muted">
         The main record of what happened on this matter: documents
-        referenced, actions run, models called, outputs written, human
-        reviews, and blocked attempts. Raw substrate rows stay
+        referenced, skills run, models called, outputs written, human
+        reviews, and blocked attempts. Raw audit rows stay
         expandable; the first view is the story.
       </p>
 

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -52,10 +52,10 @@ const CLASS_CHIPS: { key: RowClass; label: string }[] = [
   { key: "signed", label: "Sign-off" },
   { key: "review", label: "Review" },
   { key: "blocked_denied", label: "Blocked / denied" },
-  { key: "grant_role", label: "Grant / role" },
+  { key: "grant_role", label: "Permission / role" },
   { key: "advice", label: "Advice" },
   { key: "model", label: "Model" },
-  { key: "module", label: "Module" },
+  { key: "module", label: "Skill" },
   { key: "error", label: "Error" },
 ];
 
@@ -64,10 +64,10 @@ const CLASS_LABEL: Record<RowClass, string> = {
   signed: "Sign-off",
   review: "Review",
   blocked_denied: "Blocked / denied",
-  grant_role: "Grant / role",
+  grant_role: "Permission / role",
   advice: "Advice",
   model: "Model",
-  module: "Module",
+  module: "Skill",
   system: "System",
 };
 
@@ -79,7 +79,7 @@ const STORY_LABEL: Record<RowClass, string> = {
   grant_role: "Permission changed",
   advice: "Advice boundary checked",
   model: "Model used",
-  module: "Action ran",
+  module: "Skill ran",
   system: "System activity",
 };
 
@@ -569,7 +569,7 @@ function InvocationChain({
       >
         <span className="flex items-baseline gap-2">
           <span className="text-xs uppercase tracking-widest text-muted">
-            Invocation
+            Run
           </span>
           <code className="font-mono text-sm">{invocationId.slice(0, 8)}…</code>
           <span className="text-xs text-muted">{ordered.length} events</span>

--- a/frontend/src/matter/SignOffConfirmation.tsx
+++ b/frontend/src/matter/SignOffConfirmation.tsx
@@ -106,7 +106,7 @@ export function SignOffConfirmation({
           className="text-muted underline underline-offset-4 hover:text-ink"
           data-testid="signoff-trail-link"
         >
-          See it in the Activity Trail →
+          See it in the Record →
         </Link>
       </div>
     </div>

--- a/frontend/src/matter/tabs/ApprovalsTab.tsx
+++ b/frontend/src/matter/tabs/ApprovalsTab.tsx
@@ -74,7 +74,7 @@ export function ApprovalsTab({ slug }: { slug: string }) {
         <div className="mt-6">
           <EmptyState
             title="No reviews yet"
-            body='Open a Contract Review findings pack in Outputs and choose "Request review" to start one.'
+            body='Open a Contract Review findings pack in Signed outputs and choose "Request review" to start one.'
           />
         </div>
       )}

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -253,12 +253,12 @@ export function AssistantTab({
           <div className="space-y-6 border border-rule bg-paper-sunken p-5">
             <div className="text-sm text-prose space-y-2">
               <p>
-                Ask anything about this matter, or run a governed action when
-                you need an output to sign.
+                Ask anything about this matter, or run a skill when you need
+                an output to sign.
               </p>
               <p className="text-xs text-muted">
                 Sources appear as chips below each answer. Material outputs
-                move to Outputs for sign-off and export.
+                move to Signed outputs for sign-off and export.
               </p>
             </div>
             <div>
@@ -379,7 +379,7 @@ export function AssistantTab({
                 onClick={() => setTabAndHash("workflows")}
                 className="font-mono text-[11px] text-muted hover:text-ink transition-colors"
               >
-                Actions
+                Skills
               </button>
               {attachOpen && recentDocs.length > 0 && (
                 <div className="absolute bottom-full left-0 mb-2 border border-rule bg-paper p-3 w-[280px] z-10">
@@ -444,7 +444,7 @@ function formatError(err: unknown): string {
     // not JSON
   }
   if (status === "401") return "You need to sign in again to use the assistant.";
-  if (status === "409") return body || "This matter's posture blocks cloud model calls. Switch posture or use a local model.";
+  if (status === "409") return body || "This matter's privilege state blocks cloud model calls. Change privilege or use a local model.";
   if (status === "422") return body || "The request was rejected. Check your API key and try again.";
   return `HTTP ${status}: ${body}`;
 }

--- a/frontend/src/matter/tabs/LettersTab.tsx
+++ b/frontend/src/matter/tabs/LettersTab.tsx
@@ -84,7 +84,7 @@ export function LettersTab({
             </button>
             {blocked && (
               <span className="text-sm text-muted">
-                Privilege posture C_paused blocks LLM calls.
+                Privilege control C_paused blocks LLM calls.
               </span>
             )}
           </div>

--- a/frontend/src/matter/tabs/PreMotionTab.tsx
+++ b/frontend/src/matter/tabs/PreMotionTab.tsx
@@ -48,11 +48,11 @@ export function PreMotionTab({
       {blocked && (
         <div className="border border-rule p-6 mb-6">
           <div className="text-sm font-semibold text-ink mb-1">
-            Privilege posture C_paused
+            Privilege control: C_paused
           </div>
           <p className="text-sm text-prose m-0 leading-relaxed">
-            Cloud model calls are refused while posture is paused. Change
-            the posture in the matter sidebar to run a premortem.
+            Cloud model calls are refused while privilege is paused. Change
+            the privilege control in the matter sidebar to run a premortem.
           </p>
         </div>
       )}

--- a/frontend/src/matter/tabs/WorkflowsTab.tsx
+++ b/frontend/src/matter/tabs/WorkflowsTab.tsx
@@ -25,8 +25,8 @@ const GRANT_LABEL: Record<WorkflowGrant, string> = {
 
 const AVAILABILITY_LABEL: Record<WorkflowAvailability, string> = {
   ok: "ok",
-  "blocked-by-posture": "blocked by posture",
-  "blocked-by-grant": "blocked by grant",
+  "blocked-by-posture": "blocked by privilege",
+  "blocked-by-grant": "blocked by permission",
 };
 
 function availabilityClasses(value: WorkflowAvailability): string {
@@ -74,9 +74,9 @@ export function WorkflowsTab({ slug }: { slug: string; posture?: string }) {
         if (!cancelled) {
           const msg = e instanceof Error ? e.message : String(e);
           if (msg.includes("401")) {
-            setError("Sign in to see which workflows are runnable on this matter.");
+            setError("Sign in to see which skills are runnable on this matter.");
           } else {
-            setError("Workflows could not be loaded. Try again, or open the module catalogue.");
+            setError("Skills could not be loaded. Try again, or open the skill catalogue.");
           }
         }
       });
@@ -88,13 +88,13 @@ export function WorkflowsTab({ slug }: { slug: string; posture?: string }) {
   return (
     <div className="max-w-4xl">
       <p className="text-sm text-prose max-w-2xl leading-relaxed mb-8">
-        Run the installed legal actions for this matter. Each card says whether
+        Run the installed legal skills for this matter. Each card says whether
         it is ready before you open it.
       </p>
 
       {error && (
         <div className="border border-rule bg-paper p-5 text-sm">
-          <p className="font-semibold text-ink">Actions are available inside your workspace.</p>
+          <p className="font-semibold text-ink">Skills are available inside your workspace.</p>
           <p className="mt-2 text-muted">{error}</p>
           <a
             href="/auth/signup"
@@ -104,7 +104,7 @@ export function WorkflowsTab({ slug }: { slug: string; posture?: string }) {
           </a>
         </div>
       )}
-      {!data && !error && <LoadingLine label="loading workflows" />}
+      {!data && !error && <LoadingLine label="loading skills" />}
 
       {data && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -115,9 +115,9 @@ export function WorkflowsTab({ slug }: { slug: string; posture?: string }) {
       )}
 
       <p className="text-xs text-muted mt-8">
-        Browse all available modules in the{" "}
-        <a href="/modules" className="text-[#0066CC] hover:underline">
-          module catalogue
+        Browse all available skills in the{" "}
+        <a href="/skills" className="text-[#0066CC] hover:underline">
+          skill catalogue
         </a>
         .
       </p>
@@ -136,7 +136,7 @@ function WorkflowCard({ workflow, slug }: { workflow: WorkflowState; slug: strin
       <p className="text-xs text-prose leading-relaxed">{workflow.description}</p>
 
       <dl className="mt-4 grid grid-cols-[88px_1fr] gap-y-1 text-[11px] font-mono">
-        <dt className="text-muted uppercase tracking-track2 text-[9px] self-center">Grant</dt>
+        <dt className="text-muted uppercase tracking-track2 text-[9px] self-center">Permission</dt>
         <dd className={grantClasses(workflow.grant)}>{GRANT_LABEL[workflow.grant]}</dd>
         <dt className="text-muted uppercase tracking-track2 text-[9px] self-center">Last run</dt>
         <dd className="text-prose">{formatLastRun(workflow.last_run_at)}</dd>

--- a/frontend/src/matter/tabs/types.ts
+++ b/frontend/src/matter/tabs/types.ts
@@ -3,12 +3,19 @@
 // SIDEBAR_NAV is the core nav that renders in the matter rail.
 // Secondary/legacy surfaces (chronology, approvals, individual
 // workflow pages) remain routable for deep links but do not compete
-// with the main documents → actions → trail loop.
-// WORKFLOW_TABS are historical built-in action surfaces reached from
-// the Actions page; they keep their routes for deep-linking but
+// with the main documents → skills → record loop.
+// WORKFLOW_TABS are historical built-in skill surfaces reached from
+// the Skills page; they keep their routes for deep-linking but
 // do not surface as their own sidebar items.
 //
 // Bare /matters/{slug} lands on Documents.
+//
+// PR 1 (IA reset, blueprint §3) — user-facing labels only:
+//   "Matter desk"    → "Chat"
+//   "Actions"        → "Skills"
+//   "Activity Trail" → "Record"
+// Tab URL keys (assistant/workflows/audit) are unchanged; rewiring
+// the route slugs is PR 2 scope.
 
 export type TabKey =
   | "assistant"
@@ -26,18 +33,18 @@ export type TabKey =
   | "research";
 
 export const SIDEBAR_NAV: ReadonlyArray<{ key: TabKey; label: string }> = [
-  { key: "assistant", label: "Matter desk" },
+  { key: "assistant", label: "Chat" },
   { key: "documents", label: "Documents" },
-  { key: "workflows", label: "Actions" },
-  { key: "audit", label: "Activity Trail" },
+  { key: "workflows", label: "Skills" },
+  { key: "audit", label: "Record" },
 ];
 
 export const MATTER_TAB_LABELS: Readonly<Record<TabKey, string>> = {
-  assistant: "Matter desk",
+  assistant: "Chat",
   documents: "Documents",
   chronology: "Chronology",
-  workflows: "Actions",
-  audit: "Activity Trail",
+  workflows: "Skills",
+  audit: "Record",
   approvals: "Approvals",
   premotion: "Pre-Motion",
   letters: "Letters",

--- a/frontend/src/matter/tabs/types.ts
+++ b/frontend/src/matter/tabs/types.ts
@@ -10,12 +10,11 @@
 //
 // Bare /matters/{slug} lands on Documents.
 //
-// PR 1 (IA reset, blueprint §3) — user-facing labels only:
-//   "Matter desk"    → "Chat"
-//   "Actions"        → "Skills"
-//   "Activity Trail" → "Record"
-// Tab URL keys (assistant/workflows/audit) are unchanged; rewiring
-// the route slugs is PR 2 scope.
+// User-facing tab labels (Chat / Documents / Skills / Record)
+// intentionally do not match the underlying URL keys
+// (assistant / documents / workflows / audit). The keys are kept
+// stable in this slice for route compatibility; they are rewired in
+// a later slice that restructures the matter shell.
 
 export type TabKey =
   | "assistant"

--- a/frontend/src/modules-v2/CreateModule.tsx
+++ b/frontend/src/modules-v2/CreateModule.tsx
@@ -19,13 +19,13 @@ import { PageHeader } from "../ui/primitives";
 
 const REQUIRED_FIELDS: { field: string; what: string }[] = [
   { field: "schema_version", what: 'manifest schema, e.g. "2.0.0"' },
-  { field: "id", what: "stable module id" },
-  { field: "version", what: "module version" },
+  { field: "id", what: "stable skill id" },
+  { field: "version", what: "skill version" },
   { field: "publisher", what: "who publishes it" },
   { field: "visibility", what: "first_party / community / private" },
-  { field: "runtime", what: "how the module executes — native, mcp, or prompt" },
+  { field: "runtime", what: "how the skill executes — native, mcp, or prompt" },
   { field: "entrypoint", what: 'what the runtime invokes (prompt runtime: { "prompt_source": "manifest", "instructions": "..." })' },
-  { field: "capabilities", what: "what it may read/write, gates, advice tier, declared audit events" },
+  { field: "capabilities", what: "permission sets, advice tier, and declared audit events" },
 ];
 
 type Result =
@@ -61,18 +61,18 @@ export function CreateModule() {
       <PageHeader
         eyebrow="Skills"
         title="Create a skill"
-        description="Build your own Legalise module. This page explains the manifest and validates a candidate against the same rules the install path uses — it does not install or sign."
+        description="Build your own Legalise skill. This page explains the manifest and validates a candidate against the same rules the install path uses — it does not install or sign."
       />
 
       <section>
         <h2 className="text-sm uppercase tracking-widest text-muted">
-          What a module is
+          What a skill is
         </h2>
         <p className="mt-2 text-sm text-muted">
-          A module is a signed, governed unit of legal capability. Its manifest
+          A skill is a signed, governed unit of legal work. Its manifest
           declares what it may touch; the runtime enforces those declarations on
-          every call, and every run lands on the matter's audit trail. Modules
-          are installed at the workspace and granted/run per matter.
+          every call, and every run lands in the matter record. Skills are
+          installed at the workspace and enabled per matter.
         </p>
       </section>
 
@@ -89,7 +89,7 @@ export function CreateModule() {
           ))}
         </dl>
         <p className="mt-3 text-xs text-muted">
-          Each capability declares its <span className="font-mono">reads</span> /{" "}
+          Each permission set declares its <span className="font-mono">reads</span> /{" "}
           <span className="font-mono">writes</span>, <span className="font-mono">gates</span>,{" "}
           <span className="font-mono">advice_tier_max</span>, and the{" "}
           <span className="font-mono">audit_events</span> it emits — that
@@ -157,11 +157,11 @@ export function CreateModule() {
           Sign &amp; install locally
         </h2>
         <p className="mt-2 text-sm text-muted">
-          A module must be <span className="text-ink">signed</span> before it can
+          A skill must be <span className="text-ink">signed</span> before it can
           be installed — signing is a deploy-time / CLI step, not done in the
           browser. Once your manifest validates, sign it and install it with the
-          Legalise CLI, then it appears under Reference modules. See the
-          module-authoring docs in the repository for the exact commands.
+          Legalise CLI, then it appears under Reference skills. See the
+          skill-authoring docs in the repository for the exact commands.
         </p>
       </section>
     </div>

--- a/frontend/src/modules-v2/CreateModule.tsx
+++ b/frontend/src/modules-v2/CreateModule.tsx
@@ -59,8 +59,8 @@ export function CreateModule() {
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="Modules"
-        title="Create a module"
+        eyebrow="Skills"
+        title="Create a skill"
         description="Build your own Legalise module. This page explains the manifest and validates a candidate against the same rules the install path uses — it does not install or sign."
       />
 

--- a/frontend/src/modules-v2/InstallCeremony.test.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.test.tsx
@@ -7,7 +7,7 @@
  *   - 409 invalid-transition surfaces a structured banner including
  *     the module.ceremony.rejected audit-row reference + deep-link
  *     (Phase 14 E target)
- *   - Reject path bounces to /modules
+ *   - Reject path bounces to /skills
  *   - Terminal-failure states block further advances
  *
  * Reviewer-narrow: no polling, no telemetry assertions, no audit
@@ -58,7 +58,7 @@ function mountAt(initialPath: string) {
   const root = createRootRoute({ component: () => <Outlet /> });
   const ceremonyRoute = createRoute({
     getParentRoute: () => root,
-    path: "/modules/install/$ceremonyId",
+    path: "/skills/install/$ceremonyId",
     component: () => {
       const { ceremonyId } = ceremonyRoute.useParams();
       return <InstallCeremony ceremonyId={ceremonyId} />;
@@ -66,7 +66,7 @@ function mountAt(initialPath: string) {
   });
   const modulesStub = createRoute({
     getParentRoute: () => root,
-    path: "/modules",
+    path: "/skills",
     component: () => <div data-testid="modules-stub" />,
   });
   const tree = root.addChildren([ceremonyRoute, modulesStub]);
@@ -89,7 +89,7 @@ describe("InstallCeremony — stepper", () => {
     vi.spyOn(api, "getCeremony").mockResolvedValue(
       makeCeremony({ state: "permissions_reviewed" }),
     );
-    mountAt("/modules/install/cer-1");
+    mountAt("/skills/install/cer-1");
     await waitFor(() => {
       expect(screen.getByText("Permissions reviewed")).toBeInTheDocument();
     });
@@ -108,12 +108,12 @@ describe("InstallCeremony — advance actions", () => {
       .spyOn(api, "advanceCeremony")
       .mockResolvedValue(makeCeremony({ state: "inspected" }));
 
-    mountAt("/modules/install/cer-1");
+    mountAt("/skills/install/cer-1");
     await waitFor(() => {
       expect(screen.getByText("Continue review")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Enable module")).toBeNull();
+    expect(screen.queryByText("Enable skill")).toBeNull();
 
     fireEvent.click(screen.getByText("Continue review"));
     await waitFor(() => {
@@ -129,20 +129,20 @@ describe("InstallCeremony — advance actions", () => {
       .spyOn(api, "advanceCeremony")
       .mockResolvedValue(makeCeremony({ state: "enabled", is_terminal: true }));
 
-    mountAt("/modules/install/cer-1");
+    mountAt("/skills/install/cer-1");
     await waitFor(() => {
-      expect(screen.getByText("Enable module")).toBeInTheDocument();
+      expect(screen.getByText("Enable skill")).toBeInTheDocument();
     });
 
     expect(screen.queryByText("Continue review")).toBeNull();
 
-    fireEvent.click(screen.getByText("Enable module"));
+    fireEvent.click(screen.getByText("Enable skill"));
     await waitFor(() => {
       expect(advance).toHaveBeenCalledWith("cer-1", "grant");
     });
   });
 
-  it("reject bounces to /modules after the terminal state renders", async () => {
+  it("reject bounces to /skills after the terminal state renders", async () => {
     vi.spyOn(api, "getCeremony").mockResolvedValue(makeCeremony());
     vi.spyOn(api, "advanceCeremony").mockResolvedValue(
       makeCeremony({
@@ -151,7 +151,7 @@ describe("InstallCeremony — advance actions", () => {
       }),
     );
 
-    mountAt("/modules/install/cer-1");
+    mountAt("/skills/install/cer-1");
     await waitFor(() => {
       expect(screen.getByText("Reject")).toBeInTheDocument();
     });
@@ -179,11 +179,11 @@ describe("InstallCeremony — 409 invalid-transition", () => {
       ),
     );
 
-    mountAt("/modules/install/cer-1");
+    mountAt("/skills/install/cer-1");
     await waitFor(() => {
-      expect(screen.getByText("Enable module")).toBeInTheDocument();
+      expect(screen.getByText("Enable skill")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText("Enable module"));
+    fireEvent.click(screen.getByText("Enable skill"));
 
     await waitFor(() => {
       expect(
@@ -209,14 +209,14 @@ describe("InstallCeremony — terminal failures", () => {
     vi.spyOn(api, "getCeremony").mockResolvedValue(
       makeCeremony({ state: "publisher_blocked", is_terminal: true }),
     );
-    mountAt("/modules/install/cer-1");
+    mountAt("/skills/install/cer-1");
     await waitFor(() => {
       expect(
         screen.getByText(/ceremony terminated/i),
       ).toBeInTheDocument();
     });
     expect(screen.queryByText("Continue review")).toBeNull();
-    expect(screen.queryByText("Enable module")).toBeNull();
+    expect(screen.queryByText("Enable skill")).toBeNull();
     expect(screen.queryByText("Reject")).toBeNull();
   });
 });

--- a/frontend/src/modules-v2/InstallCeremony.test.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.test.tsx
@@ -194,7 +194,7 @@ describe("InstallCeremony — 409 invalid-transition", () => {
     expect(screen.getByText(/module\.ceremony\.rejected/)).toBeInTheDocument();
     // Phase 14.5 C — the deep-link is back. Action-filter only per
     // the Phase 14.5 plan P1 redline (no ?ceremony= param).
-    const link = screen.getByRole("link", { name: /workspace audit/i });
+    const link = screen.getByRole("link", { name: /audit log/i });
     expect(link.getAttribute("href")).toBe(
       "/admin/audit?action=module.ceremony.rejected",
     );

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -44,14 +44,14 @@ const ORDERED_STATES: ReadonlyArray<{
   label: string;
   blurb: string;
 }> = [
-  { key: "discovered", label: "Discovered", blurb: "Module manifest located in the registry." },
+  { key: "discovered", label: "Discovered", blurb: "Skill manifest located in the registry." },
   { key: "inspected", label: "Inspected", blurb: "Manifest shape + structural validation passed." },
   { key: "signature_checked", label: "Signature checked", blurb: "Signature verified (or fast-path declared)." },
   { key: "publisher_checked", label: "Publisher checked", blurb: "Publisher identity confirmed against policy." },
-  { key: "permissions_reviewed", label: "Permissions reviewed", blurb: "Capabilities + data-movement summary acknowledged." },
+  { key: "permissions_reviewed", label: "Permissions reviewed", blurb: "Permission sets + data movement acknowledged." },
   { key: "gates_reviewed", label: "Gates reviewed", blurb: "Privilege + advice-tier gates acknowledged." },
-  { key: "granted", label: "Granted", blurb: "All capabilities approved; ready to enable." },
-  { key: "enabled", label: "Enabled", blurb: "Module installed and available." },
+  { key: "granted", label: "Granted", blurb: "All permissions approved; ready to enable." },
+  { key: "enabled", label: "Enabled", blurb: "Skill installed and available." },
 ];
 
 const TERMINAL_FAILURE_STATES: ReadonlySet<string> = new Set([
@@ -106,7 +106,7 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
         // user sees the terminal-state row before the route change.
         setQ({ status: "ready", ceremony: next });
         window.setTimeout(() => {
-          void nav({ to: "/modules" });
+          void nav({ to: "/skills" });
         }, 700);
         return;
       }
@@ -155,7 +155,7 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
         eyebrow="Install review"
         title={c.permission_card.module_name ?? c.module_id}
         subId={`ceremony ${c.ceremony_id}`}
-        description="Verify the publisher, review the permissions this module is asking for, then enable it. Each step is recorded in the audit trail."
+        description="Verify the publisher, review the permissions this skill is asking for, then enable it. Each step is recorded in the audit log."
       />
 
       <Stepper currentState={c.state} />
@@ -177,7 +177,7 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
             Ceremony terminated: {c.state}
           </p>
           <p className="mt-1 text-sm text-muted">
-            No further actions. Return to the catalog to start a new
+            No further steps. Return to the catalog to start a new
             ceremony if needed.
           </p>
         </div>
@@ -207,7 +207,7 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
             >
               {adv.kind === "running" && adv.action === "grant"
                 ? "Enabling…"
-                : "Enable module"}
+                : "Enable skill"}
             </button>
           )}
           <button
@@ -225,10 +225,10 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
 
       {c.state === "enabled" && (
         <div className="mt-8 rounded-md border border-line p-4">
-          <p className="text-sm font-medium">Module enabled</p>
+          <p className="text-sm font-medium">Skill enabled</p>
           <p className="mt-1 text-sm text-muted">
-            This module is now installed and can be granted on your
-            matters. The install was recorded in the audit trail.
+            This skill is now installed and can be enabled on your
+            matters. The install was recorded in the audit log.
           </p>
         </div>
       )}
@@ -288,7 +288,7 @@ function PermissionCard({
         Review permissions
       </h2>
       <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-        <DT label="Module">
+        <DT label="Skill">
           {card.module_name ?? card.module_id}
         </DT>
         <DT label="Version">{card.version ?? "—"}</DT>
@@ -299,7 +299,7 @@ function PermissionCard({
         <DT label="Signature">{card.signature_status ?? "—"}</DT>
         <DT label="Visibility">{card.visibility ?? "—"}</DT>
         <DT label="Advice tier max">{card.advice_tier_max ?? "—"}</DT>
-        <DT label="Capabilities">{caps.length}</DT>
+        <DT label="Permission sets">{caps.length}</DT>
         <DT label="Audit events">{events.length}</DT>
       </dl>
     </section>
@@ -326,7 +326,7 @@ function InvalidTransitionBanner({
         not valid from the current state. {state.message}
       </p>
       <p className="mt-2 text-sm text-muted">
-        The substrate wrote a{" "}
+        The runtime wrote a{" "}
         <span className="font-mono">module.ceremony.rejected</span> audit
         row for this attempt.{" "}
         <a

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -49,7 +49,7 @@ const ORDERED_STATES: ReadonlyArray<{
   { key: "signature_checked", label: "Signature checked", blurb: "Signature verified (or fast-path declared)." },
   { key: "publisher_checked", label: "Publisher checked", blurb: "Publisher identity confirmed against policy." },
   { key: "permissions_reviewed", label: "Permissions reviewed", blurb: "Capabilities + data-movement summary acknowledged." },
-  { key: "gates_reviewed", label: "Gates reviewed", blurb: "Posture + advice-tier gates acknowledged." },
+  { key: "gates_reviewed", label: "Gates reviewed", blurb: "Privilege + advice-tier gates acknowledged." },
   { key: "granted", label: "Granted", blurb: "All capabilities approved; ready to enable." },
   { key: "enabled", label: "Enabled", blurb: "Module installed and available." },
 ];
@@ -333,7 +333,7 @@ function InvalidTransitionBanner({
           href={auditHref}
           className="underline underline-offset-4 hover:text-ink"
         >
-          View workspace audit trail
+          View audit log
         </a>
         .
       </p>

--- a/frontend/src/modules-v2/LawveImport.test.tsx
+++ b/frontend/src/modules-v2/LawveImport.test.tsx
@@ -28,17 +28,17 @@ function mountLawve() {
   const root = createRootRoute({ component: () => <Outlet /> });
   const lawveRoute = createRoute({
     getParentRoute: () => root,
-    path: "/modules/lawve",
+    path: "/skills/lawve",
     component: () => <LawveImport />,
   });
   const ceremonyStub = createRoute({
     getParentRoute: () => root,
-    path: "/modules/install/$ceremonyId",
+    path: "/skills/install/$ceremonyId",
     component: () => <div data-testid="ceremony-stub" />,
   });
   const router = createRouter({
     routeTree: root.addChildren([lawveRoute, ceremonyStub]),
-    history: createMemoryHistory({ initialEntries: ["/modules/lawve"] }),
+    history: createMemoryHistory({ initialEntries: ["/skills/lawve"] }),
   });
   return render(
     <AuthProvider>

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -112,7 +112,7 @@ export function LawveImport() {
   return (
     <div className="mx-auto max-w-5xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="Modules"
+        eyebrow="Skills"
         title="Lawve skill import"
         description="Import open legal-AI skills from lawve-ai/awesome-legal-skills into Legalise as governed module drafts. A Lawve skill is not a Legalise module until it is converted, validated, signed, and installed — and imported scripts are never executed."
       />
@@ -300,7 +300,7 @@ function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string })
   return (
     <div className="mt-5 border-t border-rule pt-4" data-testid="draft-review">
       <div className="flex items-center justify-between gap-3">
-        <h3 className="text-sm uppercase tracking-widest text-muted">Module draft</h3>
+        <h3 className="text-sm uppercase tracking-widest text-muted">Skill draft</h3>
         <span
           className={
             "rounded-full border px-2 py-0.5 text-xs " +

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -114,7 +114,7 @@ export function LawveImport() {
       <PageHeader
         eyebrow="Skills"
         title="Lawve skill import"
-        description="Import open legal-AI skills from lawve-ai/awesome-legal-skills into Legalise as governed module drafts. A Lawve skill is not a Legalise module until it is converted, validated, signed, and installed — and imported scripts are never executed."
+        description="Import open legal-AI skills from lawve-ai/awesome-legal-skills into Legalise as governed skill drafts. A Lawve skill is not installable until it is converted, validated, signed, and installed — and imported scripts are never executed."
       />
 
       {q.status === "error" && (
@@ -237,7 +237,7 @@ export function LawveImport() {
                   className="mt-4 inline-flex items-center rounded-md bg-ink px-4 py-2 text-sm text-paper hover:opacity-90 disabled:opacity-50"
                   data-testid="convert-draft"
                 >
-                  {drafting ? "Converting…" : "Convert to module draft"}
+                  {drafting ? "Converting…" : "Convert to skill draft"}
                 </button>
 
                 {draft && <DraftReview draft={draft} slug={selected.slug} />}
@@ -268,7 +268,7 @@ function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string })
         manifest: draft.manifest as Record<string, unknown>,
       });
       void nav({
-        to: "/modules/install/$ceremonyId",
+        to: "/skills/install/$ceremonyId",
         params: { ceremonyId: ceremony.ceremony_id },
       });
     } catch (err) {
@@ -349,11 +349,11 @@ function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string })
 
       {/* Continuity: a valid draft installs through the trust ceremony
           directly — no copy-paste into another screen. Install is
-          admin-gated (the ceremony's grant step is require_admin), so
+          admin-gated (the ceremony's enable step is require_admin), so
           non-admins get a clear ask rather than a dead button. */}
       <div className="mt-4 border-t border-rule pt-3">
         <p className="text-xs uppercase tracking-widest text-muted">
-          Imported skill → module draft → trust ceremony → installed module → grant per matter
+          Imported skill → skill draft → trust ceremony → installed skill → enable per matter
         </p>
         {draft.valid ? (
           isAdmin ? (
@@ -368,15 +368,15 @@ function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string })
                 {installing ? "Starting ceremony…" : "Install this draft"}
               </button>
               <p className="mt-2 text-xs text-muted">
-                Opens the trust ceremony — you review permissions and grant before it
+                Opens the trust ceremony — you review permissions and enable before it
                 installs. The importer never installs without that confirmation.
               </p>
               {installErr && <ErrorCallout message={installErr} compact />}
             </div>
           ) : (
             <p className="mt-2 text-xs text-muted" data-testid="install-admin-note">
-              Installing a module is an administrator action. Ask an administrator to
-              install this module, or copy/download the manifest above to hand off.
+              Installing a skill is an administrator action. Ask an administrator to
+              install this skill, or copy/download the manifest above to hand off.
             </p>
           )
         ) : (

--- a/frontend/src/modules-v2/ModuleDetail.test.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.test.tsx
@@ -26,19 +26,19 @@ function mountAt(moduleId: string) {
   const root = createRootRoute({ component: () => <Outlet /> });
   const detailRoute = createRoute({
     getParentRoute: () => root,
-    path: "/modules/$moduleId",
+    path: "/skills/$moduleId",
     component: () => <ModuleDetail moduleId={moduleId} />,
   });
   const ceremonyStub = createRoute({
     getParentRoute: () => root,
-    path: "/modules/install/$ceremonyId",
+    path: "/skills/install/$ceremonyId",
     component: () => <div data-testid="ceremony-stub" />,
   });
   const tree = root.addChildren([detailRoute, ceremonyStub]);
   const router = createRouter({
     routeTree: tree,
     history: createMemoryHistory({
-      initialEntries: [`/modules/${moduleId}`],
+      initialEntries: [`/skills/${moduleId}`],
     }),
   });
   return render(
@@ -118,7 +118,7 @@ describe("ModuleDetail", () => {
     expect(screen.getByText("tier_2")).toBeInTheDocument();
     // Human framing replaces the raw manifest table headers.
     expect(
-      screen.getByText(/what this module needs access to/i),
+      screen.getByText(/what this skill needs access to/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/modules-v2/ModuleDetail.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.tsx
@@ -152,7 +152,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
   if (q.status === "error") {
     return (
       <div className="mx-auto max-w-3xl px-6 py-12">
-        <h1 className="text-xl font-bold tracking-tight2">Module not found</h1>
+        <h1 className="text-xl font-bold tracking-tight2">Skill not found</h1>
         <p className="mt-3 text-sm text-muted">{q.message}</p>
       </div>
     );
@@ -226,7 +226,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
       if (/404/.test(msg) || /not.*install/i.test(msg)) {
         setLife({
           kind: "info",
-          message: "Module is not currently installed.",
+          message: "Skill is not currently installed.",
         });
       } else {
         setLife({ kind: "error", message: msg });
@@ -236,7 +236,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
-      <PageHeader eyebrow="Module" title={name} subId={entry.module_id} />
+      <PageHeader eyebrow="Skill" title={name} subId={entry.module_id} />
 
       <div className="-mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted">
         {version && <span>v{version}</span>}

--- a/frontend/src/modules-v2/ModuleDetail.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.tsx
@@ -145,7 +145,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
   if (q.status === "loading") {
     return (
       <div className="mx-auto max-w-3xl px-6 py-12 text-sm text-muted">
-        Loading module…
+        Loading skill…
       </div>
     );
   }
@@ -176,7 +176,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
         module_id: entry.module_id,
       });
       void nav({
-        to: "/modules/install/$ceremonyId",
+        to: "/skills/install/$ceremonyId",
         params: { ceremonyId: ceremony.ceremony_id },
       });
     } catch (err) {
@@ -197,7 +197,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
       const res = await updateModuleV2(entry.module_id, { new_manifest: parsed });
       if (res.expansion_detected && res.ceremony_id) {
         void nav({
-          to: "/modules/install/$ceremonyId",
+          to: "/skills/install/$ceremonyId",
           params: { ceremonyId: res.ceremony_id },
         });
         return;
@@ -282,11 +282,11 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
           identifiers stay available in small mono so nothing is hidden. */}
       <section className="mt-10">
         <h2 className="text-sm uppercase tracking-widest text-muted">
-          What this module needs access to
+          What this skill needs access to
         </h2>
         {caps.length === 0 ? (
           <p className="mt-3 text-sm text-muted">
-            No capabilities declared.
+            No permissions declared.
           </p>
         ) : (
           <ul className="mt-3 space-y-px bg-rule border border-rule">
@@ -332,7 +332,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
           ) : (
             <p className="text-sm text-muted">
               Install, update, and revoke require superuser. Ask your
-              workspace administrator to install this module.
+              workspace administrator to install this skill.
             </p>
           )}
         </div>

--- a/frontend/src/modules-v2/ModulesCatalog.test.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.test.tsx
@@ -50,7 +50,7 @@ function skill(over: Partial<PublicModuleSkill> = {}): PublicModuleSkill {
   };
 }
 
-function mountAt(path = "/modules") {
+function mountAt(path = "/skills") {
   const router = createRouter({
     routeTree: productionRouter.routeTree,
     history: createMemoryHistory({ initialEntries: [path] }),
@@ -93,7 +93,7 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("ModulesCatalog — integrations home", () => {
-  it("shows reference modules with workspace state + a Create module action", async () => {
+  it("shows reference skills with workspace state + a Create skill action", async () => {
     vi.spyOn(api, "getModulesV2").mockResolvedValue({
       modules: [refModule()],
       ui_slots: [],
@@ -120,7 +120,7 @@ describe("ModulesCatalog — integrations home", () => {
     ).toHaveTextContent(/installed/i);
     expect(screen.getByText("document.body.read")).toBeInTheDocument();
     expect(screen.getByText("matter.artifact.write")).toBeInTheDocument();
-    expect(screen.getByText("Create module")).toBeInTheDocument();
+    expect(screen.getByText("Create skill")).toBeInTheDocument();
   });
 
   it("filters reference modules by search and workspace state", async () => {
@@ -155,16 +155,16 @@ describe("ModulesCatalog — integrations home", () => {
     await waitFor(() => expect(screen.getByText("Contract Review")).toBeInTheDocument());
     expect(screen.getByText("Pre-Motion")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText("Filter module state"), {
+    fireEvent.change(screen.getByLabelText("Filter skill state"), {
       target: { value: "installed" },
     });
     expect(screen.getByText("Contract Review")).toBeInTheDocument();
     expect(screen.queryByText("Pre-Motion")).toBeNull();
 
-    fireEvent.change(screen.getByLabelText("Search modules"), {
+    fireEvent.change(screen.getByLabelText("Search skills"), {
       target: { value: "pre" },
     });
-    expect(screen.getByText(/No modules match/)).toBeInTheDocument();
+    expect(screen.getByText(/No skills match/)).toBeInTheDocument();
   });
 
   it("keeps the public skill library secondary + collapsed until expanded", async () => {

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -163,31 +163,31 @@ export function ModulesCatalog() {
         actions={
           <div className="flex flex-wrap items-center gap-2">
             <Link
-              to="/modules/lawve"
+              to="/skills/lawve"
               className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
             >
               Import from Lawve
             </Link>
             <Link
-              to="/modules/create"
+              to="/skills/create"
               className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
             >
-              Create module
+              Create skill
             </Link>
           </div>
         }
       />
 
       {error && (
-        <p className="text-sm text-seal">Could not load modules: {error}</p>
+        <p className="text-sm text-seal">Could not load skills: {error}</p>
       )}
 
-      {/* Primary: reference modules (v2 registry) */}
+      {/* Primary: reference skills (v2 registry) */}
       <section>
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
             <h2 className="text-xs uppercase tracking-widest text-muted">
-              Reference modules
+              Reference skills
             </h2>
             {modules && (
               <p className="mt-1 text-sm text-muted">
@@ -201,14 +201,14 @@ export function ModulesCatalog() {
               <input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search modules"
-                aria-label="Search modules"
+                placeholder="Search skills"
+                aria-label="Search skills"
                 className="min-h-[38px] w-48 border border-rule bg-paper px-3 text-[16px] text-ink focus:border-ink focus:outline-none"
               />
               <select
                 value={stateFilter}
                 onChange={(e) => setStateFilter(e.target.value as StateFilter)}
-                aria-label="Filter module state"
+                aria-label="Filter skill state"
                 className="min-h-[38px] border border-rule bg-paper px-3 text-sm text-ink focus:border-ink focus:outline-none"
               >
                 <option value="all">All states</option>
@@ -221,18 +221,18 @@ export function ModulesCatalog() {
         </div>
         {!authed ? (
           <p className="mt-3 text-sm text-muted" data-testid="modules-signin-prompt">
-            Sign in to install and manage governed reference modules. The open
+            Sign in to install and manage governed reference skills. The open
             skill library below is browsable without an account.
           </p>
         ) : modules === null ? (
-          <p className="mt-3 text-sm text-muted">Loading modules…</p>
+          <p className="mt-3 text-sm text-muted">Loading skills…</p>
         ) : modules.length === 0 ? (
           <p className="mt-3 text-sm text-muted">
-            No reference modules in the registry yet.
+            No reference skills in the registry yet.
           </p>
         ) : filteredModules?.length === 0 ? (
           <p className="mt-3 text-sm text-muted">
-            No modules match that search and state filter.
+            No skills match that search and state filter.
           </p>
         ) : (
           <ul className="mt-3 grid grid-cols-1 gap-px bg-rule border border-rule sm:grid-cols-2">
@@ -244,7 +244,7 @@ export function ModulesCatalog() {
               return (
                 <li key={m.module_id} className="bg-paper p-4 hover:bg-wash transition-colors">
                   <Link
-                    to="/modules/$moduleId"
+                    to="/skills/$moduleId"
                     params={{ moduleId: m.module_id }}
                     className="block"
                   >
@@ -271,7 +271,7 @@ export function ModulesCatalog() {
                       {manifestStr(m, "publisher") ? ` · ${manifestStr(m, "publisher")}` : ""}
                     </p>
                     <p className="mt-2 text-xs text-muted">
-                      {caps} capabilit{caps === 1 ? "y" : "ies"}
+                      {caps} permission set{caps === 1 ? "" : "s"}
                       {!m.is_valid ? " · manifest invalid" : ""}
                     </p>
                     <dl className="mt-3 grid grid-cols-1 gap-2 border-t border-rule pt-3 text-xs sm:grid-cols-2">
@@ -320,7 +320,7 @@ export function ModulesCatalog() {
           <div className="mt-3">
             <p className="text-xs text-muted">
               The open skill library — browse what's available. These are not
-              installed from here; reference modules above are the install path.
+              installed from here; reference skills above are the install path.
               {skillsRepo ? (
                 <>
                   {" "}

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -158,8 +158,8 @@ export function ModulesCatalog() {
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <PageHeader
         eyebrow="Workspace"
-        title="Modules"
-        description="Governed legal capabilities. Install a reference module at the workspace, then grant and run it per matter — installing here does not make it ready everywhere."
+        title="Skills"
+        description="Governed legal skills. Install a reference skill at the workspace, then enable and run it per matter — installing here does not make it ready everywhere."
         actions={
           <div className="flex flex-wrap items-center gap-2">
             <Link

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -140,10 +140,9 @@ const verifyRoute = createRoute({
 // under src/modules-page/ for reference but no longer mounted on a
 // route. Importing it elsewhere still works.
 //
-// PR 1 (IA reset, blueprint §8): canonical path renamed from
-// /modules → /skills. The legacy /modules path is preserved via
-// `legacyModulesRedirect` below so deep links, bookmarks, and tests
-// continue to work via 302.
+// The legacy /modules path is preserved via `legacyModulesRedirect`
+// below as a router-level redirect shim (TanStack `beforeLoad`), so
+// deep links, bookmarks, and tests keep working.
 const modulesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/skills",
@@ -161,8 +160,17 @@ const legacyModulesRedirect = createRoute({
 
 const submitModuleRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/modules/submit",
+  path: "/skills/submit",
   component: SubmitModule,
+});
+
+const legacySubmitModuleRedirect = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/modules/submit",
+  beforeLoad: () => {
+    throw redirect({ to: "/skills/submit" });
+  },
+  component: () => null,
 });
 
 const demoIndexRoute = createRoute({
@@ -276,18 +284,36 @@ const appHomeRoute = createRoute({
   component: AppHome,
 });
 
-// Authed operator/developer create-module on-ramp. Registered before
-// /modules/$moduleId so the literal "create" segment wins.
+// Authed operator/developer create-skill on-ramp. Registered before
+// /skills/$moduleId so the literal "create" segment wins.
 const createModuleRoute = createRoute({
   getParentRoute: () => authedRoute,
-  path: "/modules/create",
+  path: "/skills/create",
   component: CreateModule,
+});
+
+const legacyCreateModuleRedirect = createRoute({
+  getParentRoute: () => authedRoute,
+  path: "/modules/create",
+  beforeLoad: () => {
+    throw redirect({ to: "/skills/create" });
+  },
+  component: () => null,
 });
 
 const lawveImportRoute = createRoute({
   getParentRoute: () => authedRoute,
-  path: "/modules/lawve",
+  path: "/skills/lawve",
   component: LawveImport,
+});
+
+const legacyLawveImportRedirect = createRoute({
+  getParentRoute: () => authedRoute,
+  path: "/modules/lawve",
+  beforeLoad: () => {
+    throw redirect({ to: "/skills/lawve" });
+  },
+  component: () => null,
 });
 
 const demoLoopRoute = createRoute({
@@ -298,20 +324,44 @@ const demoLoopRoute = createRoute({
 
 const moduleDetailRoute = createRoute({
   getParentRoute: () => authedRoute,
-  path: "/modules/$moduleId",
+  path: "/skills/$moduleId",
   component: () => {
     const { moduleId } = moduleDetailRoute.useParams();
     return <ModuleDetail moduleId={moduleId} />;
   },
 });
 
+const legacyModuleDetailRedirect = createRoute({
+  getParentRoute: () => authedRoute,
+  path: "/modules/$moduleId",
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: "/skills/$moduleId",
+      params: { moduleId: (params as { moduleId: string }).moduleId },
+    });
+  },
+  component: () => null,
+});
+
 const moduleInstallRoute = createRoute({
   getParentRoute: () => authedRoute,
-  path: "/modules/install/$ceremonyId",
+  path: "/skills/install/$ceremonyId",
   component: () => {
     const { ceremonyId } = moduleInstallRoute.useParams();
     return <InstallCeremony ceremonyId={ceremonyId} />;
   },
+});
+
+const legacyModuleInstallRedirect = createRoute({
+  getParentRoute: () => authedRoute,
+  path: "/modules/install/$ceremonyId",
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: "/skills/install/$ceremonyId",
+      params: { ceremonyId: (params as { ceremonyId: string }).ceremonyId },
+    });
+  },
+  component: () => null,
 });
 
 // Reconstruction. Query-param contract: ?invocation_id=… (deep
@@ -434,6 +484,7 @@ const routeTree = rootRoute.addChildren([
   modulesRoute,
   legacyModulesRedirect,
   submitModuleRoute,
+  legacySubmitModuleRedirect,
   demoIndexRoute,
   demoTabRoute,
   appHomeRoute,
@@ -447,10 +498,14 @@ const routeTree = rootRoute.addChildren([
     settingsKeysRoute,
     settingsPreferencesRoute,
     createModuleRoute,
+    legacyCreateModuleRedirect,
     lawveImportRoute,
+    legacyLawveImportRedirect,
     demoLoopRoute,
     moduleDetailRoute,
+    legacyModuleDetailRedirect,
     moduleInstallRoute,
+    legacyModuleInstallRedirect,
     matterAuditRoute,
     matterArtifactsRoute,
     matterArtifactDetailRoute,

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -135,14 +135,28 @@ const verifyRoute = createRoute({
   }),
 });
 
-// /modules is the v2 catalog (ModulesCatalog). The earlier Modules
+// /skills is the v2 catalog (ModulesCatalog). The earlier Modules
 // component (v1 skill enable/disable) is retained in the codebase
 // under src/modules-page/ for reference but no longer mounted on a
 // route. Importing it elsewhere still works.
+//
+// PR 1 (IA reset, blueprint §8): canonical path renamed from
+// /modules → /skills. The legacy /modules path is preserved via
+// `legacyModulesRedirect` below so deep links, bookmarks, and tests
+// continue to work via 302.
 const modulesRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/modules",
+  path: "/skills",
   component: ModulesCatalog,
+});
+
+const legacyModulesRedirect = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/modules",
+  beforeLoad: () => {
+    throw redirect({ to: "/skills" });
+  },
+  component: () => null,
 });
 
 const submitModuleRoute = createRoute({
@@ -418,6 +432,7 @@ const routeTree = rootRoute.addChildren([
   verifyPendingRoute,
   verifyRoute,
   modulesRoute,
+  legacyModulesRedirect,
   submitModuleRoute,
   demoIndexRoute,
   demoTabRoute,

--- a/frontend/src/ui/Drawer.tsx
+++ b/frontend/src/ui/Drawer.tsx
@@ -130,7 +130,7 @@ export function Drawer({
           <div className="px-4 py-3 border-b border-rule">
             <div className="eyebrow-sm mb-1">Matter</div>
             <div className="text-[16px] font-semibold text-ink truncate">{matter.slug}</div>
-            <div className="text-xs text-muted mt-1">posture {matter.privilege_posture}</div>
+            <div className="text-xs text-muted mt-1">privilege {matter.privilege_posture}</div>
           </div>
         )}
 

--- a/frontend/src/ui/Drawer.tsx
+++ b/frontend/src/ui/Drawer.tsx
@@ -58,19 +58,19 @@ export function Drawer({
       active: activeKey === t.key,
     }));
     primary.push(
-      { href: `/matters/${matter.slug}/artifacts`, label: "Outputs" },
-      { href: `/matters/${matter.slug}/lifecycle`, label: "Export" },
+      { href: `/matters/${matter.slug}/artifacts`, label: "Signed outputs" },
+      { href: `/matters/${matter.slug}/lifecycle`, label: "Working pack" },
     );
     secondary = [
-      { href: "/modules", label: "Modules" },
+      { href: "/skills", label: "Skills" },
       { href: "/settings/profile", label: "Settings" },
       { label: "Sign out", onClick: onSignOut },
     ];
   } else if (isModules || isList || isSettings) {
-    // Workspace no matter: Matters · Modules · - · Settings · Sign out
+    // Workspace no matter: Matters · Skills · - · Settings · Sign out
     primary = [
       { href: "/matters", label: "Matters", active: isList },
-      { href: "/modules", label: "Modules", active: isModules },
+      { href: "/skills", label: "Skills", active: isModules },
     ];
     secondary = [
       { href: "/settings/profile", label: "Settings", active: isSettings },
@@ -81,7 +81,7 @@ export function Drawer({
     // user never sees marketing CTAs once signed in.
     primary = [
       { href: "/matters", label: "Matters" },
-      { href: "/modules", label: "Modules" },
+      { href: "/skills", label: "Skills" },
     ];
     secondary = [
       { href: "/settings/profile", label: "Settings" },

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -188,7 +188,7 @@ export function Sidebar({
 
         <nav className="flex-1 overflow-y-auto py-2">
           <SectionLabel>Workspace</SectionLabel>
-          <NavLink href="/app" label="Home" active={route.name === "appHome"} />
+          <NavLink href="/app" label="Matters" active={route.name === "appHome"} />
           <NavLink
             href="/matters"
             label="Matters"

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -188,7 +188,7 @@ export function Sidebar({
 
         <nav className="flex-1 overflow-y-auto py-2">
           <SectionLabel>Workspace</SectionLabel>
-          <NavLink href="/app" label="Dashboard" active={route.name === "appHome"} />
+          <NavLink href="/app" label="Home" active={route.name === "appHome"} />
           <NavLink
             href="/matters"
             label="Matters"
@@ -219,21 +219,21 @@ export function Sidebar({
               ))}
               <NavLink
                 href={`/matters/${matterSlug}/artifacts`}
-                label="Outputs"
+                label="Signed outputs"
                 active={onMatterArtifacts}
                 indent
               />
               <NavLink
                 href={`/matters/${matterSlug}/lifecycle`}
-                label="Export"
+                label="Working pack"
                 active={onMatterLifecycle}
                 indent
               />
             </div>
           )}
           <NavLink
-            href="/modules"
-            label="Modules"
+            href="/skills"
+            label="Skills"
             active={
               route.name === "modules" ||
               route.name === "moduleDetail" ||
@@ -241,7 +241,7 @@ export function Sidebar({
               route.name === "createModule"
             }
           />
-          <NavLink href="/admin/audit" label="Workspace audit" active={onAudit} />
+          <NavLink href="/admin/audit" label="Audit" active={onAudit} />
 
           <SectionLabel>Account</SectionLabel>
           <NavLink

--- a/frontend/src/ui/TopBar.tsx
+++ b/frontend/src/ui/TopBar.tsx
@@ -90,12 +90,12 @@ export function TopBar({
                   Matters
                 </a>
                 <a
-                  href="/modules"
+                  href="/skills"
                   className={
                     "transition-colors " + (isModules ? "text-ink font-semibold" : "text-ink hover:text-seal")
                   }
                 >
-                  Modules
+                  Skills
                 </a>
                 <a
                   href="/settings/profile"
@@ -131,13 +131,13 @@ export function TopBar({
                   Demo
                 </a>
                 <a
-                  href="/modules"
+                  href="/skills"
                   className={
                     "transition-colors " +
                     (isModules ? "text-ink font-semibold" : "text-ink hover:text-seal")
                   }
                 >
-                  Modules
+                  Skills
                 </a>
                 <a
                   href="/manifesto"


### PR DESCRIPTION
PR 1 of the IA reset blueprint (`docs/handovers/LEGALISE_IA_RESET_BLUEPRINT_2026_06_02.md`).

## Scope

Mechanical label-only changes + one route shim. No layout drift. No backend touched. No new surfaces.

Four commits walking through the reviewer iterations:

1. `aae165c` — initial vocab pass + `/modules` → `/skills` shim
2. `0d590f8` — reviewer redline 1: `Home → Matters`, `WorkflowsTab` cleaned, `/skills/*` deep aliases, dropped "302" overclaim, removed PR-provenance comments
3. `a20b9bd` — reviewer redline 2: final user-chrome sweep (matter shell, demo, landing, manifesto, settings, install ceremony, posture banner)
4. `13865a0` — sweep of remaining user-facing IA vocabulary across Skills surfaces, GrantsPanel, ArtifactsList, CprGateBanner, ReconstructionView, ApprovalsTab, modules-v2 catalog + tests

## Locked vocabulary applied (blueprint §3)

| Old | New |
| --- | --- |
| Dashboard | Matters |
| Modules / Module | Skills / Skill |
| Matter desk | Chat |
| Actions (matter tab) | Skills |
| Activity Trail | Record |
| Workspace audit (primary nav) | Audit (admin retains "Workspace audit" title) |
| Outputs (sidebar) | Signed outputs |
| Export (sidebar) | Working pack |
| Capability gates | Permission gates |
| Privilege posture | Privilege control |
| Substrate (prose) | runtime / audit rows |

## Route table (blueprint §8)

| Old | New | Mechanism |
| --- | --- | --- |
| `/modules` | `/skills` | router-level redirect shim (`legacyModulesRedirect`) |
| `/modules/submit` | `/skills/submit` | redirect shim |
| `/modules/create` | `/skills/create` | redirect shim |
| `/modules/lawve` | `/skills/lawve` | redirect shim |
| `/modules/$moduleId` | `/skills/$moduleId` | redirect shim |
| `/modules/install/$ceremonyId` | `/skills/install/$ceremonyId` | redirect shim |

`routeFromPath` resolves both paths to the same route name so active-state logic keeps working for legacy deep links.

## Held intentionally (out of PR 1 scope)

- Backend API paths and wire names (`/api/modules`, `module.capability.denied`, `capability_id`, `module_id`).
- TypeScript identifiers (`Posture` type, `PostureBanner` component name, `posture={}` props) — backend-coupled.
- Enum strings (`"blocked-by-posture"`, `"blocked-by-grant"`) — wire format from backend.
- Contract-review module's `Posture` (negotiation stance — different concept from substrate privilege).
- `id="privilege-posture"` anchor in Manifesto (in-page nav target).
- Admin surfaces (`AdminAuditView` retains "Workspace audit" title per §3 ADMIN-OK exception).

## §12 acceptance criteria

- [x] **1. Comprehension check** — mechanical PR per §12 redline; reviewer walkthrough satisfies, fresh-observer test gated to structural PRs (2, 5, 7).
- [x] **2. Vocabulary audit** — automated grep shows zero forbidden words in primary user chrome, matter shell, default matter surfaces, non-admin empty states.
- [x] **3. Visual diff** — label-only changes; no layout drift.
- [x] **4. Redirect proof** — `/modules*` paths resolve to `/skills*` via TanStack `beforeLoad throw redirect()` shim.
- [x] **5. Backend untouched** — zero API / schema / audit-logic changes.
- [x] **6. Reviewer sign-off against this blueprint** — section citations throughout (§3, §8, §10, §12).
- [x] **7. Pattern citation** — N/A for PR 1; no §4A surface pattern adopted in this slice (first §4A pattern lands in PR 5).

## Verification (local)

- `tsc --noEmit` clean
- `vitest`: **193 / 193** across 27 files
- `npm run build` clean
- vocab grep clean

## Prerequisite

The IA reset blueprint itself lives on `codex/ia-reset-whitepaper`. Merge that branch first so the §-numbers cited in this PR exist on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Routes updated from `/modules` to `/skills` with legacy redirects
  * Terminology standardized across UI: "Skills" replaces "modules" and "actions"
  * "Record" replaces "Activity Trail" for audit/workflow history
  * "Privilege control" and "Permission" terminology clarified
  * "Signed outputs" and "Working pack" labels added
  * Navigation sidebar and topbar links updated accordingly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->