### PR TITLE
Clarify public demo documents and skills

### DIFF
--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -1,7 +1,5 @@
-// Read-only demo workspace for `#/demo`. Mirrors MatterDetail's shell
-// (MatterHeader + MatterTabBar + main column) but feeds every tab from
-// the hard-coded snapshot. Mutation handlers flash a workspace-framed
-// sign-up CTA. Zero backend calls.
+// Read-only demo workspace for `/demo`. Mirrors the matter shell but
+// feeds every surface from the hard-coded snapshot. Zero backend calls.
 
 import { useEffect, useState } from "react";
 import type { MatterDocument } from "../lib/api";
@@ -20,14 +18,15 @@ import { ResearchTab } from "../modules/case_law/ResearchTab";
 import { ContractReviewTab } from "../modules/contract_review/ContractReviewTab";
 import { DEMO_SNAPSHOT } from "./snapshot";
 
-// Open evaluation: one consistent prompt across all disabled demo
-// actions, not six different waitlist nags. Signup is open, so the
-// action is "create an account", not "join a waitlist".
-const CTA_CREATE_ACCOUNT = "Create a free account to run this on your own matter";
-const CTA_RUN_PREMOTION = CTA_CREATE_ACCOUNT;
-const CTA_DRAFT_LETTER = CTA_CREATE_ACCOUNT;
-const CTA_EXPORT = CTA_CREATE_ACCOUNT;
-const CTA_CONTRACT_REVIEW = CTA_CREATE_ACCOUNT;
+const DEMO_NAV: ReadonlyArray<{ key: TabKey; label: string }> = [
+  { key: "assistant", label: "Chat" },
+  { key: "documents", label: "Documents" },
+  { key: "workflows", label: "Skills" },
+  { key: "audit", label: "Record" },
+];
+
+const DEMO_READ_ONLY =
+  "This public demo is read-only. Use the previews to inspect the project loop.";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n}B`;
@@ -44,6 +43,7 @@ export function DemoMatter() {
   const [tab, setTab] = useState<TabKey>(initialTab);
   const [flash, setFlash] = useState<string | null>(null);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [inspectedDocId, setInspectedDocId] = useState<string | null>(null);
 
   useEffect(() => {
     if (route.name === "demo" && route.tab && isTabKey(route.tab)) {
@@ -87,7 +87,7 @@ export function DemoMatter() {
   );
 
   const [showSoF, setShowSoF] = useState(false);
-  const flashPosture = () => flashCta(CTA_CREATE_ACCOUNT);
+  const flashPosture = () => flashCta(DEMO_READ_ONLY);
 
   return (
     <>
@@ -103,6 +103,7 @@ export function DemoMatter() {
           mobileOpen={mobileNavOpen}
           onMobileClose={() => setMobileNavOpen(false)}
           showPosture={false}
+          navItems={DEMO_NAV}
         />
         <div className="flex-1 min-w-0">
           <MatterBreadcrumb
@@ -113,23 +114,34 @@ export function DemoMatter() {
           <div className="flex bg-wash">
           <main className="flex-1 min-w-0 px-4 sm:px-6 lg:px-10 py-8 lg:py-12 min-h-[calc(100vh-80px)]">
             {tab === "assistant" && (
-              <AssistantTab
-                matter={matter}
-                docs={documents}
-                chronology={DEMO_SNAPSHOT.chronology.events}
-                auditCount={DEMO_SNAPSHOT.audit.length}
-                workflowsGrantedCount={4}
-                setTabAndHash={setTabAndHash}
-                initialMessages={DEMO_SNAPSHOT.assistantMessages}
-                disabled
-                showPostureInPulse={false}
-                disabledPlaceholder="Create a free account to chat with the assistant on your own matter"
-                onDisabledAction={() => flashCta(CTA_CREATE_ACCOUNT)}
-              />
+              <div className="space-y-8">
+                <DemoStartPanel
+                  docs={documents}
+                  auditCount={DEMO_SNAPSHOT.audit.length}
+                  onOpen={setTabAndHash}
+                  onRun={() => setTabAndHash("contract-review")}
+                />
+                <AssistantTab
+                  matter={matter}
+                  docs={documents}
+                  chronology={DEMO_SNAPSHOT.chronology.events}
+                  auditCount={DEMO_SNAPSHOT.audit.length}
+                  workflowsGrantedCount={4}
+                  setTabAndHash={setTabAndHash}
+                  initialMessages={DEMO_SNAPSHOT.assistantMessages}
+                  disabled
+                  showPostureInPulse={false}
+                  showDisabledFooter={false}
+                  showContextRail={false}
+                  onDisabledAction={() => setTabAndHash("workflows")}
+                />
+              </div>
             )}
             {tab === "documents" && (
               <DemoDocumentsTab
                 docs={documents}
+                inspectedDocId={inspectedDocId}
+                onInspect={setInspectedDocId}
               />
             )}
             {tab === "chronology" && (
@@ -141,7 +153,7 @@ export function DemoMatter() {
               />
             )}
             {tab === "workflows" && (
-              <DemoWorkflowsTab onOpen={setTabAndHash} onRun={() => flashCta(CTA_CREATE_ACCOUNT)} />
+              <DemoWorkflowsTab onOpen={setTabAndHash} />
             )}
             {tab === "audit" && <AuditTab audit={DEMO_SNAPSHOT.audit} matter={matter} />}
             {tab === "premotion" && (
@@ -151,13 +163,13 @@ export function DemoMatter() {
                 error={null}
                 stages={[]}
                 result={DEMO_SNAPSHOT.preMotion}
-                onRun={() => flashCta(CTA_RUN_PREMOTION)}
+                onRun={() => flashCta(DEMO_READ_ONLY)}
                 pdfBusy={false}
                 pdfError={null}
-                onExportPdf={() => flashCta(CTA_EXPORT)}
+                onExportPdf={() => flashCta(DEMO_READ_ONLY)}
                 docxBusy={false}
                 docxError={null}
-                onExportDocx={() => flashCta(CTA_EXPORT)}
+                onExportDocx={() => flashCta(DEMO_READ_ONLY)}
               />
             )}
             {tab === "letters" && (
@@ -173,10 +185,10 @@ export function DemoMatter() {
                     ? DEMO_SNAPSHOT.letterDraft
                     : null
                 }
-                onDraft={() => flashCta(CTA_DRAFT_LETTER)}
+                onDraft={() => flashCta(DEMO_READ_ONLY)}
                 docxBusy={false}
                 docxError={null}
-                onDownloadDocx={() => flashCta(CTA_EXPORT)}
+                onDownloadDocx={() => flashCta(DEMO_READ_ONLY)}
               />
             )}
             {tab === "contract-review" && (
@@ -184,7 +196,7 @@ export function DemoMatter() {
                 matter={matter}
                 docs={documents}
                 previewResult={DEMO_SNAPSHOT.contractReview}
-                onRunOverride={() => flashCta(CTA_CONTRACT_REVIEW)}
+                onRunOverride={() => flashCta(DEMO_READ_ONLY)}
               />
             )}
             {tab === "reviews" && (
@@ -201,19 +213,93 @@ export function DemoMatter() {
   );
 }
 
+function DemoStartPanel({
+  docs,
+  auditCount,
+  onOpen,
+  onRun,
+}: {
+  docs: MatterDocument[];
+  auditCount: number;
+  onOpen: (tab: TabKey) => void;
+  onRun: () => void;
+}) {
+  return (
+    <section className="mx-auto w-full max-w-[1220px] border border-rule bg-paper p-5 sm:p-6">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+            Public demo
+          </p>
+          <h1 className="mt-2 max-w-3xl text-2xl font-semibold tracking-tight2 text-ink sm:text-3xl">
+            A legal project with documents, skills, and a record of what the AI did.
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-prose">
+            This read-only Khan v Acme matter shows the current Legalise loop:
+            open a project, inspect the documents, run a skill, review the
+            output, then trace it in the matter Record.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <button
+              type="button"
+              onClick={() => onOpen("documents")}
+              className="border border-rule bg-paper px-3 py-2 text-sm font-medium text-ink hover:border-ink"
+            >
+              View documents
+            </button>
+            <button
+              type="button"
+              onClick={() => onOpen("workflows")}
+              className="border border-rule bg-paper px-3 py-2 text-sm font-medium text-ink hover:border-ink"
+            >
+              View skills
+            </button>
+            <button
+              type="button"
+              onClick={onRun}
+              className="bg-ink px-3 py-2 text-sm font-medium text-paper hover:bg-black"
+            >
+              Open skill preview
+            </button>
+          </div>
+        </div>
+        <div className="grid gap-3 text-sm">
+          <DemoFact label="Documents" value={`${docs.length} loaded`} body="Matter evidence and drafts are in one folder." />
+          <DemoFact label="Skills" value="4 ready" body="Skills say what they read and what they produce." />
+          <DemoFact label="Record" value={`${auditCount} entries`} body="AI work, source use, and sign-off stay traceable." />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DemoFact({
+  label,
+  value,
+  body,
+}: {
+  label: string;
+  value: string;
+  body: string;
+}) {
+  return (
+    <div className="border border-rule bg-paper-sunken p-3">
+      <div className="font-mono text-[10px] uppercase tracking-track2 text-muted">
+        {label}
+      </div>
+      <div className="mt-1 font-semibold text-ink">{value}</div>
+      <p className="mt-1 text-xs leading-5 text-muted">{body}</p>
+    </div>
+  );
+}
+
 function FlashCta({ message, onClose }: { message: string; onClose: () => void }) {
   return (
     <div className="border-b border-rule bg-paper px-4 sm:px-6 lg:px-10 py-3 flex flex-wrap items-center gap-x-4 gap-y-2">
       <span className="font-mono uppercase tracking-track2 text-[10px] font-bold text-ink">
-        Sandbox
+        Demo
       </span>
       <span className="text-sm text-ink">{message}.</span>
-      <a
-        href="/auth/signup"
-        className="bg-ink text-paper px-3 py-1.5 hover:bg-black transition-colors text-xs font-medium min-h-[32px] inline-flex items-center"
-      >
-        Create account
-      </a>
       <button
         onClick={onClose}
         className="ml-auto text-xs text-muted hover:text-ink min-h-[32px] px-2"
@@ -227,10 +313,8 @@ function FlashCta({ message, onClose }: { message: string; onClose: () => void }
 
 function DemoWorkflowsTab({
   onOpen,
-  onRun,
 }: {
   onOpen: (tab: TabKey) => void;
-  onRun: () => void;
 }) {
   const workflows: Array<{
     key: TabKey;
@@ -278,15 +362,15 @@ function DemoWorkflowsTab({
     <div className="max-w-5xl">
       <div className="mb-8 border border-rule bg-paper-sunken p-5">
         <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
-          Governed skills
+          Skills in this project
         </p>
         <h2 className="mt-1 text-2xl font-semibold tracking-tight2 text-ink">
-          Pick the work you want the AI to prepare.
+          Run a legal skill against the matter file.
         </h2>
         <p className="mt-2 text-sm text-prose max-w-2xl leading-relaxed">
-          Each skill declares the material it reads, the output it writes, and
-          the record it leaves behind. The demo previews the loop; your own
-          workspace can run it.
+          Skills are installed at workspace level, then enabled inside a
+          project. This public snapshot shows the ready state: what each skill
+          reads, what it produces, and where the result is recorded.
         </p>
       </div>
 
@@ -320,16 +404,9 @@ function DemoWorkflowsTab({
               <button
                 type="button"
                 onClick={() => onOpen(w.key)}
-                className="border border-rule px-3 py-2 text-sm text-ink hover:border-ink hover:bg-wash transition-colors"
-              >
-                Open preview
-              </button>
-              <button
-                type="button"
-                onClick={onRun}
                 className="bg-ink px-3 py-2 text-sm font-medium text-paper hover:bg-black transition-colors"
               >
-                Run on my matter
+                Open preview
               </button>
             </div>
           </section>
@@ -337,8 +414,8 @@ function DemoWorkflowsTab({
       </div>
 
       <p className="mt-8 border-t border-rule pt-4 text-xs text-muted">
-        Skill installation and permission setup are hidden in this public
-        snapshot. They appear when you work inside your own matter.
+        Installation and setup stay behind the scenes in this public demo. The
+        previews show the outputs and record trail without asking you to sign in.
       </p>
     </div>
   );
@@ -350,53 +427,101 @@ function DemoWorkflowsTab({
 
 function DemoDocumentsTab({
   docs,
+  inspectedDocId,
+  onInspect,
 }: {
   docs: MatterDocument[];
+  inspectedDocId: string | null;
+  onInspect: (id: string) => void;
 }) {
+  const inspectedDoc = docs.find((doc) => doc.id === inspectedDocId) ?? docs[0];
+
   return (
     <div className="max-w-5xl">
       <div className="mb-8 border border-rule bg-paper-sunken p-5">
         <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
-          Matter file
+          Documents in this project
         </p>
         <h2 className="mt-1 text-2xl font-semibold tracking-tight2 text-ink">
-          The demo matter is already loaded.
+          The matter file is already loaded.
         </h2>
         <p className="mt-2 text-sm text-prose max-w-2xl leading-relaxed">
-          These are the documents the assistant and skills can cite. In your
-          own workspace, uploaded material is hashed, stored, and recorded.
+          These are the sources the chat and skills can use. In your own
+          workspace, documents open in the reader, edits create versions, and
+          source citations link back here.
         </p>
       </div>
 
       <div className="overflow-hidden border border-rule bg-paper">
         <div className="min-w-[680px]">
-          <div className="grid grid-cols-[1.5fr_110px_90px_120px_100px] gap-4 px-5 py-3 text-muted bg-paper-sunken border-b border-rule font-mono uppercase tracking-track2 text-[9px]">
+          <div className="grid grid-cols-[1.5fr_110px_90px_120px_120px] gap-4 px-5 py-3 text-muted bg-paper-sunken border-b border-rule font-mono uppercase tracking-track2 text-[9px]">
             <span>Document</span>
             <span>Type</span>
             <span>Size</span>
             <span>Source</span>
-            <span className="text-right">Status</span>
+            <span className="text-right">Workspace</span>
           </div>
           {docs.map((d) => (
             <div key={d.id} className="border-b border-rule">
-              <div className="grid grid-cols-[1.5fr_110px_90px_120px_100px] gap-4 px-5 py-4 items-center hover:bg-wash transition-colors">
+              <div className="grid grid-cols-[1.5fr_110px_90px_120px_120px] gap-4 px-5 py-4 items-center hover:bg-wash transition-colors">
                 <div className="min-w-0">
                   <div className="text-sm font-semibold text-ink truncate">{d.filename}</div>
-                  <div className="mt-0.5 text-[11px] text-muted truncate">{d.sha256.slice(0, 8)}</div>
+                  <div className="mt-0.5 text-[11px] text-muted truncate">
+                    hashed · source-ready · {d.sha256.slice(0, 8)}
+                  </div>
                 </div>
                 <span>{d.tag && <Badge>{d.tag.toUpperCase()}</Badge>}</span>
                 <span className="text-xs text-ink">{formatBytes(d.size_bytes)}</span>
                 <span>{d.from_disclosure ? <Badge>CPR 31</Badge> : <span className="text-xs text-muted">Upload</span>}</span>
-                <span className="text-muted uppercase tracking-track2 text-[9px] text-right">
-                  Ready
-                </span>
+                <button
+                  type="button"
+                  onClick={() => onInspect(d.id)}
+                  className="text-right text-[10px] font-semibold uppercase tracking-track2 text-muted hover:text-ink"
+                >
+                  Open reader
+                </button>
               </div>
             </div>
           ))}
         </div>
       </div>
+
+      {inspectedDoc && (
+        <section className="mt-6 border border-rule bg-paper p-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+                Reader preview
+              </p>
+              <h3 className="mt-1 text-lg font-semibold tracking-tight2 text-ink">
+                {inspectedDoc.filename}
+              </h3>
+            </div>
+            <span className="border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
+              Source-ready
+            </span>
+          </div>
+          <div className="mt-4 max-w-3xl whitespace-pre-wrap border border-rule bg-paper-sunken p-4 text-sm leading-relaxed text-prose">
+            {demoDocumentExtract(inspectedDoc)}
+          </div>
+          <p className="mt-3 text-xs leading-5 text-muted">
+            In the live workspace, source chips on AI outputs open back to this
+            reader so you can check what the skill relied on.
+          </p>
+        </section>
+      )}
     </div>
   );
+}
+
+function demoDocumentExtract(doc: MatterDocument): string {
+  if (doc.filename.includes("dismissal")) {
+    return "Acme Trading Ltd confirms dismissal with effect from 12 March 2026. The reason given is alleged breach of the company social-media policy. The letter refers to a disciplinary meeting chaired by the same manager named in Ms Khan's earlier grievance.";
+  }
+  if (doc.filename.includes("witness")) {
+    return "Ms Khan says the social-media post was made from a private account, outside working hours, to a closed audience. She had raised a grievance six weeks earlier about her line manager's conduct toward female warehouse staff.";
+  }
+  return "The synthetic mutual NDA contains indefinite confidentiality obligations, broad mutual indemnity language, a data-protection clause, and no governing law or jurisdiction clause.";
 }
 
 // Public demo shares the MatterNav + MatterBreadcrumb shell with the

--- a/frontend/src/demo/snapshot.ts
+++ b/frontend/src/demo/snapshot.ts
@@ -51,7 +51,7 @@ const MATTER: Matter = {
   pivot_fact:
     "The social-media post the respondent treats as gross misconduct was a private comment on a personal Instagram account, set to a closed audience of 47 followers, none of whom were customers, suppliers, or named in the post.",
   privilege_posture: "B_mixed",
-  default_model_id: "claude-opus-4-7",
+  default_model_id: "claude-sonnet-4-6",
   required_provider: "anthropic",
   facts: {
     side: "claimant",

--- a/frontend/src/matter/MatterNav.tsx
+++ b/frontend/src/matter/MatterNav.tsx
@@ -22,6 +22,7 @@ export function MatterNav({
   mobileOpen,
   onMobileClose,
   showPosture = false,
+  navItems = SIDEBAR_NAV,
 }: {
   matter: Matter;
   tab: TabKey;
@@ -30,6 +31,7 @@ export function MatterNav({
   mobileOpen?: boolean;
   onMobileClose?: () => void;
   showPosture?: boolean;
+  navItems?: ReadonlyArray<{ key: TabKey; label: string }>;
 }) {
   const activeKey = sidebarActiveFor(tab);
 
@@ -40,6 +42,7 @@ export function MatterNav({
       onChange={onChange}
       onPostureChange={onPostureChange}
       showPosture={showPosture}
+      navItems={navItems}
     />
   );
 
@@ -76,6 +79,7 @@ export function MatterNav({
               }}
               onPostureChange={onPostureChange}
               showPosture={showPosture}
+              navItems={navItems}
               closeButton={
                 <button
                   type="button"
@@ -102,6 +106,7 @@ function NavBody({
   onChange,
   onPostureChange,
   showPosture,
+  navItems,
   closeButton,
 }: {
   matter: Matter;
@@ -109,6 +114,7 @@ function NavBody({
   onChange: (next: TabKey) => void;
   onPostureChange: (next: string) => void;
   showPosture: boolean;
+  navItems: ReadonlyArray<{ key: TabKey; label: string }>;
   closeButton?: ReactNode;
 }) {
   return (
@@ -142,7 +148,7 @@ function NavBody({
 
       {/* Nav list */}
       <nav className="px-2 py-3 flex flex-col gap-0.5" aria-label="Matter sections">
-        {SIDEBAR_NAV.map((item) => {
+        {navItems.map((item) => {
           const active = activeKey === item.key;
           return (
             <button

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -42,6 +42,8 @@ interface AssistantTabProps {
   initialMessages?: AssistantMessage[];
   disabled?: boolean;
   disabledPlaceholder?: string;
+  showDisabledFooter?: boolean;
+  showContextRail?: boolean;
   // Called when a Suggested Action chip is clicked in disabled (demo) mode.
   onDisabledAction?: () => void;
 }
@@ -84,6 +86,8 @@ export function AssistantTab({
   initialMessages,
   disabled = false,
   disabledPlaceholder,
+  showDisabledFooter = true,
+  showContextRail = true,
   onDisabledAction,
   // back-compat — see AssistantTabProps; deliberately unused.
   auditCount: _auditCount,
@@ -339,8 +343,12 @@ export function AssistantTab({
                   ? `${docs.length} document${docs.length === 1 ? "" : "s"}`
                   : "No documents yet"}
             </span>
-            <span aria-hidden="true">·</span>
-            <span>{runnableSkillCount} runnable skill{runnableSkillCount === 1 ? "" : "s"}</span>
+            {showContextRail && (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>{runnableSkillCount} runnable skill{runnableSkillCount === 1 ? "" : "s"}</span>
+              </>
+            )}
             <span aria-hidden="true">·</span>
             <button
               type="button"
@@ -438,6 +446,7 @@ export function AssistantTab({
 
         {disabled ? (
           // Compact unauth state - sticky strip, attached to chat column.
+          showDisabledFooter ? (
           <div className="mt-3 sticky bottom-0 bg-paper pt-3">
           <div className="border-t border-rule py-3 flex flex-wrap items-center gap-3">
             <p className="text-sm text-prose m-0 flex-1 min-w-[200px]">
@@ -459,6 +468,7 @@ export function AssistantTab({
             </div>
           </div>
           </div>
+          ) : null
         ) : (
           <div className="mt-3 sticky bottom-0 bg-paper pt-3">
           {/* Context attachments as chips ABOVE the composer */}
@@ -622,20 +632,22 @@ export function AssistantTab({
         )}
       </div>
 
-      <MatterContextRail
-        docs={docs}
-        recentDocs={recentDocs}
-        runnableSkillCount={runnableSkillCount}
-        readySkillLabels={[
-          ...runnableModuleSkills.map((skill) => skill.title),
-        ]}
-        selectedCount={selectedDocIds.size}
-        onOpenDocuments={() => setTabAndHash("documents")}
-        onOpenSkills={() => setTabAndHash("workflows")}
-        onOpenRecord={openRecord}
-        onOpenOutputs={openOutputs}
-        onOpenPack={openWorkingPack}
-      />
+      {showContextRail && (
+        <MatterContextRail
+          docs={docs}
+          recentDocs={recentDocs}
+          runnableSkillCount={runnableSkillCount}
+          readySkillLabels={[
+            ...runnableModuleSkills.map((skill) => skill.title),
+          ]}
+          selectedCount={selectedDocIds.size}
+          onOpenDocuments={() => setTabAndHash("documents")}
+          onOpenSkills={() => setTabAndHash("workflows")}
+          onOpenRecord={openRecord}
+          onOpenOutputs={openOutputs}
+          onOpenPack={openWorkingPack}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a clearer public-demo intro panel on `/demo` that frames Legalise as a project with documents, skills, and a matter record.
- Refreshes the demo Documents tab around source material, reader entry points, versions, and source citations.
- Refreshes the demo Skills tab around workspace install, project enablement, reads/writes, and record traceability.
- Updates the demo model label to Claude Sonnet 4.6 to match the current concept.

## Scope
Frontend-only. Keeps the existing left-hand demo shell and does not mix in the document-engine branch.

## Verification
- `npm run typecheck`
- `npm run test -- --run`
- `npm run build`
- `git diff --check`
- Local browser walk of `/demo`, `/demo/documents`, and `/demo/workflows`