### PR TITLE
documents: add rich editor version saves

### DIFF
--- a/backend/alembic/versions/0023_document_version_user_edit.py
+++ b/backend/alembic/versions/0023_document_version_user_edit.py
@@ -1,0 +1,56 @@
+"""Allow direct editor saves as document versions.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-06-03
+
+The document engine stores manual rich-editor saves as immutable
+``document_versions`` rows with ``kind='user_edit'``. This widens the
+existing kind check constraint; it does not add a table or column.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+_OLD_KIND_CHECK = (
+    "kind IN ('upload','assistant_edit','user_accept','user_reject','generated','replicated')"
+)
+_NEW_KIND_CHECK = (
+    "kind IN ('upload','assistant_edit','user_accept','user_reject','user_edit',"
+    "'generated','replicated')"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_document_versions_kind",
+        "document_versions",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_document_versions_kind",
+        "document_versions",
+        sa.text(_NEW_KIND_CHECK),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_document_versions_kind",
+        "document_versions",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_document_versions_kind",
+        "document_versions",
+        sa.text(_OLD_KIND_CHECK),
+    )

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -32,6 +32,7 @@ from app.models.document_edit import (
     EDIT_STATUS_PENDING,
     EDIT_STATUS_REJECTED,
 )
+from app.models.document_version import VERSION_KIND_USER_EDIT
 from app.modules.document_edit import EDIT_MODES, propose_edits
 from app.modules.document_edit.resolver import (
     EditAlreadyResolved,
@@ -139,6 +140,7 @@ class DocumentVersionRead(BaseModel):
     created_at: datetime
     storage_uri: str | None
     notes: str | None
+    resolved_text: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -447,6 +449,11 @@ class DocumentVersionSummary(BaseModel):
     rejected_count: int
 
 
+class ManualDocumentVersionRequest(BaseModel):
+    resolved_text: str = Field(min_length=1, max_length=500_000)
+    notes: str | None = Field(default=None, max_length=500)
+
+
 async def _resolve_one(
     document_id_unused: None,
     edit_id: uuid.UUID,
@@ -541,6 +548,51 @@ async def post_reject_all(
 ) -> BulkResolutionResponse:
     """Reject every pending edit on this version in a single transaction."""
     return await _resolve_all(version_id, "reject_all", session, user)
+
+
+@router.post("/{document_id}/versions/manual", response_model=DocumentVersionRead)
+async def post_manual_document_version(
+    document_id: uuid.UUID,
+    body: ManualDocumentVersionRequest,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentVersionRead:
+    """Save user-edited text as a new immutable document version."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    next_version = (
+        await session.scalar(
+            select(func.coalesce(func.max(DocumentVersion.version_number), 0) + 1)
+            .where(DocumentVersion.document_id == doc.id)
+        )
+        or 1
+    )
+    version = DocumentVersion(
+        document_id=doc.id,
+        version_number=int(next_version),
+        kind=VERSION_KIND_USER_EDIT,
+        created_by_id=user.id,
+        resolved_text=body.resolved_text,
+        notes=body.notes or "Edited in Legalise document editor",
+    )
+    session.add(version)
+    await session.flush()
+    await audit.log(
+        session,
+        "document.version.saved",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_version",
+        resource_id=str(version.id),
+        payload={
+            "document_id": str(doc.id),
+            "version_number": version.version_number,
+            "kind": version.kind,
+            "char_count": len(body.resolved_text),
+        },
+    )
+    await session.commit()
+    return DocumentVersionRead.model_validate(version)
 
 
 @router.get("/{document_id}/versions", response_model=list[DocumentVersionSummary])

--- a/backend/app/models/document_version.py
+++ b/backend/app/models/document_version.py
@@ -3,7 +3,8 @@
 Each document starts with a `version_number=1, kind='upload'` row. Subsequent
 versions are produced by edit instructions (`assistant_edit`), user
 accept/reject flows (`user_accept`/`user_reject`), pure generation
-(`generated`), or replication (`replicated`).
+(`generated`), replication (`replicated`), or direct editor saves
+(`user_edit`).
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ VERSION_KIND_UPLOAD = "upload"
 VERSION_KIND_ASSISTANT_EDIT = "assistant_edit"
 VERSION_KIND_USER_ACCEPT = "user_accept"
 VERSION_KIND_USER_REJECT = "user_reject"
