### PR TITLE
PR 6: Document reader — content hero, metadata in Details, source chip honesty

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -1,11 +1,7 @@
-/**
- * Document Workspace v1 — DocumentDetail focused tests.
- *
- * Asserts the honest-rendering contracts: metadata + extracted text +
- * versions render; the body-missing state is honest; and there is NO
- * "download original" / "open source file" button (the original-file
- * gap G1 is surfaced as a note, never a fake button).
- */
+// DocumentDetail focused tests: content is the hero, metadata sits
+// behind the Details disclosure, Open / Download original land on
+// the real proxy URLs, source-anchor honesty banner appears when
+// arrived from Chat, body-missing state is honest.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -39,11 +39,14 @@ function doc(over: Partial<MatterDocument> = {}): MatterDocument {
   };
 }
 
-function mount(documentId = "doc-1") {
+function mount(documentId = "doc-1", search = "") {
   const root = createRootRoute({ component: () => <Outlet /> });
   const detail = createRoute({
     getParentRoute: () => root,
     path: "/matters/$slug/documents/$documentId",
+    validateSearch: (s: Record<string, unknown>) => ({
+      from: typeof s.from === "string" ? s.from : undefined,
+    }),
     component: () => <DocumentDetail slug="khan" documentId={documentId} />,
   });
   const tabStub = createRoute({
@@ -54,7 +57,7 @@ function mount(documentId = "doc-1") {
   const router = createRouter({
     routeTree: root.addChildren([detail, tabStub]),
     history: createMemoryHistory({
-      initialEntries: [`/matters/khan/documents/${documentId}`],
+      initialEntries: [`/matters/khan/documents/${documentId}${search}`],
     }),
   });
   return render(<RouterProvider router={router} />);
@@ -71,7 +74,7 @@ beforeEach(() => {
 afterEach(() => cleanup());
 
 describe("DocumentDetail", () => {
-  it("renders metadata + extracted text + real Open/Download original actions", async () => {
+  it("renders content as the hero, with Open/Download original as secondary actions", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
     vi.spyOn(api, "getDocumentBody").mockResolvedValue({
       document_id: "doc-1",
@@ -88,17 +91,43 @@ describe("DocumentDetail", () => {
     await waitFor(() => {
       expect(screen.getByText("claim-form.pdf")).toBeInTheDocument();
     });
-    expect(screen.getByText("application/pdf")).toBeInTheDocument();
+    // Content is the hero — extracted text visible without any
+    // disclosure being opened first.
     expect(screen.getByText(/IN THE COUNTY COURT/)).toBeInTheDocument();
-    // G1 closed: the old "not available" note is gone, real actions present.
-    expect(
-      screen.queryByText(/original uploaded file isn't available/i),
-    ).toBeNull();
+    // Metadata starts collapsed behind a Details disclosure.
+    expect(screen.queryByText("application/pdf")).toBeNull();
+    // Original-file actions are still present (secondary).
     const open = screen.getByText("Open original");
     const download = screen.getByText("Download original");
     expect(open.getAttribute("href")).toContain("/documents/doc-1/original");
     expect(open.getAttribute("href")).not.toContain("download=1");
     expect(download.getAttribute("href")).toContain("download=1");
+    // Old "not available" note is gone.
+    expect(
+      screen.queryByText(/original uploaded file isn't available/i),
+    ).toBeNull();
+  });
+
+  it("surfaces full metadata once the Details disclosure is opened", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue({
+      document_id: "doc-1",
+      kind: "extracted",
+      extracted_text: "BODY",
+      extraction_method: "pypdf",
+      extracted_at: "2026-05-28T09:01:00",
+      char_count: 4,
+      page_count: 1,
+      error_reason: null,
+    });
+
+    mount();
+    await waitFor(() => {
+      expect(screen.getByText("claim-form.pdf")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("document-details-toggle"));
+    expect(screen.getByText("application/pdf")).toBeInTheDocument();
+    expect(screen.getByText(/a{8}/)).toBeInTheDocument(); // sha prefix
   });
 
   it("shows an honest empty state when no extracted body exists", async () => {
@@ -109,6 +138,27 @@ describe("DocumentDetail", () => {
     await waitFor(() => {
       expect(screen.getByText(/no extracted text/i)).toBeInTheDocument();
     });
+  });
+
+  it("surfaces the source-anchor honesty banner when arrived from chat", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue({
+      document_id: "doc-1",
+      kind: "extracted",
+      extracted_text: "BODY",
+      extraction_method: "pypdf",
+      extracted_at: "2026-05-28T09:01:00",
+      char_count: 4,
+      page_count: 1,
+      error_reason: null,
+    });
+
+    mount("doc-1", "?from=assistant");
+    await waitFor(() => {
+      expect(screen.getByTestId("from-chat-note")).toBeInTheDocument();
+    });
+    // Smart back reflects the arrived-from tab.
+    expect(screen.getByTestId("document-back-link")).toHaveTextContent(/Back to Chat/i);
   });
 
   it("shows not-found when the document is not in the matter", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -12,7 +12,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Link } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
+import type { TabKey } from "./tabs/types";
+import { MATTER_TAB_LABELS, isTabKey } from "./tabs/types";
 import {
   documentOriginalUrl,
   getAnonymisation,
@@ -59,6 +61,25 @@ export function DocumentDetail({
   const [versions, setVersions] = useState<DocumentVersionSummary[]>([]);
   const [anon, setAnon] = useState<AnonymisationResult | null>(null);
   const [showEdit, setShowEdit] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
+
+  // Source-anchor honesty: when arrived from chat, surface a single
+  // line noting that passage-level anchoring isn't yet wired through
+  // the substrate. Without this the user might think a chip click
+  // failed to scroll them anywhere.
+  const fromTab = useRouterState({
+    select: (s) => {
+      const search = s.location.search as Record<string, unknown> | undefined;
+      const raw = search?.from;
+      return typeof raw === "string" && isTabKey(raw) ? (raw as TabKey) : null;
+    },
+  });
+  const backTab: TabKey = fromTab ?? "documents";
+  const backLabel =
+    fromTab && fromTab !== "documents"
+      ? `← Back to ${MATTER_TAB_LABELS[fromTab] ?? "matter"}`
+      : "← Documents";
+  const arrivedFromChat = fromTab === "assistant";
 
   // Metadata: there's no single-document GET; the matter document list
   // is the authoritative source. Find the row by id.
@@ -127,168 +148,207 @@ export function DocumentDetail({
   }
 
   const doc = q.doc;
-  const auditHref = `/matters/${encodeURIComponent(slug)}/audit`;
+  const recordHref = `/matters/${encodeURIComponent(slug)}/audit`;
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
+      {/* Smart back — returns to the matter surface the user came
+          from. ?from=assistant lands here from a chat source chip;
+          everything else falls back to the Documents tab. */}
       <p className="text-xs">
         <Link
           to="/matters/$slug/$tab"
-          params={{ slug, tab: "documents" }}
+          params={{ slug, tab: backTab }}
           className="text-muted underline underline-offset-4 hover:text-ink"
+          data-testid="document-back-link"
         >
-          ← Documents
+          {backLabel}
         </Link>
       </p>
       <PageHeader eyebrow="Document" title={doc.filename} subId={doc.id} />
 
-      <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-        <DescItem label="Type">
-          <span className="font-mono text-xs">{doc.mime_type}</span>
-        </DescItem>
-        <DescItem label="Size">{formatBytes(doc.size_bytes)}</DescItem>
-        <DescItem label="Tag">{doc.tag || "—"}</DescItem>
-        <DescItem label="From disclosure">
-          {doc.from_disclosure ? "Yes (CPR 31)" : "No"}
-        </DescItem>
-        <DescItem label="Uploaded">
-          {doc.uploaded_at.replace("T", " ").slice(0, 19)}
-        </DescItem>
-        <DescItem label="SHA-256">
-          <span className="font-mono text-xs break-all">{doc.sha256}</span>
-        </DescItem>
-      </dl>
+      {arrivedFromChat && (
+        <p
+          className="mt-3 border-l-2 border-rule pl-3 text-xs text-muted"
+          data-testid="from-chat-note"
+        >
+          Opened from Chat. Pinpointing the exact passage isn't supported
+          yet — the document text is shown in full below.
+        </p>
+      )}
 
-      {/* Original file — streamed backend proxy (G1 closed). */}
-      <div className="mt-4 flex flex-wrap items-center gap-3">
+      {/* Content hero — extracted text is the primary surface. Full
+          height, generous container, ready to read. */}
+      <section className="mt-6" data-testid="document-content">
+        {bodyMissing ? (
+          <EmptyState
+            title="No extracted text"
+            body="No extracted body is available for this document (extraction may have failed or not run). The original file is still available below."
+          />
+        ) : !body ? (
+          <LoadingLine label="loading document text" />
+        ) : (
+          <article className="rounded-md border border-rule bg-paper px-5 py-4 text-sm leading-relaxed whitespace-pre-wrap font-sans text-ink">
+            {body.extracted_text || "(empty)"}
+          </article>
+        )}
+      </section>
+
+      {/* Secondary actions — original file open/download. Always
+          available, never the hero. */}
+      <div className="mt-6 flex flex-wrap items-center gap-3 text-xs">
         <a
           href={documentOriginalUrl(documentId)}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
+          className="inline-flex items-center text-muted underline underline-offset-4 hover:text-ink"
+          data-testid="document-open-original"
         >
           Open original
         </a>
         <a
           href={documentOriginalUrl(documentId, { download: true })}
-          className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
+          className="inline-flex items-center text-muted underline underline-offset-4 hover:text-ink"
         >
           Download original
         </a>
-        <span className="text-xs text-muted">Original file access is audited.</span>
+        <span className="text-muted">Original file access is audited.</span>
       </div>
 
-      {/* Extracted text */}
-      <section className="mt-8">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Extracted text
-        </h2>
-        {bodyMissing ? (
-          <div className="mt-3">
-            <EmptyState
-              title="No extracted text"
-              body="No extracted body is available for this document (extraction may have failed or not run)."
-            />
-          </div>
-        ) : !body ? (
-          <LoadingLine label="loading text" />
-        ) : (
-          <>
-            <p className="mt-1 text-xs text-muted">
-              {body.extraction_method} · {body.char_count.toLocaleString()} chars
-              {body.page_count ? ` · ${body.page_count} pages` : ""}
-              {body.error_reason ? ` · ${body.error_reason}` : ""}
-            </p>
-            <pre className="mt-3 max-h-[40vh] overflow-auto rounded-md border border-rule bg-paper px-3 py-2 text-xs whitespace-pre-wrap">
-              {body.extracted_text || "(empty)"}
-            </pre>
-          </>
-        )}
-      </section>
-
-      {/* Versions */}
-      <section className="mt-8">
-        <h2 className="text-sm uppercase tracking-widest text-muted">Versions</h2>
-        {versions.length === 0 ? (
-          <p className="mt-3 text-sm text-muted">No versions recorded.</p>
-        ) : (
-          <ul className="mt-3 space-y-px bg-rule border border-rule">
-            {versions.map((v) => (
-              <li
-                key={v.version.id}
-                className="flex items-baseline justify-between gap-3 bg-paper p-3 text-sm"
-              >
-                <span>
-                  <span className="font-mono text-xs text-muted">
-                    v{v.version.version_number}
-                  </span>{" "}
-                  {v.version.kind}
-                </span>
-                <span className="text-xs text-muted">
-                  {v.pending_count > 0 && `${v.pending_count} pending · `}
-                  {v.version.created_at.replace("T", " ").slice(0, 16)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      {/* Anonymisation */}
-      <section className="mt-8">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Anonymisation
-        </h2>
-        <p className="mt-1 text-xs text-muted">
-          {anon
-            ? `Redacted body available — ${anon.entity_count} entities via ${anon.engine}, ${anon.anonymised_at.replace("T", " ").slice(0, 16)}.`
-            : "No redacted body yet."}
-        </p>
-        <div className="mt-3">
-          <AnonymiseButton
-            documentId={documentId}
-            onResult={(r) => setAnon(r)}
-          />
-        </div>
-      </section>
-
-      {/* Model edits */}
-      <section className="mt-8">
-        <div className="flex items-center justify-between">
+      {/* Details disclosure — metadata, versions, anonymisation, and
+          model edits are accessible but not the hero. The user opens
+          this when they want to drill into provenance; the default
+          surface stays the document content. */}
+      <section className="mt-8 border-t border-rule pt-4">
+        <button
+          type="button"
+          onClick={() => setShowDetails((v) => !v)}
+          aria-expanded={showDetails}
+          data-testid="document-details-toggle"
+          className="flex w-full items-center justify-between text-left"
+        >
           <h2 className="text-sm uppercase tracking-widest text-muted">
-            Model edits
+            Details
           </h2>
-          <button
-            type="button"
-            onClick={() => setShowEdit((v) => !v)}
-            className="text-xs text-muted underline underline-offset-4 hover:text-ink"
-          >
-            {showEdit ? "Hide" : "Open editor"}
-          </button>
-        </div>
-        {showEdit && (
-          <div className="mt-3">
-            <EditPanel
-              documentId={documentId}
-              filename={doc.filename}
-              onClose={() => {
-                setShowEdit(false);
-                loadBody();
-                getDocumentVersions(documentId).then(setVersions).catch(() => undefined);
-              }}
-            />
+          <span aria-hidden="true" className="text-xs text-muted">
+            {showDetails ? "Hide" : "Show"}
+          </span>
+        </button>
+
+        {showDetails && (
+          <div className="mt-4 space-y-8">
+            {body && !bodyMissing && (
+              <p className="text-xs text-muted">
+                {body.extraction_method} · {body.char_count.toLocaleString()} chars
+                {body.page_count ? ` · ${body.page_count} pages` : ""}
+                {body.error_reason ? ` · ${body.error_reason}` : ""}
+              </p>
+            )}
+
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+              <DescItem label="Type">
+                <span className="font-mono text-xs">{doc.mime_type}</span>
+              </DescItem>
+              <DescItem label="Size">{formatBytes(doc.size_bytes)}</DescItem>
+              <DescItem label="Tag">{doc.tag || "—"}</DescItem>
+              <DescItem label="From disclosure">
+                {doc.from_disclosure ? "Yes (CPR 31)" : "No"}
+              </DescItem>
+              <DescItem label="Uploaded">
+                {doc.uploaded_at.replace("T", " ").slice(0, 19)}
+              </DescItem>
+              <DescItem label="SHA-256">
+                <span className="font-mono text-xs break-all">{doc.sha256}</span>
+              </DescItem>
+            </dl>
+
+            <div>
+              <h3 className="text-xs uppercase tracking-widest text-muted">
+                Versions
+              </h3>
+              {versions.length === 0 ? (
+                <p className="mt-2 text-sm text-muted">No versions recorded.</p>
+              ) : (
+                <ul className="mt-2 space-y-px bg-rule border border-rule">
+                  {versions.map((v) => (
+                    <li
+                      key={v.version.id}
+                      className="flex items-baseline justify-between gap-3 bg-paper p-3 text-sm"
+                    >
+                      <span>
+                        <span className="font-mono text-xs text-muted">
+                          v{v.version.version_number}
+                        </span>{" "}
+                        {v.version.kind}
+                      </span>
+                      <span className="text-xs text-muted">
+                        {v.pending_count > 0 && `${v.pending_count} pending · `}
+                        {v.version.created_at.replace("T", " ").slice(0, 16)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <div>
+              <h3 className="text-xs uppercase tracking-widest text-muted">
+                Anonymisation
+              </h3>
+              <p className="mt-1 text-xs text-muted">
+                {anon
+                  ? `Redacted body available — ${anon.entity_count} entities via ${anon.engine}, ${anon.anonymised_at.replace("T", " ").slice(0, 16)}.`
+                  : "No redacted body yet."}
+              </p>
+              <div className="mt-2">
+                <AnonymiseButton
+                  documentId={documentId}
+                  onResult={(r) => setAnon(r)}
+                />
+              </div>
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <h3 className="text-xs uppercase tracking-widest text-muted">
+                  Model edits
+                </h3>
+                <button
+                  type="button"
+                  onClick={() => setShowEdit((v) => !v)}
+                  className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+                >
+                  {showEdit ? "Hide" : "Open editor"}
+                </button>
+              </div>
+              {showEdit && (
+                <div className="mt-2">
+                  <EditPanel
+                    documentId={documentId}
+                    filename={doc.filename}
+                    onClose={() => {
+                      setShowEdit(false);
+                      loadBody();
+                      getDocumentVersions(documentId)
+                        .then(setVersions)
+                        .catch(() => undefined);
+                    }}
+                  />
+                </div>
+              )}
+            </div>
           </div>
         )}
       </section>
 
-      <section className="mt-10 text-sm">
+      <p className="mt-10 text-sm">
         <a
-          href={auditHref}
+          href={recordHref}
           className="text-muted underline underline-offset-4 hover:text-ink"
         >
-          View this matter's audit trail
+          View matter Record →
         </a>
-      </section>
+      </p>
     </div>
   );
 }

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1,15 +1,8 @@
-/**
- * Document Workspace v1 — /matters/{slug}/documents/{document_id}.
- *
- * First-class routed detail page for a matter document. Surfaces only
- * what the substrate actually supports: provenance metadata, extracted
- * text, version history, anonymisation, and model edits. There is
- * deliberately NO "download original" / "open source file" button — the
- * original uploaded bytes are not retrievable via any API today
- * (Document.storage_uri is never exposed; only generated docx stream).
- * That gap is logged in DOCUMENT_WORKSPACE_V1_PLAN.md (G1); we surface an
- * honest note rather than a disabled-fiction button.
- */
+// Matter document reader at /matters/{slug}/documents/{document_id}.
+// Content (extracted text) is the hero; metadata, versions,
+// anonymisation, and model edits live behind a Details disclosure.
+// Open / Download original stream through the documentOriginalUrl
+// proxy and are presented as secondary links beneath the content.
 
 import { useCallback, useEffect, useState } from "react";
 import { Link, useRouterState } from "@tanstack/react-router";

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -19,8 +19,11 @@ interface Props {
   message: AssistantMessage;
   docs: MatterDocument[] | null;
   chronology: ChronologyEvent[];
-  onDocChip: () => void;
-  onChronChip: () => void;
+  // Source-anchor callbacks. The doc callback receives the
+  // document_id from the citation so the chat surface can route
+  // straight to that document, not just to the Documents tab.
+  onDocChip: (documentId: string) => void;
+  onChronChip: (eventId: string) => void;
   onAction?: (a: SuggestedAction) => void;
   compact?: boolean;
 }
@@ -100,7 +103,9 @@ function AssistantMessageView({
               <button
                 key={`${c.kind}-${c.id}-${i}`}
                 type="button"
-                onClick={c.kind === "doc" ? onDocChip : onChronChip}
+                onClick={() =>
+                  c.kind === "doc" ? onDocChip(c.id) : onChronChip(c.id)
+                }
                 title={c.full}
                 className={`inline-flex items-center border border-rule bg-paper text-ink px-2 py-0.5 font-mono ${
                   compact ? "text-[10px]" : "text-[11px]"

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import {
   getMatterWorkflows,
   listAssistantMessages,
@@ -237,8 +238,23 @@ export function AssistantTab({
     if (target) setTabAndHash(target);
   };
 
-  const dispatchDocChip = () => setTabAndHash("documents");
-  const dispatchChronChip = () => setTabAndHash("chronology");
+  // Source-anchor click-through: a document chip in chat takes you
+  // straight to the document reader for that file, not just to the
+  // Documents tab. ?from=assistant tells the reader to surface the
+  // honest note that exact-passage anchoring isn't supported yet.
+  const navigate = useNavigate();
+  const dispatchDocChip = (documentId: string) => {
+    void navigate({
+      to: "/matters/$slug/documents/$documentId",
+      params: { slug: matter.slug, documentId },
+      search: { from: "assistant" },
+    });
+  };
+  // The substrate doesn't yet carry per-event anchoring, so the
+  // chronology chip still drops the user on the Chronology tab.
+  // Accepting the eventId keeps the callback shape future-proof
+  // for when per-event deep links land.
+  const dispatchChronChip = (_eventId: string) => setTabAndHash("chronology");
 
   const suggestions = useMemo(
     () => SUGGESTED_BY_TYPE[matter.matter_type] ?? SUGGESTED_DEFAULT,

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -418,9 +418,15 @@ const matterSignoffRoute = createRoute({
   },
 });
 
+// ?from=<tab> tells DocumentDetail which matter surface to send the
+// user back to. Optional; falls back to Documents when absent.
+type MatterDocumentDetailSearch = { from?: string };
 const matterDocumentDetailRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: "/matters/$slug/documents/$documentId",
+  validateSearch: (s: Record<string, unknown>): MatterDocumentDetailSearch => ({
+    from: typeof s.from === "string" ? s.from : undefined,
+  }),
   component: () => {
     const { slug, documentId } = matterDocumentDetailRoute.useParams();
     return <DocumentDetail slug={slug} documentId={documentId} />;


### PR DESCRIPTION
PR 6 of the IA reset blueprint. Documents feel like first-class project assets, not rows in a database. No backend, no full DOCX/PDF editor, no speculative redliner.

## What the reader now does

1. **Smart back link** — `?from=<tab>` returns the user to the matter surface they came from (Chat / Documents / Record). Falls back to Documents when `?from` is absent.
2. **Eyebrow + filename H1.**
3. **Source-anchor honesty banner** — if arrived from Chat, one muted line: *"Opened from Chat. Pinpointing the exact passage isn't supported yet — the document text is shown in full below."* The substrate has no per-passage offsets; the reader tells the truth.
4. **Content hero** — extracted text in a generous rounded container, sans-font, leading-relaxed, no max-height clamp. The reader IS the document.
5. **Secondary actions** — Open original / Download original as muted text links, not chunky buttons. "Original file access is audited."
6. **Details disclosure (collapsed)** — type / size / SHA-256 / tag / from-disclosure / uploaded + versions + anonymisation + model edits. Operators get everything they need; the document content keeps the stage.
7. **Ambient "View matter Record →"** in the footer.

## Source-chip click-through

Doc chips in chat used to call `setTabAndHash("documents")` — dropped the user on the list, made them hunt. Now:

- `MessageBubble.onDocChip` / `onChronChip` accept the cited entity id.
- `AssistantTab` navigates straight to `/matters/$slug/documents/$documentId?from=assistant`.
- The reader surfaces the honesty banner.
- Chronology chip still drops on the Chronology tab — substrate doesn't carry per-event anchors. Callback shape is future-proof.

## Router

`matterDocumentDetailRoute` gains `validateSearch` for `?from` (type-safe optional string; unknown values dropped silently).

## What PR 6 does NOT do (honest deviations from §4A.3)

- **No full DOCX/PDF rendering.** Extracted text is the hero; download to see the rendered file.
- **No redliner / track-changes / accept-reject UI.** Substrate doesn't carry that data; speculative redliner is out of scope per brief.
- **No pixel-accurate passage scroll.** Substrate doesn't carry per-passage offsets; the banner is honest. When that data lands, the banner becomes a real scroll target.
- **No backend changes.**
- **No changes to Chat, Skills, Record, Sign-off, Export** beyond the chat source-chip routing improvement (which is the explicit "Source anchors from Chat/artifacts should click through to this reader where possible" item in the brief).

## Brief gates

| Gate | Status |
| --- | --- |
| Opens a document → immediately sees content, not metadata | ✅ content hero, metadata behind Details |
| User can answer "what doc / what matter / how to get back" | ✅ filename H1, sidebar matter section visible (via PR 2 matterSlugFromRoute fix), smart back |
| Metadata accessible but not the hero | ✅ Details disclosure collapsed by default |
| Source-anchor / deep-link does something honest | ✅ chip routes to specific doc + banner names the substrate gap |
| No backend drift | ✅ |

## Verification (local)

- `tsc --noEmit` clean
- `vitest`: **203 / 203** across 29 files (+2 from disclosure + from-chat-note tests)
- `npm run build` clean
- backend untouched

## Three-gate review

- **Blueprint Gate** — §4A.3 reader shape adopted; full redline rendering deferred per blueprint §10 escalation rules.
- **Comprehension Gate** — reviewer walkthrough should land on the four brief questions. PR 6 is mechanical per §12 item 1 redline — reviewer walkthrough, not fresh-observer.
- **Truth Gate** — the banner names the substrate gap; the Open/Download links are real; Details only surfaces what the substrate actually returns.

## How to walk it

```bash
cd frontend && npm run dev
# 1. Sign in, open any matter
# 2. From Chat, send a question that produces a [doc:id] citation
# 3. Click the source chip — should land at /documents/<id>?from=assistant
# 4. Confirm: content visible immediately, honesty banner present,
#    Back link says "Back to Chat", Details disclosure collapsed.
# 5. Open Details → metadata + versions + anonymisation + edits.
# 6. From Documents tab, click a doc row → same reader, no banner,
#    Back link says "← Documents".
```

## Diff summary

```
frontend/src/matter/DocumentDetail.test.tsx |  68 +++++-
frontend/src/matter/DocumentDetail.tsx      | 310 +++++++++++++++++-----------
frontend/src/matter/MessageBubble.tsx       |  11 +-
frontend/src/matter/tabs/AssistantTab.tsx   |  20 +-
frontend/src/router/index.tsx               |   6 +
5 files changed, 276 insertions(+), 139 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)