### PR TITLE
Clarify manifesto and public skills page

### DIFF
--- a/frontend/src/landing/Manifesto.tsx
+++ b/frontend/src/landing/Manifesto.tsx
@@ -1,407 +1,175 @@
 import { Footer } from "../ui/Footer";
 
-// Standalone manifesto page. The repository copy is still the canonical
-// long-form source; this route gives the launch thesis its own reading
-// experience inside the site's typography and design language.
-//
-// When docs/MANIFESTO.md changes meaningfully, update this file in step.
-// The "View source on GitHub" link at the foot is the receipt that the
-// repository copy is authoritative.
+const TENETS = [
+  {
+    title: "The matter is the unit of work",
+    body: "Documents, skills, model calls, outputs, signatures, and records all sit inside a matter. The AI does not float outside the file.",
+  },
+  {
+    title: "The solicitor stays accountable",
+    body: "AI prepares work. A human reviews it, changes it where needed, and signs what they are prepared to stand behind.",
+  },
+  {
+    title: "Skills are controlled work units",
+    body: "A skill declares what it reads and what it writes. Legalise checks that before it runs, then records what happened.",
+  },
+  {
+    title: "The record is the receipt",
+    body: "The audit trail is not the product. It is the evidence. It answers what the system saw, what it produced, and who took responsibility.",
+  },
+  {
+    title: "Sources must stay visible",
+    body: "Outputs should point back to the documents they used. A citation is not a guarantee, but it gives the reviewer somewhere concrete to check.",
+  },
+  {
+    title: "Providers are replaceable",
+    body: "Claude is the MVP target because the skill format works well there. The architecture is built so a firm can later run GPT, local models, or its own approved stack.",
+  },
+];
 
