### PR TITLE
GSR: add generic skill runner

### DIFF
--- a/backend/app/core/demo_loop.py
+++ b/backend/app/core/demo_loop.py
@@ -279,17 +279,8 @@ async def _ensure_demo_matter(session: AsyncSession, user: User) -> tuple[Matter
 async def ensure_guided_demo(session: AsyncSession, user: User) -> dict[str, Any]:
     """Idempotently provision the guided demo for ``user`` and return its
     handles. Commits its own transaction."""
-    installed = await _ensure_demo_module(session, user)
     matter, document = await _ensure_demo_matter(session, user)
-    # Real grant creation — matter-scoped grants for the capability's
-    # declared reads + writes. No bypass; the invocation still enforces.
-    await create_grants_for_capability(
-        session,
-        user=user,
-        matter=matter,
-        installed_module=installed,
-        capability_id=DEMO_CAPABILITY_ID,
-    )
+    await ensure_demo_skill_on_matter(session, user=user, matter=matter)
     await session.commit()
     materialise_matter(matter)
     return {
@@ -303,9 +294,35 @@ async def ensure_guided_demo(session: AsyncSession, user: User) -> dict[str, Any
     }
 
 
+async def ensure_demo_skill_on_matter(
+    session: AsyncSession,
+    *,
+    user: User,
+    matter: Matter,
+) -> InstalledModule:
+    """Install the demo V2 skill and grant it on ``matter``.
+
+    This is the reusable seed primitive for both `/demo-loop` and the
+    Khan sample matter. It does not commit; callers keep the install +
+    grant write in their existing transaction.
+    """
+    installed = await _ensure_demo_module(session, user)
+    # Real grant creation — matter-scoped grants for the capability's
+    # declared reads + writes. No bypass; invocation still enforces.
+    await create_grants_for_capability(
+        session,
+        user=user,
+        matter=matter,
+        installed_module=installed,
+        capability_id=DEMO_CAPABILITY_ID,
+    )
+    return installed
+
+
 __all__ = [
     "DEMO_CAPABILITY_ID",
     "DEMO_MATTER_SLUG",
     "DEMO_MODULE_ID",
     "ensure_guided_demo",
+    "ensure_demo_skill_on_matter",
 ]

--- a/backend/app/core/demo_loop.py
+++ b/backend/app/core/demo_loop.py
@@ -105,7 +105,11 @@ DEMO_MANIFEST: dict[str, Any] = {
             "external_network": False,
             "data_movement": {"external_destinations": [], "local_only": True},
             "gates": ["privilege_posture"],
-            "ui": {"slot": "matter.workflows", "label": "Plain-English Summary (demo)"},
+            "ui": {
+                "slot": "matter.workflows",
+                "label": "Plain-English Summary (demo)",
+                "default_request": "Summarise {filename}.",
+            },
             "streaming_mode": "sync",
             "advice_tier_max": "draft_advice",
             "audit_events": [

--- a/backend/app/core/demo_loop.py
+++ b/backend/app/core/demo_loop.py
@@ -110,6 +110,17 @@ DEMO_MANIFEST: dict[str, Any] = {
                 "label": "Plain-English Summary (demo)",
                 "default_request": "Summarise {filename}.",
             },
+            "args_schema": {
+                "type": "object",
+                "properties": {
+                    "style": {
+                        "type": "string",
+                        "title": "Style",
+                        "enum": ["Plain English", "Issue list"],
+                        "default": "Plain English",
+                    }
+                },
+            },
             "streaming_mode": "sync",
             "advice_tier_max": "draft_advice",
             "audit_events": [

--- a/backend/app/core/prompt_runtime.py
+++ b/backend/app/core/prompt_runtime.py
@@ -59,6 +59,7 @@ ARTIFACT_KIND = "skill_response"
 # How a caller asks the skill to read matter documents. Reading only
 # happens when these args are present AND the capability declares reads.
 _DOC_ARG_KEYS = ("document_ids", "document_id")
+_RESERVED_PROMPT_ARG_KEYS = {"input", "question", *_DOC_ARG_KEYS}
 _POSTURE_GATE = "privilege_posture"
 _JSON_FENCE_RE = re.compile(
     r"```(?:json)?\s*(\{.*?\})\s*```",
@@ -150,6 +151,17 @@ def _build_prompt(
     user_input = args.get("input") or args.get("question")
     if user_input:
         parts.append(f"\n--- request ---\n{user_input}")
+
+    extra_args = {
+        key: value
+        for key, value in args.items()
+        if key not in _RESERVED_PROMPT_ARG_KEYS and value not in (None, "")
+    }
+    if extra_args:
+        parts.append(
+            "\n--- request options ---\n"
+            f"{json.dumps(extra_args, ensure_ascii=False, sort_keys=True)}"
+        )
 
     if document_blocks:
         # Opt-in citation format. Lenient — the runtime always records

--- a/backend/app/core/seed.py
+++ b/backend/app/core/seed.py
@@ -575,6 +575,8 @@ async def seed_demo_matter_for_user(session: AsyncSession, user: User) -> Matter
     existing = await session.scalar(
         select(Matter).where(Matter.slug == KHAN_SLUG, Matter.created_by_id == user.id)
     )
+    from app.core.demo_loop import ensure_demo_skill_on_matter
+
     if existing is not None:
         # Backfill body rows on previously-seeded matters (idempotent).
         existing_docs_list = list(
@@ -641,6 +643,7 @@ async def seed_demo_matter_for_user(session: AsyncSession, user: User) -> Matter
             )
             await _write_seed_audit_rows(session, existing, current_docs, current_events)
 
+        await ensure_demo_skill_on_matter(session, user=user, matter=existing)
         await session.commit()
         materialise_matter(existing)
         return existing
@@ -678,6 +681,7 @@ async def seed_demo_matter_for_user(session: AsyncSession, user: User) -> Matter
     await _write_seed_audit_rows(
         session, matter, list(docs.values()), seeded_events
     )
+    await ensure_demo_skill_on_matter(session, user=user, matter=matter)
 
     materialise_matter(matter)
     append_history(matter.slug, user.id, "matter.seeded", "Khan v Acme demo matter inserted")

--- a/backend/schemas/module.v2.json
+++ b/backend/schemas/module.v2.json
@@ -214,7 +214,11 @@
           "required": ["slot"],
           "properties": {
             "slot": {"type": "string"},
-            "label": {"type": "string"}
+            "label": {"type": "string"},
+            "default_request": {
+              "type": "string",
+              "description": "Optional user-facing starter request for generic runners. May include {filename} for the selected document filename."
+            }
           },
           "additionalProperties": false
         },

--- a/backend/schemas/module.v2.json
+++ b/backend/schemas/module.v2.json
@@ -241,6 +241,35 @@
           "items": {"type": "string"},
           "description": "Expected audit action names this capability will emit."
         },
+        "args_schema": {
+          "type": "object",
+          "description": "Optional JSON-Schema-like input shape for generic runners. V1 runner supports top-level string fields and string enum selects.",
+          "properties": {
+            "type": {"const": "object"},
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "type": {"const": "string"},
+                  "title": {"type": "string"},
+                  "description": {"type": "string"},
+                  "enum": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                  },
+                  "default": {"type": "string"}
+                },
+                "additionalProperties": true
+              }
+            },
+            "required": {
+              "type": "array",
+              "items": {"type": "string"}
+            }
+          },
+          "additionalProperties": true
+        },
         "output_lifecycle_target": {
           "anyOf": [
             {"type": "null"},

--- a/backend/tests/test_matters_routes.py
+++ b/backend/tests/test_matters_routes.py
@@ -65,6 +65,25 @@ async def test_get_matter_by_slug_returns_full_detail(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_seeded_khan_has_v2_demo_skill_grants(client) -> None:
+    await _signup_and_login(client)
+
+    resp = await client.get(f"/api/matters/{KHAN_SLUG}/grants")
+    assert resp.status_code == 200, resp.text
+
+    grants = resp.json()["grants"]
+    demo_grants = {
+        (g["plugin"], g["skill"], g["capability"])
+        for g in grants
+        if g["plugin"] == "demo.guided-skill"
+    }
+    assert demo_grants == {
+        ("demo.guided-skill", "summarise", "document.body.read"),
+        ("demo.guided-skill", "summarise", "matter.artifact.write"),
+    }
+
+
+@pytest.mark.asyncio
 async def test_get_matter_unknown_slug_returns_404(client) -> None:
     await _signup_and_login(client)
     resp = await client.get("/api/matters/this-slug-does-not-exist")

--- a/backend/tests/test_phase2_schema.py
+++ b/backend/tests/test_phase2_schema.py
@@ -161,6 +161,24 @@ def test_ui_default_request_accepted() -> None:
     assert is_valid, errors
 
 
+def test_capability_args_schema_accepted() -> None:
+    m = _base_manifest()
+    m["capabilities"][0]["args_schema"] = {
+        "type": "object",
+        "properties": {
+            "style": {
+                "type": "string",
+                "title": "Style",
+                "enum": ["Plain English", "Issue list"],
+                "default": "Plain English",
+            }
+        },
+        "required": ["style"],
+    }
+    is_valid, errors = validate_manifest_v2(m)
+    assert is_valid, errors
+
+
 def test_gate_with_gates_rejected() -> None:
     """A capability kind=gate cannot itself declare gates."""
     m = _base_manifest()

--- a/backend/tests/test_phase2_schema.py
+++ b/backend/tests/test_phase2_schema.py
@@ -154,6 +154,13 @@ def test_unknown_ui_slot_rejected() -> None:
     assert any("ui/slot" in e["path"] for e in errors)
 
 
+def test_ui_default_request_accepted() -> None:
+    m = _base_manifest()
+    m["capabilities"][0]["ui"]["default_request"] = "Summarise {filename}."
+    is_valid, errors = validate_manifest_v2(m)
+    assert is_valid, errors
+
+
 def test_gate_with_gates_rejected() -> None:
     """A capability kind=gate cannot itself declare gates."""
     m = _base_manifest()

--- a/backend/tests/test_seed_audit.py
+++ b/backend/tests/test_seed_audit.py
@@ -33,7 +33,14 @@ from app.core.seed import (
     _write_seed_audit_rows,
     seed_demo_matter_for_user,
 )
-from app.models import AuditEntry, Document, Event, Matter
+from app.models import (
+    AuditEntry,
+    Document,
+    Event,
+    InstalledModule,
+    Matter,
+    WorkspaceSkillCapabilityGrant,
+)
 
 
 def _fake_matter(user_id: uuid.UUID) -> Matter:
@@ -98,11 +105,15 @@ class _StubSession:
         documents: list[Document] | None = None,
         events: list[Event] | None = None,
         audit_entries: list[AuditEntry] | None = None,
+        installed_modules: list[InstalledModule] | None = None,
+        grants: list[WorkspaceSkillCapabilityGrant] | None = None,
     ) -> None:
         self.matters: list[Matter] = list(matters or [])
         self.documents: list[Document] = list(documents or [])
         self.events: list[Event] = list(events or [])
         self.audit_entries: list[AuditEntry] = list(audit_entries or [])
+        self.installed_modules: list[InstalledModule] = list(installed_modules or [])
+        self.grants: list[WorkspaceSkillCapabilityGrant] = list(grants or [])
         self.added: list = []
         self.commits = 0
 
@@ -115,6 +126,10 @@ class _StubSession:
             return self.events
         if isinstance(obj, Matter):
             return self.matters
+        if isinstance(obj, InstalledModule):
+            return self.installed_modules
+        if isinstance(obj, WorkspaceSkillCapabilityGrant):
+            return self.grants
         return None
 
     def add(self, obj) -> None:
@@ -154,6 +169,36 @@ class _StubSession:
                 ),
                 None,
             )
+        if target == "installed_modules":
+            module_id = self._param(stmt, "module_id")
+            return next(
+                (
+                    m
+                    for m in self.installed_modules
+                    if module_id is None or m.module_id == module_id
+                ),
+                None,
+            )
+        if target == "workspace_skill_capability_grants":
+            user_id = self._param(stmt, "user_id")
+            plugin = self._param(stmt, "plugin")
+            skill = self._param(stmt, "skill")
+            capability = self._param(stmt, "capability")
+            scope_type = self._param(stmt, "scope_type")
+            scope_id = self._param(stmt, "scope_id")
+            return next(
+                (
+                    g
+                    for g in self.grants
+                    if (user_id is None or g.user_id == user_id)
+                    and (plugin is None or g.plugin == plugin)
+                    and (skill is None or g.skill == skill)
+                    and (capability is None or g.capability == capability)
+                    and (scope_type is None or g.scope_type == scope_type)
+                    and (scope_id is None or g.scope_id == scope_id)
+                ),
+                None,
+            )
         return None
 
     async def scalars(self, stmt):
@@ -176,6 +221,17 @@ class _StubSession:
             return froms[0].name
         except Exception:
             return ""
+
+    @staticmethod
+    def _param(stmt, name: str):
+        try:
+            params = stmt.compile().params
+        except Exception:
+            return None
+        for key, value in params.items():
+            if key == name or key.startswith(f"{name}_"):
+                return value
+        return None
 
 
 @pytest.fixture(autouse=True)
@@ -230,19 +286,27 @@ class TestWriteSeedAuditRows:
 class TestSeedDemoMatterForUserIdempotency:
     @pytest.mark.asyncio
     async def test_second_call_does_not_duplicate_audit_rows(self) -> None:
-        """First call writes the bootstrap rows. Second call sees the
-        matter already exists and the seed.matter.created marker is
-        present, so it short-circuits and writes nothing."""
+        """First call writes bootstrap rows and demo grants. Second call
+        sees both already exist and writes no duplicate audit rows."""
         user = SimpleNamespace(id=uuid.uuid4())
         session = _StubSession()
 
         await seed_demo_matter_for_user(session, user)
         first_count = len(session.audit_entries)
-        # 1 matter + 3 docs + 7 events = 11 bootstrap rows.
-        assert first_count == 11
+        bootstrap_rows = [
+            a for a in session.audit_entries if a.module == SEED_AUDIT_MODULE
+        ]
+        grant_rows = [
+            a for a in session.audit_entries if a.action == "module.grant.created"
+        ]
+        # 1 matter + 3 docs + 7 events = 11 bootstrap rows. The demo
+        # V2 skill grants are legitimate non-bootstrap rows.
+        assert len(bootstrap_rows) == 11
+        assert len(grant_rows) == 2
 
         await seed_demo_matter_for_user(session, user)
         assert len(session.audit_entries) == first_count
+        assert len(session.grants) == 2
 
     @pytest.mark.asyncio
     async def test_upgrade_path_backfills_when_matter_exists_without_audit_rows(

--- a/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
+++ b/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
@@ -30,9 +30,11 @@ The runner is deliberately narrow:
 - `frontend/src/matter/GenericSkillRunner.tsx`
   - Shared runner component for V2 capabilities.
   - Builds invocation args from the user request plus selected document ids.
+  - Reads `ui.default_request` from the manifest when present, so starter copy lives with the skill rather than in a runner-side skill opinion.
   - Calls `invokeCapability` only.
   - Reads the produced artifact when `artifact_id` is returned.
   - Renders `ArtifactPreview`, `Open output`, `Review & sign`, and `View Record for this run`.
+  - Provides `Close run` after a successful inline run, so Chat can dismiss the runner without leaving the page.
 
 - `frontend/src/matter/MatterSkillsTab.tsx`
   - Shows runnable V2 skills with the generic runner.
@@ -47,6 +49,11 @@ The runner is deliberately narrow:
 
 - `backend/app/core/demo_loop.py`
   - Extracts `ensure_demo_skill_on_matter()` so the existing demo V2 skill can be installed and granted on any seeded matter.
+  - Adds a manifest-owned `ui.default_request` to the demo skill: `Summarise {filename}.`.
+
+- `schemas/module.v2.json` and `backend/schemas/module.v2.json`
+  - Add optional `capabilities[].ui.default_request`.
+  - This is intentionally UI metadata only; it does not change invocation semantics, trust ceremony semantics, or runtime enforcement.
 
 - `backend/app/core/seed.py`
   - Khan v Acme seed now idempotently installs and grants `demo.guided-skill / summarise`.
@@ -54,6 +61,14 @@ The runner is deliberately narrow:
 
 - `backend/tests/test_matters_routes.py`
   - Adds a public-route regression that a fresh user's Khan matter includes the two required demo skill grants.
+
+- `frontend/src/matter/GenericSkillRunner.test.tsx`
+  - Pins manifest-owned starter request rendering.
+  - Pins neutral fallback copy when a manifest does not provide `ui.default_request`.
+  - Pins closing a completed inline run.
+
+- `backend/tests/test_phase2_schema.py`
+  - Pins `ui.default_request` as accepted v2 manifest metadata.
 
 ## What this proves
 
@@ -75,12 +90,14 @@ That path is now represented in both:
 - Does not add `if (skill === ...)` branching.
 - Does not call `/letters/draft` or any other legacy workflow endpoint from the generic runner.
 - Does not change backend schema or API.
-- Does not change the manifest schema.
+- Does not change backend API or persistence schema.
+- Does extend the manifest schema with optional `ui.default_request`, scoped to runner UI copy.
 - Does not change Khan's default model. Khan still uses its configured real-model path, so running the seeded skill may still require the relevant provider key. The keyless fully-green path remains `/demo-loop`.
 
 ## GSR status
 
 - `GSR-2`: mostly complete for the first V2 proof target.
+- `GSR-2.1`: complete for runner contract polish: manifest starter request, neutral fallback copy, and close affordance.
 - `GSR-3`: partially satisfied via existing `ArtifactPreview` support, including `skill_response`. More output kinds can be added later through typed artifact viewers, not through bespoke skill pages.
 - `GSR-4`: complete for V2 skills in Chat. Chat mounts the same runner component.
 - `GSR-5`: not complete. Legacy routes remain. The next step is a deprecation/retirement plan once first-party workflows are either wrapped as V2 skills or intentionally left legacy.
@@ -112,11 +129,12 @@ Local frontend verification:
 
 - `npm run typecheck` — clean
 - `npm run test -- AssistantTab MatterSkillsTab --run` — 10/10
-- `npm run test -- --run` — 205/205
+- `npm run test -- GenericSkillRunner AssistantTab MatterSkillsTab --run` — 13/13
+- `npm run test -- --run` — 208/208
 - `npm run build` — clean, with the existing Vite chunk-size warning
 
 Local backend verification:
 
-- `python3 -m py_compile backend/app/core/demo_loop.py backend/app/core/seed.py backend/tests/test_matters_routes.py` — clean
+- `python3 -m py_compile backend/app/core/demo_loop.py backend/app/core/seed.py backend/tests/test_matters_routes.py backend/tests/test_phase2_schema.py backend/tests/test_seed_audit.py` — clean
 
 Backend pytest could not be run locally because this shell has neither `pytest` nor `uv` on PATH. GitHub CI runs the backend test suite in the proper container and is the merge gate for the seed regression.

--- a/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
+++ b/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
@@ -34,7 +34,7 @@ The runner is deliberately narrow:
   - Reads `ui.default_request` from the manifest when present, so starter copy lives with the skill rather than in a runner-side skill opinion.
   - Renders manifest-declared input fields from `args_schema` and sends completed values as invocation args.
   - Calls `invokeCapability` only.
-  - Reads the produced artifact when `artifact_id` is returned.
+  - Reads produced artifacts when the result returns `artifact_id` or generic `*_artifact_id` keys, so native-style skills can return multiple artifacts without a runner-side adapter.
   - Renders `ArtifactPreview`, `Open output`, `Review & sign`, and `View Record for this run`.
   - Provides `Close run` after a successful inline run, so Chat can dismiss the runner without leaving the page.
 
@@ -73,6 +73,7 @@ The runner is deliberately narrow:
   - Pins manifest-owned starter request rendering.
   - Pins neutral fallback copy when a manifest does not provide `ui.default_request`.
   - Pins manifest string-enum field rendering and invocation args.
+  - Pins generic extraction/rendering of multiple `*_artifact_id` values from native-style invocation results.
   - Pins closing a completed inline run.
 
 - `backend/tests/test_phase2_schema.py`
@@ -106,7 +107,7 @@ That path is now represented in both:
 
 - `GSR-2`: mostly complete for the first V2 proof target.
 - `GSR-2.1`: complete for runner contract polish: manifest starter request, manifest input fields, neutral fallback copy, and close affordance.
-- `GSR-3`: partially satisfied via existing `ArtifactPreview` support, including `skill_response`. More output kinds can be added later through typed artifact viewers, not through bespoke skill pages.
+- `GSR-3`: partially satisfied via existing `ArtifactPreview` support, including `skill_response`, and by generic multi-artifact result handling. More output kinds can be added later through typed artifact viewers, not through bespoke skill pages.
 - `GSR-4`: complete for V2 skills in Chat. Chat mounts the same runner component.
 - `GSR-5`: not complete. Legacy routes remain. The next step is a deprecation/retirement plan once first-party workflows are either wrapped as V2 skills or intentionally left legacy.
 
@@ -139,7 +140,8 @@ Local frontend verification:
 - `npm run test -- AssistantTab MatterSkillsTab --run` — 10/10
 - `npm run test -- GenericSkillRunner AssistantTab MatterSkillsTab --run` — 13/13
 - `npm run test -- GenericSkillRunner AssistantTab MatterSkillsTab --run` — 14/14 after `args_schema`
-- `npm run test -- --run` — 209/209
+- `npm run test -- GenericSkillRunner --run` — 6/6 after multi-artifact result handling
+- `npm run test -- --run` — 211/211
 - `npm run build` — clean, with the existing Vite chunk-size warning
 
 Local backend verification:

--- a/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
+++ b/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
@@ -1,0 +1,106 @@
+# Generic Skill Runner v1 — handover
+
+Date: 2026-06-02  
+Branch: `codex/gsr2-generic-runner`
+
+## What shipped
+
+This implements the first real Generic Skill Runner slice after `GSR-1`.
+
+The runner is deliberately narrow:
+
+- It runs V2 manifest capabilities through the existing invocation endpoint.
+- It does not call legacy first-party endpoints.
+- It renders the artifact returned by the invocation and links directly to:
+  - the artifact detail page,
+  - Professional Sign-Off,
+  - the matter Record filtered to that invocation.
+- It hides permission plumbing from the primary surface. The first-read states are:
+  - `Ready in this project`
+  - `Needs setup`
+  - `Available to enable`
+
+## Files changed
+
+- `frontend/src/matter/skillRunnerModel.ts`
+  - Parses V2 manifest capabilities into a normalized runner model.
+  - Filters to installed, enabled, matter-scoped, invokable capabilities.
+  - Requires all declared read/write permission rows to be present before a skill is treated as runnable.
+
+- `frontend/src/matter/GenericSkillRunner.tsx`
+  - Shared runner component for V2 capabilities.
+  - Builds invocation args from the user request plus selected document ids.
+  - Calls `invokeCapability` only.
+  - Reads the produced artifact when `artifact_id` is returned.
+  - Renders `ArtifactPreview`, `Open output`, `Review & sign`, and `View Record for this run`.
+
+- `frontend/src/matter/MatterSkillsTab.tsx`
+  - Shows runnable V2 skills with the generic runner.
+  - Leaves legacy built-in workflows as openable legacy rows.
+  - Keeps setup-only V2 modules as `Needs setup`, with no fake `Run` link.
+  - Removes primary-surface raw permission vocabulary where touched.
+
+- `frontend/src/matter/tabs/AssistantTab.tsx`
+  - Chat Skills picker now counts runnable V2 skills plus runnable legacy workflows.
+  - Picking a V2 skill mounts `GenericSkillRunner` in Chat instead of routing to a bespoke tab.
+  - Picking a legacy workflow still routes to its legacy tab.
+
+## What this proves
+
+The clean proof target is an existing V2 module such as `demo.guided-skill`:
+
+`select skill -> run generic invocation -> artifact exists -> typed preview renders -> sign-off link -> Record deep-link`
+
+That path is now represented in both:
+
+- Matter Skills
+- Chat
+
+## What this deliberately does not do
+
+- Does not wrap Letters, Contract Review, Pre-Motion, Research, or Reviews as V2 skills.
+- Does not delete legacy first-party routes.
+- Does not introduce a bespoke Letters adapter.
+- Does not add `if (skill === ...)` branching.
+- Does not call `/letters/draft` or any other legacy workflow endpoint from the generic runner.
+- Does not change backend schema or API.
+- Does not change the manifest schema.
+
+## GSR status
+
+- `GSR-2`: mostly complete for the first V2 proof target.
+- `GSR-3`: partially satisfied via existing `ArtifactPreview` support, including `skill_response`. More output kinds can be added later through typed artifact viewers, not through bespoke skill pages.
+- `GSR-4`: complete for V2 skills in Chat. Chat mounts the same runner component.
+- `GSR-5`: not complete. Legacy routes remain. The next step is a deprecation/retirement plan once first-party workflows are either wrapped as V2 skills or intentionally left legacy.
+
+## Reviewer checks
+
+Run these checks against the diff:
+
+1. Search the new runner path for bespoke adapters:
+   - `/letters/draft`
+   - `draft_markdown`
+   - `if (skill ===`
+   - `skill ===`
+
+2. Open a matter with `demo.guided-skill` installed and granted:
+   - Matter Skills should show a generic runner.
+   - Chat Skills should show the same skill.
+   - Running should produce an artifact and expose Sign-Off + Record links.
+
+3. Confirm the primary UI does not lead with raw permission states:
+   - `partial`
+   - `blocked`
+   - raw capability ids
+   - manifest/setup internals
+
+## Verification
+
+Local frontend verification:
+
+- `npm run typecheck` — clean
+- `npm run test -- AssistantTab MatterSkillsTab --run` — 10/10
+- `npm run test -- --run` — 205/205
+- `npm run build` — clean, with the existing Vite chunk-size warning
+
+Backend was not run because this is a frontend-only slice over existing endpoints.

--- a/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
+++ b/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
@@ -26,11 +26,13 @@ The runner is deliberately narrow:
   - Parses V2 manifest capabilities into a normalized runner model.
   - Filters to installed, enabled, matter-scoped, invokable capabilities.
   - Requires all declared read/write permission rows to be present before a skill is treated as runnable.
+  - Parses optional `capabilities[].args_schema` into generic runner fields. V1 supports top-level string inputs and string enum selects only; reserved runtime keys such as `input`, `document_id`, and `document_ids` are ignored.
 
 - `frontend/src/matter/GenericSkillRunner.tsx`
   - Shared runner component for V2 capabilities.
   - Builds invocation args from the user request plus selected document ids.
   - Reads `ui.default_request` from the manifest when present, so starter copy lives with the skill rather than in a runner-side skill opinion.
+  - Renders manifest-declared input fields from `args_schema` and sends completed values as invocation args.
   - Calls `invokeCapability` only.
   - Reads the produced artifact when `artifact_id` is returned.
   - Renders `ArtifactPreview`, `Open output`, `Review & sign`, and `View Record for this run`.
@@ -50,9 +52,14 @@ The runner is deliberately narrow:
 - `backend/app/core/demo_loop.py`
   - Extracts `ensure_demo_skill_on_matter()` so the existing demo V2 skill can be installed and granted on any seeded matter.
   - Adds a manifest-owned `ui.default_request` to the demo skill: `Summarise {filename}.`.
+  - Adds a manifest-owned `args_schema` field for the demo skill's `Style` selector, proving runner form fields without bespoke UI.
+
+- `backend/app/core/prompt_runtime.py`
+  - Carries non-reserved invocation args into the prompt under `request options`, so manifest form fields can affect prompt skills without changing the generic invocation endpoint.
 
 - `schemas/module.v2.json` and `backend/schemas/module.v2.json`
   - Add optional `capabilities[].ui.default_request`.
+  - Add optional `capabilities[].args_schema` for generic runner form fields.
   - This is intentionally UI metadata only; it does not change invocation semantics, trust ceremony semantics, or runtime enforcement.
 
 - `backend/app/core/seed.py`
@@ -65,10 +72,12 @@ The runner is deliberately narrow:
 - `frontend/src/matter/GenericSkillRunner.test.tsx`
   - Pins manifest-owned starter request rendering.
   - Pins neutral fallback copy when a manifest does not provide `ui.default_request`.
+  - Pins manifest string-enum field rendering and invocation args.
   - Pins closing a completed inline run.
 
 - `backend/tests/test_phase2_schema.py`
   - Pins `ui.default_request` as accepted v2 manifest metadata.
+  - Pins `args_schema` as accepted v2 manifest metadata.
 
 ## What this proves
 
@@ -89,15 +98,14 @@ That path is now represented in both:
 - Does not introduce a bespoke Letters adapter.
 - Does not add `if (skill === ...)` branching.
 - Does not call `/letters/draft` or any other legacy workflow endpoint from the generic runner.
-- Does not change backend schema or API.
 - Does not change backend API or persistence schema.
-- Does extend the manifest schema with optional `ui.default_request`, scoped to runner UI copy.
+- Does extend the manifest schema with optional `ui.default_request` and `args_schema`, scoped to runner UI copy and form inputs.
 - Does not change Khan's default model. Khan still uses its configured real-model path, so running the seeded skill may still require the relevant provider key. The keyless fully-green path remains `/demo-loop`.
 
 ## GSR status
 
 - `GSR-2`: mostly complete for the first V2 proof target.
-- `GSR-2.1`: complete for runner contract polish: manifest starter request, neutral fallback copy, and close affordance.
+- `GSR-2.1`: complete for runner contract polish: manifest starter request, manifest input fields, neutral fallback copy, and close affordance.
 - `GSR-3`: partially satisfied via existing `ArtifactPreview` support, including `skill_response`. More output kinds can be added later through typed artifact viewers, not through bespoke skill pages.
 - `GSR-4`: complete for V2 skills in Chat. Chat mounts the same runner component.
 - `GSR-5`: not complete. Legacy routes remain. The next step is a deprecation/retirement plan once first-party workflows are either wrapped as V2 skills or intentionally left legacy.
@@ -130,11 +138,13 @@ Local frontend verification:
 - `npm run typecheck` — clean
 - `npm run test -- AssistantTab MatterSkillsTab --run` — 10/10
 - `npm run test -- GenericSkillRunner AssistantTab MatterSkillsTab --run` — 13/13
-- `npm run test -- --run` — 208/208
+- `npm run test -- GenericSkillRunner AssistantTab MatterSkillsTab --run` — 14/14 after `args_schema`
+- `npm run test -- --run` — 209/209
 - `npm run build` — clean, with the existing Vite chunk-size warning
 
 Local backend verification:
 
-- `python3 -m py_compile backend/app/core/demo_loop.py backend/app/core/seed.py backend/tests/test_matters_routes.py backend/tests/test_phase2_schema.py backend/tests/test_seed_audit.py` — clean
+- `python3 -m py_compile backend/app/core/demo_loop.py backend/app/core/prompt_runtime.py backend/app/core/seed.py backend/tests/test_matters_routes.py backend/tests/test_phase2_schema.py backend/tests/test_seed_audit.py` — clean
+- root and backend manifest schemas are JSON-equal after the runner metadata additions
 
 Backend pytest could not be run locally because this shell has neither `pytest` nor `uv` on PATH. GitHub CI runs the backend test suite in the proper container and is the merge gate for the seed regression.

--- a/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
+++ b/docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md
@@ -45,6 +45,16 @@ The runner is deliberately narrow:
   - Picking a V2 skill mounts `GenericSkillRunner` in Chat instead of routing to a bespoke tab.
   - Picking a legacy workflow still routes to its legacy tab.
 
+- `backend/app/core/demo_loop.py`
+  - Extracts `ensure_demo_skill_on_matter()` so the existing demo V2 skill can be installed and granted on any seeded matter.
+
+- `backend/app/core/seed.py`
+  - Khan v Acme seed now idempotently installs and grants `demo.guided-skill / summarise`.
+  - This satisfies the GSR demo precondition: the first V2 proof skill is enabled on the canonical Khan workspace matter.
+
+- `backend/tests/test_matters_routes.py`
+  - Adds a public-route regression that a fresh user's Khan matter includes the two required demo skill grants.
+
 ## What this proves
 
 The clean proof target is an existing V2 module such as `demo.guided-skill`:
@@ -55,6 +65,7 @@ That path is now represented in both:
 
 - Matter Skills
 - Chat
+- Khan v Acme seed grants
 
 ## What this deliberately does not do
 
@@ -65,6 +76,7 @@ That path is now represented in both:
 - Does not call `/letters/draft` or any other legacy workflow endpoint from the generic runner.
 - Does not change backend schema or API.
 - Does not change the manifest schema.
+- Does not change Khan's default model. Khan still uses its configured real-model path, so running the seeded skill may still require the relevant provider key. The keyless fully-green path remains `/demo-loop`.
 
 ## GSR status
 
@@ -103,4 +115,8 @@ Local frontend verification:
 - `npm run test -- --run` — 205/205
 - `npm run build` — clean, with the existing Vite chunk-size warning
 
-Backend was not run because this is a frontend-only slice over existing endpoints.
+Local backend verification:
+
+- `python3 -m py_compile backend/app/core/demo_loop.py backend/app/core/seed.py backend/tests/test_matters_routes.py` — clean
+
+Backend pytest could not be run locally because this shell has neither `pytest` nor `uv` on PATH. GitHub CI runs the backend test suite in the proper container and is the merge gate for the seed regression.

--- a/frontend/src/matter/ArtifactPreview.test.tsx
+++ b/frontend/src/matter/ArtifactPreview.test.tsx
@@ -1,7 +1,3 @@
-/**
- * Phase 14 D — ArtifactPreview kind-routing regressions.
- */
-
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ArtifactPreview } from "./ArtifactPreview";

--- a/frontend/src/matter/GenericSkillRunner.test.tsx
+++ b/frontend/src/matter/GenericSkillRunner.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as api from "../lib/api";
+import { GenericSkillRunner } from "./GenericSkillRunner";
+import type { RunnableMatterSkill } from "./skillRunnerModel";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+
+const baseSkill: RunnableMatterSkill = {
+  moduleId: "demo.guided-skill",
+  capabilityId: "summarise",
+  title: "Plain-English Summary",
+  description: "Summarises a document.",
+  defaultRequest: "Summarise {filename}.",
+  reads: ["document.body.read"],
+  writes: ["matter.artifact.write"],
+  modelAccess: "required",
+  signatureStatus: "verified",
+  sourceKind: "v2",
+};
+
+const docs = [
+  {
+    id: "doc-1",
+    matter_id: "m-1",
+    filename: "witness.txt",
+    mime_type: "text/plain",
+    size_bytes: 200,
+    sha256: "sha",
+    tag: "demo",
+    from_disclosure: false,
+    uploaded_at: "2026-01-01T00:00:00",
+    uploaded_by_id: "u-1",
+  },
+];
+
+function renderRunner(skill: RunnableMatterSkill = baseSkill) {
+  return render(
+    <GenericSkillRunner slug="khan-v-acme" skill={skill} documents={docs} compact />,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GenericSkillRunner", () => {
+  it("uses manifest default_request instead of inventing skill copy", () => {
+    renderRunner();
+
+    expect(screen.getByDisplayValue("Summarise witness.txt.")).toBeInTheDocument();
+  });
+
+  it("falls back to neutral document copy when no manifest default_request exists", () => {
+    renderRunner({ ...baseSkill, defaultRequest: null });
+
+    expect(screen.getByDisplayValue("Run this skill on the selected document.")).toBeInTheDocument();
+  });
+
+  it("can close a completed run from the inline runner", async () => {
+    vi.spyOn(api, "invokeCapability").mockResolvedValue({
+      invocation_id: "inv-1",
+      result: { artifact_id: "artifact-1" },
+    } as never);
+    vi.spyOn(api, "readArtifact").mockResolvedValue({
+      id: "artifact-1",
+      kind: "skill_response",
+      payload: { output: "The witness statement says X." },
+      invocation_id: "inv-1",
+      created_at: "2026-01-01T00:00:00",
+    } as never);
+    renderRunner();
+
+    fireEvent.click(screen.getByTestId("generic-run-demo.guided-skill-summarise"));
+
+    expect(await screen.findByTestId("generic-runner-result")).toBeInTheDocument();
+    expect(screen.getByText(/The witness statement says X/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Close run/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("generic-runner-result")).toBeNull();
+    });
+  });
+});

