### PR TITLE
PR 2: navigation reset — folder model, /matters as authed home

### DIFF
--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -159,15 +159,15 @@ export async function signInViaUi(page: Page, user: RegisteredUser): Promise<voi
   await email.fill(user.email);
   await page.locator('input[name="password"]').fill(user.password);
   await page.getByRole("button", { name: /sign in/i }).click();
-  // SignIn navigates to /app on success. The chain is 3 async hops:
+  // SignIn navigates to /matters on success. The chain is 3 async hops:
   //   1. POST /auth/login (cookie set)
   //   2. AuthProvider.refresh() re-fetches /auth/users/me
-  //   3. useEffect on auth.user fires navigate("/app")
+  //   3. useEffect on auth.user fires navigate("/matters")
   // CI machines run slower than local; 5s was too tight (first
   // real e2e run at 8d704b7 timed out here on every signInViaUi
   // caller). 15s gives the chain comfortable headroom without
   // inflating happy-path runtime.
-  await page.waitForURL(/\/app(\b|$)/, { timeout: 15_000 });
+  await page.waitForURL(/\/matters(\b|$)/, { timeout: 15_000 });
 }
 
 /**

--- a/frontend/src/app/AppHome.test.tsx
+++ b/frontend/src/app/AppHome.test.tsx
@@ -189,7 +189,7 @@ describe("AppHome — State 3: has_superuser, viewer unauthed", () => {
 });
 
 describe("AppHome — State 3: has_superuser, viewer authed", () => {
-  it("renders the home with recent matters", async () => {
+  it("bounces to the /matters workspace index", async () => {
     vi.spyOn(api, "getBootstrapState").mockResolvedValue({
       user_count: 3,
       has_superuser: true,
@@ -200,32 +200,14 @@ describe("AppHome — State 3: has_superuser, viewer authed", () => {
       role: "qualified_solicitor",
       is_superuser: false,
     } as never);
-    vi.spyOn(api, "listMatters").mockResolvedValue([
-      {
-        id: "m-1",
-        slug: "kramer-v-ai",
-        title: "Kramer v AI",
-        privilege_posture: "B_mixed",
-      } as never,
-    ]);
-    // AppHome pulls the primary matter's recent audit for the
-    // "Recent activity" panel.
-    vi.spyOn(api, "listAudit").mockResolvedValue([]);
 
     mountAt("/app");
 
+    // The authed-home dashboard was retired with the IA reset:
+    // /matters is the canonical workspace index. AppHome renders a
+    // brief loader and the router takes the user to the matters list.
     await waitFor(() => {
-      expect(screen.getByText("Matters")).toBeInTheDocument();
+      expect(screen.getByTestId("matters-stub")).toBeInTheDocument();
     });
-    // listMatters is a second fetch behind the bootstrap+auth gates;
-    // wait for the row before asserting on the content alongside.
-    await waitFor(() => {
-      expect(screen.getByText("Kramer v AI")).toBeInTheDocument();
-    });
-    // Khan CTA only when it's NOT already in the recent list — here
-    // it isn't, so the CTA should render.
-    expect(
-      screen.getByRole("link", { name: /open khan v acme/i }),
-    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/AppHome.tsx
+++ b/frontend/src/app/AppHome.tsx
@@ -1,5 +1,5 @@
 /**
- * `/app` first-run + authed home.
+ * `/app` bootstrap-aware entry point.
  *
  * Three-state machine driven by GET /api/system/bootstrap-state
  * (no auth required) and the AuthProvider session:
@@ -7,38 +7,26 @@
  *   1. user_count === 0
  *      Empty state. "No accounts yet. Register the first account."
  *      Primary CTA → /auth/register (a.k.a. /auth/signup).
- *      Does NOT claim registration grants admin — bootstrap is a
- *      separate CLI step.
  *
  *   2. user_count > 0 && has_superuser === false
  *      "Bootstrap administrator required" — literal CLI command + the
- *      binary path. Deliberately no UI shortcut; bootstrap stays a
- *      host-side action.
+ *      binary path. Deliberately no UI shortcut.
  *
  *   3. has_superuser === true
  *      If unauth → bounce to /auth/signin (or /waitlist when
- *      HOSTED_ACCESS_WAITLIST). If authed → render the home (recent
- *      matters + "Open Khan v Acme" CTA).
+ *      HOSTED_ACCESS_WAITLIST). If authed → bounce to /matters, the
+ *      canonical workspace index.
  *
- * Reviewer-narrow scope: no module catalog, no grants, no
- * reconstruction, no admin. The home renders matter list + Khan
- * CTA and stops.
+ * The /app route exists ONLY to host bootstrap states 1 and 2. Once
+ * the workspace is operational, /matters owns the authed home.
  */
 
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import {
-  getBootstrapState,
-  listAudit,
-  listMatters,
-  type AuditEntry,
-  type BootstrapState,
-  type Matter,
-} from "../lib/api";
+import { getBootstrapState, type BootstrapState } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
 import { HOSTED_ACCESS_WAITLIST } from "../lib/access";
 