-type Section = {
-  id: string;
-  title: string;
-  body: React.ReactNode;
-};
-
-const SECTIONS: Section[] = [
-  {
-    id: "wedge",
-    title: "The wedge",
-    body: (
-      <>
-        <p className="prose-p">
-          UK legal AI sits under rules most products ignore. Heppner made
-          it concrete. A firm using AI must show, later and on demand,
-          what privileged material the AI saw, who held it, and under
-          what protection.
-        </p>
-        <p className="prose-p">
-          The audit log is not a nice-to-have. It is the canonical record.
-          Privilege control is not a preference. It is a constraint on
-          dispatch.
-        </p>
-        <p className="prose-p">
-          The market frames AI inside legal work as a chatbot problem. We
-          frame it as a workspace problem. The matter is the unit of work.
-          Every model call, every document mutation, every chronology
-          entry exists inside one matter, owned by one user, governed by
-          one privilege control, written into one audit log.
-        </p>
-        <p className="prose-p">
-          Outside that frame, the legal use case stops being legal. It is
-          a generic question that happens to mention the law.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "supervised-autonomy",
-    title: "Supervised autonomy, not unsupervised automation",
-    body: (
-      <>
-        <p className="prose-p">
-          The interesting question is no longer only what AI can automate.
-          It is what a firm would choose not to automate, where human
-          judgement must remain named, and how the system proves that
-          boundary held.
-        </p>
-        <p className="prose-p">
-          Legalise is not trying to make legal work unsupervised. It is
-          trying to make supervision explicit, inspectable, and auditable.
-        </p>
-        <p className="prose-p">
-          The unit is not a prompt. It is a matter. The control points are
-          not vibes. They are permissions, privilege control, source
-          evidence, review gates, and audit rows. Audit is not the
-          product. Audit is the receipt.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "matter-first",
-    title: "Matter-first, not prompt-first",
-    body: (
-      <>
-        <p className="prose-p">
-          The workspace organises around the matter. Documents, prompts,
-          outputs, audit rows. All hang off a slug, a title, a parties
-          record, a privilege control, a retention clock.
-        </p>
-        <p className="prose-p">
-          AI tooling that operates outside the matter frame is fine for
-          research. Not acceptable as the runtime for regulated
-          practice.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "how-it-works",
-    title: "How the workspace works",
-    body: (
-      <>
-        <p className="prose-p">
-          Open a matter. Ask the assistant. Install a legal skill. Run it.
-          See what it touched. See the record.
-        </p>
-        <p className="prose-p">
-          The product mechanic is intentionally plain. A matter carries the
-          parties, documents, chronology, privilege control, retention clock,
-          skill installs, permission grants, model calls, and audit rows.
-          The AI does not float outside the file.
-        </p>
-        <p className="prose-p">
-          Skills declare what they need. The workspace enables it. Runtime
-          checks it. Denials are structured and audited. That is the trust
-          model in one line.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "audit-canonical",
-    title: "Audit as the canonical record",
-    body: (
-      <>
-        <p className="prose-p">
-          Every model call writes an audit row. Every matter mutation
-          writes an audit row. Every disclosure-tainted chronology entry
-          writes an audit row with the CPR 31.22 acknowledgement attached.
-        </p>
-        <p className="prose-p">
-          The audit log is what a solicitor uses to answer the questions a
-          regulator, a client, or opposing counsel will eventually ask.
-          What did your AI see. When did it see it. Under what protection.
-          What did it produce.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "why-audit",
-    title: "Why the audit trail",
-    body: (
-      <>
-        <p className="prose-p">
-          Professional liability is boring until it is existential.
-        </p>
-        <p className="prose-p">
-          If AI touches a matter, the solicitor remains accountable. The
-          client may ask what happened. The insurer may ask what happened.
-          The SRA may ask what happened. A partner may ask why a deadline,
-          citation, disclosure decision, or letter went wrong.
-        </p>
-        <p className="prose-p">
-          A solicitor cannot responsibly supervise something if they
-          cannot reconstruct what material the system saw, whether
-          privileged material was involved, which model or module touched
-          it, what it produced, who approved or relied on it, and what
-          changed after human review.
-        </p>
-        <p className="prose-p">
-          Without that, supervised autonomy is just trust me, a lawyer was
-          nearby.
-        </p>
-        <p className="prose-p">
-          Legalise records the path. The audit trail is not the product.
-          It is the receipt.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "privilege-posture",
-    title: "Privilege control is a dispatch constraint",
-    body: (
-      <>
-        <p className="prose-p">
-          Three states. <code className="text-sm">A_cleared</code>,{" "}
-          <code className="text-sm">B_mixed</code>,{" "}
-          <code className="text-sm">C_paused</code>. Each matter carries
-          one. The gateway reads the privilege state before every model call
-          and decides which providers can serve it.
-        </p>
-        <p className="prose-p">
-          Cloud providers are commodities behind the gateway, not direct
-          dependencies of any module. Local models (Ollama) exist from day
-          one for <code className="text-sm">C_paused</code> matters.
-        </p>
-        <p className="prose-p">
-          If the privilege rules and the providers configured for a matter
-          cannot serve a call, the gateway refuses it. The refusal is
-          audited. Privilege is not a soft setting.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "providers-commodity",
-    title: "Providers are commodity",
-    body: (
-      <>
-        <p className="prose-p">
-          Anthropic, OpenAI, Ollama, all behind one gateway interface.
-          Models change. Providers come and go. The matter spine, the
-          audit log, the privilege gate, the chronology surface. These
-          survive any provider rotation.
-        </p>
-        <p className="prose-p">
-          No dependencies on provider-specific features unless the gateway
-          can offer a clean fallback.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "boring-stack",
-    title: "Boring stack, ambitious composition",
-    body: (
-      <>
-        <p className="prose-p">
-          Python, FastAPI, Postgres, React 19, Tailwind. Nothing on this
-          list surprises anyone in 2030.
-        </p>
-        <p className="prose-p">
-          The novelty is the composition. Privilege-aware gateway.
-          Adversarial premortem pipelines. Audit-first model dispatch.
-          Matter folder represented as markdown on disk so it survives any
-          future database migration. We optimise for the parts of the
-          system that do not care which model you used in 2026 versus
-          2030.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "human-in-the-loop",
-    title: "Human-in-the-loop, permanently",
-    body: (
-      <>
-        <p className="prose-p">
-          Every output is a draft. The product should make human review
-          explicit, inspectable, and impossible to confuse with autonomous
-          legal advice.
-        </p>
-        <p className="prose-p">
-          Drafts and accelerants, yes. Substitutes, no. A constraint on
-          the product surface, not an aspiration.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "what-this-is-not",
-    title: "What this release is not",
-    body: (
-      <>
-        <p className="prose-p">
-          This is not a law firm. It is not legal advice. It is not for live
-          client matters. The hosted site is a limited evaluation environment,
-          and real model calls require the operator's own provider keys.
-        </p>
-        <p className="prose-p">
-          The current release proves the matter workspace, modules, privilege
-          privilege control, permission gates, BYO keys, and audit trail. Firm-specific
-          seniority gates are staged for real deployments, not required for the
-          evaluator path.
-        </p>
-        <p className="prose-p">
-          Some hard problems are deliberately staged: durable job recovery,
-          formal WORM database roles, richer evals, hallucination controls,
-          prompt shrouding, and production-grade regulator reconstruction.
-          Those are engineering gates, not ignored problems.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "uk-jurisdiction",
-    title: "UK-jurisdiction-aware, not US-shaped",
-    body: (
-      <>
-        <p className="prose-p">
-          England &amp; Wales has its own procedural shape, its own
-          statutory scaffolding, its own privilege model. Most legal AI is
-          US-shaped because most legal AI capital is American.
-        </p>
-        <p className="prose-p">
-          Translating US patterns into Anglicised vocabulary produces
-          software that breaks on the procedural details. We build for UK
-          practice on UK rules.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "self-host",
-    title: "Self-host without limits",
-    body: (
-      <>
-        <p className="prose-p">
-          The core is Apache-2.0 forever. Self-host on any infrastructure.
-          Run any models. Fork. Modify.
-        </p>
-        <p className="prose-p">
-          We do not gate the matter spine, audit log, plugin bridge, or
-          any v0.1 module behind a commercial tier. If a commercial tier
-          ever exists, it sells managed operations and certifications. Not
-          functionality.
-        </p>
-      </>
-    ),
-  },
-  {
-    id: "wont-do",
-    title: "What we won't do",
-    body: (
-      <>
-        <ul className="list-none space-y-3 text-prose text-sm pl-0">
-          <li className="flex items-start gap-4">
-            <span className="font-bold text-ink">-</span>
-            <span>Replace solicitor sign-off.</span>
-          </li>
-          <li className="flex items-start gap-4">
-            <span className="font-bold text-ink">-</span>
-            <span>Add a chatbot as the primary surface.</span>
-          </li>
-          <li className="flex items-start gap-4">
-            <span className="font-bold text-ink">-</span>
-            <span>
-              Take dependencies on closed proprietary APIs without an open
-              alternative.
-            </span>
-          </li>
-          <li className="flex items-start gap-4">
-            <span className="font-bold text-ink">-</span>
-            <span>
-              Ship a feature that breaks audit-row contract or
-              privilege-control dispatch.
-            </span>
-          </li>
-        </ul>
-        <p className="prose-p mt-8">Push back if we drift.</p>
-      </>
-    ),
-  },
+const STACK = [
+  "Matter workspace",
+  "Document store and reader",
+  "Skill install and permission checks",
+  "Model gateway",
+  "Professional sign-off",
+  "Audit record and working pack export",
 ];
 
 export function Manifesto() {
   return (
     <div className="max-w-page mx-auto">
-      {/* Hero: eyebrow + title + opening tagline */}
       <section className="px-4 sm:px-6 md:px-16 lg:px-24 py-20 border-b border-rule">
-        <div className="max-w-3xl">
+        <div className="max-w-4xl">
           <div className="eyebrow text-muted mb-6">Manifesto</div>
-          <h1 className="text-4xl md:text-5xl font-bold tracking-tight2 text-ink mb-6 leading-[1.05]">
-            Commitments that don't move.
+          <h1 className="text-4xl md:text-6xl font-semibold tracking-tight2 text-ink leading-[1.04] max-w-4xl">
+            Legalise is backend infrastructure for regulated AI legal work.
           </h1>
-          <p className="text-xl text-muted leading-relaxed max-w-2xl">
-            What we believe. How we built it. What we will not ship.
+          <p className="mt-8 text-xl md:text-2xl leading-relaxed text-prose max-w-3xl">
+            We are building the rails for an SRA-regulated, insurable law firm
+            to use AI without losing control of the matter, the documents, or
+            the professional record.
           </p>
-          <div className="mt-8">
-            <a
-              href="/"
-              className="text-sm text-muted hover:text-ink transition-colors"
-            >
-              ← Back to Legalise
-            </a>
-          </div>
         </div>
       </section>
 
-      {/* Body: flowing sections, no sidebar TOC — manifesto reads as essay */}
-      <main className="px-4 sm:px-6 md:px-16 lg:px-24 py-20">
-        <article className="max-w-3xl mx-auto">
-          {SECTIONS.map((section, idx) => (
-            <section
-              key={section.id}
-              id={section.id}
-              className={idx === 0 ? "mb-20" : "mb-20 pt-4"}
-            >
-              <h2 className="text-2xl md:text-3xl font-bold tracking-tight2 text-ink mb-8 leading-tight">
-                {section.title}
-              </h2>
-              {section.body}
-            </section>
-          ))}
-
-          {/* Source-of-truth pointer */}
-          <div className="mt-16 pt-12 border-t border-rule">
-            <p className="text-sm text-muted mb-6">
-              The canonical copy of the manifesto lives in the repository.
-              When the source-of-truth file changes, this page is updated
-              to match.
-            </p>
-            <div className="flex flex-wrap gap-4">
-              <a
-                href="https://github.com/b1rdmania/legalise/blob/master/docs/MANIFESTO.md"
-                target="_blank"
-                rel="noreferrer"
-                className="border border-rule hover:border-ink text-ink px-4 py-2 hover:bg-wash transition-colors text-sm font-medium min-h-[44px] inline-flex items-center"
-              >
-                View source on GitHub
-              </a>
-              <a
-                href="/"
-                className="text-sm text-muted hover:text-ink transition-colors inline-flex items-center"
-              >
-                ← Back to Legalise
-              </a>
+      <main className="px-4 sm:px-6 md:px-16 lg:px-24 py-16">
+        <section className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_340px]">
+          <div className="max-w-3xl">
+            <h2 className="text-2xl md:text-3xl font-semibold tracking-tight2 text-ink">
+              What we are actually building
+            </h2>
+            <div className="mt-6 space-y-5 text-base leading-relaxed text-prose">
+              <p>
+                Not a chatbot for legal questions. Not a replacement lawyer.
+                Not a black box that drafts documents and hopes someone checks
+                them.
+              </p>
+              <p>
+                Legalise is a matter workspace where a solicitor can open a
+                project, add documents, run legal skills, review the output,
+                sign what they accept, and export the working record.
+              </p>
+              <p>
+                The point is not that AI does legal work by itself. The point
+                is that AI can prepare more of the work, faster, while the
+                solicitor keeps judgement, responsibility, and a record that can
+                be inspected later.
+              </p>
             </div>
           </div>
-        </article>
+
+          <aside className="border border-rule bg-paper-sunken p-5 h-fit">
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+              The product loop
+            </p>
+            <ol className="mt-4 space-y-3 text-sm text-ink">
+              {["Open project", "Install skill", "Run against documents", "Review output", "Sign", "Export record"].map(
+                (item, idx) => (
+                  <li key={item} className="flex gap-3">
+                    <span className="font-mono text-muted">{idx + 1}</span>
+                    <span>{item}</span>
+                  </li>
+                ),
+              )}
+            </ol>
+          </aside>
+        </section>
+
+        <section className="mt-20 border-t border-rule pt-14">
+          <div className="max-w-3xl">
+            <h2 className="text-2xl md:text-3xl font-semibold tracking-tight2 text-ink">
+              Why this exists
+            </h2>
+            <p className="mt-5 text-base leading-relaxed text-prose">
+              A regulated firm cannot just “use AI” and hope the supervision
+              story works out afterwards. It needs a system that knows which
+              matter the work belongs to, which documents were used, which
+              model ran, what was produced, who reviewed it, and what became
+              part of the final file.
+            </p>
+            <p className="mt-5 text-base leading-relaxed text-prose">
+              That is what makes AI work insurable and regulatorable. Not magic
+              prompts. Not a prettier chat window. A controlled backend with a
+              clean surface on top.
+            </p>
+          </div>
+        </section>
+
+        <section className="mt-20">
+          <div className="mb-8 max-w-3xl">
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+              Tenets
+            </p>
+            <h2 className="mt-2 text-2xl md:text-3xl font-semibold tracking-tight2 text-ink">
+              The rules we build against
+            </h2>
+          </div>
+          <div className="grid gap-px border border-rule bg-rule md:grid-cols-2">
+            {TENETS.map((tenet) => (
+              <section key={tenet.title} className="bg-paper p-5">
+                <h3 className="text-base font-semibold text-ink">
+                  {tenet.title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-prose">
+                  {tenet.body}
+                </p>
+              </section>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-20 grid gap-10 lg:grid-cols-[340px_minmax(0,1fr)]">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+              What is in the stack
+            </p>
+            <h2 className="mt-2 text-2xl md:text-3xl font-semibold tracking-tight2 text-ink">
+              Boring infrastructure, legal shape.
+            </h2>
+          </div>
+          <div className="grid gap-px border border-rule bg-rule sm:grid-cols-2">
+            {STACK.map((item) => (
+              <div key={item} className="bg-paper p-4 text-sm font-medium text-ink">
+                {item}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-20 border border-rule bg-paper-sunken p-6">
+          <div className="max-w-3xl">
+            <h2 className="text-xl md:text-2xl font-semibold tracking-tight2 text-ink">
+              What this is not
+            </h2>
+            <p className="mt-4 text-sm leading-relaxed text-prose">
+              The hosted demo is not a law firm and does not give legal advice.
+              It is a working product demonstration. The ambition is bigger:
+              infrastructure a real regulated firm could deploy, inspect,
+              insure, and explain.
+            </p>
+          </div>
+        </section>
       </main>
 
       <Footer />

--- a/frontend/src/modules-v2/ModulesCatalog.test.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.test.tsx
@@ -171,7 +171,21 @@ describe("ModulesCatalog — integrations home", () => {
     expect(screen.getByText(/No skills match/)).toBeInTheDocument();
   });
 
-  it("keeps the public skill library secondary + collapsed until expanded", async () => {
+  it("shows the public skill library immediately without a sign-in wall", async () => {
+    vi.spyOn(api, "getCurrentUser").mockRejectedValue(new Error("401"));
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByText("Unfair Dismissal Screener")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("modules-signin-prompt")).toBeNull();
+    expect(screen.getByText(/Browse legal skills/)).toBeInTheDocument();
+    expect(screen.getByText("Open demo")).toBeInTheDocument();
+  });
+
+  it("keeps the public skill library secondary + collapsed for signed-in users", async () => {
     vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
     vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
 
@@ -179,11 +193,8 @@ describe("ModulesCatalog — integrations home", () => {
     await waitFor(() => {
       expect(screen.getByTestId("toggle-skills")).toBeInTheDocument();
     });
-    // Skill is not visible until the secondary section is expanded.
     expect(screen.queryByText("Unfair Dismissal Screener")).toBeNull();
     fireEvent.click(screen.getByTestId("toggle-skills"));
-    await waitFor(() => {
-      expect(screen.getByText("Unfair Dismissal Screener")).toBeInTheDocument();
-    });
+    expect(screen.getByText("Unfair Dismissal Screener")).toBeInTheDocument();
   });
 });

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -91,7 +91,7 @@ const TAB_LABEL: Record<SkillTab, string> = {
 function CompatibilityBadge() {
   return (
     <span
-      title="Tested against Anthropic Claude Sonnet 4.6 or newer. The Legalise substrate is provider-agnostic; the skill format is Claude-native in V1."
+      title="Tested against Anthropic Claude Sonnet 4.6 or newer. Legalise can support other approved model providers; the skill format is Claude-native in V1."
       className="inline-flex items-center gap-1 rounded-full border border-rule px-2 py-0.5 font-mono text-[9px] uppercase tracking-widest text-muted"
     >
       Tested with Claude Sonnet 4.6+
@@ -192,28 +192,60 @@ export function ModulesCatalog() {
   }, [modules, tab, tabCounts.installed, tabCounts.available]);
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
+    <div className="mx-auto max-w-5xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="Workspace"
+        eyebrow={authed ? "Workspace" : "Skill library"}
         title="Skills"
-        description="Governed legal skills. Install a reference skill at the workspace, then enable and run it per matter — installing here does not make it ready everywhere."
+        description={
+          authed
+            ? "Install legal skills at the workspace, then enable them inside the matter where they should run."
+            : "Legal skills are small pieces of legal work: review an NDA, test a claim, draft a letter, check authorities. Browse the library, then open the demo to see one run against a matter."
+        }
         actions={
           <div className="flex flex-wrap items-center gap-2">
-            <Link
-              to="/skills/lawve"
-              className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
-            >
-              Import from Lawve
-            </Link>
-            <Link
-              to="/skills/create"
-              className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
-            >
-              Create skill
-            </Link>
+            {authed ? (
+              <>
+                <Link
+                  to="/skills/lawve"
+                  className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
+                >
+                  Import from Lawve
+                </Link>
+                <Link
+                  to="/skills/create"
+                  className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
+                >
+                  Create skill
+                </Link>
+              </>
+            ) : (
+              <a
+                href="/demo"
+                className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-sm font-medium text-paper hover:bg-black"
+              >
+                Open demo
+              </a>
+            )}
           </div>
         }
       />
+
+      {!authed && (
+        <section className="mb-10 grid gap-px border border-rule bg-rule sm:grid-cols-3">
+          <DemoStep
+            title="1. Pick a skill"
+            body="A skill is a governed action with declared inputs and outputs."
+          />
+          <DemoStep
+            title="2. Run it in a matter"
+            body="The skill works against the project documents, not a loose prompt."
+          />
+          <DemoStep
+            title="3. Check the record"
+            body="The output, sources, and sign-off become part of the matter record."
+          />
+        </section>
+      )}
 
       {error && (
         <p className="text-sm text-seal">Could not load skills: {error}</p>
@@ -222,10 +254,11 @@ export function ModulesCatalog() {
       {/* Primary: reference skills (v2 registry).
           §7 tab structure: Installed / Available / Revoked
           (Revoked is operator-only). */}
+      {authed && (
       <section>
         <div className="flex flex-wrap items-end justify-between gap-3">
           <h2 className="text-xs uppercase tracking-widest text-muted">
-            Reference skills
+            Workspace skills
           </h2>
           {authed && modules && modules.length > 0 && (
             <input
@@ -272,12 +305,7 @@ export function ModulesCatalog() {
             )}
           </div>
         )}
-        {!authed ? (
-          <p className="mt-3 text-sm text-muted" data-testid="modules-signin-prompt">
-            Sign in to install and manage governed reference skills. The open
-            skill library below is browsable without an account.
-          </p>
-        ) : modules === null ? (
+        {modules === null ? (
           <p className="mt-3 text-sm text-muted">Loading skills…</p>
         ) : modules.length === 0 ? (
           <p className="mt-3 text-sm text-muted">
@@ -365,21 +393,46 @@ export function ModulesCatalog() {
           </ul>
         )}
       </section>
+      )}
 
       {/* Secondary: open skill library (browse only, not an install path) */}
-      <section className="mt-10">
-        <button
-          type="button"
-          onClick={() => setShowSkills((v) => !v)}
-          className="text-xs uppercase tracking-widest text-muted hover:text-ink"
-          data-testid="toggle-skills"
-          aria-expanded={showSkills}
-        >
-          {showSkills ? "Hide" : "Browse"} UK legal skills
-          {skills ? ` (${skills.length})` : ""}
-        </button>
-        {showSkills && (
+      <section className={authed ? "mt-10" : "mt-4"}>
+        {authed ? (
+          <button
+            type="button"
+            onClick={() => setShowSkills((v) => !v)}
+            className="text-xs uppercase tracking-widest text-muted hover:text-ink"
+            data-testid="toggle-skills"
+            aria-expanded={showSkills}
+          >
+            {showSkills ? "Hide" : "Browse"} open skill library
+            {skills ? ` (${skills.length})` : ""}
+          </button>
+        ) : (
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h2 className="text-xs uppercase tracking-widest text-muted">
+                Browse legal skills{skills ? ` (${skills.length})` : ""}
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm leading-relaxed text-prose">
+                These examples come from the open legal skills library. Legalise
+                turns this kind of skill into something a firm can install, run
+                inside a matter, review, sign, and audit.
+              </p>
+            </div>
+            <a
+              href="https://github.com/lawve-ai/awesome-legal-skills"
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm text-muted underline underline-offset-4 hover:text-ink"
+            >
+              View source
+            </a>
+          </div>
+        )}
+        {(showSkills || !authed) && (
           <div className="mt-3">
+            {authed && (
             <p className="text-xs text-muted">
               The open skill library — browse what's available. These are not
               installed from here; reference skills above are the install path.
@@ -401,6 +454,7 @@ export function ModulesCatalog() {
                 </>
               ) : null}
             </p>
+            )}
             {skills === null ? (
               <p className="mt-3 text-sm text-muted">Loading skills…</p>
             ) : skills.length === 0 ? (
@@ -411,6 +465,15 @@ export function ModulesCatalog() {
           </div>
         )}
       </section>
+    </div>
+  );
+}
+
+function DemoStep({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="bg-paper p-4">
+      <h2 className="text-sm font-semibold text-ink">{title}</h2>
+      <p className="mt-2 text-sm leading-relaxed text-prose">{body}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Rewrites `/manifesto` into concise plain-English marketing: what Legalise is, what we are building, and the tenets behind regulated AI legal work.
- Reworks unauthenticated `/skills` so it is a browsable public skill-library page instead of a sign-in wall.
- Keeps workspace install/manage controls for signed-in users, while public users get a clear Open demo path.
- Adds regression coverage that the public skill library is visible without the old sign-in prompt.

## Verification
- `npm run typecheck`
- `npm run test -- ModulesCatalog --run`
- `npm run test -- --run`
- `npm run build`
- `git diff --check`
- Local browser text smoke for `/manifesto` and `/skills`