--- a/frontend/src/matter/GenericSkillRunner.test.tsx
+++ b/frontend/src/matter/GenericSkillRunner.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as api from "../lib/api";
-import { GenericSkillRunner } from "./GenericSkillRunner";
+import { artifactIdsFromResult, GenericSkillRunner } from "./GenericSkillRunner";
 import type { RunnableMatterSkill } from "./skillRunnerModel";
 
 vi.mock("@tanstack/react-router", () => ({
@@ -48,6 +48,18 @@ afterEach(() => {
 });
 
 describe("GenericSkillRunner", () => {
+  it("extracts all artifact ids from a generic invocation result", () => {
+    expect(
+      artifactIdsFromResult({
+        artifact_id: "primary",
+        motion_artifact_id: "motion",
+        evidence_artifact_id: "evidence",
+        duplicate_artifact_id: "motion",
+        not_artifact_idish: "ignored",
+      }),
+    ).toEqual(["primary", "motion", "evidence"]);
+  });
+
   it("uses manifest default_request instead of inventing skill copy", () => {
     renderRunner();
 
@@ -130,5 +142,39 @@ describe("GenericSkillRunner", () => {
         },
       });
     });
+  });
+
+  it("renders every artifact id returned by a native-style result", async () => {
+    vi.spyOn(api, "invokeCapability").mockResolvedValue({
+      invocation_id: "inv-1",
+      result: {
+        motion_artifact_id: "motion-1",
+        evidence_artifact_id: "evidence-1",
+      },
+    } as never);
+    const read = vi.spyOn(api, "readArtifact");
+    read.mockResolvedValueOnce({
+      id: "motion-1",
+      kind: "motion_draft",
+      payload: { markdown: "# Draft motion" },
+      invocation_id: "inv-1",
+      created_at: "2026-01-01T00:00:00",
+    } as never);
+    read.mockResolvedValueOnce({
+      id: "evidence-1",
+      kind: "evidence_list",
+      payload: { evidence: [{ document_id: "doc-1", relevance: "high" }] },
+      invocation_id: "inv-1",
+      created_at: "2026-01-01T00:00:00",
+    } as never);
+
+    renderRunner();
+    fireEvent.click(screen.getByTestId("generic-run-demo.guided-skill-summarise"));
+
+    expect(await screen.findByText("2 outputs written")).toBeInTheDocument();
+    expect(screen.getByTestId("motion-draft-view")).toBeInTheDocument();
+    expect(screen.getByTestId("evidence-list-view")).toBeInTheDocument();
+    expect(read).toHaveBeenCalledWith("khan-v-acme", "motion-1");
+    expect(read).toHaveBeenCalledWith("khan-v-acme", "evidence-1");
   });
 });

