### PR TITLE
documents: polish reader workspace

### DIFF
--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -436,9 +436,17 @@ function DemoDocumentsTab({
 }) {
   const inspectedDoc = docs.find((doc) => doc.id === inspectedDocId) ?? docs[0];
 
+  if (!inspectedDoc) {
+    return (
+      <div className="max-w-5xl border border-rule bg-paper p-5 text-sm text-muted">
+        No demo documents are available.
+      </div>
+    );
+  }
+
   return (
-    <div className="max-w-5xl">
-      <div className="mb-8 border border-rule bg-paper-sunken p-5">
+    <div className="max-w-6xl">
+      <div className="mb-6 border border-rule bg-paper-sunken p-5">
         <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
           Documents in this project
         </p>
@@ -452,64 +460,65 @@ function DemoDocumentsTab({
         </p>
       </div>
 
-      <div className="overflow-hidden border border-rule bg-paper">
-        <div className="min-w-[680px]">
-          <div className="grid grid-cols-[1.5fr_110px_90px_120px_120px] gap-4 px-5 py-3 text-muted bg-paper-sunken border-b border-rule font-mono uppercase tracking-track2 text-[9px]">
-            <span>Document</span>
-            <span>Type</span>
-            <span>Size</span>
-            <span>Source</span>
-            <span className="text-right">Workspace</span>
+      <div className="grid gap-5 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <div className="border border-rule bg-paper">
+          <div className="border-b border-rule bg-paper-sunken px-4 py-3">
+            <p className="text-[10px] font-semibold uppercase tracking-track2 text-muted">
+              Matter files
+            </p>
           </div>
-          {docs.map((d) => (
-            <div key={d.id} className="border-b border-rule">
-              <div className="grid grid-cols-[1.5fr_110px_90px_120px_120px] gap-4 px-5 py-4 items-center hover:bg-wash transition-colors">
-                <div className="min-w-0">
-                  <div className="text-sm font-semibold text-ink truncate">{d.filename}</div>
-                  <div className="mt-0.5 text-[11px] text-muted truncate">
-                    hashed · source-ready · {d.sha256.slice(0, 8)}
-                  </div>
-                </div>
-                <span>{d.tag && <Badge>{d.tag.toUpperCase()}</Badge>}</span>
-                <span className="text-xs text-ink">{formatBytes(d.size_bytes)}</span>
-                <span>{d.from_disclosure ? <Badge>CPR 31</Badge> : <span className="text-xs text-muted">Upload</span>}</span>
+          <div>
+            {docs.map((d) => {
+              const active = d.id === inspectedDoc.id;
+              return (
                 <button
+                  key={d.id}
                   type="button"
                   onClick={() => onInspect(d.id)}
-                  className="text-right text-[10px] font-semibold uppercase tracking-track2 text-muted hover:text-ink"
+                  className={`block w-full border-b border-rule px-4 py-4 text-left transition-colors ${
+                    active ? "bg-wash" : "bg-paper hover:bg-wash"
+                  }`}
                 >
-                  Open reader
+                  <div className="text-sm font-semibold text-ink">{d.filename}</div>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-muted">
+                    {d.tag && <Badge>{d.tag.toUpperCase()}</Badge>}
+                    <span>{formatBytes(d.size_bytes)}</span>
+                    <span>{d.from_disclosure ? "CPR 31" : "Upload"}</span>
+                  </div>
+                  <div className="mt-2 text-[10px] uppercase tracking-track2 text-muted">
+                    Source-ready · {d.sha256.slice(0, 8)}
+                  </div>
                 </button>
-              </div>
-            </div>
-          ))}
+              );
+            })}
+          </div>
         </div>
-      </div>
 
-      {inspectedDoc && (
-        <section className="mt-6 border border-rule bg-paper p-5">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
+        <section className="min-h-[620px] border border-rule bg-paper">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-rule px-5 py-4">
+            <div className="min-w-0">
               <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
-                Reader preview
+                Document reader
               </p>
-              <h3 className="mt-1 text-lg font-semibold tracking-tight2 text-ink">
+              <h3 className="mt-1 text-2xl font-semibold tracking-tight2 text-ink">
                 {inspectedDoc.filename}
               </h3>
+              <p className="mt-1 text-xs text-muted">
+                Extracted text preview. In the live workspace, source chips open this reader.
+              </p>
             </div>
             <span className="border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
               Source-ready
             </span>
           </div>
-          <div className="mt-4 max-w-3xl whitespace-pre-wrap border border-rule bg-paper-sunken p-4 text-sm leading-relaxed text-prose">
+          <div className="px-6 py-6 text-[15px] leading-8 text-ink whitespace-pre-wrap">
             {demoDocumentExtract(inspectedDoc)}
           </div>
-          <p className="mt-3 text-xs leading-5 text-muted">
-            In the live workspace, source chips on AI outputs open back to this
-            reader so you can check what the skill relied on.
-          </p>
+          <div className="border-t border-rule px-5 py-4 text-xs leading-5 text-muted">
+            Original files, extracted text, edit versions, redactions, and record links live on this document surface in the working product.
+          </div>
         </section>
-      )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -1,8 +1,7 @@
-// DocumentDetail focused tests: content is the hero, the document
-// workspace exposes Read / Redline / History, Open / Download original
-// land on the real proxy URLs, source-anchor honesty banner appears
-// when arrived from Chat, body-missing state is honest, and deep
-// metadata sits behind Details.
+// DocumentDetail focused tests: content is the hero, document tools
+// sit beside it, Open / Download original land on the real proxy URLs,
+// source-anchor honesty banner appears when arrived from Chat,
+// body-missing state is honest, and deep metadata sits behind Details.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -86,20 +85,18 @@ describe("DocumentDetail", () => {
 
     mount();
     await waitFor(() => {
-      expect(screen.getByText("claim-form.pdf")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "claim-form.pdf" }),
+      ).toBeInTheDocument();
     });
     // Content is the hero — extracted text visible without any
     // disclosure being opened first.
     expect(screen.getByText(/IN THE COUNTY COURT/)).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Read" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
-    expect(screen.getByRole("tab", { name: "Redline" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "History" })).toBeInTheDocument();
-    // Basic document facts sit in the quiet side rail; deep facts
-    // such as the full SHA stay behind Details.
-    expect(screen.getByText("application/pdf")).toBeInTheDocument();
+    expect(screen.getByText("Document tools")).toBeInTheDocument();
+    expect(screen.getByText("Version record")).toBeInTheDocument();
+    // Admin-ish document facts sit behind Details; the primary scan
+    // path is filename, text, original actions, and document tools.
+    expect(screen.queryByText("application/pdf")).toBeNull();
     expect(screen.queryByText(/a{8}/)).toBeNull();
     // Original-file actions are still present (secondary).
     const open = screen.getByText("Open original");
@@ -128,14 +125,16 @@ describe("DocumentDetail", () => {
 
     mount();
     await waitFor(() => {
-      expect(screen.getByText("claim-form.pdf")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "claim-form.pdf" }),
+      ).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId("document-details-toggle"));
-    expect(screen.getAllByText("application/pdf").length).toBeGreaterThan(1);
+    expect(screen.getByText("application/pdf")).toBeInTheDocument();
     expect(screen.getByText(/a{8}/)).toBeInTheDocument(); // sha prefix
   });
 
-  it("promotes redline and history into first-class document workspace tabs", async () => {
+  it("keeps redline tools and history visible on the document workspace", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
     vi.spyOn(api, "getDocumentBody").mockResolvedValue({
       document_id: "doc-1",
@@ -150,17 +149,16 @@ describe("DocumentDetail", () => {
 
     mount();
     await waitFor(() => {
-      expect(screen.getByText("claim-form.pdf")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "claim-form.pdf" }),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole("tab", { name: "Redline" }));
     expect(screen.getByTestId("document-redline-workspace")).toBeInTheDocument();
-    expect(screen.getByText("Propose tracked edits")).toBeInTheDocument();
     expect(screen.getByText("Tighten this clause")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("tab", { name: "History" }));
     expect(screen.getByTestId("document-history-workspace")).toBeInTheDocument();
-    expect(screen.getByText("Document history")).toBeInTheDocument();
+    expect(screen.getByText("Version record")).toBeInTheDocument();
     expect(screen.getByText("Redaction")).toBeInTheDocument();
   });
 

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1,8 +1,7 @@
 // Matter document reader at /matters/{slug}/documents/{document_id}.
-// Content (extracted text) is the hero; metadata, versions,
-// anonymisation, and model edits live behind a Details disclosure.
-// Open / Download original stream through the documentOriginalUrl
-// proxy and are presented as secondary links beneath the content.
+// Content (extracted text) is the document surface; model edit,
+// version, redaction, and record tools sit beside it so the page reads
+// like a working file rather than an admin metadata screen.
 
 import { useCallback, useEffect, useState } from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
@@ -24,7 +23,6 @@ import {
   EmptyState,
   ErrorCallout,
   LoadingLine,
-  PageHeader,
 } from "../ui/primitives";
 import { EditPanel } from "../modules/document_edit/EditPanel";
 import { AnonymiseButton } from "../modules/anonymisation/AnonymiseButton";
@@ -42,26 +40,6 @@ type DocQuery =
   | { status: "not_found" }
   | { status: "error"; message: string };
 
-type DocumentWorkspaceTab = "read" | "redline" | "history";
-
-const DOCUMENT_TABS: { key: DocumentWorkspaceTab; label: string; hint: string }[] = [
-  {
-    key: "read",
-    label: "Read",
-    hint: "Read the extracted text and open the original file.",
-  },
-  {
-    key: "redline",
-    label: "Redline",
-    hint: "Ask Legalise to propose edits, then accept or reject them.",
-  },
-  {
-    key: "history",
-    label: "History",
-    hint: "See versions, redactions, and document facts.",
-  },
-];
-
 export function DocumentDetail({
   slug,
   documentId,
@@ -75,7 +53,6 @@ export function DocumentDetail({
   const [versions, setVersions] = useState<DocumentVersionSummary[]>([]);
   const [anon, setAnon] = useState<AnonymisationResult | null>(null);
   const [showDetails, setShowDetails] = useState(false);
-  const [activeTab, setActiveTab] = useState<DocumentWorkspaceTab>("read");
 
   // Source-anchor honesty: when arrived from chat, surface a single
   // line noting that passage-level anchoring isn't yet wired through
@@ -163,247 +140,239 @@ export function DocumentDetail({
 
   const doc = q.doc;
   const recordHref = `/matters/${encodeURIComponent(slug)}/audit`;
-  const selectedTab = DOCUMENT_TABS.find((t) => t.key === activeTab) ?? DOCUMENT_TABS[0];
+  const latestVersion = versions[0]?.version;
+  const pendingEdits = versions.reduce((total, v) => total + v.pending_count, 0);
+  const acceptedEdits = versions.reduce((total, v) => total + v.accepted_count, 0);
+  const rejectedEdits = versions.reduce((total, v) => total + v.rejected_count, 0);
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-10 text-ink">
-      {/* Smart back — returns to the matter surface the user came
-          from. ?from=assistant lands here from a chat source chip;
-          everything else falls back to the Documents tab. */}
-      <p className="text-xs">
-        <Link
-          to="/matters/$slug/$tab"
-          params={{ slug, tab: backTab }}
-          className="text-muted underline underline-offset-4 hover:text-ink"
-          data-testid="document-back-link"
-        >
-          {backLabel}
-        </Link>
-      </p>
-      <div className="flex flex-wrap items-start justify-between gap-6">
-        <div className="max-w-3xl">
-          <PageHeader eyebrow="Document workspace" title={doc.filename} subId={doc.id} />
-          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted">
-            Read the document, propose tracked edits, and keep the version record in one place.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <a
-            href={documentOriginalUrl(documentId)}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center border border-rule px-3 py-2 text-ink hover:bg-wash"
-            data-testid="document-open-original"
+    <div className="bg-wash px-4 py-6 text-ink sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-[1400px]">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <Link
+            to="/matters/$slug/$tab"
+            params={{ slug, tab: backTab }}
+            className="text-sm text-muted underline underline-offset-4 hover:text-ink"
+            data-testid="document-back-link"
           >
-            Open original
-          </a>
+            {backLabel}
+          </Link>
           <a
-            href={documentOriginalUrl(documentId, { download: true })}
-            className="inline-flex items-center border border-rule px-3 py-2 text-ink hover:bg-wash"
+            href={recordHref}
+            className="text-sm text-muted underline underline-offset-4 hover:text-ink"
           >
-            Download
+            View matter Record →
           </a>
         </div>
-      </div>
 
-      {arrivedFromChat && (
-        <p
-          className="mt-3 border-l-2 border-rule pl-3 text-xs text-muted"
-          data-testid="from-chat-note"
-        >
-          Opened from Chat. Pinpointing the exact passage isn't supported
-          yet — the document text is shown in full below.
-        </p>
-      )}
-
-      <div className="mt-8 grid gap-8 lg:grid-cols-[minmax(0,1fr)_280px]">
-        <main>
-          <div className="border-b border-rule">
-            <div className="flex flex-wrap gap-1" role="tablist" aria-label="Document workspace">
-              {DOCUMENT_TABS.map((tab) => {
-                const active = activeTab === tab.key;
-                return (
-                  <button
-                    key={tab.key}
-                    type="button"
-                    role="tab"
-                    aria-selected={active}
-                    onClick={() => setActiveTab(tab.key)}
-                    className={`border border-b-0 border-rule px-4 py-2 text-sm font-medium ${
-                      active
-                        ? "bg-paper text-ink"
-                        : "bg-wash text-muted hover:text-ink"
-                    }`}
-                  >
-                    {tab.label}
-                  </button>
-                );
-              })}
+        <header className="border border-rule bg-paper px-5 py-5 sm:px-6">
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto]">
+            <div className="min-w-0">
+              <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+                Document
+              </p>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight2 text-ink sm:text-4xl">
+                {doc.filename}
+              </h1>
+              <div className="mt-4 flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                <span className="border border-rule bg-paper-sunken px-2 py-1">
+                  {doc.tag || "untagged"}
+                </span>
+                <span className="border border-rule bg-paper-sunken px-2 py-1">
+                  {doc.from_disclosure ? "CPR 31 disclosure" : "uploaded"}
+                </span>
+                <span className="border border-rule bg-paper-sunken px-2 py-1">
+                  {formatBytes(doc.size_bytes)}
+                </span>
+                {latestVersion && (
+                  <span className="border border-rule bg-paper-sunken px-2 py-1">
+                    v{latestVersion.version_number}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-wrap items-start gap-2 text-sm">
+              <a
+                href={documentOriginalUrl(documentId)}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center border border-rule px-3 py-2 text-ink hover:border-ink"
+                data-testid="document-open-original"
+              >
+                Open original
+              </a>
+              <a
+                href={documentOriginalUrl(documentId, { download: true })}
+                className="inline-flex items-center border border-rule px-3 py-2 text-ink hover:border-ink"
+              >
+                Download
+              </a>
             </div>
           </div>
+        </header>
 
-          <p className="mt-3 text-xs text-muted">{selectedTab.hint}</p>
+        {arrivedFromChat && (
+          <p
+            className="mt-4 border-l-2 border-rule bg-paper px-4 py-3 text-sm text-muted"
+            data-testid="from-chat-note"
+          >
+            Opened from Chat. Pinpointing the exact passage isn't supported
+            yet — the document text is shown in full below.
+          </p>
+        )}
 
-          {activeTab === "read" && (
-            <section className="mt-5" data-testid="document-content">
+        <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_390px]">
+          <main className="min-w-0">
+            <section
+              className="min-h-[760px] border border-rule bg-paper"
+              data-testid="document-content"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-rule px-5 py-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-ink">Extracted text</h2>
+                  {body && !bodyMissing && (
+                    <p className="mt-0.5 text-xs text-muted">
+                      {body.extraction_method} · {body.char_count.toLocaleString()} chars
+                      {body.page_count ? ` · ${body.page_count} pages` : ""}
+                    </p>
+                  )}
+                </div>
+                <p className="text-xs text-muted">
+                  Source chips and skills read from this text.
+                </p>
+              </div>
               {bodyMissing ? (
-                <EmptyState
-                  title="No extracted text"
-                  body="No extracted body is available for this document (extraction may have failed or not run). The original file is still available."
-                />
+                <div className="p-6">
+                  <EmptyState
+                    title="No extracted text"
+                    body="No extracted body is available for this document (extraction may have failed or not run). The original file is still available."
+                  />
+                </div>
               ) : !body ? (
-                <LoadingLine label="loading document text" />
+                <div className="p-6">
+                  <LoadingLine label="loading document text" />
+                </div>
               ) : (
-                <article className="min-h-[520px] rounded-md border border-rule bg-paper px-6 py-5 text-[15px] leading-7 whitespace-pre-wrap font-sans text-ink">
+                <article className="px-7 py-7 text-[16px] leading-8 whitespace-pre-wrap font-sans text-ink sm:px-10">
                   {body.extracted_text || "(empty)"}
                 </article>
               )}
             </section>
-          )}
 
-          {activeTab === "redline" && (
-            <section className="mt-5" data-testid="document-redline-workspace">
-              <div className="mb-4 border-l-2 border-ink pl-4">
-                <h2 className="text-lg font-bold tracking-tight2">
-                  Propose tracked edits
-                </h2>
-                <p className="mt-1 max-w-2xl text-sm leading-relaxed text-muted">
-                  Legalise can suggest changes against the extracted text. You decide which edits become part of the document history.
-                </p>
-              </div>
-              <EditPanel
-                documentId={documentId}
-                filename={doc.filename}
-                onClose={() => {
-                  setActiveTab("read");
-                  loadBody();
-                  getDocumentVersions(documentId)
-                    .then(setVersions)
-                    .catch(() => undefined);
-                }}
-              />
-            </section>
-          )}
-
-          {activeTab === "history" && (
-            <section className="mt-5" data-testid="document-history-workspace">
-              <div className="rounded-md border border-rule bg-paper p-5">
-                <h2 className="text-lg font-bold tracking-tight2">
-                  Document history
-                </h2>
-                <p className="mt-1 text-sm leading-relaxed text-muted">
-                  Versions, accepted edits, rejected edits, and redaction state stay attached to this document.
-                </p>
-                <VersionTimeline documentId={documentId} />
-                {versions.length === 0 && (
-                  <p className="mt-4 text-sm text-muted">No versions recorded.</p>
-                )}
-              </div>
-
-              <div className="mt-6 rounded-md border border-rule bg-paper p-5">
-                <h3 className="text-xs uppercase tracking-widest text-muted">
-                  Redaction
-                </h3>
-                <p className="mt-2 text-sm text-muted">
-                  {anon
-                    ? `Redacted body available — ${anon.entity_count} entities via ${anon.engine}, ${anon.anonymised_at.replace("T", " ").slice(0, 16)}.`
-                    : "No redacted body yet."}
-                </p>
-                <div className="mt-3">
-                  <AnonymiseButton
-                    documentId={documentId}
-                    onResult={(r) => setAnon(r)}
-                  />
-                </div>
-              </div>
-            </section>
-          )}
-        </main>
-
-        <aside className="space-y-4">
-          <div className="rounded-md border border-rule bg-paper p-4">
-            <h2 className="font-mono text-[10px] uppercase tracking-track2 text-muted">
-              Document
-            </h2>
-            <dl className="mt-3 space-y-3 text-sm">
-              <DescItem label="Type">
-                <span className="font-mono text-xs">{doc.mime_type}</span>
-              </DescItem>
-              <DescItem label="Size">{formatBytes(doc.size_bytes)}</DescItem>
-              <DescItem label="Tag">{doc.tag || "—"}</DescItem>
-              <DescItem label="Source">
-                {doc.from_disclosure ? "Disclosure · CPR 31" : "Upload"}
-              </DescItem>
-            </dl>
-            <p className="mt-4 text-xs text-muted">
-              Original file access is audited.
-            </p>
-          </div>
-
-          <div className="rounded-md border border-rule bg-paper p-4">
-            <h2 className="font-mono text-[10px] uppercase tracking-track2 text-muted">
-              Record
-            </h2>
-            <p className="mt-2 text-sm text-muted">
-              Document opens, edits, redactions, and downloads are part of the matter record where supported.
-            </p>
-            <p className="mt-3 text-sm">
-              <a
-                href={recordHref}
-                className="text-muted underline underline-offset-4 hover:text-ink"
-              >
-                View matter Record →
-              </a>
-            </p>
-          </div>
-        </aside>
-      </div>
-
-      <section className="mt-8 border-t border-rule pt-4">
-        <button
-          type="button"
-          onClick={() => setShowDetails((v) => !v)}
-          aria-expanded={showDetails}
-          data-testid="document-details-toggle"
-          className="flex w-full items-center justify-between text-left"
-        >
-          <h2 className="text-sm uppercase tracking-widest text-muted">
-            Details
-          </h2>
-          <span aria-hidden="true" className="text-xs text-muted">
-            {showDetails ? "Hide" : "Show"}
-          </span>
-        </button>
-
-        {showDetails && (
-          <div className="mt-4 space-y-8">
-            {body && !bodyMissing && (
-              <p className="text-xs text-muted">
-                {body.extraction_method} · {body.char_count.toLocaleString()} chars
-                {body.page_count ? ` · ${body.page_count} pages` : ""}
-                {body.error_reason ? ` · ${body.error_reason}` : ""}
+            <section
+              className="mt-6 border border-rule bg-paper p-5"
+              data-testid="document-history-workspace"
+            >
+              <h2 className="text-lg font-semibold tracking-tight2 text-ink">
+                Version record
+              </h2>
+              <p className="mt-1 text-sm leading-relaxed text-muted">
+                Accepted edits create new versions. Rejected edits stay in the document record.
               </p>
-            )}
+              <VersionTimeline documentId={documentId} />
+              {versions.length === 0 && (
+                <p className="mt-4 text-sm text-muted">No versions recorded.</p>
+              )}
+            </section>
+          </main>
 
-            <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-              <DescItem label="Type">
-                <span className="font-mono text-xs">{doc.mime_type}</span>
-              </DescItem>
-              <DescItem label="Size">{formatBytes(doc.size_bytes)}</DescItem>
-              <DescItem label="Tag">{doc.tag || "—"}</DescItem>
-              <DescItem label="From disclosure">
-                {doc.from_disclosure ? "Yes (CPR 31)" : "No"}
-              </DescItem>
-              <DescItem label="Uploaded">
-                {doc.uploaded_at.replace("T", " ").slice(0, 19)}
-              </DescItem>
-              <DescItem label="SHA-256">
-                <span className="font-mono text-xs break-all">{doc.sha256}</span>
-              </DescItem>
-            </dl>
-          </div>
-        )}
-      </section>
+          <aside className="space-y-4 lg:sticky lg:top-6 lg:self-start">
+            <section className="border border-rule bg-paper p-4">
+              <h2 className="text-sm font-semibold text-ink">
+                Document tools
+              </h2>
+              <p className="mt-1 text-sm leading-6 text-muted">
+                Propose edits against the extracted text. You choose which suggestions become a new version.
+              </p>
+              <div className="mt-4" data-testid="document-redline-workspace">
+                <EditPanel
+                  documentId={documentId}
+                  filename={doc.filename}
+                  showTimeline={false}
+                  onResolved={() => {
+                    loadBody();
+                    getDocumentVersions(documentId)
+                      .then(setVersions)
+                      .catch(() => undefined);
+                  }}
+                />
+              </div>
+            </section>
+
+            <section className="border border-rule bg-paper p-4">
+              <h2 className="text-sm font-semibold text-ink">
+                Review state
+              </h2>
+              <dl className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+                <div className="border border-rule bg-paper-sunken p-2">
+                  <dt className="uppercase tracking-track2 text-muted">Pending</dt>
+                  <dd className="mt-1 text-lg font-semibold text-ink">{pendingEdits}</dd>
+                </div>
+                <div className="border border-rule bg-paper-sunken p-2">
+                  <dt className="uppercase tracking-track2 text-muted">Accepted</dt>
+                  <dd className="mt-1 text-lg font-semibold text-ink">{acceptedEdits}</dd>
+                </div>
+                <div className="border border-rule bg-paper-sunken p-2">
+                  <dt className="uppercase tracking-track2 text-muted">Rejected</dt>
+                  <dd className="mt-1 text-lg font-semibold text-ink">{rejectedEdits}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="border border-rule bg-paper p-4">
+              <h2 className="text-sm font-semibold text-ink">Redaction</h2>
+              <p className="mt-2 text-sm text-muted">
+                {anon
+                  ? `Redacted body available — ${anon.entity_count} entities via ${anon.engine}, ${anon.anonymised_at.replace("T", " ").slice(0, 16)}.`
+                  : "No redacted body yet."}
+              </p>
+              <div className="mt-3">
+                <AnonymiseButton
+                  documentId={documentId}
+                  onResult={(r) => setAnon(r)}
+                />
+              </div>
+            </section>
+
+            <section className="border border-rule bg-paper p-4">
+              <button
+                type="button"
+                onClick={() => setShowDetails((v) => !v)}
+                aria-expanded={showDetails}
+                data-testid="document-details-toggle"
+                className="flex w-full items-center justify-between text-left"
+              >
+                <h2 className="text-sm font-semibold text-ink">Details</h2>
+                <span aria-hidden="true" className="text-xs text-muted">
+                  {showDetails ? "Hide" : "Show"}
+                </span>
+              </button>
+
+              {showDetails && (
+                <div className="mt-4 space-y-4">
+                  {body && !bodyMissing && body.error_reason && (
+                    <p className="text-xs text-muted">{body.error_reason}</p>
+                  )}
+                  <dl className="space-y-3 text-sm">
+                    <DescItem label="Type">
+                      <span className="font-mono text-xs">{doc.mime_type}</span>
+                    </DescItem>
+                    <DescItem label="Uploaded">
+                      {doc.uploaded_at.replace("T", " ").slice(0, 19)}
+                    </DescItem>
+                    <DescItem label="SHA-256">
+                      <span className="font-mono text-xs break-all">{doc.sha256}</span>
+                    </DescItem>
+                  </dl>
+                  <p className="text-xs text-muted">
+                    Original file access is audited.
+                  </p>
+                </div>
+              )}
+            </section>
+          </aside>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/modules/document_edit/EditPanel.tsx
+++ b/frontend/src/modules/document_edit/EditPanel.tsx
@@ -47,9 +47,17 @@ type EditPanelProps = {
   documentId: string;
   filename: string;
   onClose?: () => void;
+  onResolved?: () => void;
+  showTimeline?: boolean;
 };
 
-export function EditPanel({ documentId, filename, onClose }: EditPanelProps) {
+export function EditPanel({
+  documentId,
+  filename,
+  onClose,
+  onResolved,
+  showTimeline = true,
+}: EditPanelProps) {
   const [instruction, setInstruction] = useState("");
   const [mode, setMode] = useState<EditMode>("free-text");
   const [busy, setBusy] = useState(false);
@@ -84,10 +92,10 @@ export function EditPanel({ documentId, filename, onClose }: EditPanelProps) {
   const disabled = busy || instruction.trim().length < 4;
 
   return (
-    <div className="border-t border-rule bg-paper p-5">
-      <div className="flex items-center justify-between mb-3">
-        <div className="font-mono uppercase tracking-track2 text-[10px] text-muted">
-          Edit · {filename}
+    <div className="space-y-4 bg-paper">
+      <div className="flex items-center justify-between">
+        <div className="text-xs text-muted">
+          Editing <span className="font-medium text-ink">{filename}</span>
         </div>
         {onClose && (
           <button
@@ -99,13 +107,13 @@ export function EditPanel({ documentId, filename, onClose }: EditPanelProps) {
         )}
       </div>
 
-      <div className="flex flex-wrap gap-2 mb-3">
+      <div className="grid grid-cols-2 gap-2">
         {PRESETS.map((p) => (
           <button
             key={p.label}
             onClick={() => applyPreset(p)}
             disabled={busy}
-            className="border border-rule px-3 py-1.5 text-[12px] hover:bg-wash transition-colors text-ink disabled:opacity-40"
+            className="min-h-[44px] border border-rule px-3 py-2 text-left text-[12px] leading-4 text-ink transition-colors hover:border-ink disabled:opacity-40"
           >
             {p.label}
           </button>
@@ -118,10 +126,10 @@ export function EditPanel({ documentId, filename, onClose }: EditPanelProps) {
         rows={4}
         placeholder="Type an edit instruction, or pick a preset above."
         disabled={busy}
-        className="w-full bg-paper border border-rule px-3 py-2 text-[14px] focus:border-ink focus:outline-none transition-colors font-sans text-ink resize-vertical"
+        className="w-full resize-vertical border border-rule bg-paper px-3 py-2 font-sans text-[14px] text-ink transition-colors focus:border-ink focus:outline-none"
       />
 
-      <div className="mt-3 flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <label className="font-mono uppercase tracking-track2 text-[10px] text-muted">
           Mode
         </label>
@@ -155,11 +163,16 @@ export function EditPanel({ documentId, filename, onClose }: EditPanelProps) {
       {result && (
         <TrackedChangesView
           result={result}
-          onResolved={() => setTimelineKey((k) => k + 1)}
+          onResolved={() => {
+            setTimelineKey((k) => k + 1);
+            onResolved?.();
+          }}
         />
       )}
 
-      <VersionTimeline documentId={documentId} refreshKey={timelineKey} />
+      {showTimeline && (
+        <VersionTimeline documentId={documentId} refreshKey={timelineKey} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- flatten the live document detail page into a document canvas with a working tools rail instead of Read/Redline/History tabs
- keep tracked edit proposals, accept/reject flow, version record, redaction, original open/download, and matter Record link on one coherent surface
- upgrade the public demo Documents tab into a two-pane reader so sample files can be opened and inspected without sign-in

## Boundaries
- frontend-only; no backend, schema, or route changes
- honest editor boundary: this is extracted-text reading plus tracked edit proposals, not native DOCX/PDF collaborative editing

## Verification
- npm run typecheck
- npm run test -- --run src/matter/DocumentDetail.test.tsx
- npm run test -- --run
- npm run build
- local browser smoke: /demo/documents shows Matter files + Document reader, sample extracted text, and no sign-in prompts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Demo documents tab now displays matter files and document reader in an improved two-column grid layout with empty state handling.
  * Document detail page redesigned to a single-page layout with consolidated review state metrics and collapsible details.
  * Editing panel layout improved with reorganized controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/b1rdmania/legalise/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->