### PR TITLE
PR 5: Chat-first matter surface — Chat is the matter front door

### DIFF
--- a/frontend/src/matter/MatterDetail.tsx
+++ b/frontend/src/matter/MatterDetail.tsx
@@ -56,11 +56,12 @@ export function MatterDetail({ slug }: { slug: string }) {
   // posture banner reads the current user role.
   const auth = useAuth();
   const route = useRoute();
-  // a freshly-opened matter leads with the record
-  // (documents), not the assistant chat (MD-2). The assistant is the
-  // collapsible right rail / its own sidebar item, not the front door.
+  // Bare /matters/:slug lands on Chat — opening a matter feels like
+  // opening a project folder where work happens, with documents and
+  // the record one click away. The previous documents-first default
+  // surfaced the file cabinet before the work, contra blueprint §4A.2.
   const initialTab: TabKey =
-    route.name === "detail" && route.tab && isTabKey(route.tab) ? route.tab : "documents";
+    route.name === "detail" && route.tab && isTabKey(route.tab) ? route.tab : "assistant";
   const [tab, setTab] = useState<TabKey>(initialTab);
 
   // sync tab → drawer label
@@ -69,12 +70,12 @@ export function MatterDetail({ slug }: { slug: string }) {
   }, [tab, onTabChange]);
 
   // Sync tab from path changes (back/forward). Bare /matters/:slug
