### PR TITLE
PR 3: Workspace Skills surface — tabs, compat badge, §4A.5 ceremony anatomy

### DIFF
--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -282,6 +282,17 @@ function PermissionCard({
 }) {
   const caps = Array.isArray(card.capabilities) ? card.capabilities : [];
   const events = Array.isArray(card.audit_events) ? card.audit_events : [];
+
+  // Blueprint §4A.5 step 5: signature/manifest disclosure is collapsed
+  // by default. The trust ceremony stays a multi-step page (the
+  // backend ceremony chain forces it), but the visible review now
+  // matches the Vercel install-pattern anatomy step-for-step:
+  //   1. skill icon + name        (Skill row, top of card)
+  //   2. install-to header        (page eyebrow + title above)
+  //   3. scope picker             (Workspace scope section below)
+  //   4. permissions checklist    (CapabilityChecklist below)
+  //   5. signature/manifest       (SignatureDisclosure, collapsed)
+  //   6. footer cancel/install    (advance buttons in the parent page)
   return (
     <section className="mt-10 rounded-md border border-line p-4">
       <h2 className="text-sm uppercase tracking-widest text-muted">
@@ -296,13 +307,148 @@ function PermissionCard({
           {card.publisher ?? "—"}
           {card.publisher_verified ? " (verified)" : ""}
         </DT>
-        <DT label="Signature">{card.signature_status ?? "—"}</DT>
         <DT label="Visibility">{card.visibility ?? "—"}</DT>
         <DT label="Advice tier max">{card.advice_tier_max ?? "—"}</DT>
-        <DT label="Permission sets">{caps.length}</DT>
         <DT label="Audit events">{events.length}</DT>
       </dl>
+
+      <WorkspaceScopePicker />
+      <CapabilityChecklist capabilities={caps} />
+      <SignatureDisclosure card={card} />
     </section>
+  );
+}
+
+// §4A.5 step 3 — scope picker. The current substrate trusts a skill
+// workspace-wide (no per-matter narrowing at install time; matter
+// enablement is the separate ceremony in PR 4). This input states the
+// honest semantics so the user isn't misled, and is wired as a
+// read-only acknowledgement until matter-scoped trust lands.
+function WorkspaceScopePicker() {
+  return (
+    <div className="mt-4 border-t border-rule pt-4">
+      <p className="text-xs uppercase tracking-widest text-muted">
+        Workspace scope
+      </p>
+      <label className="mt-2 flex items-start gap-2 text-sm">
+        <input
+          type="radio"
+          checked
+          readOnly
+          aria-label="All matters in this workspace"
+          className="mt-1"
+        />
+        <span>
+          <span className="text-ink">All matters in this workspace</span>
+          <span className="mt-0.5 block text-xs text-muted">
+            Per-matter enablement is a separate step inside each matter.
+            Trusting a skill here does not run it anywhere on its own.
+          </span>
+        </span>
+      </label>
+    </div>
+  );
+}
+
+// §4A.5 step 4 — permissions list with checkmarks. Each capability is
+// rendered as a tickable row so the operator can read off what the
+// runtime will enforce, not just count them.
+function CapabilityChecklist({ capabilities }: { capabilities: unknown[] }) {
+  if (capabilities.length === 0) {
+    return (
+      <div className="mt-4 border-t border-rule pt-4">
+        <p className="text-xs uppercase tracking-widest text-muted">
+          Permissions requested
+        </p>
+        <p className="mt-2 text-sm text-muted">
+          This skill declares no permissions.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-4 border-t border-rule pt-4">
+      <p className="text-xs uppercase tracking-widest text-muted">
+        Permissions requested
+      </p>
+      <ul className="mt-2 space-y-1.5 text-sm">
+        {capabilities.map((raw, i) => {
+          const c =
+            raw && typeof raw === "object"
+              ? (raw as Record<string, unknown>)
+              : {};
+          const id = typeof c.id === "string" ? c.id : `capability-${i + 1}`;
+          const kind = typeof c.kind === "string" ? c.kind : null;
+          const reads = Array.isArray(c.reads)
+            ? c.reads.filter((v): v is string => typeof v === "string")
+            : [];
+          const writes = Array.isArray(c.writes)
+            ? c.writes.filter((v): v is string => typeof v === "string")
+            : [];
+          return (
+            <li key={id} className="flex items-start gap-2">
+              <span aria-hidden="true" className="mt-0.5 text-ink">
+                ✓
+              </span>
+              <span>
+                <span className="font-mono text-xs text-ink">{id}</span>
+                {kind && (
+                  <span className="ml-2 text-xs text-muted">({kind})</span>
+                )}
+                {(reads.length > 0 || writes.length > 0) && (
+                  <span className="mt-0.5 block text-xs text-muted">
+                    {reads.length > 0 && `reads ${reads.join(", ")}`}
+                    {reads.length > 0 && writes.length > 0 && " · "}
+                    {writes.length > 0 && `writes ${writes.join(", ")}`}
+                  </span>
+                )}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+// §4A.5 step 5 — signature & manifest disclosure, collapsed by default.
+// Surfaces signer/version/visibility/permission-count without making
+// the operator hunt for them in the audit trail.
+function SignatureDisclosure({
+  card,
+}: {
+  card: CeremonyResponse["permission_card"];
+}) {
+  const [open, setOpen] = useState(false);
+  const caps = Array.isArray(card.capabilities) ? card.capabilities : [];
+  return (
+    <div className="mt-4 border-t border-rule pt-4">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        data-testid="ceremony-signature-disclosure"
+        className="flex w-full items-center justify-between text-left"
+      >
+        <span className="text-xs uppercase tracking-widest text-muted">
+          Signature &amp; manifest
+        </span>
+        <span aria-hidden="true" className="text-xs text-muted">
+          {open ? "Hide" : "Show"}
+        </span>
+      </button>
+      {open && (
+        <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+          <DT label="Module id">{card.module_id}</DT>
+          <DT label="Signature">{card.signature_status ?? "—"}</DT>
+          <DT label="Publisher">
+            {card.publisher ?? "—"}
+            {card.publisher_verified ? " (verified)" : ""}
+          </DT>
+          <DT label="Permission sets">{caps.length}</DT>
+        </dl>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/modules-v2/ModuleDetail.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.tsx
@@ -297,6 +297,12 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
         )}
       </section>
 
+      {/* Manifest & signature disclosure (blueprint §4A.5 step 5).
+          Collapsed by default; opens to show signer status, version,
+          install metadata, and validity. Nothing is hidden — these
+          fields are all already returned by the substrate. */}
+      <ManifestDisclosure entry={entry} installStatus={installStatus} />
+
       {/* Lifecycle controls */}
       <section className="mt-10">
         <h2 className="text-sm uppercase tracking-widest text-muted">
@@ -451,6 +457,116 @@ function Access({ label, items }: { label: string; items: string[] }) {
     <div>
       <dt className="text-xs uppercase tracking-widest text-muted">{label}</dt>
       <dd className="mt-0.5 font-mono text-xs text-muted">{items.join(", ")}</dd>
+    </div>
+  );
+}
+
+function ManifestDisclosure({
+  entry,
+  installStatus,
+}: {
+  entry: V2ManifestEntry;
+  installStatus: InstallStatus;
+}) {
+  const [open, setOpen] = useState(false);
+  const manifest = entry.manifest as Record<string, unknown>;
+  const version = typeof manifest.version === "string" ? manifest.version : "—";
+  const publisher = typeof manifest.publisher === "string" ? manifest.publisher : "—";
+  const visibility = typeof manifest.visibility === "string" ? manifest.visibility : "—";
+  const sourceUrl = typeof manifest.source_url === "string" ? manifest.source_url : null;
+  const installed = installStatus.kind === "installed" ? installStatus.row : null;
+  const signature = installed?.signature_status ?? "not yet inspected";
+
+  return (
+    <section className="mt-10">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        data-testid="manifest-disclosure-toggle"
+        className="flex w-full items-center justify-between border-b border-rule pb-2 text-left"
+      >
+        <h2 className="text-sm uppercase tracking-widest text-muted">
+          Manifest &amp; signature
+        </h2>
+        <span aria-hidden="true" className="text-xs text-muted">
+          {open ? "Hide" : "Show"}
+        </span>
+      </button>
+      {open && (
+        <dl className="mt-3 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+          <Field label="Module id" value={entry.module_id} mono />
+          <Field label="Version" value={version} mono />
+          <Field label="Publisher" value={publisher} />
+          <Field label="Visibility" value={visibility} />
+          <Field
+            label="Signature"
+            value={signature}
+            mono
+            hint={
+              installStatus.kind === "installed"
+                ? undefined
+                : "Signature is verified at install time."
+            }
+          />
+          <Field
+            label="Manifest"
+            value={entry.is_valid ? "valid" : "invalid"}
+          />
+          {installed && (
+            <>
+              <Field
+                label="Installed"
+                value={new Date(installed.installed_at).toLocaleString()}
+              />
+              <Field
+                label="Installed by"
+                value={installed.installed_by_user_id ?? "—"}
+                mono
+              />
+            </>
+          )}
+          {sourceUrl && (
+            <div className="sm:col-span-2">
+              <dt className="text-xs uppercase tracking-widest text-muted">
+                Source
+              </dt>
+              <dd className="mt-0.5">
+                <a
+                  href={sourceUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="text-sm underline underline-offset-4 hover:text-ink"
+                >
+                  {sourceUrl}
+                </a>
+              </dd>
+            </div>
+          )}
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function Field({
+  label,
+  value,
+  mono = false,
+  hint,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  hint?: string;
+}) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-widest text-muted">{label}</dt>
+      <dd className={"mt-0.5 " + (mono ? "font-mono text-xs" : "text-sm")}>
+        {value}
+      </dd>
+      {hint && <p className="mt-0.5 text-[11px] text-muted">{hint}</p>}
     </div>
   );
 }

--- a/frontend/src/modules-v2/ModulesCatalog.test.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.test.tsx
@@ -152,17 +152,21 @@ describe("ModulesCatalog — integrations home", () => {
     ]);
 
     mountAt();
-    await waitFor(() => expect(screen.getByText("Contract Review")).toBeInTheDocument());
-    expect(screen.getByText("Pre-Motion")).toBeInTheDocument();
-
-    fireEvent.change(screen.getByLabelText("Filter skill state"), {
-      target: { value: "installed" },
-    });
-    expect(screen.getByText("Contract Review")).toBeInTheDocument();
+    // PR 3 (blueprint §7) replaces the state dropdown with three tabs:
+    // Installed / Available / (Revoked, operator-only). Default lands
+    // on Installed; switching to Available exposes the not-yet-installed
+    // skills.
+    await waitFor(() =>
+      expect(screen.getByText("Contract Review")).toBeInTheDocument(),
+    );
     expect(screen.queryByText("Pre-Motion")).toBeNull();
 
+    fireEvent.click(screen.getByTestId("skills-tab-available"));
+    expect(screen.getByText("Pre-Motion")).toBeInTheDocument();
+    expect(screen.queryByText("Contract Review")).toBeNull();
+
     fireEvent.change(screen.getByLabelText("Search skills"), {
-      target: { value: "pre" },
+      target: { value: "zzzzz" },
     });
     expect(screen.getByText(/No skills match/)).toBeInTheDocument();
   });

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -28,7 +28,14 @@ import { PageHeader } from "../ui/primitives";
 import { useAuth } from "../auth/AuthProvider";
 
 type ModuleState = "available" | "installed" | "disabled";
-type StateFilter = "all" | ModuleState;
+type SkillTab = "installed" | "available" | "revoked";
+
+// "disabled" in the substrate (InstalledModule.enabled === false) is the
+// user-facing "Revoked" state per blueprint §7: a skill that was
+// previously trusted in this workspace and is no longer active.
+function tabOf(state: ModuleState): SkillTab {
+  return state === "disabled" ? "revoked" : state;
+}
 
 function manifestStr(entry: V2ManifestEntry, key: string): string | undefined {
   const v = (entry.manifest as Record<string, unknown>)[key];
@@ -68,8 +75,29 @@ function suiteLabel(plugin: string): string {
 const STATE_LABEL: Record<ModuleState, string> = {
   available: "Available",
   installed: "Installed",
-  disabled: "Installed · disabled",
+  disabled: "Revoked",
 };
+
+const TAB_LABEL: Record<SkillTab, string> = {
+  installed: "Installed",
+  available: "Available",
+  revoked: "Revoked",
+};
+
+// Compatibility badge per blueprint §7 Marketplace Compatibility Badge.
+// V1 ships a Claude-native skill format; every skill in the V2 registry
+// is tested against Sonnet 4.6+, so the badge is unconditional here.
+// When the manifest grows a compatibility field it can move to per-skill.
+function CompatibilityBadge() {
+  return (
+    <span
+      title="Tested against Anthropic Claude Sonnet 4.6 or newer. The Legalise substrate is provider-agnostic; the skill format is Claude-native in V1."
+      className="inline-flex items-center gap-1 rounded-full border border-rule px-2 py-0.5 font-mono text-[9px] uppercase tracking-widest text-muted"
+    >
+      Tested with Claude Sonnet 4.6+
+    </span>
+  );
+}
 
 export function ModulesCatalog() {
   // /modules is a public route (anyone can browse). The v2 registry +
@@ -84,7 +112,8 @@ export function ModulesCatalog() {
   const [error, setError] = useState<string | null>(null);
   const [showSkills, setShowSkills] = useState(false);
   const [query, setQuery] = useState("");
-  const [stateFilter, setStateFilter] = useState<StateFilter>("all");
+  const [tab, setTab] = useState<SkillTab>("installed");
+  const isOperator = !!auth.user?.is_superuser;
 
   useEffect(() => {
     let cancelled = false;
@@ -127,8 +156,7 @@ export function ModulesCatalog() {
     if (modules === null) return null;
     const q = query.trim().toLowerCase();
     return modules.filter((m) => {
-      const st = stateOf(m.module_id);
-      if (stateFilter !== "all" && st !== stateFilter) return false;
+      if (tabOf(stateOf(m.module_id)) !== tab) return false;
       if (!q) return true;
       const haystack = [
         m.module_id,
@@ -140,19 +168,28 @@ export function ModulesCatalog() {
         .toLowerCase();
       return haystack.includes(q);
     });
-  }, [installed, modules, query, stateFilter]);
+  }, [installed, modules, query, tab]);
 
-  const stateCounts = useMemo(() => {
-    const counts: Record<ModuleState, number> = {
-      available: 0,
+  const tabCounts = useMemo(() => {
+    const counts: Record<SkillTab, number> = {
       installed: 0,
-      disabled: 0,
+      available: 0,
+      revoked: 0,
     };
     if (modules) {
-      for (const m of modules) counts[stateOf(m.module_id)] += 1;
+      for (const m of modules) counts[tabOf(stateOf(m.module_id))] += 1;
     }
     return counts;
   }, [installed, modules]);
+
+  // Default to Installed if anything is installed, otherwise show
+  // Available so a fresh workspace lands on the discovery view.
+  useEffect(() => {
+    if (modules === null) return;
+    if (tabCounts.installed === 0 && tabCounts.available > 0 && tab === "installed") {
+      setTab("available");
+    }
+  }, [modules, tab, tabCounts.installed, tabCounts.available]);
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
@@ -182,43 +219,59 @@ export function ModulesCatalog() {
         <p className="text-sm text-seal">Could not load skills: {error}</p>
       )}
 
-      {/* Primary: reference skills (v2 registry) */}
+      {/* Primary: reference skills (v2 registry).
+          §7 tab structure: Installed / Available / Revoked
+          (Revoked is operator-only). */}
       <section>
         <div className="flex flex-wrap items-end justify-between gap-3">
-          <div>
-            <h2 className="text-xs uppercase tracking-widest text-muted">
-              Reference skills
-            </h2>
-            {modules && (
-              <p className="mt-1 text-sm text-muted">
-                {stateCounts.installed} installed · {stateCounts.disabled} disabled ·{" "}
-                {stateCounts.available} available
-              </p>
-            )}
-          </div>
+          <h2 className="text-xs uppercase tracking-widest text-muted">
+            Reference skills
+          </h2>
           {authed && modules && modules.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2">
-              <input
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search skills"
-                aria-label="Search skills"
-                className="min-h-[38px] w-48 border border-rule bg-paper px-3 text-[16px] text-ink focus:border-ink focus:outline-none"
-              />
-              <select
-                value={stateFilter}
-                onChange={(e) => setStateFilter(e.target.value as StateFilter)}
-                aria-label="Filter skill state"
-                className="min-h-[38px] border border-rule bg-paper px-3 text-sm text-ink focus:border-ink focus:outline-none"
-              >
-                <option value="all">All states</option>
-                <option value="installed">Installed</option>
-                <option value="available">Available</option>
-                <option value="disabled">Disabled</option>
-              </select>
-            </div>
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search skills"
+              aria-label="Search skills"
+              className="min-h-[38px] w-48 border border-rule bg-paper px-3 text-[16px] text-ink focus:border-ink focus:outline-none"
+            />
           )}
         </div>
+
+        {authed && modules && modules.length > 0 && (
+          <div
+            role="tablist"
+            aria-label="Skill state"
+            className="mt-3 flex border-b border-rule"
+          >
+            {(["installed", "available", ...(isOperator ? (["revoked"] as const) : [])] as SkillTab[]).map(
+              (t) => {
+                const active = tab === t;
+                return (
+                  <button
+                    key={t}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setTab(t)}
+                    data-testid={`skills-tab-${t}`}
+                    className={
+                      "-mb-px border-b-2 px-3 py-2 text-sm font-medium transition-colors " +
+                      (active
+                        ? "border-ink text-ink"
+                        : "border-transparent text-muted hover:text-ink")
+                    }
+                  >
+                    {TAB_LABEL[t]}
+                    <span className="ml-1.5 font-mono text-xs text-muted">
+                      {tabCounts[t]}
+                    </span>
+                  </button>
+                );
+              },
+            )}
+          </div>
+        )}
         {!authed ? (
           <p className="mt-3 text-sm text-muted" data-testid="modules-signin-prompt">
             Sign in to install and manage governed reference skills. The open
@@ -232,7 +285,13 @@ export function ModulesCatalog() {
           </p>
         ) : filteredModules?.length === 0 ? (
           <p className="mt-3 text-sm text-muted">
-            No skills match that search and state filter.
+            {tab === "installed"
+              ? "No skills installed in this workspace yet. Switch to Available to browse the registry."
+              : tab === "revoked"
+                ? "No skills have been revoked in this workspace."
+                : query
+                  ? "No skills match that search."
+                  : "Nothing to install — all reference skills are already trusted in this workspace."}
           </p>
         ) : (
           <ul className="mt-3 grid grid-cols-1 gap-px bg-rule border border-rule sm:grid-cols-2">
@@ -270,6 +329,9 @@ export function ModulesCatalog() {
                       {m.module_id}
                       {manifestStr(m, "publisher") ? ` · ${manifestStr(m, "publisher")}` : ""}
                     </p>
+                    <div className="mt-2">
+                      <CompatibilityBadge />
+                    </div>
                     <p className="mt-2 text-xs text-muted">
                       {caps} permission set{caps === 1 ? "" : "s"}
                       {!m.is_valid ? " · manifest invalid" : ""}


### PR DESCRIPTION
PR 3 of the IA reset blueprint. Reshapes `/skills` into the §7 trust-ceremony surface. No backend changes.

## What's in

### `/skills` index — tabbed catalog (blueprint §7)

Three tabs replace the old state dropdown:
- **Installed** (default) — trusted in this workspace
- **Available** — registry skills not yet installed
- **Revoked** (operator-only) — substrate "disabled" surfaced honestly

Fresh workspaces auto-land on Available so discovery is the first surface, not an empty list. Counts shown per tab. Search scopes to the active tab. Empty states call out the right next action.

### Compatibility badge

`<CompatibilityBadge>` renders **"Tested with Claude Sonnet 4.6+"** on every reference-skill card. Unconditional in V1 per the blueprint V1 Provider Decision — the V2 registry only contains skills tested against that line. Moves to data-driven once the manifest grows a per-skill compatibility field.

### Skill detail — manifest & signature disclosure (§4A.5 step 5)

New collapsed "Manifest & signature" section on `/skills/:id`. Opens to show module_id, version, publisher, visibility, signature_status (from `InstalledModule`), manifest validity, installed-at + installed-by, source URL. Nothing newly fetched — surfaces fields the substrate already returns.

### Install ceremony aligned to §4A.5 anatomy

The backend ceremony chain forces multi-step, so the ceremony stays a full-page stepper rather than a single-shot modal — **explicit §4A.5 deviation, documented in code**. Inside the PermissionCard the §4A.5 step-for-step anatomy lands:

| §4A.5 step | Implementation |
| --- | --- |
| 1. Skill icon + name | existing page eyebrow + title |
| 2. Install-to header | page title above PermissionCard |
| 3. Scope picker | `<WorkspaceScopePicker>` (honest "All matters" semantics; per-matter narrowing is PR 4) |
| 4. Permissions checklist | `<CapabilityChecklist>` ticks each capability with reads/writes (replaces count-only line) |
| 5. Signature/manifest disclosure | `<SignatureDisclosure>` collapsed by default |
| 6. Cancel/Install footer | existing advance buttons |

## Out of scope (held)

- **Per-capability Read-only / Modify** (Stripe §4A.6 variant). Optional in blueprint; substrate capability contract is read-only.
- **Cross-matter revocation cascade visibility**. §11 PR 3 Gate calls for this — current substrate doesn't surface a cross-matter view in one endpoint. Treated as PR 4 territory where the per-matter view exists.
- **Modal-vs-full-page ceremony refactor**. Backend chain forces multi-step; full-page layout is honest. Logged as a §4A.5 deviation in code.
- **Matter-side anything**. Strictly /skills surface.

## Verification (local)

- `tsc --noEmit` clean
- `vitest`: **193 / 193** across 27 files
  - One assertion in `ModulesCatalog.test.tsx` rewired from the dropdown contract to the tab contract
- `npm run build` clean

## §12 acceptance

- [x] Vocab gate: unchanged from PR 1.
- [x] Visual diff: structural, no token edits.
- [x] Backend untouched.
- [x] Pattern citation: §7 (tab structure + badge), §4A.5 (ceremony anatomy with documented full-page deviation), §4A.6 variant intentionally not adopted.
- [ ] **Comprehension check** — PR 3 is mechanical per §12 item 1 redline. Reviewer walkthrough acceptable; fresh-observer gated to structural PRs 2/5/7.

## Diff summary

```
frontend/src/modules-v2/InstallCeremony.tsx     | 150 +++++++++++++++++++++++-
frontend/src/modules-v2/ModuleDetail.tsx        | 116 ++++++++++++++++++
frontend/src/modules-v2/ModulesCatalog.test.tsx |  20 ++--
frontend/src/modules-v2/ModulesCatalog.tsx      | 150 +++++++++++++++++-------
4 files changed, 382 insertions(+), 54 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)