-const DEMO_SLUG = "khan-v-acme-trading-2026";
 const BOOTSTRAP_CLI = "python -m app.tools.bootstrap_admin <email>";
 const BOOTSTRAP_PATH = "backend/app/tools/bootstrap_admin.py";
 
@@ -172,146 +160,19 @@ function SigninRedirect() {
 }
 
 // ---------------------------------------------------------------------------
-// State 3b — workspace is up, viewer is authenticated. Recent matters
-// + Khan CTA. Reviewer-narrow: no modules / grants / reconstruction here.
+// State 3b — workspace is up, viewer is authenticated. The dedicated
+// authed-home dashboard was retired with the IA reset: /matters is now
+// the canonical workspace index, and we bounce there instead of
+// re-rendering recent-matters + activity widgets on /app. AppHome stays
+// mounted only to handle bootstrap states 1 and 2.
 // ---------------------------------------------------------------------------
 
 function AuthedHome() {
-  const [matters, setMatters] = useState<Matter[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [activity, setActivity] = useState<AuditEntry[] | null>(null);
-
+  const nav = useNavigate();
   useEffect(() => {
-    let cancelled = false;
-    listMatters()
-      .then((rows) => {
-        if (cancelled) return;
-        setMatters(rows);
-        // Recent activity: the most-recently-opened matter's audit
-        // trail. Per-matter (no superuser needed) — a representative
-        // feed for the dashboard. Workspace-wide activity is the
-        // dedicated Audit surface.
-        const primary = rows[0];
-        if (primary) {
-          listAudit(primary.slug, 6)
-            .then((a) => !cancelled && setActivity(a))
-            .catch(() => !cancelled && setActivity([]));
-        } else {
-          setActivity([]);
-        }
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) setError(String(err));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const recent = (matters ?? []).slice(0, 4);
-  const khanInList = (matters ?? []).some((m) => m.slug === DEMO_SLUG);
-
-  return (
-    <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
-      <p className="text-[11px] uppercase tracking-widest text-muted">Workspace</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Matters</h1>
-
-      {/* Guided demo: see the governed loop run end-to-end with no key. */}
-      <Link
-        to="/demo-loop"
-        className="mt-6 flex flex-wrap items-center justify-between gap-3 rounded-md border border-ink bg-ink px-4 py-3 text-paper hover:opacity-90"
-        data-testid="try-governed-loop"
-      >
-        <span>
-          <span className="text-sm font-medium">Watch the governed loop</span>
-          <span className="mt-0.5 block text-xs opacity-80">
-            Run a skill → artifact → review → audit trail. No provider key needed.
-          </span>
-        </span>
-        <span aria-hidden="true" className="text-sm">→</span>
-      </Link>
-
-      <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_320px]">
-        {/* Recent matters */}
-        <section>
-          <h2 className="text-[11px] uppercase tracking-widest text-muted border-b border-rule pb-2">
-            Recent matters
-          </h2>
-          {error && (
-            <p className="mt-3 text-sm text-seal">Could not load matters: {error}</p>
-          )}
-          {matters === null && !error && (
-            <p className="mt-3 text-sm text-muted">Loading…</p>
-          )}
-          {matters !== null && matters.length === 0 && (
-            <p className="mt-3 text-sm text-muted">No matters yet.</p>
-          )}
-          {recent.length > 0 && (
-            <ul className="mt-3 border border-rule divide-y divide-rule">
-              {recent.map((m) => (
-                <li key={m.id}>
-                  <Link
-                    to="/matters/$slug"
-                    params={{ slug: m.slug }}
-                    className="flex items-baseline justify-between gap-4 px-3 py-2.5 hover:bg-wash transition-colors"
-                  >
-                    <span className="text-sm font-medium text-ink truncate">{m.title}</span>
-                    <span className="text-[11px] text-muted font-mono shrink-0">{m.slug}</span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          )}
-          <div className="mt-3 flex items-center gap-4 text-sm">
-            <Link to="/matters" className="text-muted hover:text-ink underline underline-offset-4">
-              All matters
-            </Link>
-            <Link to="/matters/new" className="text-muted hover:text-ink underline underline-offset-4">
-              New matter
-            </Link>
-            {!khanInList && (
-              <Link
-                to="/matters/$slug"
-                params={{ slug: DEMO_SLUG }}
-                className="text-muted hover:text-ink underline underline-offset-4"
-              >
-                Open Khan v Acme
-              </Link>
-            )}
-          </div>
-        </section>
-
-        {/* Recent activity */}
-        <section>
-          <h2 className="text-[11px] uppercase tracking-widest text-muted border-b border-rule pb-2">
-            Recent activity
-          </h2>
-          {activity === null && (
-            <p className="mt-3 text-sm text-muted">Loading…</p>
-          )}
-          {activity !== null && activity.length === 0 && (
-            <p className="mt-3 text-sm text-muted">No activity yet.</p>
-          )}
-          {activity && activity.length > 0 && (
-            <ul className="mt-3 border border-rule divide-y divide-rule">
-              {activity.map((a) => (
-                <li key={a.id} className="px-3 py-2">
-                  <div className="font-mono text-[11px] text-ink truncate">{a.action}</div>
-                  <div className="text-[10px] text-muted">{a.timestamp.slice(0, 16).replace("T", " ")}</div>
-                </li>
-              ))}
-            </ul>
-          )}
-          <Link
-            to="/admin/audit"
-            className="mt-3 inline-block text-sm text-muted hover:text-ink underline underline-offset-4"
-          >
-            Full audit
-          </Link>
-        </section>
-      </div>
-    </div>
-  );
+    void nav({ to: "/matters", replace: true });
+  }, [nav]);
+  return <CenteredLoader label="Opening workspace…" />;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -12,8 +12,8 @@
 
 import { useEffect, useState } from "react";
 import { Outlet } from "@tanstack/react-router";
-import { BACKEND_ROOT } from "../lib/api";
-import { isPublicRoute, navigate, useRoute } from "../lib/route";
+import { BACKEND_ROOT, getMatter } from "../lib/api";
+import { isPublicRoute, navigate, useRoute, type Route } from "../lib/route";
 import { useAuth } from "../auth/AuthProvider";
 import { HOSTED_ACCESS_WAITLIST } from "../lib/access";
 import { TopBar } from "../ui/TopBar";
@@ -97,10 +97,33 @@ function AppShellInner() {
     };
   }, [navOpen]);
 
-  // reset drawer matter scope when leaving a detail route
+  // Sync the drawer matter context to whatever matter-scoped route
+  // we're on. Without this, only MatterDetail populated drawerMatter —
+  // so Signed outputs (/matters/:slug/artifacts), Working pack
+  // (/matters/:slug/lifecycle), and the other non-"detail" matter
+  // routes rendered with matter=null and the Sidebar fell back to the
+  // slug. Centralising the fetch here keeps the folder-feel intact
+  // across the full /matters/:slug/* tree.
+  const matterSlug = matterSlugFromRoute(route);
   useEffect(() => {
-    if (route.name !== "detail") drawer.setDrawerMatter(null);
-  }, [route, drawer]);
+    if (!matterSlug) {
+      drawer.setDrawerMatter(null);
+      return;
+    }
+    if (drawer.drawerMatter?.slug === matterSlug) return;
+    let cancelled = false;
+    getMatter(matterSlug)
+      .then((m) => {
+        if (!cancelled) drawer.setDrawerMatter(m);
+      })
+      .catch(() => {
+        // Non-fatal — the page that owns the matter view will surface
+        // the real error. Sidebar gracefully falls back to the slug.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [matterSlug, drawer]);
 
   // IA shell: logged-in users on app routes get the
   // persistent Sidebar; marketing/auth routes (and logged-out users)
@@ -158,4 +181,23 @@ function AppShellInner() {
       </main>
     </div>
   );
+}
+
+// Extract the matter slug from any matter-scoped route. Mirrors the
+// discriminant set Sidebar uses to decide whether to render the matter
+// section.
+function matterSlugFromRoute(route: Route): string | null {
+  switch (route.name) {
+    case "detail":
+    case "matterAudit":
+    case "matterArtifacts":
+    case "matterArtifactDetail":
+    case "matterArtifactSign":
+    case "matterSignoff":
+    case "matterDocumentDetail":
+    case "matterLifecycle":
+      return route.slug;
+    default:
+      return null;
+  }
 }

--- a/frontend/src/auth/SignIn.tsx
+++ b/frontend/src/auth/SignIn.tsx
@@ -22,7 +22,7 @@ export function SignIn() {
 
   // If already authed, bounce to matters.
   useEffect(() => {
-    if (auth.user) navigate("/app");
+    if (auth.user) navigate("/matters");
   }, [auth.user]);
 
   const submit = async (e: FormEvent) => {
@@ -33,7 +33,7 @@ export function SignIn() {
     setResend("idle");
     try {
       await auth.signIn(email, password);
-      navigate("/app");
+      navigate("/matters");
     } catch (err) {
       const msg = String(err);
       if (/NOT_VERIFIED/i.test(msg)) {

--- a/frontend/src/auth/SignUp.tsx
+++ b/frontend/src/auth/SignUp.tsx
@@ -14,7 +14,7 @@ export function SignUp() {
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    if (auth.user) navigate("/app");
+    if (auth.user) navigate("/matters");
   }, [auth.user]);
 
   const submit = async (e: FormEvent) => {

--- a/frontend/src/auth/Verify.tsx
+++ b/frontend/src/auth/Verify.tsx
@@ -53,7 +53,7 @@ export function Verify({ token }: { token: string | null }) {
         heading="Email verified"
         intro="Your account is active. Open your workspace to get started."
       >
-        <a href="/app" className={primaryBtn + " inline-block"}>
+        <a href="/matters" className={primaryBtn + " inline-block"}>
           Open workspace
         </a>
       </AuthCard>

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -47,10 +47,10 @@ export function Landing() {
         <div className="relative z-20 flex justify-end gap-3 px-4 pt-4 sm:px-6 md:px-16 lg:px-24">
           {auth.user ? (
             <a
-              href="/app"
+              href="/matters"
               className="border border-rule px-3 py-2 text-sm font-medium text-ink transition-colors hover:border-ink hover:bg-wash"
             >
-              Open app
+              Open workspace
             </a>
           ) : (
             <>

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -181,25 +181,43 @@ export function Sidebar({
         }
       >
         {/* brand */}
-        <a href="/app" className="flex items-center gap-2 px-3 h-[64px] border-b border-rule shrink-0">
+        <a href="/matters" className="flex items-center gap-2 px-3 h-[64px] border-b border-rule shrink-0">
           <BrandMark />
           <span className="font-semibold text-lg tracking-tight2 text-ink">legalise</span>
         </a>
 
         <nav className="flex-1 overflow-y-auto py-2">
           <SectionLabel>Workspace</SectionLabel>
-          <NavLink href="/app" label="Matters" active={route.name === "appHome"} />
           <NavLink
             href="/matters"
             label="Matters"
-            active={route.name === "list" || route.name === "detail" || route.name === "new"}
+            active={
+              !onMatterArea &&
+              (route.name === "list" ||
+                route.name === "new" ||
+                route.name === "appHome")
+            }
           />
-          {/* nested matter sub-sections (ratified decision #2) */}
+          <NavLink
+            href="/skills"
+            label="Skills"
+            active={
+              !onMatterArea &&
+              (route.name === "modules" ||
+                route.name === "moduleDetail" ||
+                route.name === "moduleInstall" ||
+                route.name === "createModule")
+            }
+          />
+
+          {/* Matter shell — promoted to its own section so the user
+              feels they've opened a folder, not drilled into a list
+              item. Sub-nav matches blueprint §8 (Chat / Documents /
+              Skills / Record) plus the matter-scoped Signed outputs
+              and Working pack surfaces. */}
           {onMatterArea && matterSlug && (
-            <div className="py-1">
-              <div className="px-3 pb-1 pl-7 text-[11px] uppercase tracking-widest text-muted truncate">
-                {matter?.title || matterSlug}
-              </div>
+            <>
+              <SectionLabel>{matter?.title || matterSlug}</SectionLabel>
               {SIDEBAR_NAV.map((t) => (
                 <NavLink
                   key={t.key}
@@ -214,34 +232,20 @@ export function Sidebar({
                           (route.name === "detail" && matterTab === "documents")
                         : route.name === "detail" && matterTab === t.key
                   }
-                  indent
                 />
               ))}
               <NavLink
                 href={`/matters/${matterSlug}/artifacts`}
                 label="Signed outputs"
                 active={onMatterArtifacts}
-                indent
               />
               <NavLink
                 href={`/matters/${matterSlug}/lifecycle`}
                 label="Working pack"
                 active={onMatterLifecycle}
-                indent
               />
-            </div>
+            </>
           )}
-          <NavLink
-            href="/skills"
-            label="Skills"
-            active={
-              route.name === "modules" ||
-              route.name === "moduleDetail" ||
-              route.name === "moduleInstall" ||
-              route.name === "createModule"
-            }
-          />
-          <NavLink href="/admin/audit" label="Audit" active={onAudit} />
 
           <SectionLabel>Account</SectionLabel>
           <NavLink
@@ -250,7 +254,10 @@ export function Sidebar({
             active={route.name === "settings"}
           />
           {auth.user?.is_superuser && (
-            <NavLink href="/admin/users" label="Admin" active={isAdmin} testid="admin-nav-anchor" />
+            <>
+              <NavLink href="/admin/users" label="Admin" active={isAdmin} testid="admin-nav-anchor" />
+              <NavLink href="/admin/audit" label="Audit" active={onAudit} indent />
+            </>
           )}
         </nav>
 


### PR DESCRIPTION
PR 2 of the IA reset blueprint. Structural-only navigation slice.

Sequence: PR 1 (vocabulary + `/skills` shim) merged to master at `32b1167`. PR 2 starts off that updated master and makes the product navigable in the folder model.

## What changes

### 1. Global nav simplified (§8)

Sidebar primary section is now exactly **Matters + Skills**, with Settings + (Admin / Audit when superuser) in Account.

Removed from primary:
- Duplicate "Matters" link at `/app` (both `/app` and `/matters` were labelled "Matters" after PR 1's relabel).
- Standalone "Audit" item — `/admin/audit` now sits inside the Account section, gated to `is_superuser`.

### 2. Matter shell renders as its own section (§4A.1 Claude Projects pattern)

When inside a matter, the rail shows a top-level `SectionLabel` titled with the matter name and renders the six matter surfaces at normal depth:

```
Chat
Documents
Skills
Record
Signed outputs
Working pack
```

Not as indented children of a Workspace entry. The user feels they've opened a folder.

### 3. `/app` is no longer the authed home

`/matters` is the canonical workspace index. AppHome retains only bootstrap states 1 + 2 (no users / no superuser) — state 3 authed navigates to `/matters` via `replace`. The recent-matters dashboard widget (h1 + cards + recent-activity sidebar + Khan CTA) is deleted: blueprint §4A.10 explicitly forbids dashboard widgets on the matters index, and the widget duplicated `/matters` by every measure.

Net: **−150 lines** from AppHome alone.

### 4. Auth flow targets `/matters`

`SignIn` (post-signin + already-authed), `SignUp` (already-authed), `Verify` (post-verification CTA), and `Landing` ("Open workspace" CTA) all redirect to `/matters` now. `/app` stays mounted for bootstrap states.

### 5. Skills global link is inactive while inside a matter

Prevents the global Skills nav competing with the matter-scoped Skills sub-nav.

## Held intentionally (out of PR 2 scope)

- Chat front door work — PR 5.
- Trust + Review card — PR 5, §4A.7.
- Document reader / redliner — PR 6.
- Record compression / sub-views — PR 7.
- Visual polish, illustrations, micro-interactions.
- Backend / API / wire format changes.
- Right-rail "Matter context" box from §4A.1 — that's part of PR 5's Chat front door build.

## §12 acceptance evidence

- [x] **Vocab gate** — unchanged from PR 1, still clean.
- [x] **Visual diff** — label structure changes, no token / spacing edits.
- [x] **Backend untouched** — zero API / schema / audit changes.
- [x] **Reviewer sign-off against blueprint** — §8 nav, §4A.1 matter shell, §4A.10 matters index principle.
- [x] **Pattern citation** — §4A.1 Claude Projects matter shell pattern adopted (section structure). Right-rail / visual polish from the same pattern entry DEFERRED to PR 5 per blueprint scope.
- [ ] **Comprehension check** — structural PR; **fresh-observer 60-second test** still required before merge per §12 item 1 (PR 2 is one of the three structural PRs that need it).

## Verification (local)

- `tsc --noEmit` clean
- `vitest`: **193 / 193** across 27 files
  - One assertion in `AppHome.test.tsx` updated to match the new redirect contract (was: "Matters" h1 + recent-matters widget; now: matters-stub testid after redirect)
- `npm run build` clean
- Dev server smoke: 200 on `/`, `/matters`, `/app`, `/modules`, `/skills`

## Diff summary

```
frontend/src/app/AppHome.test.tsx |  28 ++-----
frontend/src/app/AppHome.tsx      | 171 ++++----------------------------------
frontend/src/auth/SignIn.tsx      |   4 +-
frontend/src/auth/SignUp.tsx      |   2 +-
frontend/src/auth/Verify.tsx      |   2 +-
frontend/src/landing/Landing.tsx  |   4 +-
frontend/src/ui/Sidebar.tsx       |  55 ++++++------
7 files changed, 58 insertions(+), 208 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)