+VERSION_KIND_USER_EDIT = "user_edit"
 VERSION_KIND_GENERATED = "generated"
 VERSION_KIND_REPLICATED = "replicated"
 VERSION_KIND_VALUES = {
@@ -29,6 +31,7 @@ VERSION_KIND_VALUES = {
     VERSION_KIND_ASSISTANT_EDIT,
     VERSION_KIND_USER_ACCEPT,
     VERSION_KIND_USER_REJECT,
+    VERSION_KIND_USER_EDIT,
     VERSION_KIND_GENERATED,
     VERSION_KIND_REPLICATED,
 }

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -84,6 +84,48 @@ async def test_get_document_versions_cross_user_returns_404(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_post_manual_document_version_creates_user_edit_version(client) -> None:
+    """Owner can save editor text as a new immutable document version."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+
+    resp = await client.post(
+        f"/api/documents/{doc_id}/versions/manual",
+        json={
+            "resolved_text": "Edited witness statement.\n\nSecond paragraph.",
+            "notes": "Manual edit from document editor",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["kind"] == "user_edit"
+    assert payload["version_number"] == 2
+    assert payload["resolved_text"] == "Edited witness statement.\n\nSecond paragraph."
+    assert payload["notes"] == "Manual edit from document editor"
+
+    versions = await client.get(f"/api/documents/{doc_id}/versions")
+    assert versions.status_code == 200, versions.text
+    rows = versions.json()
+    assert rows[-1]["version"]["kind"] == "user_edit"
+    assert rows[-1]["version"]["resolved_text"] == "Edited witness statement.\n\nSecond paragraph."
+
+
+@pytest.mark.asyncio
+async def test_post_manual_document_version_cross_user_returns_404(client) -> None:
+    """User B cannot save a version on User A's document by UUID."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+    await client.post("/auth/logout")
+
+    await _signup_and_login(client, EMAIL_B, PASSWORD_B)
+    resp = await client.post(
+        f"/api/documents/{doc_id}/versions/manual",
+        json={"resolved_text": "Cross-user edit should not land."},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
 async def test_get_document_body_archived_matter_returns_404(client) -> None:
     """After the owning matter is archived, GET document body 404s."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
@@ -116,6 +158,22 @@ async def test_get_document_versions_archived_matter_returns_404(client) -> None
     assert del_resp.status_code == 204, del_resp.text
 
     resp = await client.get(f"/api/documents/{doc_id}/versions")
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_post_manual_document_version_archived_matter_returns_404(client) -> None:
+    """After the owning matter is archived, manual editor saves 404."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    slug, doc_id = await _create_matter_and_upload(client)
+
+    del_resp = await client.delete(f"/api/matters/{slug}")
+    assert del_resp.status_code == 204, del_resp.text
+
+    resp = await client.post(
+        f"/api/documents/{doc_id}/versions/manual",
+        json={"resolved_text": "Archived matter edit should not land."},
+    )
     assert resp.status_code == 404, resp.text
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,11 @@
       "dependencies": {
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.85.0",
+        "@tiptap/extension-highlight": "^3.25.0",
+        "@tiptap/extension-placeholder": "^3.25.0",
+        "@tiptap/extension-typography": "^3.25.0",
+        "@tiptap/react": "^3.25.0",
+        "@tiptap/starter-kit": "^3.25.0",
         "clsx": "^2.1.1",
         "diff-match-patch": "^1.0.5",
         "lucide-react": "^0.460.0",
@@ -1171,6 +1176,34 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1911,6 +1944,474 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.25.0.tgz",
+      "integrity": "sha512-I9edH6vUXgbjUl5GPICYYYQeql8hC77VZnHLvWg8wc7FwaOw242Uy4Y89c/eX7LGmKwVxz28JFvAsZ8tIdDVvg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.25.0.tgz",
+      "integrity": "sha512-nSWhYtAKVFAZluRTew+BZUMHo5+87uQqTBOnbyy9ZFBp3gjHjCgGqhboJg5ksMHLCEz1XVoHnS5iXcu9d6Bm6Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.25.0.tgz",
+      "integrity": "sha512-owygVm6XMtk8VVclm2CCCz3Q1HfNpkjeoRTIbeM5r/R1cDrPQAVOuAd3w+mdXlC3iDsvCkfYzSTSphZcDpwThQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.25.0.tgz",
+      "integrity": "sha512-IL6WRTMS0X6szJ1F9qrAbslbet8awUcQ4cJEJLL2lxDgcxpxDHcKxIQRsX5A7qmrWnHxo0tCIpsXKvJ6toaSCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.25.0.tgz",
+      "integrity": "sha512-v0+0kvg0CddW4bz05YVssnMhfe+4x32Tg9qNzYMYK4jGtSm5GDLYG7JaOqAUwiXj5jhKmoOTfXzV6cB5Tk4OEA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.25.0.tgz",
+      "integrity": "sha512-1Lcwwny7JwQ6m2wEqytKWmSfQzV0ONhZqUmMaAAAFvDCCG7dRPOVKT+3s0UqFlGePP1xbYl0Yy0YOVv3M6sedg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.25.0.tgz",
+      "integrity": "sha512-bMKhg+Qcve1O3L5k6dzNCbCI/QsWPK1ez+1k9CQEd5rO0mwCpqLGb5tyFztI6umdFr5dulI3FZVt8IOtUptuxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.25.0.tgz",
+      "integrity": "sha512-YEENTItTHdOiIAemTDej2HsbMvq4IlrgQ7obR89Kyaxs2oE4gYw0GPA3gjHfuJnv2VHMQqFn7K37nlyuiABhHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.25.0.tgz",
+      "integrity": "sha512-4SyWreaR82Gx1vMp5fYTM+acijNNWXQyrx7yKQPFSjh1I9cPNz3wvQEY6gEpBQ6WDwS/WdUIZq9nw99JQx7XRQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.25.0.tgz",
+      "integrity": "sha512-ZUC+89Kggg4zxRcb8NxyMwErnGxwp5GDVqjxrqo7DReYiOuKeKF/tqvxxa/x+ADJ0Hsy36hVUJqd6gzoi02njA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.25.0.tgz",
+      "integrity": "sha512-XLXfYLtP744b88qLEWcUUAMB0yD3TFGUtfiFh5eYw3ybOW/BA0f6SIJQWk6l0Uk8TZ1x/YQURWNo07/csJcwew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.25.0.tgz",
+      "integrity": "sha512-86JdgqwBUSPhLH5l5TaOA1JbdaE1nCEv/INdPykVCC0Tlf1sdoF356rmFNLo8cLxmDLp9bTVo85EZx7HWl+d+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.25.0.tgz",
+      "integrity": "sha512-3SJGZgV3cNQiUi98dWQQ3SFQAKaZg+O8PTdQmA4XC4JJn3NgDpBHiRz+bSE4NYjaRXk8DOq3+zxgGGiaGsC1Ww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-highlight": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-3.25.0.tgz",
+      "integrity": "sha512-YEtqiiyjYUxdIuSbwC5wvUrdK/hK8uPab70avVmiHlmuav+e8FGShdsKCQ17F9z/ECfwlhr0u9sojYyyhSJXLg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.25.0.tgz",
+      "integrity": "sha512-Ku1PQxiBoprEwf7O2uzJSYvfpkQ26UhZ4tptXqCUdsG9IXYn/Gg9qAtJrm8UFnPwsxm0CrkMsAlAG3JmBrtXKQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.25.0.tgz",
+      "integrity": "sha512-eZw+q8mtap8n0B5LtvPSgpyqkSIL7FzT7syD5ut++29FoXNl3fhJO6ct0hspWKFB4ihbvo3NG2gIwHi2ESXQow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.25.0.tgz",
+      "integrity": "sha512-DauqQS55xZACzPb0+KxXDiDw1GVDszltMUikHSLZSCp1+EjPSVt86X8CxJNc83rC/ZrqJMM/iUK74DHRUg2XSA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.25.0.tgz",
+      "integrity": "sha512-bYw4o2YiTdj/tdgktgbMRUfqAJgsnRkwUQTTKElycPdIwlNNs6EQiXku+E2ACftLaFxd3Ek+P50H0AQ5fA/hPw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.25.0.tgz",
+      "integrity": "sha512-RfxDdLXUggC4tKB9V8Vhfxqjn4ZFbL2suFpl3ct0RY7ynrv9tE66ukYQ2SPg6rAYZK+WxVND0VSeLFB5QclO2A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.25.0.tgz",
+      "integrity": "sha512-8JOWSQc4mpXNmQWn52THIEpcGdVgBz51J/pz/KcbJBMDZIPvB7nDwFsLkkURrcWDX0DO7G9uepjvAEb8LfBFXg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.25.0.tgz",
+      "integrity": "sha512-3qs1Q7HgJWlgI0VDXGMiTKTOQdNKN6omAgaq5i+jITCbKn+OKC95E9tbkTq9fPWPgH0svJRUfvvACRem4rhJew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.25.0.tgz",
+      "integrity": "sha512-yETzkQFjcRA7JeaAw927qaT5xTweAMr1rznN5fRxJdHdURPjvm+8gz76W/8DuloN4EF/fzAjpVBXZwwcJ+61yg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.25.0.tgz",
+      "integrity": "sha512-QrMwpQeHQ+DPbbaNe1i4ppofYkEZycZg0hFLeYHTVeGBf6cHkoBuF9LEEuaLIKoOVfVpNx0PT54eQAN9YAETEw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.25.0.tgz",
+      "integrity": "sha512-rtM9tkqH8XWay7TplUcXPjlBiNg/dbEOuaCvZGvNxTw8xbH+cmEGPxojWVW6oVMsQodBlUoNveATE2yzhiUB1A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.25.0.tgz",
+      "integrity": "sha512-qXAYiIIOX7F6wVftN7FeHTAg9lDLzgqrscrT4BJxTL3Vk38EP1R3w1sDDfSCTQ53ui8SzoaKe0iyzkTa6V/1LQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-typography": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-typography/-/extension-typography-3.25.0.tgz",
+      "integrity": "sha512-6wm/U4D7VgTLywOZBws++lu9APu9C3q52b+mM3BDeOHT85D0syc/fF+WdFQJR9PI2bWmSLl0g/adaWz1VPSBMw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.25.0.tgz",
+      "integrity": "sha512-GTCjXnOhjQ8ipiOrdskMdBqQ8nUnczFWWNJ5IoCkMcEDWviOS14Mr2n6zewjlKjtPoRTzwOpFDQUevSK1SHpJg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.25.0.tgz",
+      "integrity": "sha512-aRXZwOPLdIRey28uctNT/Nbh3EaiNYnKt5qBhBbxs5aTtwoExzYAEtR7D8KjpUVBJAZNeLwFxvD2Ub+F94uAAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.25.0.tgz",
+      "integrity": "sha512-JeaVgyLj0gQZ1gVxDI73QkP+/Ozcjyp37HyL1pXLCRVjY8nnsDrdMzuKsP1SWN2fOhC+JBGW8/88g0rPmwZQFg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.7",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.0",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.25.0.tgz",
+      "integrity": "sha512-S0KhuF+Vs/bJeKc2oxgCA33C3q5rMFOqleQCSx18W80jygeGnLaQ6c8yVUlbR1YQJwVk2gm1X15719580kBYIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.25.0",
+        "@tiptap/extension-floating-menu": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0",
+        "@tiptap/pm": "3.25.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.25.0.tgz",
+      "integrity": "sha512-bKe1BhA8YXX7DHC6dsvkkedeQM7r2Iif36i9meTY4szNd9limlnP0ZlFBrBcktl7D/XFy1rkDfD+diWfYeG9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.25.0",
+        "@tiptap/extension-blockquote": "^3.25.0",
+        "@tiptap/extension-bold": "^3.25.0",
+        "@tiptap/extension-bullet-list": "^3.25.0",
+        "@tiptap/extension-code": "^3.25.0",
+        "@tiptap/extension-code-block": "^3.25.0",
+        "@tiptap/extension-document": "^3.25.0",
+        "@tiptap/extension-dropcursor": "^3.25.0",
+        "@tiptap/extension-gapcursor": "^3.25.0",
+        "@tiptap/extension-hard-break": "^3.25.0",
+        "@tiptap/extension-heading": "^3.25.0",
+        "@tiptap/extension-horizontal-rule": "^3.25.0",
+        "@tiptap/extension-italic": "^3.25.0",
+        "@tiptap/extension-link": "^3.25.0",
+        "@tiptap/extension-list": "^3.25.0",
+        "@tiptap/extension-list-item": "^3.25.0",
+        "@tiptap/extension-list-keymap": "^3.25.0",
+        "@tiptap/extension-ordered-list": "^3.25.0",
+        "@tiptap/extension-paragraph": "^3.25.0",
+        "@tiptap/extension-strike": "^3.25.0",
+        "@tiptap/extension-text": "^3.25.0",
+        "@tiptap/extension-underline": "^3.25.0",
+        "@tiptap/extensions": "^3.25.0",
+        "@tiptap/pm": "^3.25.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2070,7 +2571,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2080,11 +2580,16 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -3843,6 +4348,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4097,6 +4608,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -4505,6 +5022,145 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4776,6 +5432,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -5555,6 +6217,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,11 @@
   "dependencies": {
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.85.0",
+    "@tiptap/extension-highlight": "^3.25.0",
+    "@tiptap/extension-placeholder": "^3.25.0",
+    "@tiptap/extension-typography": "^3.25.0",
+    "@tiptap/react": "^3.25.0",
+    "@tiptap/starter-kit": "^3.25.0",
     "clsx": "^2.1.1",
     "diff-match-patch": "^1.0.5",
     "lucide-react": "^0.460.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -64,4 +64,31 @@
   .prose-p:last-child {
     margin-bottom: 0;
   }
+
+  .legalise-document-editor p {
+    margin: 0 0 1.1rem;
+  }
+
+  .legalise-document-editor p:last-child {
+    margin-bottom: 0;
+  }
+
+  .legalise-document-editor ul,
+  .legalise-document-editor ol {
+    margin: 0 0 1.1rem 1.25rem;
+    padding: 0;
+  }
+
+  .legalise-document-editor ul {
+    list-style: disc;
+  }
+
+  .legalise-document-editor ol {
+    list-style: decimal;
+  }
+
+  .legalise-document-editor mark {
+    background: #FFF4B8;
+    padding: 0 0.1em;
+  }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1546,6 +1546,7 @@ export interface DocumentVersionRead {
   created_at: string;
   storage_uri: string | null;
   notes: string | null;
+  resolved_text: string | null;
 }
 
 export interface DocumentEditRead {
@@ -1746,6 +1747,17 @@ export const getDocumentVersions = (documentId: string) =>
   apiFetch(`${API}/documents/${documentId}/versions`).then((r) =>
     resolutionJsonOrThrow<DocumentVersionSummary[]>(r),
   );
+
+export const saveDocumentVersion = (
+  documentId: string,
+  resolvedText: string,
+  notes?: string,
+) =>
+  apiFetch(`${API}/documents/${documentId}/versions/manual`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ resolved_text: resolvedText, notes }),
+  }).then((r) => resolutionJsonOrThrow<DocumentVersionRead>(r));
 
 // ----- Auth + user --------------------------------------------------------
 // Auth endpoints live in `./api/auth` (sit at backend origin, NOT under

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -27,6 +27,7 @@ import {
 import { EditPanel } from "../modules/document_edit/EditPanel";
 import { AnonymiseButton } from "../modules/anonymisation/AnonymiseButton";
 import { VersionTimeline } from "../modules/document_edit/VersionTimeline";
+import { DocumentRichEditor } from "../modules/document_edit/DocumentRichEditor";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -140,7 +141,20 @@ export function DocumentDetail({
 
   const doc = q.doc;
   const recordHref = `/matters/${encodeURIComponent(slug)}/audit`;
-  const latestVersion = versions[0]?.version;
+  const originalHref = documentOriginalUrl(documentId);
+  const canPreviewOriginal = doc.mime_type === "application/pdf";
+  const latestVersion = versions.at(-1)?.version;
+  const latestResolvedVersion = [...versions]
+    .reverse()
+    .find((v) => v.version.resolved_text)?.version;
+  const editorText = latestResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
+  const editorSourceLabel = latestResolvedVersion
+    ? `Editing saved version v${latestResolvedVersion.version_number}`
+    : body
+      ? `${body.extraction_method} · ${body.char_count.toLocaleString()} chars${
+          body.page_count ? ` · ${body.page_count} pages` : ""
+        }`
+      : "Loading document text";
   const pendingEdits = versions.reduce((total, v) => total + v.pending_count, 0);
   const acceptedEdits = versions.reduce((total, v) => total + v.accepted_count, 0);
   const rejectedEdits = versions.reduce((total, v) => total + v.rejected_count, 0);
@@ -193,7 +207,7 @@ export function DocumentDetail({
             </div>
             <div className="flex flex-wrap items-start gap-2 text-sm">
               <a
-                href={documentOriginalUrl(documentId)}
+                href={originalHref}
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center border border-rule px-3 py-2 text-ink hover:border-ink"
@@ -223,41 +237,59 @@ export function DocumentDetail({
 
         <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_390px]">
           <main className="min-w-0">
-            <section
-              className="min-h-[760px] border border-rule bg-paper"
-              data-testid="document-content"
-            >
-              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-rule px-5 py-3">
-                <div>
-                  <h2 className="text-sm font-semibold text-ink">Extracted text</h2>
-                  {body && !bodyMissing && (
-                    <p className="mt-0.5 text-xs text-muted">
-                      {body.extraction_method} · {body.char_count.toLocaleString()} chars
-                      {body.page_count ? ` · ${body.page_count} pages` : ""}
-                    </p>
-                  )}
-                </div>
-                <p className="text-xs text-muted">
-                  Source chips and skills read from this text.
-                </p>
-              </div>
-              {bodyMissing ? (
+            <div data-testid="document-content">
+              {bodyMissing && !latestResolvedVersion ? (
                 <div className="p-6">
                   <EmptyState
                     title="No extracted text"
                     body="No extracted body is available for this document (extraction may have failed or not run). The original file is still available."
                   />
                 </div>
-              ) : !body ? (
-                <div className="p-6">
+              ) : !body && !latestResolvedVersion ? (
+                <div className="border border-rule bg-paper p-6">
                   <LoadingLine label="loading document text" />
                 </div>
               ) : (
-                <article className="px-7 py-7 text-[16px] leading-8 whitespace-pre-wrap font-sans text-ink sm:px-10">
-                  {body.extracted_text || "(empty)"}
-                </article>
+                <DocumentRichEditor
+                  documentId={documentId}
+                  filename={doc.filename}
+                  initialText={editorText}
+                  latestVersionNumber={latestVersion?.version_number}
+                  sourceLabel={editorSourceLabel}
+                  onSaved={() => {
+                    getDocumentVersions(documentId)
+                      .then(setVersions)
+                      .catch(() => undefined);
+                  }}
+                />
               )}
-            </section>
+            </div>
+
+            {canPreviewOriginal && (
+              <section className="mt-6 border border-rule bg-paper" data-testid="document-original-preview">
+                <div className="flex items-center justify-between gap-3 border-b border-rule px-5 py-3">
+                  <div>
+                    <h2 className="text-sm font-semibold text-ink">Original preview</h2>
+                    <p className="mt-0.5 text-xs text-muted">
+                      Opens through the audited document proxy.
+                    </p>
+                  </div>
+                  <a
+                    href={originalHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+                  >
+                    Open full size →
+                  </a>
+                </div>
+                <iframe
+                  title={`Original preview for ${doc.filename}`}
+                  src={originalHref}
+                  className="h-[620px] w-full bg-paper-sunken"
+                />
+              </section>
+            )}
 
             <section
               className="mt-6 border border-rule bg-paper p-5"

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  editorJsonToPlainText,
+  textToEditorHtml,
+} from "./DocumentRichEditor";
+
+describe("DocumentRichEditor text conversion", () => {
+  it("turns plain paragraphs into editor-safe HTML", () => {
+    expect(textToEditorHtml("One <two>\n\nThree & four")).toBe(
+      "<p>One &lt;two&gt;</p><p>Three &amp; four</p>",
+    );
+  });
+
+  it("preserves paragraphs and hard breaks when saving text", () => {
+    expect(
+      editorJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "text", text: "Line one" },
+              { type: "hardBreak" },
+              { type: "text", text: "line two" },
+            ],
+          },
+          { type: "paragraph", content: [{ type: "text", text: "Next" }] },
+        ],
+      }),
+    ).toBe("Line one\nline two\n\nNext");
+  });
+});

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useMemo, useState } from "react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import Typography from "@tiptap/extension-typography";
+import Highlight from "@tiptap/extension-highlight";
+
+import {
+  saveDocumentVersion,
+  type DocumentVersionRead,
+} from "../../lib/api";
+
+type TiptapNode = {
+  type?: string;
+  text?: string;
+  content?: TiptapNode[];
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function textToEditorHtml(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "<p></p>";
+  return trimmed
+    .split(/\n{2,}/)
+    .map((paragraph) => {
+      const lines = paragraph
+        .split(/\n/)
+        .map((line) => escapeHtml(line))
+        .join("<br />");
+      return `<p>${lines}</p>`;
+    })
+    .join("");
+}
+
+function plainTextFromNode(node: TiptapNode): string {
+  if (node.type === "text") return node.text ?? "";
+  if (node.type === "hardBreak") return "\n";
+  const children = node.content?.map(plainTextFromNode).join("") ?? "";
+  if (node.type === "paragraph" || node.type === "heading") return `${children}\n\n`;
+  if (node.type === "listItem") return `${children.trimEnd()}\n`;
+  return children;
+}
+
+export function editorJsonToPlainText(json: TiptapNode): string {
+  return plainTextFromNode(json).replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function ToolbarButton({
+  active,
+  children,
+  onClick,
+  label,
+}: {
+  active?: boolean;
+  children: string;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className={`inline-flex h-8 min-w-8 items-center justify-center border px-2 text-sm font-semibold ${
+        active
+          ? "border-ink bg-ink text-paper"
+          : "border-rule bg-paper text-ink hover:border-ink"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function DocumentRichEditor({
+  documentId,
+  filename,
+  initialText,
+  latestVersionNumber,
+  sourceLabel,
+  onSaved,
+}: {
+  documentId: string;
+  filename: string;
+  initialText: string;
+  latestVersionNumber?: number;
+  sourceLabel: string;
+  onSaved: (version: DocumentVersionRead) => void;
+}) {
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedMessage, setSavedMessage] = useState<string | null>(null);
+  const content = useMemo(() => textToEditorHtml(initialText), [initialText]);
+  const editor = useEditor(
+    {
+      extensions: [
+        StarterKit.configure({
+          heading: false,
+          codeBlock: false,
+          horizontalRule: false,
+        }),
+        Placeholder.configure({
+          placeholder: "Start editing this document...",
+        }),
+        Typography,
+        Highlight.configure({ multicolor: false }),
+      ],
+      content,
+      editorProps: {
+        attributes: {
+          class:
+            "legalise-document-editor min-h-[620px] px-7 py-7 text-[16px] leading-8 outline-none sm:px-10",
+        },
+      },
+      onUpdate: () => {
+        setDirty(true);
+        setSavedMessage(null);
+      },
+      immediatelyRender: false,
+    },
+    [documentId],
+  );
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.commands.setContent(content, { emitUpdate: false });
+    setDirty(false);
+    setError(null);
+    setSavedMessage(null);
+  }, [content, editor]);
+
+  const plainText = editor ? editorJsonToPlainText(editor.getJSON() as TiptapNode) : "";
+  const canSave = Boolean(editor && dirty && plainText.trim() && !saving);
+
+  async function save() {
+    if (!editor || !canSave) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const version = await saveDocumentVersion(
+        documentId,
+        plainText,
+        `Edited ${filename} in Legalise document editor`,
+      );
+      setDirty(false);
+      setSavedMessage(`Saved v${version.version_number}`);
+      onSaved(version);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function reset() {
+    editor?.commands.setContent(content, { emitUpdate: false });
+    setDirty(false);
+    setError(null);
+    setSavedMessage(null);
+  }
+
+  return (
+    <section className="min-h-[760px] border border-rule bg-paper" data-testid="document-editor">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-rule px-5 py-3">
+        <div>
+          <h2 className="text-sm font-semibold text-ink">Document editor</h2>
+          <p className="mt-0.5 text-xs text-muted">
+            {sourceLabel}
+            {latestVersionNumber ? ` · current v${latestVersionNumber}` : ""}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {editor && (
+            <>
+              <ToolbarButton
+                label="Bold"
+                active={editor.isActive("bold")}
+                onClick={() => editor.chain().focus().toggleBold().run()}
+              >
+                B
+              </ToolbarButton>
+              <ToolbarButton
+                label="Italic"
+                active={editor.isActive("italic")}
+                onClick={() => editor.chain().focus().toggleItalic().run()}
+              >
+                I
+              </ToolbarButton>
+              <ToolbarButton
+                label="Underline"
+                active={editor.isActive("underline")}
+                onClick={() => editor.chain().focus().toggleUnderline().run()}
+              >
+                U
+              </ToolbarButton>
+              <ToolbarButton
+                label="Highlight"
+                active={editor.isActive("highlight")}
+                onClick={() => editor.chain().focus().toggleHighlight().run()}
+              >
+                H
+              </ToolbarButton>
+              <ToolbarButton
+                label="Bullet list"
+                active={editor.isActive("bulletList")}
+                onClick={() => editor.chain().focus().toggleBulletList().run()}
+              >
+                *
+              </ToolbarButton>
+            </>
+          )}
+          <button
+            type="button"
+            onClick={reset}
+            disabled={!dirty || saving}
+            className="inline-flex h-8 items-center border border-rule px-3 text-xs font-semibold text-muted hover:border-ink hover:text-ink disabled:opacity-40"
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={!canSave}
+            className="inline-flex h-8 items-center border border-ink bg-ink px-3 text-xs font-semibold text-paper disabled:border-rule disabled:bg-paper-sunken disabled:text-muted"
+          >
+            {saving ? "Saving..." : "Save version"}
+          </button>
+        </div>
+      </div>
+
+      <div className="border-b border-rule bg-paper-sunken px-5 py-2 text-xs text-muted">
+        {dirty ? "Unsaved changes" : savedMessage ?? "Every save creates a new document version."}
+      </div>
+      {error && (
+        <p className="border-b border-red-800 bg-red-50 px-5 py-3 text-sm text-red-900">
+          {error}
+        </p>
+      )}
+      <EditorContent editor={editor} />
+    </section>
+  );
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+
+if (!document.elementFromPoint) {
+  document.elementFromPoint = () => document.body;
+}


### PR DESCRIPTION
## Summary

Document Engine v1 slice: make the document workspace a real editable document surface using a proven editor stack instead of a hand-rolled textarea.

- installs Tiptap (`@tiptap/react`, `starter-kit`, placeholder, typography, highlight)
- replaces the extracted-text-only document canvas with a Tiptap editor
- saves manual edits as immutable `document_versions` rows (`kind=user_edit`) through a new owner-only endpoint
- exposes `resolved_text` on document versions so the editor opens the latest saved text, not only the original extraction
- adds inline PDF original preview through the existing audited backend proxy
- keeps model redline, version record, redaction, and metadata as supporting tools around the editor

## Backend

New endpoint:

`POST /api/documents/{document_id}/versions/manual`

Creates a new `DocumentVersion` with `resolved_text`, `kind=user_edit`, and emits `document.version.saved`. The same owner-only / archived-matter 404 policy is used as the existing body/versions endpoints.

Schema:

- migration `0023_document_version_user_edit.py` widens `ck_document_versions_kind` to allow `user_edit`.

## Verification

Local:

- `python -m py_compile backend/app/api/documents.py backend/app/models/document_version.py backend/alembic/versions/0023_document_version_user_edit.py`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run test -- DocumentDetail DocumentRichEditor --run` — 8/8
- `npm --prefix frontend run test -- --run` — 214/214
- `npm --prefix frontend run build`

Not run locally:

- backend pytest. This shell has neither `pytest` nor `uv` available on PATH, and there is no local backend venv in the checkout. CI should run the new focused route tests in the normal backend environment.

## Boundaries

This does not claim full native DOCX/PDF collaborative editing yet. It is the first real document-engine slice: proven rich editor, immutable Legalise versions, audited original preview, and existing redline tools in one document workspace.