-  // lands on Documents — the record-first workspace front door.
+  // lands on Chat.
   useEffect(() => {
     if (route.name === "detail" && route.tab && isTabKey(route.tab)) {
       setTab(route.tab);
     } else if (route.name === "detail" && !route.tab) {
-      setTab("documents");
+      setTab("assistant");
     }
   }, [route]);
 

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * AssistantTab — chat skill picker (PR 5).
+ *
+ * Pins the source-of-truth contract: the in-chat picker reads
+ * getMatterWorkflows and shows only workflows already granted on this
+ * matter. No third skill-state model.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { AssistantTab } from "./AssistantTab";
+import * as api from "../../lib/api";
+import type { Matter } from "../../lib/api";
+
+const matter: Matter = {
+  id: "m-1",
+  slug: "khan-v-acme",
+  title: "Khan v Acme",
+  matter_type: "civil",
+  privilege_posture: "B_mixed",
+  required_provider: null,
+  default_model_id: null,
+} as never;
+
+function mountChat(overrides?: { setTabAndHash?: (k: string) => void }) {
+  const setTabAndHash = overrides?.setTabAndHash ?? vi.fn();
+  const root = createRootRoute({ component: () => <Outlet /> });
+  const tab = createRoute({
+    getParentRoute: () => root,
+    path: "/matters/$slug/assistant",
+    component: () => (
+      <AssistantTab
+        matter={matter}
+        docs={[]}
+        chronology={[]}
+        setTabAndHash={setTabAndHash as never}
+        auditCount={0}
+        showPostureInPulse={false}
+      />
+    ),
+  });
+  const router = createRouter({
+    routeTree: root.addChildren([tab]),
+    history: createMemoryHistory({
+      initialEntries: [`/matters/${matter.slug}/assistant`],
+    }),
+  });
+  render(<RouterProvider router={router} />);
+  return { setTabAndHash };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(api, "listAssistantMessages").mockResolvedValue([]);
+  vi.spyOn(api, "postAssistantMessage").mockResolvedValue({
+    user: {
+      id: "u-1",
+      role: "user",
+      content: "",
+      suggested_actions: [],
+      created_at: "",
+    },
+    assistant: {
+      id: "a-1",
+      role: "assistant",
+      content: "",
+      suggested_actions: [],
+      created_at: "",
+    },
+  } as never);
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe("AssistantTab — in-chat skill picker", () => {
+  it("counts and lists only workflows granted on this matter", async () => {
+    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
+      workflows: [
+        {
+          key: "premotion",
+          title: "Pre-Motion",
+          description: "Analyse the dispute.",
+          declared_capabilities: [],
+          granted_capabilities: [],
+          grant: "granted",
+          last_run_at: null,
+          availability: "ok",
+          reason: null,
+        },
+        {
+          key: "letters",
+          title: "Letters",
+          description: "Draft pre-action letters.",
+          declared_capabilities: [],
+          granted_capabilities: [],
+          grant: "granted",
+          last_run_at: null,
+          availability: "ok",
+          reason: null,
+        },
+        // Not granted on this matter — must not appear.
+        {
+          key: "contract-review",
+          title: "Contract Review",
+          description: "Review contracts.",
+          declared_capabilities: [],
+          granted_capabilities: [],
+          grant: "blocked",
+          last_run_at: null,
+          availability: "blocked-by-grant",
+          reason: null,
+        },
+      ],
+    } as never);
+
+    mountChat();
+
+    const toggle = await screen.findByTestId("chat-skills-toggle");
+    await waitFor(() => expect(toggle).toHaveTextContent("Skills (2)"));
+
+    fireEvent.click(toggle);
+    expect(await screen.findByTestId("chat-skills-popover")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-skill-premotion")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-skill-letters")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-skill-contract-review")).toBeNull();
+  });
+
+  it("routes to the picked skill's tab via setTabAndHash", async () => {
+    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
+      workflows: [
+        {
+          key: "premotion",
+          title: "Pre-Motion",
+          description: "Analyse.",
+          declared_capabilities: [],
+          granted_capabilities: [],
+          grant: "granted",
+          last_run_at: null,
+          availability: "ok",
+          reason: null,
+        },
+      ],
+    } as never);
+
+    const setTabAndHash = vi.fn();
+    mountChat({ setTabAndHash });
+
+    fireEvent.click(await screen.findByTestId("chat-skills-toggle"));
+    fireEvent.click(await screen.findByTestId("chat-skill-premotion"));
+
+    expect(setTabAndHash).toHaveBeenCalledWith("premotion");
+  });
+
+  it("shows the empty state and routes to the matter Skills tab when nothing is enabled", async () => {
+    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
+      workflows: [],
+    } as never);
+
+    const setTabAndHash = vi.fn();
+    mountChat({ setTabAndHash });
+
+    const toggle = await screen.findByTestId("chat-skills-toggle");
+    fireEvent.click(toggle);
+
+    expect(
+      await screen.findByText(/No skills enabled on this matter yet/i),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/Enable a skill/i));
+    expect(setTabAndHash).toHaveBeenCalledWith("workflows");
+  });
+
+  it("exposes the ambient Record and Documents links in the header", async () => {
+    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
+      workflows: [],
+    } as never);
+
+    const setTabAndHash = vi.fn();
+    mountChat({ setTabAndHash });
+
+    fireEvent.click(await screen.findByTestId("open-record-link"));
+    expect(setTabAndHash).toHaveBeenCalledWith("audit");
+
+    fireEvent.click(screen.getByTestId("open-documents-link"));
+    expect(setTabAndHash).toHaveBeenCalledWith("documents");
+  });
+});

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -88,9 +88,10 @@ afterEach(() => {
 });
 
 describe("AssistantTab — in-chat skill picker", () => {
-  it("counts and lists only workflows granted on this matter", async () => {
+  it("counts and lists only workflows that are runnable right now", async () => {
     vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
       workflows: [
+        // Granted + ok → primary list, counted.
         {
           key: "premotion",
           title: "Pre-Motion",
@@ -113,11 +114,24 @@ describe("AssistantTab — in-chat skill picker", () => {
           availability: "ok",
           reason: null,
         },
-        // Not granted on this matter — must not appear.
+        // Granted but blocked by privilege state → "Needs attention",
+        // NOT counted in the Skills (N) total.
         {
           key: "contract-review",
           title: "Contract Review",
           description: "Review contracts.",
+          declared_capabilities: [],
+          granted_capabilities: [],
+          grant: "granted",
+          last_run_at: null,
+          availability: "blocked-by-posture",
+          reason: "Privilege state C_paused blocks cloud calls.",
+        },
+        // Not granted on this matter at all → must not appear anywhere.
+        {
+          key: "reviews",
+          title: "Tabular Review",
+          description: "Review tables.",
           declared_capabilities: [],
           granted_capabilities: [],
           grant: "blocked",
@@ -137,7 +151,14 @@ describe("AssistantTab — in-chat skill picker", () => {
     expect(await screen.findByTestId("chat-skills-popover")).toBeInTheDocument();
     expect(screen.getByTestId("chat-skill-premotion")).toBeInTheDocument();
     expect(screen.getByTestId("chat-skill-letters")).toBeInTheDocument();
+    // Granted-but-blocked → in Needs attention, not in primary picker.
     expect(screen.queryByTestId("chat-skill-contract-review")).toBeNull();
+    expect(
+      screen.getByTestId("chat-skill-blocked-contract-review"),
+    ).toBeInTheDocument();
+    // Ungranted → nowhere.
+    expect(screen.queryByTestId("chat-skill-reviews")).toBeNull();
+    expect(screen.queryByTestId("chat-skill-blocked-reviews")).toBeNull();
   });
 
   it("routes to the picked skill's tab via setTabAndHash", async () => {
@@ -166,7 +187,7 @@ describe("AssistantTab — in-chat skill picker", () => {
     expect(setTabAndHash).toHaveBeenCalledWith("premotion");
   });
 
-  it("shows the empty state and routes to the matter Skills tab when nothing is enabled", async () => {
+  it("shows the empty state and routes to the matter Skills tab when nothing is runnable", async () => {
     vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
       workflows: [],
     } as never);
@@ -178,9 +199,9 @@ describe("AssistantTab — in-chat skill picker", () => {
     fireEvent.click(toggle);
 
     expect(
-      await screen.findByText(/No skills enabled on this matter yet/i),
+      await screen.findByText(/Nothing runnable here right now/i),
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByText(/Enable a skill/i));
+    fireEvent.click(screen.getByText(/Open Skills/i));
     expect(setTabAndHash).toHaveBeenCalledWith("workflows");
   });
 
@@ -197,5 +218,43 @@ describe("AssistantTab — in-chat skill picker", () => {
 
     fireEvent.click(screen.getByTestId("open-documents-link"));
     expect(setTabAndHash).toHaveBeenCalledWith("documents");
+  });
+});
+
+describe("AssistantTab — docs loading state", () => {
+  it("shows a loading line while docs are null, then resolves to the count", async () => {
+    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
+      workflows: [],
+    } as never);
+
+    // Mount with docs=null (still fetching). The header must not lie
+    // and claim "No documents yet" — that's the empty state for a
+    // resolved matter with zero documents, not the loading state.
+    const root = createRootRoute({ component: () => <Outlet /> });
+    const tab = createRoute({
+      getParentRoute: () => root,
+      path: "/matters/$slug/assistant",
+      component: () => (
+        <AssistantTab
+          matter={matter}
+          docs={null}
+          chronology={[]}
+          setTabAndHash={vi.fn() as never}
+          auditCount={0}
+          showPostureInPulse={false}
+        />
+      ),
+    });
+    const router = createRouter({
+      routeTree: root.addChildren([tab]),
+      history: createMemoryHistory({
+        initialEntries: [`/matters/${matter.slug}/assistant`],
+      }),
+    });
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByTestId("docs-context-status")).toHaveTextContent(
+      /Loading documents…/i,
+    );
   });
 });

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -15,7 +15,6 @@ import {
 } from "../../lib/api";
 import { InlineSpinner, ProviderKeyMissingBanner, primaryBtn } from "../../ui/primitives";
 import { InlineAgentStatus, MessageBubble } from "../MessageBubble";
-import { MatterPulse } from "../MatterPulse";
 import type { TabKey } from "./types";
 
 interface AssistantTabProps {
@@ -23,18 +22,18 @@ interface AssistantTabProps {
   docs: MatterDocument[] | null;
   chronology: ChronologyEvent[];
   setTabAndHash: (next: TabKey) => void;
-  // Counts for the Matter Pulse strip. Already in scope on the parent.
+  // Retained for back-compat with callers (DemoMatter, MatterDetail).
+  // The Chat front door no longer renders MatterPulse — these are
+  // accepted but ignored.
   auditCount?: number;
-  // Demo / unauth path: pre-resolved granted workflows count so the
-  // pulse doesn't fire a 401-prone fetch.
   workflowsGrantedCount?: number;
+  showPostureInPulse?: boolean;
   // Demo override: prefilled messages + disabled input + custom placeholder.
   initialMessages?: AssistantMessage[];
   disabled?: boolean;
   disabledPlaceholder?: string;
   // Called when a Suggested Action chip is clicked in disabled (demo) mode.
   onDisabledAction?: () => void;
-  showPostureInPulse?: boolean;
 }
 
 // Three concrete first-actions per matter type. Per JOY.md "Suggested
@@ -72,13 +71,14 @@ export function AssistantTab({
   docs,
   chronology,
   setTabAndHash,
-  auditCount,
-  workflowsGrantedCount,
   initialMessages,
   disabled = false,
   disabledPlaceholder,
   onDisabledAction,
-  showPostureInPulse = true,
+  // back-compat — see AssistantTabProps; deliberately unused.
+  auditCount: _auditCount,
+  workflowsGrantedCount: _workflowsGrantedCount,
+  showPostureInPulse: _showPostureInPulse,
 }: AssistantTabProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [messages, setMessages] = useState<AssistantMessage[]>(initialMessages ?? []);
@@ -124,18 +124,23 @@ export function AssistantTab({
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [messages, thinking]);
 
-  // Fetch enabled-in-matter skills for the in-chat picker. Same call
-  // MatterSkillsTab uses, same filter: grant === "granted" + availability
-  // ok. Skipped in demo (disabled) mode to avoid 401s on the unauth path.
+  // Fetch enabled-in-matter skills for the in-chat picker. The
+  // picker keeps two lists separately so the "Skills (N)" count and
+  // primary list reflect only what's actually runnable right now —
+  // grant === "granted" AND availability === "ok". Granted skills
+  // that are blocked by privilege state or a missing permission move
+  // to a quieter "Needs attention" section so the user can see why
+  // without inflating the runnable count.
+  const [needsAttention, setNeedsAttention] = useState<WorkflowState[]>([]);
   useEffect(() => {
     if (disabled) return;
     let cancelled = false;
     void getMatterWorkflows(matter.slug)
       .then((r) => {
         if (cancelled) return;
-        setEnabledSkills(
-          r.workflows.filter((w) => w.grant === "granted"),
-        );
+        const granted = r.workflows.filter((w) => w.grant === "granted");
+        setEnabledSkills(granted.filter((w) => w.availability === "ok"));
+        setNeedsAttention(granted.filter((w) => w.availability !== "ok"));
       })
       .catch(() => undefined);
     return () => {
@@ -263,24 +268,23 @@ export function AssistantTab({
 
   return (
     <div className="mx-auto w-full max-w-[1040px] flex flex-col min-h-[520px]">
-      <div className="mb-6">
-        <MatterPulse
-          matter={matter}
-          documentsCount={docs?.length ?? 0}
-          chronologyCount={chronology.length}
-          auditCount={auditCount ?? 0}
-          workflowsGrantedCount={workflowsGrantedCount}
-          skipFetch={disabled}
-          showPosture={showPostureInPulse}
-        />
+      <div className="mb-4">
+        <h1 className="text-lg font-semibold tracking-tight2 text-ink">
+          {matter.title}
+        </h1>
         {/* Quiet folder context — what's here + where the record lives.
-            Visible at a glance, never dominating the chat surface. */}
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-muted">
+            Single muted line, the only header element on the Chat
+            front door. The old readiness card has been retired here
+            because the project-folder feeling depends on Chat being
+            the surface that loads, not a status dashboard. */}
+        <div className="mt-1 flex flex-wrap items-center justify-between gap-3 text-xs text-muted">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <span>
-              {docs && docs.length > 0
-                ? `${docs.length} document${docs.length === 1 ? "" : "s"} in this matter`
-                : "No documents yet"}
+            <span data-testid="docs-context-status">
+              {docs === null
+                ? "Loading documents…"
+                : docs.length > 0
+                  ? `${docs.length} document${docs.length === 1 ? "" : "s"} in this matter`
+                  : "No documents yet"}
             </span>
             {recentDocs.length > 0 && (
               <span className="flex flex-wrap items-center gap-x-2">
@@ -474,10 +478,10 @@ export function AssistantTab({
                   className="absolute bottom-full left-0 mb-2 border border-rule bg-paper p-3 w-[300px] z-10"
                   data-testid="chat-skills-popover"
                 >
-                  <div className="eyebrow mb-2">Enabled in this matter</div>
+                  <div className="eyebrow mb-2">Run a skill</div>
                   {enabledSkills.length === 0 ? (
                     <p className="text-xs text-muted">
-                      No skills enabled on this matter yet.{" "}
+                      Nothing runnable here right now.{" "}
                       <button
                         type="button"
                         onClick={() => {
@@ -486,54 +490,67 @@ export function AssistantTab({
                         }}
                         className="underline underline-offset-4 hover:text-ink"
                       >
-                        Enable a skill →
+                        Open Skills →
                       </button>
                     </p>
                   ) : (
+                    <ul className="space-y-2">
+                      {enabledSkills.map((w) => (
+                        <li key={w.key}>
+                          <button
+                            type="button"
+                            role="menuitem"
+                            onClick={() => onPickSkill(w)}
+                            className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
+                            data-testid={`chat-skill-${w.key}`}
+                          >
+                            <span className="block text-ink font-medium">
+                              {w.title}
+                            </span>
+                            <span aria-hidden="true" className="text-muted">
+                              →
+                            </span>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  {needsAttention.length > 0 && (
                     <>
-                      <ul className="space-y-2">
-                        {enabledSkills.map((w) => (
-                          <li key={w.key}>
-                            <button
-                              type="button"
-                              role="menuitem"
-                              onClick={() => onPickSkill(w)}
-                              disabled={w.availability !== "ok"}
-                              title={w.reason ?? undefined}
-                              className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink disabled:opacity-50"
-                              data-testid={`chat-skill-${w.key}`}
-                            >
-                              <span>
-                                <span className="block text-ink font-medium">
-                                  {w.title}
-                                </span>
-                                {w.availability !== "ok" && (
-                                  <span className="block text-[10px] text-muted">
-                                    {w.availability === "blocked-by-posture"
-                                      ? "Blocked by privilege state"
-                                      : "Needs permission in this matter"}
-                                  </span>
-                                )}
-                              </span>
-                              <span aria-hidden="true" className="text-muted">
-                                →
-                              </span>
-                            </button>
+                      <div className="mt-3 eyebrow text-muted">
+                        Needs attention
+                      </div>
+                      <ul
+                        className="mt-1 space-y-1"
+                        data-testid="chat-skills-needs-attention"
+                      >
+                        {needsAttention.map((w) => (
+                          <li
+                            key={w.key}
+                            className="text-[11px] text-muted"
+                            data-testid={`chat-skill-blocked-${w.key}`}
+                          >
+                            <span className="block text-ink">{w.title}</span>
+                            <span className="block">
+                              {w.availability === "blocked-by-posture"
+                                ? "Blocked by privilege state"
+                                : "Needs permission in this matter"}
+                            </span>
                           </li>
                         ))}
                       </ul>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setSkillsOpen(false);
-                          setTabAndHash("workflows");
-                        }}
-                        className="mt-3 text-xs text-muted underline underline-offset-4 hover:text-ink"
-                      >
-                        Manage skills →
-                      </button>
                     </>
                   )}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSkillsOpen(false);
+                      setTabAndHash("workflows");
+                    }}
+                    className="mt-3 text-xs text-muted underline underline-offset-4 hover:text-ink"
+                  >
+                    Manage skills →
+                  </button>
                 </div>
               )}
               {attachOpen && recentDocs.length > 0 && (

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import {
+  getMatterWorkflows,
   listAssistantMessages,
   postAssistantMessage,
   ProviderKeyMissingError,
@@ -10,6 +11,7 @@ import {
   type Matter,
   type MatterDocument,
   type SuggestedAction,
+  type WorkflowState,
 } from "../../lib/api";
 import { InlineSpinner, ProviderKeyMissingBanner, primaryBtn } from "../../ui/primitives";
 import { InlineAgentStatus, MessageBubble } from "../MessageBubble";
@@ -87,6 +89,11 @@ export function AssistantTab({
   const [keyMissingProvider, setKeyMissingProvider] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(Boolean(initialMessages));
   const [selectedDocIds, setSelectedDocIds] = useState<Set<string>>(new Set());
+  // In-chat skill picker reads PR 4's source-of-truth: getMatterWorkflows.
+  // Only workflows already granted on this matter appear — the chat
+  // surface never invents skill state.
+  const [enabledSkills, setEnabledSkills] = useState<WorkflowState[]>([]);
+  const [skillsOpen, setSkillsOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   // Initial fetch (skip in demo: initialMessages provided).
@@ -116,6 +123,25 @@ export function AssistantTab({
     if (!scrollRef.current) return;
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [messages, thinking]);
+
+  // Fetch enabled-in-matter skills for the in-chat picker. Same call
+  // MatterSkillsTab uses, same filter: grant === "granted" + availability
+  // ok. Skipped in demo (disabled) mode to avoid 401s on the unauth path.
+  useEffect(() => {
+    if (disabled) return;
+    let cancelled = false;
+    void getMatterWorkflows(matter.slug)
+      .then((r) => {
+        if (cancelled) return;
+        setEnabledSkills(
+          r.workflows.filter((w) => w.grant === "granted"),
+        );
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [matter.slug, disabled]);
 
   const docsById = useMemo(() => {
     const map = new Map<string, MatterDocument>();
@@ -226,6 +252,15 @@ export function AssistantTab({
 
   const [attachOpen, setAttachOpen] = useState(false);
 
+  const onPickSkill = (w: WorkflowState) => {
+    setSkillsOpen(false);
+    if (disabled) {
+      onDisabledAction?.();
+      return;
+    }
+    setTabAndHash(w.key as TabKey);
+  };
+
   return (
     <div className="mx-auto w-full max-w-[1040px] flex flex-col min-h-[520px]">
       <div className="mb-6">
@@ -238,6 +273,53 @@ export function AssistantTab({
           skipFetch={disabled}
           showPosture={showPostureInPulse}
         />
+        {/* Quiet folder context — what's here + where the record lives.
+            Visible at a glance, never dominating the chat surface. */}
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-muted">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span>
+              {docs && docs.length > 0
+                ? `${docs.length} document${docs.length === 1 ? "" : "s"} in this matter`
+                : "No documents yet"}
+            </span>
+            {recentDocs.length > 0 && (
+              <span className="flex flex-wrap items-center gap-x-2">
+                <span aria-hidden="true">·</span>
+                {recentDocs.slice(0, 2).map((d, i) => (
+                  <span key={d.id} className="font-mono truncate max-w-[180px]">
+                    {i > 0 && <span aria-hidden="true" className="mr-2">·</span>}
+                    {d.filename}
+                  </span>
+                ))}
+                {docs && docs.length > 2 && (
+                  <button
+                    type="button"
+                    onClick={() => setTabAndHash("documents")}
+                    className="underline underline-offset-4 hover:text-ink"
+                  >
+                    +{docs.length - 2} more
+                  </button>
+                )}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => setTabAndHash("documents")}
+              className="underline underline-offset-4 hover:text-ink"
+              data-testid="open-documents-link"
+            >
+              Open documents →
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setTabAndHash("audit")}
+            className="underline underline-offset-4 hover:text-ink"
+            data-testid="open-record-link"
+          >
+            View record →
+          </button>
+        </div>
       </div>
       <div
         ref={scrollRef}
@@ -250,15 +332,16 @@ export function AssistantTab({
           </p>
         )}
         {loaded && messages.length === 0 && (
-          <div className="space-y-6 border border-rule bg-paper-sunken p-5">
+          <div className="space-y-6 border border-rule bg-paper-sunken p-5" data-testid="chat-empty-state">
             <div className="text-sm text-prose space-y-2">
               <p>
-                Ask anything about this matter, or run a skill when you need
-                an output to sign.
+                This is the folder for <strong>{matter.title}</strong>. Ask
+                anything about the documents in here, or run a skill enabled
+                on this matter.
               </p>
               <p className="text-xs text-muted">
-                Sources appear as chips below each answer. Material outputs
-                move to Signed outputs for sign-off and export.
+                Sources appear as chips below each answer. Outputs you sign
+                off land in the matter Record.
               </p>
             </div>
             <div>
@@ -376,11 +459,83 @@ export function AssistantTab({
               </button>
               <button
                 type="button"
-                onClick={() => setTabAndHash("workflows")}
+                onClick={() => setSkillsOpen((v) => !v)}
+                aria-expanded={skillsOpen}
+                aria-haspopup="menu"
+                data-testid="chat-skills-toggle"
                 className="font-mono text-[11px] text-muted hover:text-ink transition-colors"
               >
-                Skills
+                Skills{enabledSkills.length > 0 ? ` (${enabledSkills.length})` : ""}
               </button>
+              {skillsOpen && (
+                <div
+                  role="menu"
+                  aria-label="Skills enabled in this matter"
+                  className="absolute bottom-full left-0 mb-2 border border-rule bg-paper p-3 w-[300px] z-10"
+                  data-testid="chat-skills-popover"
+                >
+                  <div className="eyebrow mb-2">Enabled in this matter</div>
+                  {enabledSkills.length === 0 ? (
+                    <p className="text-xs text-muted">
+                      No skills enabled on this matter yet.{" "}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setSkillsOpen(false);
+                          setTabAndHash("workflows");
+                        }}
+                        className="underline underline-offset-4 hover:text-ink"
+                      >
+                        Enable a skill →
+                      </button>
+                    </p>
+                  ) : (
+                    <>
+                      <ul className="space-y-2">
+                        {enabledSkills.map((w) => (
+                          <li key={w.key}>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              onClick={() => onPickSkill(w)}
+                              disabled={w.availability !== "ok"}
+                              title={w.reason ?? undefined}
+                              className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink disabled:opacity-50"
+                              data-testid={`chat-skill-${w.key}`}
+                            >
+                              <span>
+                                <span className="block text-ink font-medium">
+                                  {w.title}
+                                </span>
+                                {w.availability !== "ok" && (
+                                  <span className="block text-[10px] text-muted">
+                                    {w.availability === "blocked-by-posture"
+                                      ? "Blocked by privilege state"
+                                      : "Needs permission in this matter"}
+                                  </span>
+                                )}
+                              </span>
+                              <span aria-hidden="true" className="text-muted">
+                                →
+                              </span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setSkillsOpen(false);
+                          setTabAndHash("workflows");
+                        }}
+                        className="mt-3 text-xs text-muted underline underline-offset-4 hover:text-ink"
+                      >
+                        Manage skills →
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
               {attachOpen && recentDocs.length > 0 && (
                 <div className="absolute bottom-full left-0 mb-2 border border-rule bg-paper p-3 w-[280px] z-10">
                   <div className="eyebrow mb-2">Attach documents</div>

--- a/frontend/src/matter/tabs/types.ts
+++ b/frontend/src/matter/tabs/types.ts
@@ -8,7 +8,7 @@
 // the Skills page; they keep their routes for deep-linking but
 // do not surface as their own sidebar items.
 //
-// Bare /matters/{slug} lands on Documents.
+// Bare /matters/{slug} lands on Chat (the assistant key).
 //
 // User-facing tab labels (Chat / Documents / Skills / Record)
 // intentionally do not match the underlying URL keys


### PR DESCRIPTION
PR 5 of the IA reset blueprint. Implements the tight brief: opening a matter opens its Chat. No backend, no Trust + Review card, no sign-off in chat, no global nav changes.

## What changed (six focused edits)

| # | File | Change |
| --- | --- | --- |
| 1 | `MatterDetail.tsx` | Bare `/matters/:slug` now lands on Chat (`assistant`), not Documents |
| 2 | `tabs/types.ts` | Stale "lands on Documents" comment updated |
| 3 | `AssistantTab.tsx` | In-chat **skill picker popover** reading `getMatterWorkflows` (same source as MatterSkillsTab) |
| 4 | `AssistantTab.tsx` | Quiet **documents context strip** in the header (count + 2 recent filenames + "Open documents →") |
| 5 | `AssistantTab.tsx` | Ambient **"View record →"** link in the header |
| 6 | `AssistantTab.tsx` | Empty-state copy tightened to project-folder framing |
| + | `AssistantTab.test.tsx` (new) | Four focused tests pinning the picker contract |

## The four merge gates from your brief

| Gate | Status |
| --- | --- |
| Matter opens to **Chat first** | ✅ routing flipped + tested |
| Documents **visible but quiet** | ✅ single muted header line, count + 2 recent + link |
| Skills **suggested in-chat, from PR4 state** | ✅ popover reads `getMatterWorkflows`, filter `grant === "granted"`; same derivation MatterSkillsTab uses |
| Trust/Record **ambient, not separate dashboard** | ✅ quiet "View record →" link in header; no proof dashboard built |
| **60-second comprehension test** | 🟦 **needs your walk** — see "How to walk it" below |
| No raw substrate vocab on default | ✅ vocab grep clean (MatterPulse internal identifiers translate to user labels before render, unchanged since PR1) |
| Old chaos absent | ✅ no equal-weight tiles, no dashboard widget, no "matter desk" wording, no exposed substrate vocab |
| Tests green | ✅ 200/200 (+4 from new AssistantTab tests) |

## Hard constraints honored

- ✅ Used `getMatterWorkflows` as the source — no third skill-state model
- ✅ No `listGrants` / `listInstalledModules` fetch added to AssistantTab; the substrate's `grant` field already encodes the matter-level state
- ✅ No sign-off or Record moved into PR5 — only links/ambient status
- ✅ No new backend
- ✅ No decorative redesign — IA + comprehension first; chat layout itself unchanged

## How to walk it (please capture screenshots into the PR thread)

```bash
cd frontend && npm run dev
# Sign in (or use the demo path), then visit:
#   1. /matters → click any matter row
#   2. Expect to land on Chat, NOT Documents
#   3. Header should show: matter title pulse, doc count + recent filenames,
#      "Open documents →" and "View record →" links
#   4. Click "Skills (N)" in the composer footer — popover shows enabled
#      skills only. Click one → routes to its run page.
#   5. Empty matter: empty-state names the matter as a folder; "Try one
#      of these" still works.
```

**Fresh-observer 60s test (the §12 gate):** show the matter to someone who hasn't seen the IA before. In under 60s they must be able to say: *"This is a legal project folder where I can ask questions or run skills against the documents, and everything is recorded."*

If that lands, PR5 is mergeable. If it doesn't, the redline goes against the IA / copy / picker location — not against the architecture.

## Three-gate review

- **Blueprint Gate** — §4A.2 (Chat front door) at IA level. §4A.7 (Trust + Review card) explicitly deferred per your brief. No PR4 surfaces touched. No backend.
- **Comprehension Gate** — needs the fresh-observer walk before merge (see above).
- **Truth Gate** — picker reads `getMatterWorkflows.grant === "granted"`. Workflows with `blocked`/`partial` grants are visibly disabled with the substrate's reason text. The picker can never report "Enabled" for a skill the runtime would refuse.

## Verification (local)

- `tsc --noEmit` clean
- `vitest`: **200 / 200** across 29 files
- `npm run build` clean
- backend untouched

## Diff summary

```
frontend/src/matter/MatterDetail.tsx       |  13 +--
frontend/src/matter/tabs/AssistantTab.tsx  | 169 +++++++++++++++++++++++++++--
frontend/src/matter/tabs/AssistantTab.test.tsx | 201 +++++++ (new)
frontend/src/matter/tabs/types.ts          |   2 +-
4 files changed, 371 insertions(+), 14 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-chat "Skills" picker to run workflows directly from the chat interface with visibility into runnable and blocked skills
  * Blocked skills now display in a "Needs attention" section explaining why they're unavailable

* **Changes**
  * Chat/Assistant tab is now the default landing page when opening a matter
  * Removed status strip from the chat interface
  * Updated chat messaging to reflect the new chat-first experience

* **Tests**
  * Added comprehensive test suite for the in-chat skills functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->