### PR TITLE
documents: land source anchors in reader

### DIFF
--- a/frontend/src/matter/ArtifactPreview.test.tsx
+++ b/frontend/src/matter/ArtifactPreview.test.tsx
@@ -141,14 +141,46 @@ describe("ArtifactPreview", () => {
     const chip = screen.getByTestId("source-chip-src_d1");
     expect(chip).toHaveTextContent(/khan-dismissal-letter\.pdf/);
     expect(chip.querySelector("a")?.getAttribute("href")).toBe(
-      "/matters/khan/documents/doc-9",
+      "/matters/khan/documents/doc-9?from=assistant&source=src_d1",
     );
+  });
+
+  it("links quote anchors into the document reader with source context", () => {
+    render(
+      <ArtifactPreview
+        kindHint="skill_response"
+        matterSlug="khan"
+        payload={{
+          output: "Summary.",
+          source_anchors: [
+            {
+              id: "src_q1",
+              source_type: "document",
+              document_id: "doc-9",
+              filename: "f.pdf",
+              label: "Document · f.pdf",
+              quote: "dismissed for a single social-media post",
+              quote_found_in_source: true,
+            },
+          ],
+        }}
+      />,
+    );
+    const quote = screen.getByTestId("source-quote-src_q1");
+    const href = quote.querySelector("a")?.getAttribute("href") ?? "";
+    expect(href).toContain("/matters/khan/documents/doc-9?");
+    expect(href).toContain("from=assistant");
+    expect(href).toContain("source=src_q1");
+    expect(href).toContain("quote=dismissed+for+a+single+social-media+post");
+    expect(href).toContain("quote_found=true");
+    expect(href).toContain("quoteFound=true");
   });
 
   it("flags a quote not found in source as a caution, not a verification", () => {
     render(
       <ArtifactPreview
         kindHint="skill_response"
+        matterSlug="khan"
         payload={{
           output: "Summary.",
           source_anchors: [
@@ -166,6 +198,7 @@ describe("ArtifactPreview", () => {
       />,
     );
     expect(screen.getByText(/quote not found in source/i)).toBeInTheDocument();
+    expect(screen.getByText("Open passage")).toBeInTheDocument();
   });
 
   it("shows 'No sources cited' for an empty anchors array", () => {

--- a/frontend/src/matter/ArtifactPreview.tsx
+++ b/frontend/src/matter/ArtifactPreview.tsx
@@ -99,6 +99,24 @@ function looksLikeSkillResponse(p: unknown): p is SkillResponsePayload {
   return typeof v === "string";
 }
 
+function documentSourceHref(
+  matterSlug: string,
+  anchor: SourceAnchor,
+): string | null {
+  if (!anchor.document_id) return null;
+  const params = new URLSearchParams();
+  params.set("from", "assistant");
+  params.set("source", anchor.id);
+  if (anchor.quote) params.set("quote", anchor.quote);
+  if (anchor.quote_found_in_source !== undefined) {
+    params.set("quote_found", anchor.quote_found_in_source ? "true" : "false");
+    params.set("quoteFound", anchor.quote_found_in_source ? "true" : "false");
+  }
+  return `/matters/${encodeURIComponent(matterSlug)}/documents/${encodeURIComponent(
+    anchor.document_id,
+  )}?${params.toString()}`;
+}
+
 export function ArtifactPreview({
   payload,
   kindHint,
@@ -292,6 +310,7 @@ export function SourceAnchorsBlock({
       <ul className="mt-2 flex flex-wrap gap-2">
         {docAnchors.map((a) => {
           const label = a.label ?? a.filename ?? a.id;
+          const href = matterSlug ? documentSourceHref(matterSlug, a) : null;
           const chip = (
             <span className="inline-flex items-center rounded-full border border-line bg-paper px-2 py-0.5 text-[11px]">
               {label}
@@ -299,9 +318,9 @@ export function SourceAnchorsBlock({
           );
           return (
             <li key={a.id} data-testid={`source-chip-${a.id}`}>
-              {matterSlug && a.document_id ? (
+              {href ? (
                 <a
-                  href={`/matters/${encodeURIComponent(matterSlug)}/documents/${encodeURIComponent(a.document_id)}`}
+                  href={href}
                   className="hover:text-ink"
                 >
                   {chip}
@@ -315,17 +334,31 @@ export function SourceAnchorsBlock({
       </ul>
       {quoteAnchors.length > 0 && (
         <ul className="mt-2 space-y-1">
-          {quoteAnchors.map((a) => (
-            <li key={a.id} className="text-xs" data-testid={`source-quote-${a.id}`}>
-              <span className="text-muted">{a.label ?? a.filename}: </span>
-              <span className="italic">“{a.quote}”</span>{" "}
-              {a.quote_found_in_source === false ? (
-                <span className="text-seal">— quote not found in source</span>
-              ) : a.quote_found_in_source === true ? (
-                <span className="text-muted">— quote located in source</span>
-              ) : null}
-            </li>
-          ))}
+          {quoteAnchors.map((a) => {
+            const href = matterSlug ? documentSourceHref(matterSlug, a) : null;
+            return (
+              <li key={a.id} className="text-xs" data-testid={`source-quote-${a.id}`}>
+                <span className="text-muted">{a.label ?? a.filename}: </span>
+                <span className="italic">“{a.quote}”</span>{" "}
+                {a.quote_found_in_source === false ? (
+                  <span className="text-seal">— quote not found in source</span>
+                ) : a.quote_found_in_source === true ? (
+                  <span className="text-muted">— quote located in source</span>
+                ) : null}
+                {href && (
+                  <>
+                    {" "}
+                    <a
+                      href={href}
+                      className="underline underline-offset-4 hover:text-ink"
+                    >
+                      Open passage
+                    </a>
+                  </>
+                )}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -42,6 +42,10 @@ function mount(documentId = "doc-1", search = "") {
     path: "/matters/$slug/documents/$documentId",
     validateSearch: (s: Record<string, unknown>) => ({
       from: typeof s.from === "string" ? s.from : undefined,
+      source: typeof s.source === "string" ? s.source : undefined,
+      quote: typeof s.quote === "string" ? s.quote : undefined,
+      quote_found: typeof s.quote_found === "string" ? s.quote_found : undefined,
+      quoteFound: typeof s.quoteFound === "string" ? s.quoteFound : undefined,
     }),
     component: () => <DocumentDetail slug="khan" documentId={documentId} />,
   });
@@ -248,6 +252,56 @@ describe("DocumentDetail", () => {
     });
     // Smart back reflects the arrived-from tab.
     expect(screen.getByTestId("document-back-link")).toHaveTextContent(/Back to Chat/i);
+  });
+
+  it("highlights a cited quote when opened from an output source link", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue({
+      document_id: "doc-1",
+      kind: "extracted",
+      extracted_text:
+        "The employee was dismissed for a single social-media post made outside working hours.",
+      extraction_method: "pypdf",
+      extracted_at: "2026-05-28T09:01:00",
+      char_count: 85,
+      page_count: 1,
+      error_reason: null,
+    });
+
+    const { container } = mount(
+      "doc-1",
+      "?from=assistant&source=src_q1&quote=dismissed+for+a+single+social-media+post&quote_found=true",
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("from-chat-note")).toHaveTextContent(
+        /cited passage is highlighted/i,
+      );
+    });
+    expect(container.querySelector("mark")).not.toBeNull();
+  });
+
+  it("warns when a source quote was not located in the extracted source body", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue({
+      document_id: "doc-1",
+      kind: "extracted",
+      extracted_text: "The employee was dismissed.",
+      extraction_method: "pypdf",
+      extracted_at: "2026-05-28T09:01:00",
+      char_count: 27,
+      page_count: 1,
+      error_reason: null,
+    });
+
+    mount(
+      "doc-1",
+      "?from=assistant&source=src_q2&quote=governed+by+New+York+law&quoteFound=false",
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("from-chat-note")).toHaveTextContent(
+        /could not locate it/i,
+      );
+    });
   });
 
   it("shows not-found when the document is not in the matter", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -28,7 +28,10 @@ import {
 import { EditPanel } from "../modules/document_edit/EditPanel";
 import { AnonymiseButton } from "../modules/anonymisation/AnonymiseButton";
 import { VersionTimeline } from "../modules/document_edit/VersionTimeline";
-import { DocumentRichEditor } from "../modules/document_edit/DocumentRichEditor";
+import {
+  DocumentRichEditor,
+  findNormalizedRange,
+} from "../modules/document_edit/DocumentRichEditor";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -56,17 +59,20 @@ export function DocumentDetail({
   const [anon, setAnon] = useState<AnonymisationResult | null>(null);
   const [showDetails, setShowDetails] = useState(false);
 
-  // Source-anchor honesty: when arrived from chat, surface a single
-  // line noting that passage-level anchoring isn't yet wired through
-  // the substrate. Without this the user might think a chip click
-  // failed to scroll them anywhere.
-  const fromTab = useRouterState({
+  const sourceContext = useRouterState({
     select: (s) => {
       const search = s.location.search as Record<string, unknown> | undefined;
       const raw = search?.from;
-      return typeof raw === "string" && isTabKey(raw) ? (raw as TabKey) : null;
+      const quoteFound = search?.quote_found ?? search?.quoteFound;
+      return {
+        fromTab: typeof raw === "string" && isTabKey(raw) ? (raw as TabKey) : null,
+        quote: typeof search?.quote === "string" ? search.quote : null,
+        quoteFound:
+          quoteFound === "true" ? true : quoteFound === "false" ? false : null,
+      };
     },
   });
+  const fromTab = sourceContext.fromTab;
   const backTab: TabKey = fromTab ?? "documents";
   const backLabel =
     fromTab && fromTab !== "documents"
@@ -149,6 +155,9 @@ export function DocumentDetail({
     .reverse()
     .find((v) => v.version.resolved_text)?.version;
   const editorText = latestResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
+  const sourceQuoteFoundInReader = sourceContext.quote
+    ? Boolean(findNormalizedRange(editorText, sourceContext.quote))
+    : null;
   const editorSourceLabel = latestResolvedVersion
     ? `Editing saved version v${latestResolvedVersion.version_number}`
     : body
@@ -245,8 +254,22 @@ export function DocumentDetail({
             className="mt-4 border-l-2 border-rule bg-paper px-4 py-3 text-sm text-muted"
             data-testid="from-chat-note"
           >
-            Opened from Chat. Pinpointing the exact passage isn't supported
-            yet — the document text is shown in full below.
+            {sourceContext.quote ? (
+              <>
+                Opened from a cited source.{" "}
+                {sourceContext.quoteFound === false
+                  ? "The model supplied a quote, but Legalise could not locate it in the extracted source body. "
+                  : sourceQuoteFoundInReader
+                    ? "The cited passage is highlighted below. "
+                    : "Legalise could not locate it in the current reader text. "}
+                Source links are for review, not proof.
+              </>
+            ) : (
+              <>
+                Opened from Chat. This document was cited or used by the output;
+                source links are for review, not proof.
+              </>
+            )}
           </p>
         )}
 
@@ -271,6 +294,7 @@ export function DocumentDetail({
                   initialText={editorText}
                   latestVersionNumber={latestVersion?.version_number}
                   sourceLabel={editorSourceLabel}
+                  sourceHighlight={sourceContext.quote}
                   onSaved={() => {
                     getDocumentVersions(documentId)
                       .then(setVersions)

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   editorJsonToPlainText,
+  findNormalizedRange,
   textToEditorHtml,
 } from "./DocumentRichEditor";
 
@@ -10,6 +11,30 @@ describe("DocumentRichEditor text conversion", () => {
     expect(textToEditorHtml("One <two>\n\nThree & four")).toBe(
       "<p>One &lt;two&gt;</p><p>Three &amp; four</p>",
     );
+  });
+
+  it("marks the first cited quote when it can be located", () => {
+    expect(
+      textToEditorHtml(
+        "The employee was dismissed for a single social-media post.",
+        "dismissed   for a single social-media post",
+      ),
+    ).toContain(
+      '<mark data-source-anchor="true">dismissed for a single social-media post</mark>',
+    );
+  });
+
+  it("does not mark text when the quote is not located", () => {
+    expect(textToEditorHtml("The employee was dismissed.", "holiday pay")).not.toContain(
+      "data-source-anchor",
+    );
+  });
+
+  it("finds quote ranges across normalised whitespace", () => {
+    expect(findNormalizedRange("Line one\nline two", "one line")).toEqual({
+      start: 5,
+      end: 13,
+    });
   });
 
   it("preserves paragraphs and hard breaks when saving text", () => {

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -24,19 +24,68 @@ function escapeHtml(value: string): string {
     .replaceAll('"', "&quot;");
 }
 
-export function textToEditorHtml(text: string): string {
+type TextRange = { start: number; end: number };
+
+export function findNormalizedRange(
+  text: string,
+  needle: string | null | undefined,
+): TextRange | null {
+  const target = needle?.trim().replace(/\s+/g, " ").toLowerCase();
+  if (!target || target.length < 3) return null;
+
+  let normalised = "";
+  const starts: number[] = [];
+  const ends: number[] = [];
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (/\s/.test(ch)) {
+      if (normalised.length === 0) continue;
+      if (normalised.endsWith(" ")) {
+        ends[ends.length - 1] = i + 1;
+      } else {
+        normalised += " ";
+        starts.push(i);
+        ends.push(i + 1);
+      }
+      continue;
+    }
+    normalised += ch.toLowerCase();
+    starts.push(i);
+    ends.push(i + 1);
+  }
+
+  const searchable = normalised.trimEnd();
+  const index = searchable.indexOf(target);
+  if (index === -1) return null;
+  const endIndex = index + target.length - 1;
+  return { start: starts[index], end: ends[endIndex] };
+}
+
+function escapeWithOptionalMark(text: string, range: TextRange | null): string {
+  if (!range || range.end <= range.start) return escapeHtml(text);
+  const matched = text.slice(range.start, range.end);
+  if (/\n{2,}/.test(matched)) return escapeHtml(text);
+  return [
+    escapeHtml(text.slice(0, range.start)),
+    '<mark data-source-anchor="true">',
+    escapeHtml(matched),
+    "</mark>",
+    escapeHtml(text.slice(range.end)),
+  ].join("");
+}
+
+export function textToEditorHtml(
+  text: string,
+  sourceHighlight?: string | null,
+): string {
   const trimmed = text.trim();
   if (!trimmed) return "<p></p>";
-  return trimmed
-    .split(/\n{2,}/)
-    .map((paragraph) => {
-      const lines = paragraph
-        .split(/\n/)
-        .map((line) => escapeHtml(line))
-        .join("<br />");
-      return `<p>${lines}</p>`;
-    })
-    .join("");
+  const range = findNormalizedRange(trimmed, sourceHighlight);
+  const html = escapeWithOptionalMark(trimmed, range)
+    .replace(/\n{2,}/g, "</p><p>")
+    .replace(/\n/g, "<br />");
+  return `<p>${html}</p>`;
 }
 
 function plainTextFromNode(node: TiptapNode): string {
@@ -86,6 +135,7 @@ export function DocumentRichEditor({
   initialText,
   latestVersionNumber,
   sourceLabel,
+  sourceHighlight,
   onSaved,
 }: {
   documentId: string;
@@ -93,13 +143,17 @@ export function DocumentRichEditor({
   initialText: string;
   latestVersionNumber?: number;
   sourceLabel: string;
+  sourceHighlight?: string | null;
   onSaved: (version: DocumentVersionRead) => void;
 }) {
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedMessage, setSavedMessage] = useState<string | null>(null);
-  const content = useMemo(() => textToEditorHtml(initialText), [initialText]);
+  const content = useMemo(
+    () => textToEditorHtml(initialText, sourceHighlight),
+    [initialText, sourceHighlight],
+  );
   const editor = useEditor(
     {
       extensions: [

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -419,13 +419,24 @@ const matterSignoffRoute = createRoute({
 });
 
 // ?from=<tab> tells DocumentDetail which matter surface to send the
-// user back to. Optional; falls back to Documents when absent.
-type MatterDocumentDetailSearch = { from?: string };
+// user back to. Source fields let output source chips land in the
+// reader with the cited passage, when the artifact payload carries one.
+type MatterDocumentDetailSearch = {
+  from?: string;
+  source?: string;
+  quote?: string;
+  quote_found?: string;
+  quoteFound?: string;
+};
 const matterDocumentDetailRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: "/matters/$slug/documents/$documentId",
   validateSearch: (s: Record<string, unknown>): MatterDocumentDetailSearch => ({
     from: typeof s.from === "string" ? s.from : undefined,
+    source: typeof s.source === "string" ? s.source : undefined,
+    quote: typeof s.quote === "string" ? s.quote : undefined,
+    quote_found: typeof s.quote_found === "string" ? s.quote_found : undefined,
+    quoteFound: typeof s.quoteFound === "string" ? s.quoteFound : undefined,
   }),
   component: () => {
     const { slug, documentId } = matterDocumentDetailRoute.useParams();


### PR DESCRIPTION
## Summary

Continues the document-engine phase after the editor/DOCX round-trip slice.

- source chips now preserve source context when opening a document from an output
- quote anchors get an `Open passage` link into the document reader
- document reader shows an honest source-review banner and highlights the cited passage when the quote can be located in the current extracted/editor text
- quote-not-found remains a caution, not a verification claim

## Scope

Frontend-only. No backend, schema, audit, or export changes.

## Verification

- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run test -- DocumentDetail DocumentRichEditor ArtifactPreview --run`
- `npm --prefix frontend run test -- --run` (221/221)
- `npm --prefix frontend run build`

## Notes

The source link writes both `quote_found` and `quoteFound` while the route parser accepts both. TanStack search state was inconsistent in tests around the underscored key, and source-integrity context is not worth making brittle over a query-param spelling.