--- a/frontend/src/matter/GenericSkillRunner.test.tsx
+++ b/frontend/src/matter/GenericSkillRunner.test.tsx
@@ -14,6 +14,7 @@ const baseSkill: RunnableMatterSkill = {
   title: "Plain-English Summary",
   description: "Summarises a document.",
   defaultRequest: "Summarise {filename}.",
+  inputFields: [],
   reads: ["document.body.read"],
   writes: ["matter.artifact.write"],
   modelAccess: "required",
@@ -82,6 +83,52 @@ describe("GenericSkillRunner", () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId("generic-runner-result")).toBeNull();
+    });
+  });
+
+  it("renders manifest string-enum fields and sends them as args", async () => {
+    const invoke = vi.spyOn(api, "invokeCapability").mockResolvedValue({
+      invocation_id: "inv-1",
+      result: { artifact_id: "artifact-1" },
+    } as never);
+    vi.spyOn(api, "readArtifact").mockResolvedValue({
+      id: "artifact-1",
+      kind: "skill_response",
+      payload: { output: "Issue list output." },
+      invocation_id: "inv-1",
+      created_at: "2026-01-01T00:00:00",
+    } as never);
+
+    renderRunner({
+      ...baseSkill,
+      inputFields: [
+        {
+          key: "style",
+          label: "Style",
+          description: null,
+          kind: "select",
+          options: ["Plain English", "Issue list"],
+          defaultValue: "Plain English",
+          required: true,
+        },
+      ],
+    });
+
+    fireEvent.change(screen.getByLabelText(/Style/i), {
+      target: { value: "Issue list" },
+    });
+    fireEvent.click(screen.getByTestId("generic-run-demo.guided-skill-summarise"));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith("khan-v-acme", {
+        module_id: "demo.guided-skill",
+        capability_id: "summarise",
+        args: {
+          input: "Summarise witness.txt.",
+          document_id: "doc-1",
+          style: "Issue list",
+        },
+      });
     });
   });
 });

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -55,12 +55,20 @@ export function GenericSkillRunner({
   const [input, setInput] = useState(
     initialInput ?? defaultPromptFor(skill, availableDocs, initialDocs),
   );
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      skill.inputFields.map((field) => [field.key, field.defaultValue]),
+    ),
+  );
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [advancedJson, setAdvancedJson] = useState("{}");
   const [state, setState] = useState<RunnerState>({ kind: "idle" });
 
   const needsDocument = skill.reads.includes("document.body.read");
