### PR TITLE
documents: export edited versions as docx

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1,12 +1,8 @@
-"""Documents API — per-document endpoints (body, edit-instructions).
-
-Workstream 1 ships the body endpoint. The edit-instructions endpoint is
-added by Workstream 2; the router is exported so additional endpoints
-can mount onto it without disturbing the wiring in `main.py`.
-"""
+"""Documents API — per-document endpoints."""
 
 from __future__ import annotations
 
+import io
 import re
 import uuid
 from datetime import datetime
@@ -15,6 +11,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
+from docx import Document as DocxDocument
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -246,6 +243,31 @@ def _safe_filename(title: str | None, file_uuid: str) -> str:
         if cleaned:
             return f"{cleaned}.docx"
     return f"generated-{file_uuid[:8]}.docx"
+
+
+def _docx_export_filename(filename: str, version_number: int) -> str:
+    stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+    cleaned = _FILENAME_SAFE_RE.sub("-", stem).strip("-._")[:80].rstrip("-._")
+    if not cleaned:
+        cleaned = "document"
+    return f"{cleaned}-v{version_number}.docx"
+
+
+def _render_resolved_text_docx(title: str, body: str) -> bytes:
+    document = DocxDocument()
+    document.add_heading(title, level=0)
+    for block in body.split("\n\n"):
+        block = block.rstrip()
+        if not block:
+            continue
+        lines = block.split("\n")
+        para = document.add_paragraph(lines[0])
+        for line in lines[1:]:
+            para.add_run().add_break()
+            para.add_run(line)
+    buf = io.BytesIO()
+    document.save(buf)
+    return buf.getvalue()
 
 
 @router.get("/generated/{file_uuid}")
@@ -593,6 +615,55 @@ async def post_manual_document_version(
     )
     await session.commit()
     return DocumentVersionRead.model_validate(version)
+
+
+@router.get("/{document_id}/versions/{version_id}/docx")
+async def get_document_version_docx(
+    document_id: uuid.UUID,
+    version_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> StreamingResponse:
+    """Download a saved document version as a Word document."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    version = await session.scalar(
+        select(DocumentVersion).where(
+            DocumentVersion.id == version_id,
+            DocumentVersion.document_id == doc.id,
+        )
+    )
+    if version is None:
+        raise HTTPException(404, "document version not found")
+    if not version.resolved_text:
+        raise HTTPException(422, "document version has no resolved text")
+
+    data = _render_resolved_text_docx(doc.filename, version.resolved_text)
+    filename = _docx_export_filename(doc.filename, version.version_number)
+    await audit.log(
+        session,
+        "document.version.docx.exported",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_version",
+        resource_id=str(version.id),
+        payload={
+            "document_id": str(doc.id),
+            "version_number": version.version_number,
+            "char_count": len(version.resolved_text),
+            "byte_count": len(data),
+            "format": "docx",
+        },
+    )
+    await session.commit()
+    return StreamingResponse(
+        iter([data]),
+        media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(data)),
+        },
+    )
 
 
 @router.get("/{document_id}/versions", response_model=list[DocumentVersionSummary])

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import io
 import uuid
+import zipfile
 
 import pytest
 
@@ -111,6 +112,41 @@ async def test_post_manual_document_version_creates_user_edit_version(client) ->
 
 
 @pytest.mark.asyncio
+async def test_get_manual_document_version_docx_returns_word_file(client) -> None:
+    """Owner can download a saved editor version as a valid .docx."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+
+    save = await client.post(
+        f"/api/documents/{doc_id}/versions/manual",
+        json={"resolved_text": "Edited witness statement.\n\nSecond paragraph."},
+    )
+    assert save.status_code == 200, save.text
+    version_id = save.json()["id"]
+
+    resp = await client.get(f"/api/documents/{doc_id}/versions/{version_id}/docx")
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    assert resp.headers.get("content-disposition", "").endswith('.docx"')
+    assert zipfile.is_zipfile(io.BytesIO(resp.content))
+
+
+@pytest.mark.asyncio
+async def test_get_upload_document_version_docx_without_resolved_text_returns_422(client) -> None:
+    """Upload versions without resolved_text are not exportable through the editor path."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+    versions = await client.get(f"/api/documents/{doc_id}/versions")
+    assert versions.status_code == 200, versions.text
+    upload_version_id = versions.json()[0]["version"]["id"]
+
+    resp = await client.get(f"/api/documents/{doc_id}/versions/{upload_version_id}/docx")
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
 async def test_post_manual_document_version_cross_user_returns_404(client) -> None:
     """User B cannot save a version on User A's document by UUID."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
@@ -122,6 +158,24 @@ async def test_post_manual_document_version_cross_user_returns_404(client) -> No
         f"/api/documents/{doc_id}/versions/manual",
         json={"resolved_text": "Cross-user edit should not land."},
     )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_document_version_docx_cross_user_returns_404(client) -> None:
+    """User B cannot download User A's saved editor version."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+    save = await client.post(
+        f"/api/documents/{doc_id}/versions/manual",
+        json={"resolved_text": "Owned user edit."},
+    )
+    assert save.status_code == 200, save.text
+    version_id = save.json()["id"]
+    await client.post("/auth/logout")
+
+    await _signup_and_login(client, EMAIL_B, PASSWORD_B)
+    resp = await client.get(f"/api/documents/{doc_id}/versions/{version_id}/docx")
     assert resp.status_code == 404, resp.text
 
 
@@ -174,6 +228,25 @@ async def test_post_manual_document_version_archived_matter_returns_404(client) 
         f"/api/documents/{doc_id}/versions/manual",
         json={"resolved_text": "Archived matter edit should not land."},
     )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_document_version_docx_archived_matter_returns_404(client) -> None:
+    """After the owning matter is archived, version .docx download 404s."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    slug, doc_id = await _create_matter_and_upload(client)
+    save = await client.post(
+        f"/api/documents/{doc_id}/versions/manual",
+        json={"resolved_text": "Owned user edit."},
+    )
+    assert save.status_code == 200, save.text
+    version_id = save.json()["id"]
+
+    del_resp = await client.delete(f"/api/matters/{slug}")
+    assert del_resp.status_code == 204, del_resp.text
+
+    resp = await client.get(f"/api/documents/{doc_id}/versions/{version_id}/docx")
     assert resp.status_code == 404, resp.text
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1589,6 +1589,14 @@ export const documentOriginalUrl = (
     opts?.download ? "?download=1" : ""
   }`;
 
+export const documentVersionDocxUrl = (
+  documentId: string,
+  versionId: string,
+): string =>
+  `${API}/documents/${encodeURIComponent(documentId)}/versions/${encodeURIComponent(
+    versionId,
+  )}/docx`;
+
 // ---------------------------------------------------------------------------
 // Matter lifecycle + export (LMF UX v1) — over the stable LMF endpoints
 // ---------------------------------------------------------------------------

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -89,9 +89,10 @@ describe("DocumentDetail", () => {
         screen.getByRole("heading", { name: "claim-form.pdf" }),
       ).toBeInTheDocument();
     });
-    // Content is the hero — extracted text visible without any
-    // disclosure being opened first.
-    expect(screen.getByText(/IN THE COUNTY COURT/)).toBeInTheDocument();
+    // The editor is the hero — source text opens directly in the
+    // editable document surface without metadata disclosure first.
+    expect(screen.getByTestId("document-editor")).toBeInTheDocument();
+    expect(screen.getByText(/pypdf · 23 chars · 3 pages/)).toBeInTheDocument();
     expect(screen.getByText("Document tools")).toBeInTheDocument();
     expect(screen.getByText("Version record")).toBeInTheDocument();
     // Admin-ish document facts sit behind Details; the primary scan
@@ -104,10 +105,66 @@ describe("DocumentDetail", () => {
     expect(open.getAttribute("href")).toContain("/documents/doc-1/original");
     expect(open.getAttribute("href")).not.toContain("download=1");
     expect(download.getAttribute("href")).toContain("download=1");
+    expect(screen.queryByTestId("document-download-edited-docx")).toBeNull();
+    expect(screen.getByTestId("document-original-preview")).toBeInTheDocument();
     // Old "not available" note is gone.
     expect(
       screen.queryByText(/original uploaded file isn't available/i),
     ).toBeNull();
+  });
+
+  it("offers edited DOCX download when a saved resolved version exists", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc({ filename: "witness.docx" })]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue({
+      document_id: "doc-1",
+      kind: "extracted",
+      extracted_text: "Original body",
+      extraction_method: "python-docx",
+      extracted_at: "2026-05-28T09:01:00",
+      char_count: 13,
+      page_count: 1,
+      error_reason: null,
+    });
+    vi.spyOn(api, "getDocumentVersions").mockResolvedValue([
+      {
+        version: {
+          id: "v-1",
+          document_id: "doc-1",
+          version_number: 1,
+          kind: "upload",
+          created_by_id: "u-1",
+          created_at: "2026-05-28T09:00:00",
+          storage_uri: null,
+          notes: null,
+          resolved_text: null,
+        },
+        pending_count: 0,
+        accepted_count: 0,
+        rejected_count: 0,
+      },
+      {
+        version: {
+          id: "v-2",
+          document_id: "doc-1",
+          version_number: 2,
+          kind: "user_edit",
+          created_by_id: "u-1",
+          created_at: "2026-05-28T09:02:00",
+          storage_uri: null,
+          notes: "Edited",
+          resolved_text: "Edited body",
+        },
+        pending_count: 0,
+        accepted_count: 0,
+        rejected_count: 0,
+      },
+    ]);
+
+    mount();
+    const link = await screen.findByTestId("document-download-edited-docx");
+    expect(link).toHaveTextContent("Download edited DOCX");
+    expect(link.getAttribute("href")).toContain("/documents/doc-1/versions/v-2/docx");
+    expect(screen.getByText(/Editing saved version v2/)).toBeInTheDocument();
   });
 
   it("surfaces full metadata once the Details disclosure is opened", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -9,6 +9,7 @@ import type { TabKey } from "./tabs/types";
 import { MATTER_TAB_LABELS, isTabKey } from "./tabs/types";
 import {
   documentOriginalUrl,
+  documentVersionDocxUrl,
   getAnonymisation,
   getDocumentBody,
   getDocumentVersions,
@@ -181,7 +182,7 @@ export function DocumentDetail({
 
         <header className="border border-rule bg-paper px-5 py-5 sm:px-6">
           <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto]">
-            <div className="min-w-0">
+              <div className="min-w-0">
               <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
                 Document
               </p>
@@ -203,9 +204,23 @@ export function DocumentDetail({
                     v{latestVersion.version_number}
                   </span>
                 )}
+                {latestResolvedVersion && (
+                  <span className="border border-rule bg-paper-sunken px-2 py-1">
+                    editable
+                  </span>
+                )}
               </div>
             </div>
             <div className="flex flex-wrap items-start gap-2 text-sm">
+              {latestResolvedVersion && (
+                <a
+                  href={documentVersionDocxUrl(documentId, latestResolvedVersion.id)}
+                  className="inline-flex items-center border border-ink bg-ink px-3 py-2 text-paper hover:bg-black"
+                  data-testid="document-download-edited-docx"
+                >
+                  Download edited DOCX
+                </a>
+              )}
               <a
                 href={originalHref}
                 target="_blank"

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
+    testTimeout: 10_000,
   },
 });


### PR DESCRIPTION
## Summary

Second document-engine slice: saved Legalise document versions can now round-trip back out to Word.

- adds `GET /api/documents/{document_id}/versions/{version_id}/docx`
- renders a saved `resolved_text` version to a valid `.docx` using `python-docx`
- emits `document.version.docx.exported`
- keeps owner-only and archived-matter 404 policy
- returns 422 for upload versions that have no resolved text
- adds `Download edited DOCX` on the document page when a saved editable version exists
- raises frontend Vitest timeout to 10s because Tiptap/ProseMirror made the full suite heavier

## Verification

Local:

- `python -m py_compile backend/app/api/documents.py backend/tests/test_route_acl_sweep.py`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run test -- DocumentDetail DocumentRichEditor --run` — 9/9
- `npm --prefix frontend run test -- --run` — 215/215
- `npm --prefix frontend run build`

Backend DB-backed route tests are included but not runnable locally in this shell because the backend Python test runner is not installed here; CI should run them in the normal environment.

## Notes

This is not a bespoke renderer. It uses the existing backend `python-docx` dependency and the same owner-only document route pattern as the document editor save endpoint.