### PR TITLE
UX: add matter context rail to Chat

### DIFF
--- a/frontend/src/matter/MatterNav.tsx
+++ b/frontend/src/matter/MatterNav.tsx
@@ -1,8 +1,8 @@
 // MatterNav - compact left rail for the matter workspace.
 // Pattern reference: Mike, Claude.ai, Sana AI, Mistral, Fibery.
-// Core V1 loop (Chat / Documents / Skills / Record); secondary
-// review/chronology surfaces stay routable without dominating the
-// first-run matter experience.
+// Core V1 loop: opening a matter lands in Chat. Documents, Skills,
+// Signed outputs, Working pack, and Record stay one click away from
+// the Chat context rail instead of competing as equal folder exits.
 //
 // Mobile: at < md the static rail is hidden. When `mobileOpen` is true
 // the same content renders as a left-anchored 280px sheet with a
@@ -21,7 +21,7 @@ export function MatterNav({
   onPostureChange,
   mobileOpen,
   onMobileClose,
-  showPosture = true,
+  showPosture = false,
 }: {
   matter: Matter;
   tab: TabKey;
@@ -126,12 +126,17 @@ function NavBody({
           {matter.slug}
         </div>
         {showPosture && (
-          <div className="mt-3 flex items-center gap-2">
-            <span className="eyebrow">Privilege</span>
-            <span className="inline-flex items-center border border-rule px-1.5 py-0.5">
-              <PrivilegeControlInline value={matter.privilege_posture} onChange={onPostureChange} />
-            </span>
-          </div>
+          <details className="mt-3">
+            <summary className="cursor-pointer text-[10px] uppercase tracking-widest text-muted hover:text-ink">
+              Project settings
+            </summary>
+            <div className="mt-2 flex items-center gap-2">
+              <span className="eyebrow">Privilege</span>
+              <span className="inline-flex items-center border border-rule px-1.5 py-0.5">
+                <PrivilegeControlInline value={matter.privilege_posture} onChange={onPostureChange} />
+              </span>
+            </div>
+          </details>
         )}
       </div>
 

--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -205,16 +205,13 @@ export function MatterSkillsTab({ slug }: Props) {
       {/* Section 1 — Enabled in this matter */}
       <SectionHeader
         title="Enabled in this matter"
-        hint="Available in Chat. Built-in skills are always here; modules need workspace install plus matter enablement."
+        hint="Generic skills run in Chat. Legacy built-in actions stay available below, but are not the product model."
       />
 
       {workflows === null ? (
         <p className="mt-3 text-sm text-muted">Loading…</p>
       ) : (
         <div className="mt-3 grid grid-cols-1 gap-3">
-          {workflows.workflows.map((w) => (
-            <WorkflowRow key={w.key} slug={slug} workflow={w} />
-          ))}
           {runnableSkills.map((skill) => (
             <GenericSkillRunner
               key={`${skill.moduleId}:${skill.capabilityId}`}
@@ -234,11 +231,27 @@ export function MatterSkillsTab({ slug }: Props) {
               onRevoked={refresh}
             />
           ))}
-          {workflows.workflows.length === 0 && enabledModules.length === 0 && (
+          {runnableSkills.length === 0 && enabledModules.length === 0 && (
             <p className="text-sm text-muted">
               No skills are enabled in this matter yet. Pick one from
               Available to enable below.
             </p>
+          )}
+          {workflows.workflows.length > 0 && (
+            <details className="border border-rule bg-paper p-4">
+              <summary className="cursor-pointer text-sm font-medium text-muted hover:text-ink">
+                Legacy built-in actions ({workflows.workflows.length})
+              </summary>
+              <p className="mt-2 text-xs text-muted">
+                These routes remain for compatibility while first-party work is
+                migrated into the generic runner. Use Chat for normal work.
+              </p>
+              <div className="mt-3 grid grid-cols-1 gap-3">
+                {workflows.workflows.map((w) => (
+                  <WorkflowRow key={w.key} slug={slug} workflow={w} />
+                ))}
+              </div>
+            </details>
           )}
         </div>
       )}

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -1,7 +1,7 @@
 /**
- * Activity Trail page — `/matters/{slug}/audit`.
+ * Record page — `/matters/{slug}/audit`.
  *
- * Reconstruction timeline against
+ * Matter proof layer against
  * `GET /api/matters/{slug}/audit/reconstruction`. This page is the
  * deep-link target referenced from elsewhere in the product:
  *   - InstallCeremony's 409 banner names module.ceremony.rejected
@@ -248,15 +248,32 @@ export function ReconstructionView({ slug }: { slug: string }) {
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
-      <p className="text-xs uppercase tracking-widest text-muted">Matter</p>
-      <h1 className="mt-2 text-2xl font-bold tracking-tight2">Record</h1>
-      <p className="mt-1 text-xs font-mono text-muted">{slug}</p>
-      <p className="mt-3 text-sm text-muted">
-        The main record of what happened on this matter: documents
-        referenced, skills run, models called, outputs written, human
-        reviews, and blocked attempts. Raw audit rows stay
-        expandable; the first view is the story.
-      </p>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-widest text-muted">Matter record</p>
+          <h1 className="mt-2 text-2xl font-bold tracking-tight2">What happened here</h1>
+          <p className="mt-1 text-xs font-mono text-muted">{slug}</p>
+          <p className="mt-3 max-w-2xl text-sm text-muted">
+            Skills run, documents referenced, outputs written, sign-offs,
+            reviews, and blocked attempts. Raw audit sources are still here,
+            but they sit behind Advanced details.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <a
+            href={`/matters/${encodeURIComponent(slug)}/artifacts`}
+            className="inline-flex items-center border border-rule px-3 py-2 text-sm hover:border-ink"
+          >
+            Signed outputs
+          </a>
+          <a
+            href={`/matters/${encodeURIComponent(slug)}/lifecycle`}
+            className="inline-flex items-center bg-ink px-3 py-2 text-sm text-paper hover:opacity-90"
+          >
+            Working pack
+          </a>
+        </div>
+      </div>
 
       {/* Active query-param filters */}
       {(invocationFilter || actionFilter) && (
@@ -288,71 +305,6 @@ export function ReconstructionView({ slug }: { slug: string }) {
           )}
         </div>
       )}
-
-      <details className="mt-5 rounded-md border border-line bg-paper-sunken p-3">
-        <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">
-          Filters and raw sources
-        </summary>
-        {/* Source chips */}
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          <span className="text-xs uppercase tracking-widest text-muted">
-            Sources
-          </span>
-          {ALL_RECONSTRUCTION_SOURCES.map((s) => {
-            const active = sources.includes(s);
-            return (
-              <button
-                key={s}
-                type="button"
-                onClick={() => toggleSource(s)}
-                className={
-                  "rounded-full border px-3 py-1 text-xs transition-colors " +
-                  (active
-                    ? "border-ink bg-ink text-paper"
-                    : "border-line text-muted hover:border-ink")
-                }
-                data-testid={`source-chip-${s}`}
-                aria-pressed={active}
-              >
-                {SOURCE_LABEL[s]}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Class facet chips (AT-2) — loaded page only, hidden when a
-            precise deep-link filter is active. */}
-        {!deepLinked && (
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <span className="text-xs uppercase tracking-widest text-muted">
-              Decision type
-            </span>
-            {CLASS_CHIPS.map((c) => {
-              const active = classFilter === c.key;
-              return (
-                <button
-                  key={c.key}
-                  type="button"
-                  onClick={() => setClassFilter(active ? null : c.key)}
-                  className={
-                    "rounded-full border px-3 py-1 text-xs transition-colors " +
-                    (active
-                      ? "border-ink bg-ink text-paper"
-                      : "border-line text-muted hover:border-ink")
-                  }
-                  data-testid={`class-chip-${c.key}`}
-                  aria-pressed={active}
-                >
-                  {c.label}
-                </button>
-              );
-            })}
-            {classFilter && (
-              <span className="text-[11px] text-muted">filters the loaded page only</span>
-            )}
-          </div>
-        )}
-      </details>
 
       {/* Timeline */}
       {fetchState.status === "loading" && (
@@ -461,6 +413,13 @@ export function ReconstructionView({ slug }: { slug: string }) {
               )}
             </div>
           )}
+          <AdvancedDetails
+            sources={sources}
+            onToggleSource={toggleSource}
+            classFilter={classFilter}
+            onClassFilter={setClassFilter}
+            deepLinked={deepLinked}
+          />
           {fetchState.nextCursor && (
             <div className="mt-6">
               <button
@@ -599,6 +558,91 @@ function InvocationChain({
         </ol>
       )}
     </li>
+  );
+}
+
+function AdvancedDetails({
+  sources,
+  onToggleSource,
+  classFilter,
+  onClassFilter,
+  deepLinked,
+}: {
+  sources: ReconstructionSource[];
+  onToggleSource: (s: ReconstructionSource) => void;
+  classFilter: RowClass | null;
+  onClassFilter: (next: RowClass | null) => void;
+  deepLinked: boolean;
+}) {
+  return (
+    <details className="mt-8 rounded-md border border-line bg-paper-sunken p-3">
+      <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">
+        Advanced details
+      </summary>
+      <p className="mt-3 text-xs text-muted">
+        Raw audit sources and technical filters. The story above is the normal
+        matter record; use this only when investigating a specific row.
+      </p>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <span className="text-xs uppercase tracking-widest text-muted">
+          Sources
+        </span>
+        {ALL_RECONSTRUCTION_SOURCES.map((s) => {
+          const active = sources.includes(s);
+          return (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onToggleSource(s)}
+              className={
+                "rounded-full border px-3 py-1 text-xs transition-colors " +
+                (active
+                  ? "border-ink bg-ink text-paper"
+                  : "border-line text-muted hover:border-ink")
+              }
+              data-testid={`source-chip-${s}`}
+              aria-pressed={active}
+            >
+              {SOURCE_LABEL[s]}
+            </button>
+          );
+        })}
+      </div>
+
+      {!deepLinked && (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-xs uppercase tracking-widest text-muted">
+            Event type
+          </span>
+          {CLASS_CHIPS.map((c) => {
+            const active = classFilter === c.key;
+            return (
+              <button
+                key={c.key}
+                type="button"
+                onClick={() => onClassFilter(active ? null : c.key)}
+                className={
+                  "rounded-full border px-3 py-1 text-xs transition-colors " +
+                  (active
+                    ? "border-ink bg-ink text-paper"
+                    : "border-line text-muted hover:border-ink")
+                }
+                data-testid={`class-chip-${c.key}`}
+                aria-pressed={active}
+              >
+                {c.label}
+              </button>
+            );
+          })}
+          {classFilter && (
+            <span className="text-[11px] text-muted">
+              filters the loaded page only
+            </span>
+          )}
+        </div>
+      )}
+    </details>
   );
 }
 

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -93,59 +93,8 @@ afterEach(() => {
 });
 
 describe("AssistantTab — in-chat skill picker", () => {
-  it("keeps legacy workflows out of the primary runnable skill count", async () => {
-    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
-      workflows: [
-        // Granted + ok → primary list, counted.
-        {
-          key: "premotion",
-          title: "Pre-Motion",
-          description: "Analyse the dispute.",
-          declared_capabilities: [],
-          granted_capabilities: [],
-          grant: "granted",
-          last_run_at: null,
-          availability: "ok",
-          reason: null,
-        },
-        {
-          key: "letters",
-          title: "Letters",
-          description: "Draft pre-action letters.",
-          declared_capabilities: [],
-          granted_capabilities: [],
-          grant: "granted",
-          last_run_at: null,
-          availability: "ok",
-          reason: null,
-        },
-        // Granted but blocked by privilege state → "Needs attention",
-        // NOT counted in the Skills (N) total.
-        {
-          key: "contract-review",
-          title: "Contract Review",
-          description: "Review contracts.",
-          declared_capabilities: [],
-          granted_capabilities: [],
-          grant: "granted",
-          last_run_at: null,
-          availability: "blocked-by-posture",
-          reason: "Privilege state C_paused blocks cloud calls.",
-        },
-        // Not granted on this matter at all → must not appear anywhere.
-        {
-          key: "reviews",
-          title: "Tabular Review",
-          description: "Review tables.",
-          declared_capabilities: [],
-          granted_capabilities: [],
-          grant: "blocked",
-          last_run_at: null,
-          availability: "blocked-by-grant",
-          reason: null,
-        },
-      ],
-    } as never);
+  it("does not fetch or expose legacy built-in workflows in the chat picker", async () => {
+    const workflowsSpy = vi.spyOn(api, "getMatterWorkflows");
 
     mountChat();
 
@@ -154,50 +103,13 @@ describe("AssistantTab — in-chat skill picker", () => {
 
     fireEvent.click(toggle);
     expect(await screen.findByTestId("chat-skills-popover")).toBeInTheDocument();
-    expect(screen.getByText(/Legacy built-in actions \(2\)/i)).toBeInTheDocument();
-    expect(screen.getByTestId("chat-skill-premotion")).toBeInTheDocument();
-    expect(screen.getByTestId("chat-skill-letters")).toBeInTheDocument();
-    // Granted-but-blocked → in Needs attention, not in primary picker.
-    expect(screen.queryByTestId("chat-skill-contract-review")).toBeNull();
-    expect(
-      screen.getByTestId("chat-skill-blocked-contract-review"),
-    ).toBeInTheDocument();
-    // Ungranted → nowhere.
-    expect(screen.queryByTestId("chat-skill-reviews")).toBeNull();
-    expect(screen.queryByTestId("chat-skill-blocked-reviews")).toBeNull();
+    expect(workflowsSpy).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Legacy built-in actions/i)).toBeNull();
+    expect(screen.queryByTestId("chat-skill-premotion")).toBeNull();
+    expect(screen.queryByTestId("chat-skill-letters")).toBeNull();
   });
 
-  it("routes to the picked skill's tab via setTabAndHash", async () => {
-    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
-      workflows: [
-        {
-          key: "premotion",
-          title: "Pre-Motion",
-          description: "Analyse.",
-          declared_capabilities: [],
-          granted_capabilities: [],
-          grant: "granted",
-          last_run_at: null,
-          availability: "ok",
-          reason: null,
-        },
-      ],
-    } as never);
-
-    const setTabAndHash = vi.fn();
-    mountChat({ setTabAndHash });
-
-    fireEvent.click(await screen.findByTestId("chat-skills-toggle"));
-    fireEvent.click(await screen.findByTestId("chat-skill-premotion"));
-
-    expect(setTabAndHash).toHaveBeenCalledWith("premotion");
-  });
-
-  it("shows the empty state and routes to the matter Skills tab when nothing is runnable", async () => {
-    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
-      workflows: [],
-    } as never);
-
+  it("shows the empty state and routes to the matter Skills tab when no generic skill is runnable", async () => {
     const setTabAndHash = vi.fn();
     mountChat({ setTabAndHash });
 
@@ -211,25 +123,19 @@ describe("AssistantTab — in-chat skill picker", () => {
     expect(setTabAndHash).toHaveBeenCalledWith("workflows");
   });
 
-  it("exposes the ambient Record and Documents links in the header", async () => {
-    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
-      workflows: [],
-    } as never);
-
+  it("exposes ambient Record and Documents links in the shell", async () => {
     const setTabAndHash = vi.fn();
     mountChat({ setTabAndHash });
 
-    fireEvent.click(await screen.findByTestId("open-record-link"));
-    expect(setTabAndHash).toHaveBeenCalledWith("audit");
+    expect(await screen.findByTestId("open-record-link")).toHaveTextContent(
+      /View Record/i,
+    );
 
     fireEvent.click(screen.getByTestId("open-documents-link"));
     expect(setTabAndHash).toHaveBeenCalledWith("documents");
   });
 
   it("mounts the generic runner for a runnable V2 skill instead of routing to a bespoke tab", async () => {
-    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
-      workflows: [],
-    } as never);
     vi.spyOn(api, "getModulesV2").mockResolvedValue({
       modules: [
         {
@@ -309,10 +215,6 @@ describe("AssistantTab — in-chat skill picker", () => {
 
 describe("AssistantTab — docs loading state", () => {
   it("shows a loading line while docs are null, then resolves to the count", async () => {
-    vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
-      workflows: [],
-    } as never);
-
     // Mount with docs=null (still fetching). The header must not lie
     // and claim "No documents yet" — that's the empty state for a
     // resolved matter with zero documents, not the loading state.

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -93,7 +93,7 @@ afterEach(() => {
 });
 
 describe("AssistantTab — in-chat skill picker", () => {
-  it("counts and lists only workflows that are runnable right now", async () => {
+  it("keeps legacy workflows out of the primary runnable skill count", async () => {
     vi.spyOn(api, "getMatterWorkflows").mockResolvedValue({
       workflows: [
         // Granted + ok → primary list, counted.
@@ -150,10 +150,11 @@ describe("AssistantTab — in-chat skill picker", () => {
     mountChat();
 
     const toggle = await screen.findByTestId("chat-skills-toggle");
-    await waitFor(() => expect(toggle).toHaveTextContent("Skills (2)"));
+    await waitFor(() => expect(toggle).toHaveTextContent("Skills"));
 
     fireEvent.click(toggle);
     expect(await screen.findByTestId("chat-skills-popover")).toBeInTheDocument();
+    expect(screen.getByText(/Legacy built-in actions \(2\)/i)).toBeInTheDocument();
     expect(screen.getByTestId("chat-skill-premotion")).toBeInTheDocument();
     expect(screen.getByTestId("chat-skill-letters")).toBeInTheDocument();
     // Granted-but-blocked → in Needs attention, not in primary picker.

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
-  getMatterWorkflows,
   getModulesV2,
   listGrants,
   listAssistantMessages,
@@ -18,7 +17,6 @@ import {
   type MatterDocument,
   type SuggestedAction,
   type V2ManifestEntry,
-  type WorkflowState,
 } from "../../lib/api";
 import { InlineSpinner, ProviderKeyMissingBanner, primaryBtn } from "../../ui/primitives";
 import { InlineAgentStatus, MessageBubble } from "../MessageBubble";
@@ -101,10 +99,6 @@ export function AssistantTab({
   const [keyMissingProvider, setKeyMissingProvider] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(Boolean(initialMessages));
   const [selectedDocIds, setSelectedDocIds] = useState<Set<string>>(new Set());
-  // In-chat skill picker reads the same matter-workflows endpoint
-  // the matter Skills tab uses. Only workflows already granted on
-  // this matter appear — the chat surface never invents skill state.
-  const [enabledSkills, setEnabledSkills] = useState<WorkflowState[]>([]);
   const [skillsOpen, setSkillsOpen] = useState(false);
   const [moduleEntries, setModuleEntries] = useState<V2ManifestEntry[]>([]);
   const [installedModules, setInstalledModules] = useState<Map<string, InstalledModule>>(
@@ -143,30 +137,6 @@ export function AssistantTab({
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [messages, thinking]);
 
-  // Fetch enabled-in-matter skills for the in-chat picker. The
-  // picker keeps two lists separately so the "Skills (N)" count and
-  // primary list reflect only what's actually runnable right now —
-  // grant === "granted" AND availability === "ok". Granted skills
-  // that are blocked by privilege state or a missing permission move
-  // to a quieter "Needs attention" section so the user can see why
-  // without inflating the runnable count.
-  const [needsAttention, setNeedsAttention] = useState<WorkflowState[]>([]);
-  useEffect(() => {
-    if (disabled) return;
-    let cancelled = false;
-    void getMatterWorkflows(matter.slug)
-      .then((r) => {
-        if (cancelled) return;
-        const granted = r.workflows.filter((w) => w.grant === "granted");
-        setEnabledSkills(granted.filter((w) => w.availability === "ok"));
-        setNeedsAttention(granted.filter((w) => w.availability !== "ok"));
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [matter.slug, disabled]);
-
   useEffect(() => {
     if (disabled) return;
     let cancelled = false;
@@ -199,7 +169,6 @@ export function AssistantTab({
     [moduleEntries, installedModules, grantRows],
   );
 
-  const legacyRunnableCount = enabledSkills.length;
   const runnableSkillCount = runnableModuleSkills.length;
 
   const docsById = useMemo(() => {
@@ -326,16 +295,6 @@ export function AssistantTab({
 
   const [attachOpen, setAttachOpen] = useState(false);
 
-  const onPickSkill = (w: WorkflowState) => {
-    setSkillsOpen(false);
-    setActiveRunnerSkill(null);
-    if (disabled) {
-      onDisabledAction?.();
-      return;
-    }
-    setTabAndHash(w.key as TabKey);
-  };
-
   const onPickRunnerSkill = (skill: RunnableMatterSkill) => {
     setSkillsOpen(false);
     if (disabled) {
@@ -352,6 +311,10 @@ export function AssistantTab({
 
   const openWorkingPack = () => {
     void navigate({ to: "/matters/$slug/lifecycle", params: { slug: matter.slug } });
+  };
+
+  const openRecord = () => {
+    void navigate({ to: "/matters/$slug/audit", params: { slug: matter.slug } });
   };
 
   return (
@@ -381,7 +344,7 @@ export function AssistantTab({
             <span aria-hidden="true">·</span>
             <button
               type="button"
-              onClick={() => setTabAndHash("audit")}
+              onClick={openRecord}
               className="underline underline-offset-4 hover:text-ink"
               data-testid="open-record-link"
             >
@@ -600,59 +563,6 @@ export function AssistantTab({
                       )}
                     </div>
                   )}
-                  {enabledSkills.length > 0 && (
-                    <details className="mt-3 border-t border-rule pt-3">
-                      <summary className="cursor-pointer text-[11px] text-muted hover:text-ink">
-                        Legacy built-in actions ({enabledSkills.length})
-                      </summary>
-                      <ul className="mt-2 space-y-2">
-                        {enabledSkills.map((w) => (
-                          <li key={w.key}>
-                            <button
-                              type="button"
-                              role="menuitem"
-                              onClick={() => onPickSkill(w)}
-                              className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
-                              data-testid={`chat-skill-${w.key}`}
-                            >
-                              <span className="block text-ink font-medium">
-                                {w.title}
-                              </span>
-                              <span aria-hidden="true" className="text-muted">
-                                →
-                              </span>
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    </details>
-                  )}
-                  {needsAttention.length > 0 && (
-                    <>
-                      <div className="mt-3 eyebrow text-muted">
-                        Needs attention
-                      </div>
-                      <ul
-                        className="mt-1 space-y-1"
-                        data-testid="chat-skills-needs-attention"
-                      >
-                        {needsAttention.map((w) => (
-                          <li
-                            key={w.key}
-                            className="text-[11px] text-muted"
-                            data-testid={`chat-skill-blocked-${w.key}`}
-                          >
-                            <span className="block text-ink">{w.title}</span>
-                            <span className="block">
-                              {w.availability === "blocked-by-posture"
-                                ? "Blocked by privilege state"
-                                : "Needs permission in this matter"}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    </>
-                  )}
                   <button
                     type="button"
                     onClick={() => {
@@ -719,12 +629,10 @@ export function AssistantTab({
         readySkillLabels={[
           ...runnableModuleSkills.map((skill) => skill.title),
         ]}
-        legacyRunnableCount={legacyRunnableCount}
-        needsAttentionCount={needsAttention.length}
         selectedCount={selectedDocIds.size}
         onOpenDocuments={() => setTabAndHash("documents")}
         onOpenSkills={() => setTabAndHash("workflows")}
-        onOpenRecord={() => setTabAndHash("audit")}
+        onOpenRecord={openRecord}
         onOpenOutputs={openOutputs}
         onOpenPack={openWorkingPack}
       />
@@ -737,8 +645,6 @@ function MatterContextRail({
   recentDocs,
   runnableSkillCount,
   readySkillLabels,
-  legacyRunnableCount,
-  needsAttentionCount,
   selectedCount,
   onOpenDocuments,
   onOpenSkills,
@@ -750,8 +656,6 @@ function MatterContextRail({
   recentDocs: MatterDocument[];
   runnableSkillCount: number;
   readySkillLabels: string[];
-  legacyRunnableCount: number;
-  needsAttentionCount: number;
   selectedCount: number;
   onOpenDocuments: () => void;
   onOpenSkills: () => void;
@@ -801,16 +705,6 @@ function MatterContextRail({
           </ul>
         ) : (
           <p className="mt-2 text-sm text-muted">Enable a skill to run it here.</p>
-        )}
-        {needsAttentionCount > 0 && (
-          <p className="mt-3 text-xs text-muted">
-            {needsAttentionCount} needs setup
-          </p>
-        )}
-        {legacyRunnableCount > 0 && (
-          <p className="mt-3 text-xs text-muted">
-            {legacyRunnableCount} legacy action{legacyRunnableCount === 1 ? "" : "s"} available from the picker
-          </p>
         )}
       </RailPanel>
 

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   getMatterWorkflows,
@@ -345,69 +345,54 @@ export function AssistantTab({
     setTimeout(() => textareaRef.current?.focus(), 0);
   };
 
+  const openOutputs = () => {
+    void navigate({ to: "/matters/$slug/artifacts", params: { slug: matter.slug } });
+  };
+
+  const openWorkingPack = () => {
+    void navigate({ to: "/matters/$slug/lifecycle", params: { slug: matter.slug } });
+  };
+
   return (
-    <div className="mx-auto w-full max-w-[1040px] flex flex-col min-h-[520px]">
-      <div className="mb-4">
-        <h1 className="text-lg font-semibold tracking-tight2 text-ink">
-          {matter.title}
-        </h1>
-        {/* Quiet folder context — what's here + where the record lives.
-            Single muted line, the only header element on the Chat
-            front door. The old readiness card has been retired here
-            because the project-folder feeling depends on Chat being
-            the surface that loads, not a status dashboard. */}
-        <div className="mt-1 flex flex-wrap items-center justify-between gap-3 text-xs text-muted">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+    <div className="mx-auto grid w-full max-w-[1220px] gap-8 lg:grid-cols-[minmax(0,1fr)_300px]">
+      <div className="flex min-h-[620px] min-w-0 flex-col">
+        <div className="mb-5">
+          <p className="text-[11px] uppercase tracking-widest text-muted">
+            Legal project
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight2 text-ink">
+            {matter.title}
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted">
+            Ask about the documents, or run a skill from this project. Outputs
+            can be signed and traced in the Record.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-muted">
             <span data-testid="docs-context-status">
               {docs === null
                 ? "Loading documents…"
                 : docs.length > 0
-                  ? `${docs.length} document${docs.length === 1 ? "" : "s"} in this matter`
+                  ? `${docs.length} document${docs.length === 1 ? "" : "s"}`
                   : "No documents yet"}
             </span>
-            {recentDocs.length > 0 && (
-              <span className="flex flex-wrap items-center gap-x-2">
-                <span aria-hidden="true">·</span>
-                {recentDocs.slice(0, 2).map((d, i) => (
-                  <span key={d.id} className="font-mono truncate max-w-[180px]">
-                    {i > 0 && <span aria-hidden="true" className="mr-2">·</span>}
-                    {d.filename}
-                  </span>
-                ))}
-                {docs && docs.length > 2 && (
-                  <button
-                    type="button"
-                    onClick={() => setTabAndHash("documents")}
-                    className="underline underline-offset-4 hover:text-ink"
-                  >
-                    +{docs.length - 2} more
-                  </button>
-                )}
-              </span>
-            )}
+            <span aria-hidden="true">·</span>
+            <span>{runnableSkillCount} runnable skill{runnableSkillCount === 1 ? "" : "s"}</span>
+            <span aria-hidden="true">·</span>
             <button
               type="button"
-              onClick={() => setTabAndHash("documents")}
+              onClick={() => setTabAndHash("audit")}
               className="underline underline-offset-4 hover:text-ink"
-              data-testid="open-documents-link"
+              data-testid="open-record-link"
             >
-              Open documents →
+              View Record →
             </button>
           </div>
-          <button
-            type="button"
-            onClick={() => setTabAndHash("audit")}
-            className="underline underline-offset-4 hover:text-ink"
-            data-testid="open-record-link"
-          >
-            View record →
-          </button>
         </div>
-      </div>
-      <div
-        ref={scrollRef}
-        className="flex-1 overflow-y-auto pt-2 pb-6 space-y-5 max-h-[64vh]"
-      >
+
+        <div
+          ref={scrollRef}
+          className="flex-1 space-y-5 overflow-y-auto border-y border-rule py-6 lg:max-h-[62vh]"
+        >
         {!loaded && (
           <p className="font-mono text-xs text-muted flex items-center gap-2">
             <InlineSpinner />
@@ -477,19 +462,19 @@ export function AssistantTab({
             />
           </div>
         )}
-      </div>
-
-      {keyMissingProvider && <ProviderKeyMissingBanner provider={keyMissingProvider} />}
-      {error && (
-        <div className="border border-[#D9304F] bg-[#FEF2F2] text-[#B91C1C] text-sm p-3 mt-3">
-          <div className="font-semibold mb-1">Could not send message</div>
-          <p className="leading-relaxed whitespace-pre-wrap">{error}</p>
         </div>
-      )}
 
-      {disabled ? (
-        // Compact unauth state - sticky strip, attached to chat column.
-        <div className="mt-3 sticky bottom-0 bg-paper pt-3">
+        {keyMissingProvider && <ProviderKeyMissingBanner provider={keyMissingProvider} />}
+        {error && (
+          <div className="border border-[#D9304F] bg-[#FEF2F2] text-[#B91C1C] text-sm p-3 mt-3">
+            <div className="font-semibold mb-1">Could not send message</div>
+            <p className="leading-relaxed whitespace-pre-wrap">{error}</p>
+          </div>
+        )}
+
+        {disabled ? (
+          // Compact unauth state - sticky strip, attached to chat column.
+          <div className="mt-3 sticky bottom-0 bg-paper pt-3">
           <div className="border-t border-rule py-3 flex flex-wrap items-center gap-3">
             <p className="text-sm text-prose m-0 flex-1 min-w-[200px]">
               {disabledPlaceholder ?? "Create an evaluation account to ask the assistant against this matter."}
@@ -509,9 +494,9 @@ export function AssistantTab({
               </a>
             </div>
           </div>
-        </div>
-      ) : (
-        <div className="mt-3 sticky bottom-0 bg-paper pt-3">
+          </div>
+        ) : (
+          <div className="mt-3 sticky bottom-0 bg-paper pt-3">
           {/* Context attachments as chips ABOVE the composer */}
           {attachedDocs.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-2">
@@ -722,9 +707,159 @@ export function AssistantTab({
               </button>
             </div>
           </div>
-        </div>
-      )}
+          </div>
+        )}
+      </div>
+
+      <MatterContextRail
+        docs={docs}
+        recentDocs={recentDocs}
+        runnableSkillCount={runnableSkillCount}
+        readySkillLabels={[
+          ...runnableModuleSkills.map((skill) => skill.title),
+          ...enabledSkills.map((skill) => skill.title),
+        ]}
+        needsAttentionCount={needsAttention.length}
+        selectedCount={selectedDocIds.size}
+        onOpenDocuments={() => setTabAndHash("documents")}
+        onOpenSkills={() => setTabAndHash("workflows")}
+        onOpenRecord={() => setTabAndHash("audit")}
+        onOpenOutputs={openOutputs}
+        onOpenPack={openWorkingPack}
+      />
     </div>
+  );
+}
+
+function MatterContextRail({
+  docs,
+  recentDocs,
+  runnableSkillCount,
+  readySkillLabels,
+  needsAttentionCount,
+  selectedCount,
+  onOpenDocuments,
+  onOpenSkills,
+  onOpenRecord,
+  onOpenOutputs,
+  onOpenPack,
+}: {
+  docs: MatterDocument[] | null;
+  recentDocs: MatterDocument[];
+  runnableSkillCount: number;
+  readySkillLabels: string[];
+  needsAttentionCount: number;
+  selectedCount: number;
+  onOpenDocuments: () => void;
+  onOpenSkills: () => void;
+  onOpenRecord: () => void;
+  onOpenOutputs: () => void;
+  onOpenPack: () => void;
+}) {
+  return (
+    <aside className="space-y-4 lg:sticky lg:top-6 lg:self-start" data-testid="matter-context-rail">
+      <RailPanel
+        eyebrow="Documents"
+        actionLabel="Open"
+        onAction={onOpenDocuments}
+        actionTestId="open-documents-link"
+      >
+        {docs === null ? (
+          <p className="text-sm text-muted">Loading project files…</p>
+        ) : docs.length === 0 ? (
+          <p className="text-sm text-muted">No documents loaded yet.</p>
+        ) : (
+          <>
+            <p className="text-sm font-medium text-ink">
+              {docs.length} loaded{selectedCount > 0 ? ` · ${selectedCount} attached` : ""}
+            </p>
+            <ul className="mt-3 space-y-2">
+              {recentDocs.slice(0, 4).map((doc) => (
+                <li key={doc.id} className="truncate font-mono text-xs text-muted">
+                  {doc.filename}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </RailPanel>
+
+      <RailPanel eyebrow="Skills" actionLabel="Manage" onAction={onOpenSkills}>
+        <p className="text-sm font-medium text-ink">
+          {runnableSkillCount} runnable
+        </p>
+        {readySkillLabels.length > 0 ? (
+          <ul className="mt-3 space-y-2">
+            {readySkillLabels.slice(0, 4).map((label) => (
+              <li key={label} className="text-xs text-muted">
+                {label}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-sm text-muted">Enable a skill to run it here.</p>
+        )}
+        {needsAttentionCount > 0 && (
+          <p className="mt-3 text-xs text-muted">
+            {needsAttentionCount} needs setup
+          </p>
+        )}
+      </RailPanel>
+
+      <RailPanel eyebrow="Proof" actionLabel="Record" onAction={onOpenRecord}>
+        <p className="text-sm text-muted">
+          Every skill run writes to the matter Record. Signed outputs and the
+          working pack sit behind it.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-3 text-xs">
+          <button
+            type="button"
+            onClick={onOpenOutputs}
+            className="underline underline-offset-4 hover:text-ink"
+          >
+            Signed outputs
+          </button>
+          <button
+            type="button"
+            onClick={onOpenPack}
+            className="underline underline-offset-4 hover:text-ink"
+          >
+            Working pack
+          </button>
+        </div>
+      </RailPanel>
+    </aside>
+  );
+}
+
+function RailPanel({
+  eyebrow,
+  actionLabel,
+  onAction,
+  actionTestId,
+  children,
+}: {
+  eyebrow: string;
+  actionLabel: string;
+  onAction: () => void;
+  actionTestId?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border border-rule bg-paper p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] uppercase tracking-widest text-muted">{eyebrow}</p>
+        <button
+          type="button"
+          onClick={onAction}
+          data-testid={actionTestId}
+          className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+        >
+          {actionLabel}
+        </button>
+      </div>
+      <div className="mt-3">{children}</div>
+    </section>
   );
 }
 

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -199,7 +199,8 @@ export function AssistantTab({
     [moduleEntries, installedModules, grantRows],
   );
 
-  const runnableSkillCount = enabledSkills.length + runnableModuleSkills.length;
+  const legacyRunnableCount = enabledSkills.length;
+  const runnableSkillCount = runnableModuleSkills.length;
 
   const docsById = useMemo(() => {
     const map = new Map<string, MatterDocument>();
@@ -597,34 +598,34 @@ export function AssistantTab({
                           ))}
                         </ul>
                       )}
-                      {enabledSkills.length > 0 && (
-                        <div>
-                          {runnableModuleSkills.length > 0 && (
-                            <div className="mb-1 eyebrow text-muted">Built-in</div>
-                          )}
-                          <ul className="space-y-2">
-                            {enabledSkills.map((w) => (
-                              <li key={w.key}>
-                                <button
-                                  type="button"
-                                  role="menuitem"
-                                  onClick={() => onPickSkill(w)}
-                                  className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
-                                  data-testid={`chat-skill-${w.key}`}
-                                >
-                                  <span className="block text-ink font-medium">
-                                    {w.title}
-                                  </span>
-                                  <span aria-hidden="true" className="text-muted">
-                                    →
-                                  </span>
-                                </button>
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      )}
                     </div>
+                  )}
+                  {enabledSkills.length > 0 && (
+                    <details className="mt-3 border-t border-rule pt-3">
+                      <summary className="cursor-pointer text-[11px] text-muted hover:text-ink">
+                        Legacy built-in actions ({enabledSkills.length})
+                      </summary>
+                      <ul className="mt-2 space-y-2">
+                        {enabledSkills.map((w) => (
+                          <li key={w.key}>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              onClick={() => onPickSkill(w)}
+                              className="flex w-full items-start justify-between gap-2 border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
+                              data-testid={`chat-skill-${w.key}`}
+                            >
+                              <span className="block text-ink font-medium">
+                                {w.title}
+                              </span>
+                              <span aria-hidden="true" className="text-muted">
+                                →
+                              </span>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </details>
                   )}
                   {needsAttention.length > 0 && (
                     <>
@@ -717,8 +718,8 @@ export function AssistantTab({
         runnableSkillCount={runnableSkillCount}
         readySkillLabels={[
           ...runnableModuleSkills.map((skill) => skill.title),
-          ...enabledSkills.map((skill) => skill.title),
         ]}
+        legacyRunnableCount={legacyRunnableCount}
         needsAttentionCount={needsAttention.length}
         selectedCount={selectedDocIds.size}
         onOpenDocuments={() => setTabAndHash("documents")}
@@ -736,6 +737,7 @@ function MatterContextRail({
   recentDocs,
   runnableSkillCount,
   readySkillLabels,
+  legacyRunnableCount,
   needsAttentionCount,
   selectedCount,
   onOpenDocuments,
@@ -748,6 +750,7 @@ function MatterContextRail({
   recentDocs: MatterDocument[];
   runnableSkillCount: number;
   readySkillLabels: string[];
+  legacyRunnableCount: number;
   needsAttentionCount: number;
   selectedCount: number;
   onOpenDocuments: () => void;
@@ -802,6 +805,11 @@ function MatterContextRail({
         {needsAttentionCount > 0 && (
           <p className="mt-3 text-xs text-muted">
             {needsAttentionCount} needs setup
+          </p>
+        )}
+        {legacyRunnableCount > 0 && (
+          <p className="mt-3 text-xs text-muted">
+            {legacyRunnableCount} legacy action{legacyRunnableCount === 1 ? "" : "s"} available from the picker
           </p>
         )}
       </RailPanel>

--- a/frontend/src/matter/tabs/types.ts
+++ b/frontend/src/matter/tabs/types.ts
@@ -33,9 +33,6 @@ export type TabKey =
 
 export const SIDEBAR_NAV: ReadonlyArray<{ key: TabKey; label: string }> = [
   { key: "assistant", label: "Chat" },
-  { key: "documents", label: "Documents" },
-  { key: "workflows", label: "Skills" },
-  { key: "audit", label: "Record" },
 ];
 
 export const MATTER_TAB_LABELS: Readonly<Record<TabKey, string>> = {


### PR DESCRIPTION
## What

A focused Mike-inspired matter shell pass:

- Keeps Chat as the single visible matter destination in the left rail.
- Adds a persistent right rail for project context: Documents, Skills, and Proof.
- Moves Documents / Skills / Signed outputs / Working pack / Record into context actions beside Chat instead of presenting them as equal exits.
- Makes generic V2 runner skills the only normal in-chat action surface.
- Removes legacy first-party workflow fetching from Chat entirely. Legacy built-in actions remain routable and visible only from the advanced disclosure on the matter Skills page while they migrate to the generic runner.
- Reframes Record as a proof page: story first, Signed outputs + Working pack in the header, raw audit filters behind Advanced details.

## Scope held

- Frontend only.
- No backend, schema, route, skill-runtime, or audit-source changes.
- Route compatibility preserved.
- Legacy built-in pages remain available while generic-runner migration continues.
- This is structural shell compression, not the final visual polish pass.

## Verification

- `npm run typecheck`
- `npm run test -- AssistantTab MatterSkillsTab ReconstructionView --run` — 21/21
- `npm run test -- --run` — 210/210
- `npm run build`
- Local browser sanity pass on `/demo`: matter rail shows only Chat; Chat renders with Documents / Skills / Proof context rail; no legacy workflow state is pulled into Chat.

## Review focus

Does this now feel like opening a legal project folder with Chat as the work surface, while keeping governance one click away instead of making it the product?