### PR TITLE
Document engine workspace and original-file previews

### DIFF
--- a/backend/app/api/document_routes/workspace.py
+++ b/backend/app/api/document_routes/workspace.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.core.document_engine import (
+    DocumentEngineNotFound,
+    DocumentEngineUnavailable,
+    DocumentSnapshot,
+    load_document_snapshot,
+)
+
+from .common import *  # noqa: F403
+
+
+router = APIRouter()
+
+
+class DocumentBlockRead(BaseModel):
+    id: str
+    type: str
+    ordinal: int
+    text: str
+
+
+class DocumentWorkspaceRead(BaseModel):
+    document_id: uuid.UUID
+    filename: str
+    mime_type: str
+    source: str
+    source_version_id: uuid.UUID | None
+    source_version_number: int | None
+    extraction_method: str | None
+    blocks: list[DocumentBlockRead]
+    text: str
+    char_count: int
+    notes: list[str]
+
+
+class DocumentWorkspaceSaveRequest(BaseModel):
+    text: str = Field(min_length=1, max_length=500_000)
+    notes: str | None = Field(default=None, max_length=500)
+    resolved_json: dict[str, Any] | None = None
+
+
+class DocumentWorkspaceSaveResponse(BaseModel):
+    version: DocumentVersionRead
+    workspace: DocumentWorkspaceRead
+
+
+def _workspace_read(snapshot: DocumentSnapshot) -> DocumentWorkspaceRead:
+    version = snapshot.source_version
+    return DocumentWorkspaceRead(
+        document_id=snapshot.document.id,
+        filename=snapshot.document.filename,
+        mime_type=snapshot.document.mime_type,
+        source=snapshot.source,
+        source_version_id=version.id if version else None,
+        source_version_number=version.version_number if version else None,
+        extraction_method=snapshot.extraction_method,
+        blocks=[
+            DocumentBlockRead(
+                id=block.id,
+                type=block.type,
+                ordinal=block.ordinal,
+                text=block.text,
+            )
+            for block in snapshot.blocks
+        ],
+        text=snapshot.text,
+        char_count=snapshot.char_count,
+        notes=snapshot.notes,
+    )
+
+
+@router.get("/{document_id}/workspace", response_model=DocumentWorkspaceRead)
+async def get_document_workspace(
+    document_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentWorkspaceRead:
+    """Return the structured document workspace snapshot."""
+    try:
+        snapshot = await load_document_snapshot(
+            session,
+            document_id=document_id,
+            actor_id=user.id,
+        )
+    except DocumentEngineNotFound as exc:
+        raise HTTPException(404, "document not found") from exc
+    except DocumentEngineUnavailable as exc:
+        raise HTTPException(404, str(exc)) from exc
+    return _workspace_read(snapshot)
+
+
+@router.post("/{document_id}/workspace", response_model=DocumentWorkspaceSaveResponse)
+async def save_document_workspace(
+    document_id: uuid.UUID,
+    body: DocumentWorkspaceSaveRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentWorkspaceSaveResponse:
+    """Save workspace text as a new immutable document version."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    version = await _create_user_edit_version(
+        session,
+        doc=doc,
+        matter=matter,
+        user=user,
+        resolved_text=body.text,
+        resolved_json=body.resolved_json,
+        notes=body.notes or "Saved document workspace",
+        audit_source="workspace",
+    )
+    await audit.log(
+        session,
+        "document.workspace.saved",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_version",
+        resource_id=str(version.id),
+        payload={
+            "document_id": str(doc.id),
+            "version_number": version.version_number,
+            "char_count": len(body.text),
+        },
+    )
+    await session.commit()
+
+    snapshot = await load_document_snapshot(
+        session,
+        document_id=document_id,
+        actor_id=user.id,
+    )
+    return DocumentWorkspaceSaveResponse(
+        version=DocumentVersionRead.model_validate(version),
+        workspace=_workspace_read(snapshot),
+    )

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -14,6 +14,7 @@ from app.api.document_routes import (
     edits,
     original_download,
     working_draft,
+    workspace,
 )
 from app.api.document_routes.common import (
     _html_to_pdf,
@@ -31,6 +32,7 @@ for subrouter in (
     assets.router,
     body_versions.router,
     working_draft.router,
+    workspace.router,
     edits.router,
     comments.router,
     edit_sessions.router,

--- a/backend/app/core/document_engine.py
+++ b/backend/app/core/document_engine.py
@@ -1,0 +1,223 @@
+"""Document engine primitives.
+
+Legalise owns the document workspace contract rather than vendoring a full
+editor backend. Skills and UI code ask for one structured snapshot of a
+document, then render or operate on that snapshot.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.storage import StorageReadError, get_storage_backend
+from app.models import Document, DocumentVersion, Matter, STATUS_ARCHIVED
+from app.models.document_body import extracted_body_for
+
+
+BlockType = Literal["paragraph", "table_cell"]
+SnapshotSource = Literal["original_docx", "latest_version", "extracted_body"]
+
+
+@dataclass(frozen=True)
+class DocumentBlock:
+    id: str
+    type: BlockType
+    ordinal: int
+    text: str
+
+
+@dataclass(frozen=True)
+class DocumentSnapshot:
+    document: Document
+    matter: Matter
+    source: SnapshotSource
+    source_version: DocumentVersion | None
+    extraction_method: str | None
+    blocks: list[DocumentBlock]
+    text: str
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def char_count(self) -> int:
+        return len(self.text)
+
+
+class DocumentEngineNotFound(LookupError):
+    """Document is absent, archived, or not owned by the actor."""
+
+
+class DocumentEngineUnavailable(ValueError):
+    """Document exists but has no readable text yet."""
+
+
+def _normalise_blocks(blocks: list[DocumentBlock]) -> list[DocumentBlock]:
+    return [block for block in blocks if block.text.strip()]
+
+
+def blocks_from_text(text: str) -> list[DocumentBlock]:
+    """Split readable text into stable paragraph blocks."""
+    parts = [part.strip() for part in text.replace("\r\n", "\n").split("\n\n")]
+    blocks: list[DocumentBlock] = []
+    for index, part in enumerate(part for part in parts if part):
+        blocks.append(
+            DocumentBlock(
+                id=f"p{index + 1}",
+                type="paragraph",
+                ordinal=index + 1,
+                text=part,
+            )
+        )
+    return blocks
+
+
+def blocks_from_docx(file_bytes: bytes) -> list[DocumentBlock]:
+    """Extract paragraphs and table cells from a DOCX file."""
+    from docx import Document as DocxDocument
+
+    document = DocxDocument(io.BytesIO(file_bytes))
+    blocks: list[DocumentBlock] = []
+    ordinal = 1
+
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        if text:
+            blocks.append(
+                DocumentBlock(
+                    id=f"p{ordinal}",
+                    type="paragraph",
+                    ordinal=ordinal,
+                    text=text,
+                )
+            )
+            ordinal += 1
+
+    for table_index, table in enumerate(document.tables, start=1):
+        for row_index, row in enumerate(table.rows, start=1):
+            for cell_index, cell in enumerate(row.cells, start=1):
+                text = cell.text.strip()
+                if not text:
+                    continue
+                blocks.append(
+                    DocumentBlock(
+                        id=f"t{table_index}r{row_index}c{cell_index}",
+                        type="table_cell",
+                        ordinal=ordinal,
+                        text=text,
+                    )
+                )
+                ordinal += 1
+
+    return _normalise_blocks(blocks)
+
+
+async def _latest_resolved_version(
+    session: AsyncSession, document_id: uuid.UUID
+) -> DocumentVersion | None:
+    return await session.scalar(
+        select(DocumentVersion)
+        .where(
+            DocumentVersion.document_id == document_id,
+            DocumentVersion.resolved_text.is_not(None),
+        )
+        .order_by(
+            DocumentVersion.version_number.desc(),
+            DocumentVersion.created_at.desc(),
+        )
+        .limit(1)
+    )
+
+
+def _is_docx(document: Document) -> bool:
+    return document.filename.lower().endswith(".docx") or document.mime_type == (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+
+
+async def load_document_snapshot(
+    session: AsyncSession,
+    *,
+    document_id: uuid.UUID,
+    actor_id: uuid.UUID,
+) -> DocumentSnapshot:
+    """Return the current structured document snapshot for an owner.
+
+    Source precedence:
+    1. Latest resolved version text. Accepted edits define the current text.
+    2. Original DOCX blocks if no resolved version exists and object storage is
+       available.
+    3. Extracted body fallback.
+    """
+    pair = (
+        await session.execute(
+            select(Document, Matter)
+            .join(Matter, Matter.id == Document.matter_id)
+            .where(Document.id == document_id)
+        )
+    ).first()
+    if pair is None:
+        raise DocumentEngineNotFound("document not found")
+
+    document, matter = pair
+    if matter.created_by_id != actor_id or matter.status == STATUS_ARCHIVED:
+        raise DocumentEngineNotFound("document not found")
+
+    latest_version = await _latest_resolved_version(session, document_id)
+    if latest_version and latest_version.resolved_text:
+        blocks = blocks_from_text(latest_version.resolved_text)
+        if not blocks:
+            raise DocumentEngineUnavailable("document has no readable text")
+        return DocumentSnapshot(
+            document=document,
+            matter=matter,
+            source="latest_version",
+            source_version=latest_version,
+            extraction_method=None,
+            blocks=blocks,
+            text="\n\n".join(block.text for block in blocks),
+        )
+
+    notes: list[str] = []
+    if _is_docx(document) and document.storage_uri:
+        try:
+            original_bytes = get_storage_backend().get_bytes(document.storage_uri)
+            blocks = blocks_from_docx(original_bytes)
+            if blocks:
+                return DocumentSnapshot(
+                    document=document,
+                    matter=matter,
+                    source="original_docx",
+                    source_version=None,
+                    extraction_method="python-docx",
+                    blocks=blocks,
+                    text="\n\n".join(block.text for block in blocks),
+                )
+            notes.append("original DOCX had no readable blocks")
+        except (KeyError, StorageReadError):
+            notes.append("original DOCX unavailable; using extracted body")
+        except Exception:  # noqa: BLE001
+            notes.append("original DOCX could not be parsed; using extracted body")
+
+    body = await extracted_body_for(session, document_id)
+    if body is None or body.extraction_method == "failed" or not body.extracted_text.strip():
+        raise DocumentEngineUnavailable("document body not available")
+
+    blocks = blocks_from_text(body.extracted_text)
+    if not blocks:
+        raise DocumentEngineUnavailable("document has no readable text")
+
+    return DocumentSnapshot(
+        document=document,
+        matter=matter,
+        source="extracted_body",
+        source_version=None,
+        extraction_method=body.extraction_method,
+        blocks=blocks,
+        text="\n\n".join(block.text for block in blocks),
+        notes=notes,
+    )

--- a/backend/tests/test_document_engine.py
+++ b/backend/tests/test_document_engine.py
@@ -1,0 +1,39 @@
+"""Document engine contract tests."""
+
+from __future__ import annotations
+
+import io
+
+from docx import Document as DocxDocument
+
+from app.core.document_engine import blocks_from_docx, blocks_from_text
+
+
+def test_blocks_from_text_ignores_empty_paragraphs() -> None:
+    blocks = blocks_from_text("First paragraph.\n\n\nSecond paragraph.\n")
+
+    assert [block.id for block in blocks] == ["p1", "p2"]
+    assert [block.text for block in blocks] == [
+        "First paragraph.",
+        "Second paragraph.",
+    ]
+    assert all(block.type == "paragraph" for block in blocks)
+
+
+def test_blocks_from_docx_extracts_paragraphs_and_table_cells() -> None:
+    document = DocxDocument()
+    document.add_paragraph("Main clause")
+    table = document.add_table(rows=1, cols=2)
+    table.cell(0, 0).text = "Party A"
+    table.cell(0, 1).text = "Party B"
+    buf = io.BytesIO()
+    document.save(buf)
+
+    blocks = blocks_from_docx(buf.getvalue())
+
+    assert [block.text for block in blocks] == ["Main clause", "Party A", "Party B"]
+    assert [block.type for block in blocks] == [
+        "paragraph",
+        "table_cell",
+        "table_cell",
+    ]

--- a/backend/tests/test_documents_routes.py
+++ b/backend/tests/test_documents_routes.py
@@ -76,6 +76,36 @@ async def test_document_body_returns_extracted_text_for_each_seeded_doc(client) 
 
 
 @pytest.mark.asyncio
+async def test_document_workspace_reads_and_saves_seeded_doc(client) -> None:
+    await _signup_and_login(client)
+
+    docs_resp = await client.get(f"/api/matters/{KHAN_SLUG}/documents")
+    assert docs_resp.status_code == 200
+    document = docs_resp.json()[0]
+
+    workspace_resp = await client.get(f"/api/documents/{document['id']}/workspace")
+    assert workspace_resp.status_code == 200, workspace_resp.text
+    workspace = workspace_resp.json()
+    assert workspace["document_id"] == document["id"]
+    assert workspace["text"]
+    assert workspace["blocks"]
+    assert workspace["char_count"] == len(workspace["text"])
+
+    edited_text = workspace["text"] + "\n\nReviewer note added in workspace."
+    save_resp = await client.post(
+        f"/api/documents/{document['id']}/workspace",
+        json={"text": edited_text, "notes": "Save from workspace route test"},
+    )
+    assert save_resp.status_code == 200, save_resp.text
+    saved = save_resp.json()
+    assert saved["version"]["kind"] == "user_edit"
+    assert saved["version"]["resolved_text"] == edited_text
+    assert saved["workspace"]["source"] == "latest_version"
+    assert saved["workspace"]["source_version_id"] == saved["version"]["id"]
+    assert saved["workspace"]["text"] == edited_text
+
+
+@pytest.mark.asyncio
 async def test_documents_listing_unknown_matter_returns_404(client) -> None:
     await _signup_and_login(client)
     resp = await client.get("/api/matters/this-slug-does-not-exist/documents")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1511,6 +1511,27 @@ export interface DocumentBody {
   error_reason: string | null;
 }
 
+export interface DocumentWorkspaceBlock {
+  id: string;
+  type: "paragraph" | "table_cell";
+  ordinal: number;
+  text: string;
+}
+
+export interface DocumentWorkspace {
+  document_id: string;
+  filename: string;
+  mime_type: string;
+  source: "original_docx" | "latest_version" | "extracted_body";
+  source_version_id: string | null;
+  source_version_number: number | null;
+  extraction_method: string | null;
+  blocks: DocumentWorkspaceBlock[];
+  text: string;
+  char_count: number;
+  notes: string[];
+}
+
 export type EditMode =
   | "tighten"
   | "rewrite"
@@ -1561,6 +1582,32 @@ export interface EditInstructionResponse {
 export const getDocumentBody = (documentId: string) =>
   apiFetch(`${API}/documents/${documentId}/body`).then((r) =>
     jsonOrThrow<DocumentBody>(r),
+  );
+
+export const getDocumentWorkspace = (documentId: string) =>
+  apiFetch(`${API}/documents/${documentId}/workspace`).then((r) =>
+    jsonOrThrow<DocumentWorkspace>(r),
+  );
+
+export const saveDocumentWorkspace = (
+  documentId: string,
+  text: string,
+  notes?: string,
+  resolvedJson?: Record<string, unknown> | null,
+) =>
+  apiFetch(`${API}/documents/${documentId}/workspace`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      text,
+      notes: notes?.trim() || null,
+      resolved_json: resolvedJson ?? null,
+    }),
+  }).then((r) =>
+    resolutionJsonOrThrow<{
+      version: DocumentVersionRead;
+      workspace: DocumentWorkspace;
+    }>(r),
   );
 
 // Original File Retrieval v1 — browser-navigable URL for the streamed


### PR DESCRIPTION
## Summary

This PR is now the Legalise document workspace stack plus the Mike-parity document build slices. It leans on proven document packages rather than a homegrown approximation, while keeping Legalise responsible for auth, versions, skills, Record, sign-off, and export.

Foundation shipped in this branch:

- Adds `app.core.document_engine`: owner-gated document snapshot contract with stable blocks, latest-version precedence, original DOCX parsing via `python-docx`, and extracted-body fallback.
- Adds `GET /api/documents/{document_id}/workspace` and `POST /api/documents/{document_id}/workspace`; human edits save a new immutable Legalise document version and emit `document.workspace.saved`.
- Renders original DOCX via lazy `docx-preview`.
- Replaces browser-PDF iframe with direct PDF.js (`pdfjs-dist`): authenticated original fetch, canvas rendering, page navigation, zoom, search, extracted-text fallback.
- Adds TipTap editor tab that saves back into Legalise versions.
- Keeps heavy packages code-split: `docx-preview`, `PdfDocumentViewer`, `RichDocumentEditor`, PDF worker.

Mike-parity slices now included:

- Adds `docs/handovers/MIKE_PARITY_DOCUMENT_WORKSPACE_PLAN.md` as the active implementation plan.
- Adds `GET /api/documents/versions/{version_id}/text` for safe owner-gated version text reads.
- Adds `VersionCompareView`: real Legalise text-version compare using the existing `diff-match-patch` wrapper. This is explicitly not Word track changes.
- Makes Redline tab compare saved versions first, with model-proposed edits behind a disclosure.
- Adds `DocumentSkillLauncher`: run enabled document-aware skills from the document page, passing the current document and selected passage into the existing `GenericSkillRunner`.
- Captures selected text from document/editor surfaces and exposes it as optional skill context.
- Adds document comments/notes with migration `0023_document_comments`, owner-scoped API, notes panel, resolve flow, and audit rows `document.comment.created` / `document.comment.resolved`.
- Adds generated edited-version DOCX download from Legalise resolved text via `GET /api/documents/versions/{version_id}/docx`, audited as `document.version.docx.downloaded`. This is a clean generated DOCX, not preservation of original Word formatting or tracked changes.
- Connects source anchors to the document workspace: artifact source chips deep-link into the document page with source/quote context and quote-not-found caution copy.
- Enriches Working Pack export with document workspace context: per-document `versions.json`, `comments.json`, resolved-text `versions/vN.txt`, top-level `document_versions.json` / `document_comments.json`, and README/WORKING_PACK counts. Existing machine-readable export paths are preserved.

## Why

The previous direction risked creating a 10%-as-good custom document reader. This keeps Legalise responsible for governance while using proven rendering/editor packages where they already exist.

## Boundaries

- No Mike code vendored or copied.
- Uses the same calibre/category of proven packages Mike-style products lean on (`docx-preview`, PDF.js, TipTap), but Legalise owns the contract and governance.
- Includes one schema migration: `0023_document_comments`.
- Redline compare is Legalise text-version compare, not Word track changes.
- Edited DOCX export is generated from Legalise resolved text, not a round-trip of original Word formatting.
- Exact PDF text-highlight anchoring and legacy surface retirement remain later slices.
- `pdfjs-dist@5.4.624` was chosen deliberately: audit-clean and compatible with the current Node 22.12 runtime. I rejected wrapper stacks that pulled vulnerable `pdfjs-dist`/`canvas` transitive dependencies.

## Verification

Local:

- `git diff --check`
- `python -m compileall backend/app backend/alembic/versions/0023_document_comments.py backend/tests/test_documents_routes.py backend/tests/test_export_working_pack.py`
- `cd frontend && npm audit --omit=dev --json` (0 vulnerabilities after package changes, run before the later no-package-change slices)
- `cd frontend && npm run typecheck`
- `cd frontend && npm run test -- DocumentDetail ArtifactPreview --run` (21/21)
- `cd frontend && npm run test -- --run` (213/213)
- `cd frontend && npm run build`

Backend pytest is CI-gated in this shell because local `pytest` and `uv` are not installed.

## Review focus

- Migration `0023_document_comments` and owner-scoped comment endpoints.
- `DocumentDetail` document-workspace flow: preview/read/edit/redline/skills/notes/source context.
- Export compatibility: new document workspace files added without moving existing JSON paths.
- Honesty boundaries: generated DOCX is labelled as generated text-version output, source-anchor links do not claim exact highlighting or verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document workspace functionality allowing users to view and edit structured document snapshots
  * Document content now organized into content blocks with character count tracking
  * Save workspace edits with automatic versioning support
  * Improved document content extraction from multiple sources
<!-- end of auto-generated comment: release notes by coderabbit.ai -->