-  const canRun = !needsDocument || selectedDocIds.size > 0;
+  const requiredFieldsFilled = skill.inputFields.every(
+    (field) => !field.required || fieldValues[field.key]?.trim(),
+  );
+  const canRun = (!needsDocument || selectedDocIds.size > 0) && requiredFieldsFilled;
 
   const toggleDoc = (id: string) => {
     setSelectedDocIds((prev) => {
@@ -89,6 +97,9 @@ export function GenericSkillRunner({
     const docIds = Array.from(selectedDocIds);
     const args: Record<string, unknown> = {
       ...extraArgs,
+      ...Object.fromEntries(
+        Object.entries(fieldValues).filter(([, value]) => value.trim()),
+      ),
       ...(input.trim() ? { input: input.trim() } : {}),
       ...(docIds.length === 1
         ? { document_id: docIds[0] }
@@ -174,6 +185,50 @@ export function GenericSkillRunner({
         </div>
       </div>
 
+      {skill.inputFields.length > 0 && (
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          {skill.inputFields.map((field) => (
+            <label key={field.key} className="block">
+              <span className="text-[11px] uppercase tracking-widest text-muted">
+                {field.label}{field.required ? " *" : ""}
+              </span>
+              {field.kind === "select" ? (
+                <select
+                  value={fieldValues[field.key] ?? ""}
+                  onChange={(e) =>
+                    setFieldValues((prev) => ({
+                      ...prev,
+                      [field.key]: e.target.value,
+                    }))
+                  }
+                  className="mt-1 w-full rounded-md border border-line bg-paper px-3 py-2 text-sm focus:border-ink focus:outline-none"
+                >
+                  {field.options.map((option) => (
+                    <option key={option} value={option}>{option}</option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  value={fieldValues[field.key] ?? ""}
+                  onChange={(e) =>
+                    setFieldValues((prev) => ({
+                      ...prev,
+                      [field.key]: e.target.value,
+                    }))
+                  }
+                  className="mt-1 w-full rounded-md border border-line bg-paper px-3 py-2 text-sm focus:border-ink focus:outline-none"
+                />
+              )}
+              {field.description && (
+                <span className="mt-1 block text-xs text-muted">
+                  {field.description}
+                </span>
+              )}
+            </label>
+          ))}
+        </div>
+      )}
+
       <details className="mt-3 text-xs text-muted">
         <summary className="cursor-pointer hover:text-ink">Details</summary>
         <dl className="mt-2 grid gap-2 sm:grid-cols-2">
@@ -201,7 +256,9 @@ export function GenericSkillRunner({
 
       {!canRun && (
         <p className="mt-3 text-xs text-seal">
-          Select at least one document before running this skill.
+          {needsDocument && selectedDocIds.size === 0
+            ? "Select at least one document before running this skill."
+            : "Complete the required fields before running this skill."}
         </p>
       )}
 

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -1,0 +1,367 @@
+import { useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import {
+  CapabilityDeniedError,
+  InvocationInvalidArgsError,
+  Phase1BlockedError,
+  PostureBlockedError,
+  ProviderKeyMissingForInvokeError,
+  ProviderUpstreamInvokeError,
+  invokeCapability,
+  readArtifact,
+  type ArtifactRead,
+  type InvocationResponse,
+  type MatterDocument,
+} from "../lib/api";
+import { ArtifactPreview } from "./ArtifactPreview";
+import {
+  shortCapabilityList,
+  type RunnableMatterSkill,
+} from "./skillRunnerModel";
+
+type RunnerState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "success"; response: InvocationResponse; artifact: ArtifactRead | null }
+  | { kind: "blocked"; title: string; body: string; detail?: string }
+  | { kind: "error"; title: string; body: string; detail?: string };
+
+export function GenericSkillRunner({
+  slug,
+  skill,
+  documents,
+  initialDocumentIds,
+  initialInput,
+  compact = false,
+}: {
+  slug: string;
+  skill: RunnableMatterSkill;
+  documents?: MatterDocument[] | null;
+  initialDocumentIds?: string[];
+  initialInput?: string;
+  compact?: boolean;
+}) {
+  const availableDocs = documents ?? [];
+  const initialDocs = useMemo(() => {
+    if (initialDocumentIds?.length) return new Set(initialDocumentIds);
+    if (skill.reads.includes("document.body.read") && availableDocs[0]) {
+      return new Set([availableDocs[0].id]);
+    }
+    return new Set<string>();
+  }, [availableDocs, initialDocumentIds, skill.reads]);
+  const [selectedDocIds, setSelectedDocIds] = useState<Set<string>>(initialDocs);
+  const [input, setInput] = useState(
+    initialInput ?? defaultPromptFor(skill, availableDocs, initialDocs),
+  );
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [advancedJson, setAdvancedJson] = useState("{}");
+  const [state, setState] = useState<RunnerState>({ kind: "idle" });
+
+  const needsDocument = skill.reads.includes("document.body.read");
+  const canRun = !needsDocument || selectedDocIds.size > 0;
+
+  const toggleDoc = (id: string) => {
+    setSelectedDocIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const onRun = async () => {
+    if (!canRun || state.kind === "running") return;
+    let extraArgs: Record<string, unknown> = {};
+    if (advancedOpen) {
+      try {
+        extraArgs = JSON.parse(advancedJson) as Record<string, unknown>;
+      } catch (err) {
+        setState({
+          kind: "error",
+          title: "Args are not valid JSON",
+          body: String(err),
+        });
+        return;
+      }
+    }
+    const docIds = Array.from(selectedDocIds);
+    const args: Record<string, unknown> = {
+      ...extraArgs,
+      ...(input.trim() ? { input: input.trim() } : {}),
+      ...(docIds.length === 1
+        ? { document_id: docIds[0] }
+        : docIds.length > 1
+          ? { document_ids: docIds }
+          : {}),
+    };
+
+    setState({ kind: "running" });
+    try {
+      const response = await invokeCapability(slug, {
+        module_id: skill.moduleId,
+        capability_id: skill.capabilityId,
+        args,
+      });
+      const artifactId = typeof response.result.artifact_id === "string"
+        ? response.result.artifact_id
+        : null;
+      const artifact = artifactId ? await readArtifact(slug, artifactId) : null;
+      setState({ kind: "success", response, artifact });
+    } catch (err) {
+      setState(errorToState(err));
+    }
+  };
+
+  return (
+    <section
+      className={compact ? "border border-rule bg-paper p-3" : "border border-rule bg-paper p-4"}
+      data-testid={`generic-runner-${skill.moduleId}-${skill.capabilityId}`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-ink">{skill.title}</p>
+          <p className="mt-1 max-w-xl text-xs text-muted">
+            {skill.description || "Runs against this project and writes an output to the Record."}
+          </p>
+        </div>
+        <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-muted">
+          Ready in this project
+        </span>
+      </div>
+
+      <div className="mt-3 grid gap-3 md:grid-cols-[1fr_1fr]">
+        <label className="block">
+          <span className="text-[11px] uppercase tracking-widest text-muted">Request</span>
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            rows={compact ? 2 : 3}
+            className="mt-1 w-full rounded-md border border-line bg-paper px-3 py-2 text-sm focus:border-ink focus:outline-none"
+            placeholder="Tell the skill what to do."
+          />
+        </label>
+
+        <div>
+          <p className="text-[11px] uppercase tracking-widest text-muted">
+            {needsDocument ? "Documents selected" : "Project material"}
+          </p>
+          {documents === null ? (
+            <p className="mt-2 text-xs text-muted">Loading documents…</p>
+          ) : availableDocs.length === 0 ? (
+            <p className="mt-2 text-xs text-muted">
+              No documents loaded. This skill can still run if it does not need a document.
+            </p>
+          ) : needsDocument ? (
+            <div className="mt-1 max-h-28 overflow-auto rounded-md border border-line">
+              {availableDocs.map((doc) => (
+                <label key={doc.id} className="flex items-center gap-2 border-b border-line px-2 py-1.5 last:border-b-0">
+                  <input
+                    type="checkbox"
+                    checked={selectedDocIds.has(doc.id)}
+                    onChange={() => toggleDoc(doc.id)}
+                  />
+                  <span className="truncate font-mono text-xs">{doc.filename}</span>
+                </label>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-2 text-xs text-muted">
+              This skill does not require a document selection.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <details className="mt-3 text-xs text-muted">
+        <summary className="cursor-pointer hover:text-ink">Details</summary>
+        <dl className="mt-2 grid gap-2 sm:grid-cols-2">
+          <Pair label="Reads" value={shortCapabilityList(skill.reads)} />
+          <Pair label="Writes" value={shortCapabilityList(skill.writes)} />
+          <Pair label="Signature" value={skill.signatureStatus} />
+          <Pair label="Module" value={`${skill.moduleId} / ${skill.capabilityId}`} />
+        </dl>
+        <button
+          type="button"
+          className="mt-3 underline underline-offset-4 hover:text-ink"
+          onClick={() => setAdvancedOpen((v) => !v)}
+        >
+          {advancedOpen ? "Hide advanced args" : "Advanced args"}
+        </button>
+        {advancedOpen && (
+          <textarea
+            value={advancedJson}
+            onChange={(e) => setAdvancedJson(e.target.value)}
+            rows={3}
+            className="mt-2 w-full rounded-md border border-line bg-paper px-2 py-1 font-mono text-xs"
+          />
+        )}
+      </details>
+
+      {!canRun && (
+        <p className="mt-3 text-xs text-seal">
+          Select at least one document before running this skill.
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void onRun()}
+          disabled={!canRun || state.kind === "running"}
+          className="rounded-md bg-ink px-4 py-2 text-sm font-medium text-paper hover:opacity-90 disabled:opacity-50"
+          data-testid={`generic-run-${skill.moduleId}-${skill.capabilityId}`}
+        >
+          {state.kind === "running" ? "Running…" : "Run skill"}
+        </button>
+        <Link
+          to="/matters/$slug/audit"
+          params={{ slug }}
+          className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+        >
+          View Record →
+        </Link>
+      </div>
+
+      <RunnerResult state={state} slug={slug} />
+    </section>
+  );
+}
+
+function RunnerResult({ state, slug }: { state: RunnerState; slug: string }) {
+  if (state.kind === "idle") return null;
+  if (state.kind === "running") {
+    return <p className="mt-3 text-xs text-muted">Running skill…</p>;
+  }
+  if (state.kind === "blocked" || state.kind === "error") {
+    return (
+      <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-50 px-3 py-2">
+        <p className="text-sm font-medium text-ink">{state.title}</p>
+        <p className="mt-1 text-sm text-muted">{state.body}</p>
+        {state.detail && <p className="mt-1 text-xs text-muted">{state.detail}</p>}
+      </div>
+    );
+  }
+  const { response, artifact } = state;
+  return (
+    <div className="mt-4 rounded-md border border-rule p-3" data-testid="generic-runner-result">
+      <div className="flex flex-wrap items-baseline justify-between gap-3">
+        <p className="text-xs uppercase tracking-widest text-muted">
+          Output written
+        </p>
+        <p className="font-mono text-[11px] text-muted">{response.invocation_id}</p>
+      </div>
+      {artifact ? (
+        <>
+          <ArtifactPreview
+            payload={artifact.payload}
+            kindHint={artifact.kind}
+            matterSlug={slug}
+          />
+          <div className="mt-3 flex flex-wrap gap-3 text-xs">
+            <Link
+              to="/matters/$slug/artifacts/$artifactId"
+              params={{ slug, artifactId: artifact.id }}
+              className="underline underline-offset-4 hover:text-ink"
+            >
+              Open output →
+            </Link>
+            <Link
+              to="/matters/$slug/artifacts/$artifactId/sign"
+              params={{ slug, artifactId: artifact.id }}
+              className="underline underline-offset-4 hover:text-ink"
+            >
+              Review & sign →
+            </Link>
+            <a
+              href={`/matters/${encodeURIComponent(slug)}/audit?invocation_id=${encodeURIComponent(response.invocation_id)}`}
+              className="underline underline-offset-4 hover:text-ink"
+            >
+              View Record for this run →
+            </a>
+          </div>
+        </>
+      ) : (
+        <div className="mt-3">
+          <ArtifactPreview payload={response.result} kindHint={null} matterSlug={slug} />
+          <p className="mt-2 text-xs text-muted">
+            This run returned a result but did not expose an artifact id.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Pair({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-widest text-muted">{label}</dt>
+      <dd className="mt-0.5 break-words text-xs text-ink">{value}</dd>
+    </div>
+  );
+}
+
+function defaultPromptFor(
+  skill: RunnableMatterSkill,
+  docs: MatterDocument[],
+  selectedDocIds: Set<string>,
+): string {
+  if (skill.reads.includes("document.body.read")) {
+    const selected = docs.find((d) => selectedDocIds.has(d.id)) ?? docs[0];
+    return selected ? `Summarise ${selected.filename}.` : "Summarise the selected document.";
+  }
+  return "Run this skill on the project.";
+}
+
+function errorToState(err: unknown): RunnerState {
+  if (err instanceof PostureBlockedError) {
+    return {
+      kind: "blocked",
+      title: "Privilege state blocks this skill",
+      body: "This project is not currently allowed to run that skill.",
+      detail: err.reason,
+    };
+  }
+  if (err instanceof CapabilityDeniedError) {
+    return {
+      kind: "blocked",
+      title: "This skill needs setup",
+      body: "A required project permission is missing. Open Skills to enable it.",
+    };
+  }
+  if (err instanceof Phase1BlockedError) {
+    return {
+      kind: "blocked",
+      title: "Advice boundary blocked this run",
+      body: "The requested output is beyond the allowed advice level for this skill.",
+      detail: err.blockedReason,
+    };
+  }
+  if (err instanceof ProviderKeyMissingForInvokeError) {
+    return {
+      kind: "blocked",
+      title: "Provider key needed",
+      body: err.provider
+        ? `Add a ${err.provider} key in Settings, or use a keyless demo model.`
+        : "Add a provider key in Settings, or use a keyless demo model.",
+    };
+  }
+  if (err instanceof ProviderUpstreamInvokeError) {
+    return {
+      kind: "error",
+      title: "Provider error",
+      body: err.provider
+        ? `${err.provider} returned an error.`
+        : "The provider returned an error.",
+      detail: err.code ?? undefined,
+    };
+  }
+  if (err instanceof InvocationInvalidArgsError) {
+    return { kind: "error", title: "Invalid input", body: err.message };
+  }
+  return {
+    kind: "error",
+    title: "Run failed",
+    body: err instanceof Error ? err.message : String(err),
+  };
+}

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -22,7 +22,7 @@ import {
 type RunnerState =
   | { kind: "idle" }
   | { kind: "running" }
-  | { kind: "success"; response: InvocationResponse; artifact: ArtifactRead | null }
+  | { kind: "success"; response: InvocationResponse; artifacts: ArtifactRead[] }
   | { kind: "blocked"; title: string; body: string; detail?: string }
   | { kind: "error"; title: string; body: string; detail?: string };
 
@@ -115,11 +115,11 @@ export function GenericSkillRunner({
         capability_id: skill.capabilityId,
         args,
       });
-      const artifactId = typeof response.result.artifact_id === "string"
-        ? response.result.artifact_id
-        : null;
-      const artifact = artifactId ? await readArtifact(slug, artifactId) : null;
-      setState({ kind: "success", response, artifact });
+      const artifactIds = artifactIdsFromResult(response.result);
+      const artifacts = await Promise.all(
+        artifactIds.map((artifactId) => readArtifact(slug, artifactId)),
+      );
+      setState({ kind: "success", response, artifacts });
     } catch (err) {
       setState(errorToState(err));
     }
@@ -312,52 +312,69 @@ function RunnerResult({
       </div>
     );
   }
-  const { response, artifact } = state;
+  const { response, artifacts } = state;
   return (
     <div className="mt-4 rounded-md border border-rule p-3" data-testid="generic-runner-result">
       <div className="flex flex-wrap items-baseline justify-between gap-3">
         <p className="text-xs uppercase tracking-widest text-muted">
-          Output written
+          {artifacts.length === 1
+            ? "Output written"
+            : artifacts.length > 1
+              ? `${artifacts.length} outputs written`
+              : "Run complete"}
         </p>
         <p className="font-mono text-[11px] text-muted">{response.invocation_id}</p>
       </div>
-      {artifact ? (
-        <>
-          <ArtifactPreview
-            payload={artifact.payload}
-            kindHint={artifact.kind}
-            matterSlug={slug}
-          />
-          <div className="mt-3 flex flex-wrap gap-3 text-xs">
-            <Link
-              to="/matters/$slug/artifacts/$artifactId"
-              params={{ slug, artifactId: artifact.id }}
-              className="underline underline-offset-4 hover:text-ink"
+      {artifacts.length > 0 ? (
+        <div className="mt-3 space-y-4">
+          {artifacts.map((artifact, index) => (
+            <section
+              key={artifact.id}
+              className={artifacts.length > 1 ? "border-t border-line pt-3 first:border-t-0 first:pt-0" : undefined}
+              data-testid={`generic-runner-output-${artifact.id}`}
             >
-              Open output →
-            </Link>
-            <Link
-              to="/matters/$slug/artifacts/$artifactId/sign"
-              params={{ slug, artifactId: artifact.id }}
-              className="underline underline-offset-4 hover:text-ink"
-            >
-              Review & sign →
-            </Link>
-            <a
-              href={`/matters/${encodeURIComponent(slug)}/audit?invocation_id=${encodeURIComponent(response.invocation_id)}`}
-              className="underline underline-offset-4 hover:text-ink"
-            >
-              View Record for this run →
-            </a>
-            <button
-              type="button"
-              onClick={onClose}
-              className="text-muted underline underline-offset-4 hover:text-ink"
-            >
-              Close run
-            </button>
-          </div>
-        </>
+              {artifacts.length > 1 && (
+                <p className="mb-2 text-[11px] uppercase tracking-widest text-muted">
+                  Output {index + 1}
+                </p>
+              )}
+              <ArtifactPreview
+                payload={artifact.payload}
+                kindHint={artifact.kind}
+                matterSlug={slug}
+              />
+              <div className="mt-3 flex flex-wrap gap-3 text-xs">
+                <Link
+                  to="/matters/$slug/artifacts/$artifactId"
+                  params={{ slug, artifactId: artifact.id }}
+                  className="underline underline-offset-4 hover:text-ink"
+                >
+                  Open output →
+                </Link>
+                <Link
+                  to="/matters/$slug/artifacts/$artifactId/sign"
+                  params={{ slug, artifactId: artifact.id }}
+                  className="underline underline-offset-4 hover:text-ink"
+                >
+                  Review & sign →
+                </Link>
+                <a
+                  href={`/matters/${encodeURIComponent(slug)}/audit?invocation_id=${encodeURIComponent(response.invocation_id)}`}
+                  className="underline underline-offset-4 hover:text-ink"
+                >
+                  View Record for this run →
+                </a>
+              </div>
+            </section>
+          ))}
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+          >
+            Close run
+          </button>
+        </div>
       ) : (
         <div className="mt-3">
           <ArtifactPreview payload={response.result} kindHint={null} matterSlug={slug} />
@@ -368,6 +385,23 @@ function RunnerResult({
       )}
     </div>
   );
+}
+
+export function artifactIdsFromResult(result: InvocationResponse["result"]): string[] {
+  if (!result || typeof result !== "object") return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const [key, value] of Object.entries(result as Record<string, unknown>)) {
+    if (
+      typeof value === "string" &&
+      (key === "artifact_id" || key.endsWith("_artifact_id")) &&
+      !seen.has(value)
+    ) {
+      seen.add(value);
+      out.push(value);
+    }
+  }
+  return out;
 }
 
 function Pair({ label, value }: { label: string; value: string }) {

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -32,6 +32,7 @@ export function GenericSkillRunner({
   documents,
   initialDocumentIds,
   initialInput,
+  onClose,
   compact = false,
 }: {
   slug: string;
@@ -39,6 +40,7 @@ export function GenericSkillRunner({
   documents?: MatterDocument[] | null;
   initialDocumentIds?: string[];
   initialInput?: string;
+  onClose?: () => void;
   compact?: boolean;
 }) {
   const availableDocs = documents ?? [];
@@ -222,12 +224,24 @@ export function GenericSkillRunner({
         </Link>
       </div>
 
-      <RunnerResult state={state} slug={slug} />
+      <RunnerResult
+        state={state}
+        slug={slug}
+        onClose={onClose ?? (() => setState({ kind: "idle" }))}
+      />
     </section>
   );
 }
 
-function RunnerResult({ state, slug }: { state: RunnerState; slug: string }) {
+function RunnerResult({
+  state,
+  slug,
+  onClose,
+}: {
+  state: RunnerState;
+  slug: string;
+  onClose: () => void;
+}) {
   if (state.kind === "idle") return null;
   if (state.kind === "running") {
     return <p className="mt-3 text-xs text-muted">Running skill…</p>;
@@ -278,6 +292,13 @@ function RunnerResult({ state, slug }: { state: RunnerState; slug: string }) {
             >
               View Record for this run →
             </a>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-muted underline underline-offset-4 hover:text-ink"
+            >
+              Close run
+            </button>
           </div>
         </>
       ) : (
@@ -306,9 +327,15 @@ function defaultPromptFor(
   docs: MatterDocument[],
   selectedDocIds: Set<string>,
 ): string {
+  const selected = docs.find((d) => selectedDocIds.has(d.id)) ?? docs[0];
+  if (skill.defaultRequest) {
+    return skill.defaultRequest.replaceAll(
+      "{filename}",
+      selected?.filename ?? "the selected document",
+    );
+  }
   if (skill.reads.includes("document.body.read")) {
-    const selected = docs.find((d) => selectedDocIds.has(d.id)) ?? docs[0];
-    return selected ? `Summarise ${selected.filename}.` : "Summarise the selected document.";
+    return "Run this skill on the selected document.";
   }
   return "Run this skill on the project.";
 }

--- a/frontend/src/matter/MatterSkillsTab.test.tsx
+++ b/frontend/src/matter/MatterSkillsTab.test.tsx
@@ -2,9 +2,9 @@
  * MatterSkillsTab — enable-truth regression.
  *
  * Pins the contract that the matter Skills surface only posts grants
- * for capabilities the substrate will accept at matter scope. Any
+ * for capabilities the runtime will accept at matter scope. Any
  * workspace / provider / other-scope capability declared by the
- * manifest must not be sent; the substrate would reject those with
+ * manifest must not be sent; the runtime would reject those with
  * 422 and the modal would close as "enabled" while the skill is
  * still half-granted.
  */
@@ -52,6 +52,7 @@ function mountAt(slug: string) {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.spyOn(api, "listDocuments").mockResolvedValue([]);
 });
 afterEach(() => {
   cleanup();
@@ -177,7 +178,7 @@ describe("MatterSkillsTab — enable truth", () => {
     expect(btn).toBeDisabled();
     expect(
       screen.getByTestId("available-disabled-reason-workspace-only"),
-    ).toHaveTextContent(/no matter-scoped capabilities/i);
+    ).toHaveTextContent(/cannot be enabled inside a project/i);
   });
 
   it("keeps the modal open and surfaces the error on grant failure", async () => {
@@ -200,5 +201,90 @@ describe("MatterSkillsTab — enable truth", () => {
     expect(
       screen.getByRole("dialog", { name: /Enable Contract Review/i }),
     ).toBeInTheDocument();
+  });
+
+  it("renders a generic runner for a V2 module whose project permissions are complete", async () => {
+    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({ workflows: [] });
+    vi.spyOn(api, "listDocuments").mockResolvedValue([
+      {
+        id: "doc-1",
+        filename: "witness.txt",
+        sha256: "sha",
+        bytes: 200,
+        content_type: "text/plain",
+        tag: "demo",
+        from_disclosure: false,
+        disclosure_label: null,
+        uploaded_at: "2026-01-01T00:00:00",
+      },
+    ] as never);
+    vi.spyOn(api, "listGrants").mockResolvedValue({
+      matter_id: "m-1",
+      grants: [
+        {
+          id: "g-read",
+          plugin: "demo.guided-skill",
+          skill: "summarise",
+          capability: "document.body.read",
+          scope_type: "matter",
+          scope_id: "m-1",
+          granted_at: "2026-01-01T00:00:00",
+        },
+        {
+          id: "g-write",
+          plugin: "demo.guided-skill",
+          skill: "summarise",
+          capability: "matter.artifact.write",
+          scope_type: "matter",
+          scope_id: "m-1",
+          granted_at: "2026-01-01T00:00:00",
+        },
+      ],
+    });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([
+      {
+        module_id: "demo.guided-skill",
+        version: "0.1.0",
+        publisher: "legalise",
+        visibility: "first_party",
+        signature_status: "verified",
+        enabled: true,
+        installed_at: "2026-01-01T00:00:00",
+        installed_by_user_id: null,
+      },
+    ]);
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({
+      modules: [
+        {
+          module_id: "demo.guided-skill",
+          source_kind: "v2",
+          manifest: {
+            name: "Guided demo skill",
+            description: "Summarises the selected document.",
+            capabilities: [
+              {
+                id: "summarise",
+                scope: "matter",
+                kind: "skill",
+                reads: ["document.body.read"],
+                writes: ["matter.artifact.write"],
+                ui: { label: "Summarise document" },
+              },
+            ],
+          },
+          is_valid: true,
+          validation_errors: [],
+        },
+      ],
+      ui_slots: [],
+    } as never);
+
+    mountAt("m-1");
+
+    expect(
+      await screen.findByTestId("generic-runner-demo.guided-skill-summarise"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Summarise document")).toBeInTheDocument();
+    expect(screen.queryByTestId("enabled-module-demo.guided-skill")).toBeNull();
   });
 });

--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -3,40 +3,35 @@
 // matter-scoped capabilities are grantable — workspace and provider
 // capabilities are inherited from workspace trust and not surfaced as
 // per-matter actions. GrantsPanel below provides the operator-level
-// permissions table for direct grant editing.
+// permissions table for direct permission editing.
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import {
   createGrant,
   getMatterWorkflows,
   getModulesV2,
+  listDocuments,
   listGrants,
   listInstalledModules,
   revokeGrant,
   type GrantRow,
   type InstalledModule,
+  type MatterDocument,
   type MatterWorkflowsResponse,
   type V2ManifestEntry,
-  type WorkflowAvailability,
-  type WorkflowGrant,
 } from "../lib/api";
+import { GenericSkillRunner } from "./GenericSkillRunner";
+import {
+  manifestCapabilities,
+  manifestText,
+  runnableMatterSkills,
+  shortCapabilityList,
+} from "./skillRunnerModel";
 
 interface Props {
   slug: string;
 }
-
-const GRANT_TONE: Record<WorkflowGrant, string> = {
-  granted: "text-[#00A35C]",
-  partial: "text-[#E67E22]",
-  blocked: "text-[#D9304F]",
-};
-
-const AVAILABILITY_BLURB: Record<WorkflowAvailability, string> = {
-  ok: "Ready to run",
-  "blocked-by-posture": "Blocked by privilege state",
-  "blocked-by-grant": "Needs permission in this matter",
-};
 
 function formatLastRun(iso: string | null): string {
   if (!iso) return "Not run yet on this matter";
@@ -49,54 +44,52 @@ function formatLastRun(iso: string | null): string {
   })}`;
 }
 
-function manifestStr(entry: V2ManifestEntry, key: string): string | undefined {
-  const v = (entry.manifest as Record<string, unknown>)[key];
-  return typeof v === "string" ? v : undefined;
-}
-
 function capabilityStrings(
   entry: V2ManifestEntry,
   key: "reads" | "writes",
   opts: { matterOnly?: boolean } = {},
 ): string[] {
-  const caps = (entry.manifest as Record<string, unknown>).capabilities;
-  if (!Array.isArray(caps)) return [];
   const out = new Set<string>();
-  for (const raw of caps) {
-    if (!raw || typeof raw !== "object") continue;
-    const obj = raw as Record<string, unknown>;
-    if (opts.matterOnly && obj.scope !== "matter") continue;
-    const values = obj[key];
-    if (!Array.isArray(values)) continue;
-    for (const value of values) if (typeof value === "string") out.add(value);
+  for (const cap of manifestCapabilities(entry)) {
+    if (opts.matterOnly && cap.scope !== "matter") continue;
+    for (const value of cap[key]) out.add(value);
   }
   return [...out].sort();
 }
 
-// The substrate only grants capabilities with scope === "matter" at
+// The runtime only grants capabilities with scope === "matter" at
 // matter level; create_grants_for_capability rejects scope ≠ "matter"
 // with 422 (see GrantsPanel for the canonical filter at line 441).
 // Returning only those keeps the enable action honest: provider /
 // workspace / other-scope capabilities are inherited from workspace
 // trust and are not per-matter actions.
 function matterCapabilityIds(entry: V2ManifestEntry): string[] {
-  const caps = (entry.manifest as Record<string, unknown>).capabilities;
-  if (!Array.isArray(caps)) return [];
-  const out: string[] = [];
-  for (const raw of caps) {
-    if (!raw || typeof raw !== "object") continue;
-    const obj = raw as Record<string, unknown>;
-    if (obj.scope !== "matter") continue;
-    const id = obj.id;
-    if (typeof id === "string") out.push(id);
-  }
-  return out;
+  return manifestCapabilities(entry)
+    .filter((cap) => cap.scope === "matter")
+    .map((cap) => cap.id);
 }
 
-function shortList(values: string[]): string {
-  if (values.length === 0) return "None declared";
-  if (values.length <= 2) return values.join(", ");
-  return `${values.slice(0, 2).join(", ")} +${values.length - 2} more`;
+function friendlyCapabilitySummary(values: string[]): string {
+  if (values.length === 0) return "Project context";
+  const labels = new Set<string>();
+  for (const value of values) {
+    if (value.includes("document")) labels.add("Documents");
+    else if (value.includes("chronology")) labels.add("Chronology");
+    else if (value.includes("artifact") || value.includes("output")) labels.add("Outputs");
+    else if (value.includes("model")) labels.add("Model");
+    else if (value.includes("matter")) labels.add("Matter record");
+    else labels.add(value.replaceAll(".", " "));
+  }
+  const list = [...labels];
+  if (list.length <= 2) return list.join(", ");
+  return `${list.slice(0, 2).join(", ")} +${list.length - 2} more`;
+}
+
+function workflowStatus(workflow: MatterWorkflowsResponse["workflows"][number]) {
+  if (workflow.grant === "granted" && workflow.availability === "ok") {
+    return "Ready in this project";
+  }
+  return "Needs setup";
 }
 
 export function MatterSkillsTab({ slug }: Props) {
@@ -108,6 +101,7 @@ export function MatterSkillsTab({ slug }: Props) {
     new Map(),
   );
   const [grants, setGrants] = useState<GrantRow[] | null>(null);
+  const [documents, setDocuments] = useState<MatterDocument[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [enableTarget, setEnableTarget] = useState<V2ManifestEntry | null>(null);
 
@@ -121,6 +115,9 @@ export function MatterSkillsTab({ slug }: Props) {
     void listGrants(slug)
       .then((r) => setGrants(r.grants))
       .catch(() => undefined);
+    void listDocuments(slug)
+      .then(setDocuments)
+      .catch(() => setDocuments([]));
     void getModulesV2()
       .then((r) => setModules(r.modules))
       .catch(() => undefined);
@@ -140,7 +137,7 @@ export function MatterSkillsTab({ slug }: Props) {
   }, [slug]);
 
   // A module is "enabled in this matter" if any grant row references
-  // it on this matter. (Substrate grants are per (module_id, capability)
+  // it on this matter. Grants are per (module_id, capability)
   // tuple, so any presence implies the skill has been enabled at least
   // partially.)
   const grantedModuleIds = useMemo(() => {
@@ -156,6 +153,21 @@ export function MatterSkillsTab({ slug }: Props) {
         return inst?.enabled === true && grantedModuleIds.has(m.module_id);
       }),
     [modules, installed, grantedModuleIds],
+  );
+
+  const runnableSkills = useMemo(
+    () => runnableMatterSkills({ modules, installed, grants }),
+    [modules, installed, grants],
+  );
+
+  const runnableModuleIds = useMemo(
+    () => new Set(runnableSkills.map((skill) => skill.moduleId)),
+    [runnableSkills],
+  );
+
+  const setupOnlyModules = useMemo(
+    () => enabledModules.filter((module) => !runnableModuleIds.has(module.module_id)),
+    [enabledModules, runnableModuleIds],
   );
 
   const availableModules = useMemo(
@@ -203,7 +215,15 @@ export function MatterSkillsTab({ slug }: Props) {
           {workflows.workflows.map((w) => (
             <WorkflowRow key={w.key} slug={slug} workflow={w} />
           ))}
-          {enabledModules.map((m) => (
+          {runnableSkills.map((skill) => (
+            <GenericSkillRunner
+              key={`${skill.moduleId}:${skill.capabilityId}`}
+              slug={slug}
+              skill={skill}
+              documents={documents}
+            />
+          ))}
+          {setupOnlyModules.map((m) => (
             <EnabledModuleRow
               key={m.module_id}
               slug={slug}
@@ -308,15 +328,10 @@ function WorkflowRow({
         </Link>
       </div>
       <dl className="mt-3 grid grid-cols-2 gap-3 text-[11px] sm:grid-cols-3">
-        <Meta label="Reads" value={shortList(workflow.declared_capabilities)} />
-        <Meta
-          label="Permission"
-          value={workflow.grant}
-          tone={GRANT_TONE[workflow.grant]}
-        />
+        <Meta label="Reads" value={friendlyCapabilitySummary(workflow.declared_capabilities)} />
         <Meta
           label="Status"
-          value={AVAILABILITY_BLURB[workflow.availability]}
+          value={workflowStatus(workflow)}
         />
         <Meta label="Last run" value={formatLastRun(workflow.last_run_at)} />
       </dl>
@@ -342,14 +357,14 @@ function EnabledModuleRow({
   const [err, setErr] = useState<string | null>(null);
   const reads = capabilityStrings(entry, "reads");
   const writes = capabilityStrings(entry, "writes");
-  const name = manifestStr(entry, "name") ?? entry.module_id;
+  const name = manifestText(entry, "name") ?? entry.module_id;
 
   const onRevoke = async () => {
     if (grants.length === 0) return;
     setRevoking(true);
     setErr(null);
     try {
-      // Revoke the parent grant first; the substrate cascades the
+      // Revoke the parent grant first; the runtime cascades the
       // expanded per-string rows.
       await Promise.all(grants.map((g) => revokeGrant(slug, g.id)));
       onRevoked();
@@ -373,13 +388,9 @@ function EnabledModuleRow({
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <Link
-            to="/matters/$slug/$tab"
-            params={{ slug, tab: "workflows" }}
-            className="rounded-md border border-line px-3 py-1 text-xs hover:border-ink"
-          >
-            Run
-          </Link>
+          <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-muted">
+            Needs setup
+          </span>
           <button
             type="button"
             onClick={onRevoke}
@@ -391,9 +402,9 @@ function EnabledModuleRow({
         </div>
       </div>
       <dl className="mt-3 grid grid-cols-2 gap-3 text-[11px] sm:grid-cols-3">
-        <Meta label="Reads" value={shortList(reads)} />
-        <Meta label="Writes" value={shortList(writes)} />
-        <Meta label="Last run" value="Not tracked at module level" />
+        <Meta label="Reads" value={friendlyCapabilitySummary(reads)} />
+        <Meta label="Writes" value={friendlyCapabilitySummary(writes)} />
+        <Meta label="Status" value="Needs setup" />
       </dl>
       {err && <p className="mt-2 text-xs text-seal">{err}</p>}
     </article>
@@ -409,15 +420,15 @@ function AvailableModuleRow({
 }) {
   const reads = capabilityStrings(entry, "reads");
   const writes = capabilityStrings(entry, "writes");
-  const name = manifestStr(entry, "name") ?? entry.module_id;
-  const publisher = manifestStr(entry, "publisher");
+  const name = manifestText(entry, "name") ?? entry.module_id;
+  const publisher = manifestText(entry, "publisher");
   const matterCaps = matterCapabilityIds(entry);
   const hasMatterCaps = matterCaps.length > 0;
   const enableDisabled = !entry.is_valid || !hasMatterCaps;
-  const disabledReason = !entry.is_valid
-    ? "Manifest invalid — fix at the workspace before enabling."
+      const disabledReason = !entry.is_valid
+    ? "This skill needs setup in the workspace before enabling."
     : !hasMatterCaps
-      ? "This skill has no matter-scoped capabilities to enable. It runs at workspace level."
+      ? "This skill cannot be enabled inside a project yet."
       : null;
 
   return (
@@ -445,9 +456,9 @@ function AvailableModuleRow({
         </button>
       </div>
       <dl className="mt-3 grid grid-cols-2 gap-3 text-[11px] sm:grid-cols-3">
-        <Meta label="Reads" value={shortList(reads)} />
-        <Meta label="Writes" value={shortList(writes)} />
-        <Meta label="Matter capabilities" value={String(matterCaps.length)} />
+        <Meta label="Reads" value={friendlyCapabilitySummary(reads)} />
+        <Meta label="Writes" value={friendlyCapabilitySummary(writes)} />
+        <Meta label="Project actions" value={String(matterCaps.length)} />
       </dl>
       {disabledReason && (
         <p
@@ -482,7 +493,7 @@ function Meta({
 
 // Enable modal — grants every matter-scoped capability. Non-matter
 // capabilities (workspace / provider / etc.) are NOT posted: the
-// substrate rejects them with 422 at matter scope. If a skill has
+// runtime rejects them with 422 at matter scope. If a skill has
 // no matter-scoped capabilities the modal isn't reachable
 // (AvailableModuleRow disables the Enable button with an honest
 // reason). Any grant failure aborts the rest, keeps the modal open,
@@ -503,7 +514,7 @@ function EnableSkillModal({
 }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  const name = manifestStr(entry, "name") ?? entry.module_id;
+  const name = manifestText(entry, "name") ?? entry.module_id;
   // Modal copy is matter-scoped: what enabling here actually does, not
   // what the skill could do at other scopes.
   const reads = capabilityStrings(entry, "reads", { matterOnly: true });
@@ -515,7 +526,7 @@ function EnableSkillModal({
     setBusy(true);
     setErr(null);
     try {
-      // The substrate's createGrant is idempotent (was_idempotent_noop
+      // createGrant is idempotent (was_idempotent_noop
       // on a no-op rerun), so re-enable on an already-granted skill is
       // safe. Any real failure halts the run so the modal can show
       // honest state instead of silently closing as "enabled."
@@ -565,7 +576,7 @@ function EnableSkillModal({
             <span>
               <span className="text-ink">All documents in this matter</span>
               <span className="mt-0.5 block text-xs text-muted">
-                Per-document narrowing arrives once the substrate supports it.
+                Per-document narrowing can be added later without changing this permission.
               </span>
             </span>
           </label>
@@ -573,19 +584,19 @@ function EnableSkillModal({
 
         {/* Step 4 — output scope */}
         <Block label="What this skill writes">
-          <p className="text-sm text-ink">{shortList(writes)}</p>
+          <p className="text-sm text-ink">{shortCapabilityList(writes)}</p>
           <p className="mt-1 text-xs text-muted">
             Outputs land in the matter Record. Per-output narrowing arrives
-            once the substrate supports it.
+            once output-specific permissions are available.
           </p>
         </Block>
 
         {/* Step 5 — inherited workspace trust */}
         <Block label="Inherited from workspace trust">
           <dl className="grid grid-cols-2 gap-2 text-xs">
-            <Pair label="Reads" value={shortList(reads)} />
+            <Pair label="Reads" value={shortCapabilityList(reads)} />
             <Pair label="Signature" value={installed?.signature_status ?? "—"} />
-            <Pair label="Publisher" value={manifestStr(entry, "publisher") ?? "—"} />
+            <Pair label="Publisher" value={manifestText(entry, "publisher") ?? "—"} />
             <Pair
               label="Trusted on"
               value={
@@ -636,7 +647,7 @@ function Block({
   children,
 }: {
   label: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <section className="mt-4 border-t border-rule pt-3">

--- a/frontend/src/matter/skillRunnerModel.ts
+++ b/frontend/src/matter/skillRunnerModel.ts
@@ -8,6 +8,7 @@ export interface ManifestCapability {
   id: string;
   label: string;
   defaultRequest: string | null;
+  inputFields: RunnerInputField[];
   kind: string;
   scope: string;
   reads: string[];
@@ -22,6 +23,7 @@ export interface RunnableMatterSkill {
   title: string;
   description: string;
   defaultRequest: string | null;
+  inputFields: RunnerInputField[];
   reads: string[];
   writes: string[];
   modelAccess: string;
@@ -30,6 +32,22 @@ export interface RunnableMatterSkill {
 }
 
 const INVOKABLE_KINDS = new Set(["skill", "tool", "workflow"]);
+const RESERVED_ARG_KEYS = new Set([
+  "input",
+  "question",
+  "document_id",
+  "document_ids",
+]);
+
+export interface RunnerInputField {
+  key: string;
+  label: string;
+  description: string | null;
+  kind: "text" | "select";
+  options: string[];
+  defaultValue: string;
+  required: boolean;
+}
 
 function str(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value : null;
@@ -39,6 +57,32 @@ function strArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((v): v is string => typeof v === "string")
     : [];
+}
+
+function runnerInputFields(value: unknown): RunnerInputField[] {
+  if (!value || typeof value !== "object") return [];
+  const schema = value as Record<string, unknown>;
+  const rawProperties = schema.properties;
+  if (!rawProperties || typeof rawProperties !== "object") return [];
+  const required = new Set(strArray(schema.required));
+  return Object.entries(rawProperties as Record<string, unknown>).flatMap(
+    ([key, raw]): RunnerInputField[] => {
+      if (RESERVED_ARG_KEYS.has(key)) return [];
+      if (!raw || typeof raw !== "object") return [];
+      const prop = raw as Record<string, unknown>;
+      if (prop.type !== "string") return [];
+      const options = strArray(prop.enum);
+      return [{
+        key,
+        label: str(prop.title) ?? key,
+        description: str(prop.description),
+        kind: options.length > 0 ? "select" : "text",
+        options,
+        defaultValue: str(prop.default) ?? (options[0] ?? ""),
+        required: required.has(key),
+      }];
+    },
+  );
 }
 
 export function manifestText(
@@ -63,6 +107,7 @@ export function manifestCapabilities(
       id,
       label: str(ui.label) ?? id,
       defaultRequest: str(ui.default_request),
+      inputFields: runnerInputFields(obj.args_schema),
       kind: str(obj.kind) ?? "skill",
       scope: str(obj.scope) ?? "workspace",
       reads: strArray(obj.reads),
@@ -124,6 +169,7 @@ export function runnableMatterSkills({
         title: cap.label === cap.id ? moduleName : cap.label,
         description,
         defaultRequest: cap.defaultRequest,
+        inputFields: cap.inputFields,
         reads: cap.reads,
         writes: cap.writes,
         modelAccess: cap.modelAccess,

--- a/frontend/src/matter/skillRunnerModel.ts
+++ b/frontend/src/matter/skillRunnerModel.ts
@@ -7,6 +7,7 @@ import type {
 export interface ManifestCapability {
   id: string;
   label: string;
+  defaultRequest: string | null;
   kind: string;
   scope: string;
   reads: string[];
@@ -20,6 +21,7 @@ export interface RunnableMatterSkill {
   capabilityId: string;
   title: string;
   description: string;
+  defaultRequest: string | null;
   reads: string[];
   writes: string[];
   modelAccess: string;
@@ -60,6 +62,7 @@ export function manifestCapabilities(
     return [{
       id,
       label: str(ui.label) ?? id,
+      defaultRequest: str(ui.default_request),
       kind: str(obj.kind) ?? "skill",
       scope: str(obj.scope) ?? "workspace",
       reads: strArray(obj.reads),
@@ -120,6 +123,7 @@ export function runnableMatterSkills({
         capabilityId: cap.id,
         title: cap.label === cap.id ? moduleName : cap.label,
         description,
+        defaultRequest: cap.defaultRequest,
         reads: cap.reads,
         writes: cap.writes,
         modelAccess: cap.modelAccess,

--- a/frontend/src/matter/skillRunnerModel.ts
+++ b/frontend/src/matter/skillRunnerModel.ts
@@ -1,0 +1,138 @@
+import type {
+  GrantRow,
+  InstalledModule,
+  V2ManifestEntry,
+} from "../lib/api";
+
+export interface ManifestCapability {
+  id: string;
+  label: string;
+  kind: string;
+  scope: string;
+  reads: string[];
+  writes: string[];
+  modelAccess: string;
+  streamingMode: string;
+}
+
+export interface RunnableMatterSkill {
+  moduleId: string;
+  capabilityId: string;
+  title: string;
+  description: string;
+  reads: string[];
+  writes: string[];
+  modelAccess: string;
+  signatureStatus: string;
+  sourceKind: string;
+}
+
+const INVOKABLE_KINDS = new Set(["skill", "tool", "workflow"]);
+
+function str(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function strArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
+}
+
+export function manifestText(
+  entry: V2ManifestEntry,
+  key: string,
+): string | null {
+  return str((entry.manifest as Record<string, unknown>)[key]);
+}
+
+export function manifestCapabilities(
+  entry: V2ManifestEntry,
+): ManifestCapability[] {
+  const raw = (entry.manifest as Record<string, unknown>).capabilities;
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((item): ManifestCapability[] => {
+    if (!item || typeof item !== "object") return [];
+    const obj = item as Record<string, unknown>;
+    const id = str(obj.id);
+    if (!id) return [];
+    const ui = obj.ui && typeof obj.ui === "object" ? obj.ui as Record<string, unknown> : {};
+    return [{
+      id,
+      label: str(ui.label) ?? id,
+      kind: str(obj.kind) ?? "skill",
+      scope: str(obj.scope) ?? "workspace",
+      reads: strArray(obj.reads),
+      writes: strArray(obj.writes),
+      modelAccess: str(obj.model_access) ?? "none",
+      streamingMode: str(obj.streaming_mode) ?? "sync",
+    }];
+  });
+}
+
+export function grantKey(moduleId: string, capabilityId: string): string {
+  return `${moduleId}::${capabilityId}`;
+}
+
+export function grantedCapabilityKeys(grants: GrantRow[] | null): Set<string> {
+  const keys = new Set<string>();
+  for (const g of grants ?? []) keys.add(grantKey(g.plugin, g.skill));
+  return keys;
+}
+
+function capabilityHasRequiredGrantRows(
+  cap: ManifestCapability,
+  moduleId: string,
+  grants: GrantRow[] | null,
+): boolean {
+  const required = [...cap.reads, ...cap.writes];
+  if (required.length === 0) return true;
+  const granted = new Set(
+    (grants ?? [])
+      .filter((g) => g.plugin === moduleId && g.skill === cap.id)
+      .map((g) => g.capability),
+  );
+  return required.every((need) => granted.has(need));
+}
+
+export function runnableMatterSkills({
+  modules,
+  installed,
+  grants,
+}: {
+  modules: V2ManifestEntry[];
+  installed: Map<string, InstalledModule>;
+  grants: GrantRow[] | null;
+}): RunnableMatterSkill[] {
+  const out: RunnableMatterSkill[] = [];
+  for (const entry of modules) {
+    if (!entry.is_valid) continue;
+    const inst = installed.get(entry.module_id);
+    if (!inst?.enabled) continue;
+    const moduleName = manifestText(entry, "name") ?? entry.module_id;
+    const description = manifestText(entry, "description") ?? "";
+    for (const cap of manifestCapabilities(entry)) {
+      if (cap.scope !== "matter") continue;
+      if (!INVOKABLE_KINDS.has(cap.kind)) continue;
+      if (!capabilityHasRequiredGrantRows(cap, entry.module_id, grants)) continue;
+      out.push({
+        moduleId: entry.module_id,
+        capabilityId: cap.id,
+        title: cap.label === cap.id ? moduleName : cap.label,
+        description,
+        reads: cap.reads,
+        writes: cap.writes,
+        modelAccess: cap.modelAccess,
+        signatureStatus: inst.signature_status,
+        sourceKind: entry.source_kind,
+      });
+    }
+  }
+  return out.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+export function shortCapabilityList(values: string[]): string {
+  if (values.length === 0) return "Nothing extra";
+  if (values.length <= 2) return values.join(", ");
+  return `${values.slice(0, 2).join(", ")} +${values.length - 2} more`;
+}

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -1,6 +1,6 @@
-// Pins the source-of-truth contract: the in-chat picker reads
-// getMatterWorkflows and shows only workflows already granted on this
-// matter. No third skill-state model.
+// Pins the source-of-truth contract: the in-chat picker reads the
+// same matter skills sources as the Skills page and shows only skills
+// runnable right now. No third skill-state model.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -62,6 +62,15 @@ function mountChat(overrides?: { setTabAndHash?: (k: string) => void }) {
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(api, "listAssistantMessages").mockResolvedValue([]);
+  vi.spyOn(api, "getModulesV2").mockResolvedValue({
+    modules: [],
+    ui_slots: [],
+  } as never);
+  vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+  vi.spyOn(api, "listGrants").mockResolvedValue({
+    matter_id: "m-1",
+    grants: [],
+  });
   vi.spyOn(api, "postAssistantMessage").mockResolvedValue({
     user: {
       id: "u-1",
@@ -214,6 +223,86 @@ describe("AssistantTab — in-chat skill picker", () => {
 
     fireEvent.click(screen.getByTestId("open-documents-link"));
     expect(setTabAndHash).toHaveBeenCalledWith("documents");
+  });
+
+  it("mounts the generic runner for a runnable V2 skill instead of routing to a bespoke tab", async () => {
+    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
+      workflows: [],
+    } as never);
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({
+      modules: [
+        {
+          module_id: "demo.guided-skill",
+          source_kind: "v2",
+          manifest: {
+            name: "Guided demo skill",
+            description: "Summarises the selected document.",
+            capabilities: [
+              {
+                id: "summarise",
+                scope: "matter",
+                kind: "skill",
+                reads: ["document.body.read"],
+                writes: ["matter.artifact.write"],
+                ui: { label: "Summarise document" },
+              },
+            ],
+          },
+          is_valid: true,
+          validation_errors: [],
+        },
+      ],
+      ui_slots: [],
+    } as never);
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([
+      {
+        module_id: "demo.guided-skill",
+        version: "0.1.0",
+        publisher: "legalise",
+        visibility: "first_party",
+        signature_status: "verified",
+        enabled: true,
+        installed_at: "2026-01-01T00:00:00",
+        installed_by_user_id: null,
+      },
+    ]);
+    vi.spyOn(api, "listGrants").mockResolvedValue({
+      matter_id: "m-1",
+      grants: [
+        {
+          id: "g-read",
+          plugin: "demo.guided-skill",
+          skill: "summarise",
+          capability: "document.body.read",
+          scope_type: "matter",
+          scope_id: "m-1",
+          granted_at: "2026-01-01T00:00:00",
+        },
+        {
+          id: "g-write",
+          plugin: "demo.guided-skill",
+          skill: "summarise",
+          capability: "matter.artifact.write",
+          scope_type: "matter",
+          scope_id: "m-1",
+          granted_at: "2026-01-01T00:00:00",
+        },
+      ],
+    });
+    const setTabAndHash = vi.fn();
+    mountChat({ setTabAndHash });
+
+    const toggle = await screen.findByTestId("chat-skills-toggle");
+    await waitFor(() => expect(toggle).toHaveTextContent("Skills (1)"));
+    fireEvent.click(toggle);
+    fireEvent.click(
+      await screen.findByTestId("chat-runner-skill-demo.guided-skill-summarise"),
+    );
+
+    expect(setTabAndHash).not.toHaveBeenCalled();
+    expect(
+      await screen.findByTestId("generic-runner-demo.guided-skill-summarise"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -462,6 +462,7 @@ export function AssistantTab({
             documents={docs}
             initialDocumentIds={Array.from(selectedDocIds)}
             initialInput={input.trim() || undefined}
+            onClose={() => setActiveRunnerSkill(null)}
             compact
           />
         )}

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -2,20 +2,31 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react"
 import { useNavigate } from "@tanstack/react-router";
 import {
   getMatterWorkflows,
+  getModulesV2,
+  listGrants,
   listAssistantMessages,
+  listInstalledModules,
   postAssistantMessage,
   ProviderKeyMissingError,
   ProviderUpstreamError,
   providerUpstreamMessage,
   type AssistantMessage,
   type ChronologyEvent,
+  type GrantRow,
+  type InstalledModule,
   type Matter,
   type MatterDocument,
   type SuggestedAction,
+  type V2ManifestEntry,
   type WorkflowState,
 } from "../../lib/api";
 import { InlineSpinner, ProviderKeyMissingBanner, primaryBtn } from "../../ui/primitives";
 import { InlineAgentStatus, MessageBubble } from "../MessageBubble";
+import { GenericSkillRunner } from "../GenericSkillRunner";
+import {
+  runnableMatterSkills,
+  type RunnableMatterSkill,
+} from "../skillRunnerModel";
 import type { TabKey } from "./types";
 
 interface AssistantTabProps {
@@ -95,6 +106,13 @@ export function AssistantTab({
   // this matter appear — the chat surface never invents skill state.
   const [enabledSkills, setEnabledSkills] = useState<WorkflowState[]>([]);
   const [skillsOpen, setSkillsOpen] = useState(false);
+  const [moduleEntries, setModuleEntries] = useState<V2ManifestEntry[]>([]);
+  const [installedModules, setInstalledModules] = useState<Map<string, InstalledModule>>(
+    new Map(),
+  );
+  const [grantRows, setGrantRows] = useState<GrantRow[] | null>(null);
+  const [activeRunnerSkill, setActiveRunnerSkill] =
+    useState<RunnableMatterSkill | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   // Initial fetch (skip in demo: initialMessages provided).
@@ -148,6 +166,40 @@ export function AssistantTab({
       cancelled = true;
     };
   }, [matter.slug, disabled]);
+
+  useEffect(() => {
+    if (disabled) return;
+    let cancelled = false;
+    void Promise.all([
+      getModulesV2(),
+      listInstalledModules(),
+      listGrants(matter.slug),
+    ])
+      .then(([moduleResponse, installedRows, grantsResponse]) => {
+        if (cancelled) return;
+        const installedIndex = new Map<string, InstalledModule>();
+        for (const row of installedRows) installedIndex.set(row.module_id, row);
+        setModuleEntries(moduleResponse.modules);
+        setInstalledModules(installedIndex);
+        setGrantRows(grantsResponse.grants);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [matter.slug, disabled]);
+
+  const runnableModuleSkills = useMemo(
+    () =>
+      runnableMatterSkills({
+        modules: moduleEntries,
+        installed: installedModules,
+        grants: grantRows,
+      }),
+    [moduleEntries, installedModules, grantRows],
+  );
+
+  const runnableSkillCount = enabledSkills.length + runnableModuleSkills.length;
 
   const docsById = useMemo(() => {
     const map = new Map<string, MatterDocument>();
@@ -250,7 +302,7 @@ export function AssistantTab({
       search: { from: "assistant" },
     });
   };
-  // The substrate doesn't yet carry per-event anchoring, so the
+  // The timeline doesn't yet carry per-event anchoring, so the
   // chronology chip still drops the user on the Chronology tab.
   // Accepting the eventId keeps the callback shape future-proof
   // for when per-event deep links land.
@@ -275,11 +327,22 @@ export function AssistantTab({
 
   const onPickSkill = (w: WorkflowState) => {
     setSkillsOpen(false);
+    setActiveRunnerSkill(null);
     if (disabled) {
       onDisabledAction?.();
       return;
     }
     setTabAndHash(w.key as TabKey);
+  };
+
+  const onPickRunnerSkill = (skill: RunnableMatterSkill) => {
+    setSkillsOpen(false);
+    if (disabled) {
+      onDisabledAction?.();
+      return;
+    }
+    setActiveRunnerSkill(skill);
+    setTimeout(() => textareaRef.current?.focus(), 0);
   };
 
   return (
@@ -392,6 +455,16 @@ export function AssistantTab({
             onAction={dispatchAction}
           />
         ))}
+        {activeRunnerSkill && (
+          <GenericSkillRunner
+            slug={matter.slug}
+            skill={activeRunnerSkill}
+            documents={docs}
+            initialDocumentIds={Array.from(selectedDocIds)}
+            initialInput={input.trim() || undefined}
+            compact
+          />
+        )}
         {thinking && (
           <div className="flex justify-start">
             <InlineAgentStatus
@@ -485,7 +558,7 @@ export function AssistantTab({
                 data-testid="chat-skills-toggle"
                 className="font-mono text-[11px] text-muted hover:text-ink transition-colors"
               >
-                Skills{enabledSkills.length > 0 ? ` (${enabledSkills.length})` : ""}
+                Skills{runnableSkillCount > 0 ? ` (${runnableSkillCount})` : ""}
               </button>
               {skillsOpen && (
                 <div
@@ -495,7 +568,7 @@ export function AssistantTab({
                   data-testid="chat-skills-popover"
                 >
                   <div className="eyebrow mb-2">Run a skill</div>
-                  {enabledSkills.length === 0 ? (
+                  {runnableSkillCount === 0 ? (
                     <p className="text-xs text-muted">
                       Nothing runnable here right now.{" "}
                       <button
@@ -506,30 +579,66 @@ export function AssistantTab({
                         }}
                         className="underline underline-offset-4 hover:text-ink"
                       >
-                        Open Skills →
+                      Open Skills →
                       </button>
                     </p>
                   ) : (
-                    <ul className="space-y-2">
-                      {enabledSkills.map((w) => (
-                        <li key={w.key}>
-                          <button
-                            type="button"
-                            role="menuitem"
-                            onClick={() => onPickSkill(w)}
-                            className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
-                            data-testid={`chat-skill-${w.key}`}
-                          >
-                            <span className="block text-ink font-medium">
-                              {w.title}
-                            </span>
-                            <span aria-hidden="true" className="text-muted">
-                              →
-                            </span>
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
+                    <div className="space-y-3">
+                      {runnableModuleSkills.length > 0 && (
+                        <ul className="space-y-2">
+                          {runnableModuleSkills.map((skill) => (
+                            <li key={`${skill.moduleId}:${skill.capabilityId}`}>
+                              <button
+                                type="button"
+                                role="menuitem"
+                                onClick={() => onPickRunnerSkill(skill)}
+                                className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
+                                data-testid={`chat-runner-skill-${skill.moduleId}-${skill.capabilityId}`}
+                              >
+                                <span className="block">
+                                  <span className="block text-ink font-medium">
+                                    {skill.title}
+                                  </span>
+                                  <span className="mt-0.5 block text-[11px] text-muted">
+                                    Ready in this project
+                                  </span>
+                                </span>
+                                <span aria-hidden="true" className="text-muted">
+                                  →
+                                </span>
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      {enabledSkills.length > 0 && (
+                        <div>
+                          {runnableModuleSkills.length > 0 && (
+                            <div className="mb-1 eyebrow text-muted">Built-in</div>
+                          )}
+                          <ul className="space-y-2">
+                            {enabledSkills.map((w) => (
+                              <li key={w.key}>
+                                <button
+                                  type="button"
+                                  role="menuitem"
+                                  onClick={() => onPickSkill(w)}
+                                  className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
+                                  data-testid={`chat-skill-${w.key}`}
+                                >
+                                  <span className="block text-ink font-medium">
+                                    {w.title}
+                                  </span>
+                                  <span aria-hidden="true" className="text-muted">
+                                    →
+                                  </span>
+                                </button>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
                   )}
                   {needsAttention.length > 0 && (
                     <>

--- a/schemas/module.v2.json
+++ b/schemas/module.v2.json
@@ -214,7 +214,11 @@
           "required": ["slot"],
           "properties": {
             "slot": {"type": "string"},
-            "label": {"type": "string"}
+            "label": {"type": "string"},
+            "default_request": {
+              "type": "string",
+              "description": "Optional user-facing starter request for generic runners. May include {filename} for the selected document filename."
+            }
           },
           "additionalProperties": false
         },

--- a/schemas/module.v2.json
+++ b/schemas/module.v2.json
@@ -241,6 +241,35 @@
           "items": {"type": "string"},
           "description": "Expected audit action names this capability will emit."
         },
+        "args_schema": {
+          "type": "object",
+          "description": "Optional JSON-Schema-like input shape for generic runners. V1 runner supports top-level string fields and string enum selects.",
+          "properties": {
+            "type": {"const": "object"},
+            "properties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "type": {"const": "string"},
+                  "title": {"type": "string"},
+                  "description": {"type": "string"},
+                  "enum": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                  },
+                  "default": {"type": "string"}
+                },
+                "additionalProperties": true
+              }
+            },
+            "required": {
+              "type": "array",
+              "items": {"type": "string"}
+            }
+          },
+          "additionalProperties": true
+        },
         "output_lifecycle_target": {
           "anyOf": [
             {"type": "null"},


### PR DESCRIPTION
## Summary
- Adds a shared GenericSkillRunner for V2 matter-scoped skill capabilities.
- Wires runnable V2 skills into Matter Skills and Chat without bespoke first-party adapters.
- Keeps legacy first-party workflows as legacy openable rows while the V2 proof path runs through /invocations.
- Seeds and grants the demo V2 skill on Khan v Acme so the proof path is present on the canonical demo matter.
- Adds optional manifest runner metadata: `capabilities[].ui.default_request` for starter copy and `capabilities[].args_schema` for generic string fields / enum selects.
- Carries non-reserved `args_schema` values into prompt-runtime request options, so manifest form fields affect prompt skills without bespoke runner code.
- Handles native-style invocation results with `artifact_id` or generic `*_artifact_id` keys, rendering all returned artifacts through `ArtifactPreview`.
- Adds handover: docs/handovers/HANDOVER_GENERIC_SKILL_RUNNER_V1_DONE.md.

## Boundaries
- No backend persistence schema changes and no new API endpoints.
- No `/letters/draft` calls, no `draft_markdown` renderer, no skill-id branching.
- Does not retire legacy first-party routes yet.
- Does not wrap Letters, Contract Review, Pre-Motion, Case Law, or Tabular Review as V2 skills.
- `args_schema` v1 is intentionally narrow: top-level string fields and string enum selects only.
- Multi-artifact handling is generic result-shape handling, not a Pre-Motion or Contract Review adapter.

## Verification
- `npm run typecheck`
- `npm run test -- GenericSkillRunner AssistantTab MatterSkillsTab --run` (14/14 after `args_schema`)
- `npm run test -- GenericSkillRunner --run` (6/6 after multi-artifact handling)
- `npm run test -- --run` (211/211)
- `npm run build`
- manifest schema parity check: `schemas/module.v2.json == backend/schemas/module.v2.json`
- `python3 -m py_compile backend/app/core/demo_loop.py backend/app/core/prompt_runtime.py backend/app/core/seed.py backend/tests/test_matters_routes.py backend/tests/test_phase2_schema.py backend/tests/test_seed_audit.py`
- Backend pytest runs in GitHub CI; local shell has no `pytest`/`uv`.

## Reviewer walk
- Open Khan v Acme and confirm `demo.guided-skill / summarise` is enabled in Matter Skills and Chat.
- Run it through the generic runner; the demo skill should expose a `Style` select from its manifest `args_schema`.
- Confirm the output renders via `ArtifactPreview`, exposes Review & sign, and deep-links to Record for the invocation.
- Confirm primary surfaces do not lead with raw permission/capability vocabulary.
- Review the multi-artifact regression: a native-style result with `motion_artifact_id` + `evidence_artifact_id` renders both outputs without skill-id branching.