### PR TITLE
documents: preview original docx files

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@tiptap/starter-kit": "^3.25.0",
         "clsx": "^2.1.1",
         "diff-match-patch": "^1.0.5",
+        "docx-preview": "^0.3.7",
         "lucide-react": "^0.460.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3182,6 +3183,12 @@
       "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3465,6 +3472,15 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/docx-preview": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/docx-preview/-/docx-preview-0.3.7.tgz",
+      "integrity": "sha512-Lav69CTA/IYZPJTsKH7oYeoZjyg96N0wEJMNslGJnZJ+dMUZK85Lt5ASC79yUlD48ecWjuv+rkcmFt6EVPV0Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jszip": ">=3.0.0"
+      }
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -4056,6 +4072,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4092,6 +4114,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -4169,6 +4197,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isbot": {
@@ -4304,6 +4338,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4326,6 +4372,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -4646,6 +4701,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -5005,6 +5066,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5270,6 +5337,21 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5464,6 +5546,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5513,6 +5601,12 @@
       "peerDependencies": {
         "seroval": "^1.0"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5582,6 +5676,15 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -5984,7 +6087,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/victory-vendor": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@tiptap/starter-kit": "^3.25.0",
     "clsx": "^2.1.1",
     "diff-match-patch": "^1.0.5",
+    "docx-preview": "^0.3.7",
     "lucide-react": "^0.460.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -91,4 +91,20 @@
     background: #FFF4B8;
     padding: 0 0.1em;
   }
+
+  .legalise-docx-preview {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+  }
+
+  .legalise-docx-preview .legalise-docx-wrapper {
+    background: transparent;
+    padding: 0;
+  }
+
+  .legalise-docx-preview .legalise-docx {
+    box-shadow: 0 1px 2px rgba(24, 24, 24, 0.08);
+  }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1589,6 +1589,15 @@ export const documentOriginalUrl = (
     opts?.download ? "?download=1" : ""
   }`;
 
+export async function fetchDocumentOriginalBlob(documentId: string): Promise<Blob> {
+  const resp = await apiFetch(documentOriginalUrl(documentId));
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(text || `Could not load original document (${resp.status})`);
+  }
+  return resp.blob();
+}
+
 export const documentVersionDocxUrl = (
   documentId: string,
   versionId: string,

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -32,6 +32,7 @@ import {
   DocumentRichEditor,
   findNormalizedRange,
 } from "../modules/document_edit/DocumentRichEditor";
+import { DocxOriginalPreview } from "../modules/document_preview/DocxOriginalPreview";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -150,6 +151,10 @@ export function DocumentDetail({
   const recordHref = `/matters/${encodeURIComponent(slug)}/audit`;
   const originalHref = documentOriginalUrl(documentId);
   const canPreviewOriginal = doc.mime_type === "application/pdf";
+  const canPreviewDocx =
+    doc.mime_type ===
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+    doc.filename.toLowerCase().endsWith(".docx");
   const latestVersion = versions.at(-1)?.version;
   const latestResolvedVersion = [...versions]
     .reverse()
@@ -328,6 +333,10 @@ export function DocumentDetail({
                   className="h-[620px] w-full bg-paper-sunken"
                 />
               </section>
+            )}
+
+            {!canPreviewOriginal && canPreviewDocx && (
+              <DocxOriginalPreview documentId={documentId} filename={doc.filename} />
             )}
 
             <section

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { renderAsync } from "docx-preview";
+
+import { DocxOriginalPreview } from "./DocxOriginalPreview";
+import * as api from "../../lib/api";
+
+vi.mock("docx-preview", () => ({
+  renderAsync: vi.fn(async (_blob: Blob, container: HTMLElement) => {
+    container.innerHTML = "<article>Rendered Word body</article>";
+  }),
+}));
+
+describe("DocxOriginalPreview", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the audited original and renders it through docx-preview", async () => {
+    const blob = new Blob(["docx"], {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    vi.spyOn(api, "fetchDocumentOriginalBlob").mockResolvedValue(blob);
+
+    render(<DocxOriginalPreview documentId="doc-1" filename="witness.docx" />);
+
+    expect(screen.getByText(/rendering Word document/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(renderAsync).toHaveBeenCalledWith(
+        blob,
+        expect.any(HTMLElement),
+        undefined,
+        expect.objectContaining({
+          className: "legalise-docx",
+          renderComments: false,
+          renderChanges: false,
+        }),
+      );
+    });
+    expect(screen.getByText("Rendered Word body")).toBeInTheDocument();
+    expect(api.fetchDocumentOriginalBlob).toHaveBeenCalledWith("doc-1");
+  });
+
+  it("shows a useful error if the original cannot be loaded", async () => {
+    vi.spyOn(api, "fetchDocumentOriginalBlob").mockRejectedValue(
+      new Error("not available"),
+    );
+
+    render(<DocxOriginalPreview documentId="doc-1" filename="witness.docx" />);
+
+    expect(await screen.findByText("not available")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from "react";
+
+import { fetchDocumentOriginalBlob } from "../../lib/api";
+import { LoadingLine } from "../../ui/primitives";
+
+type PreviewState =
+  | { status: "loading" }
+  | { status: "ready" }
+  | { status: "error"; message: string };
+
+export function DocxOriginalPreview({
+  documentId,
+  filename,
+}: {
+  documentId: string;
+  filename: string;
+}) {
+  const [state, setState] = useState<PreviewState>({ status: "loading" });
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const container = containerRef.current;
+    if (!container) return;
+    container.innerHTML = "";
+    setState({ status: "loading" });
+
+    fetchDocumentOriginalBlob(documentId)
+      .then(async (blob) => {
+        if (cancelled || !containerRef.current) return;
+        containerRef.current.innerHTML = "";
+        const { renderAsync } = await import("docx-preview");
+        if (cancelled || !containerRef.current) return;
+        await renderAsync(blob, containerRef.current, undefined, {
+          className: "legalise-docx",
+          inWrapper: true,
+          ignoreWidth: false,
+          ignoreHeight: false,
+          breakPages: true,
+          renderHeaders: true,
+          renderFooters: true,
+          renderFootnotes: true,
+          renderEndnotes: true,
+          renderComments: false,
+          renderChanges: false,
+          useBase64URL: true,
+        });
+        if (!cancelled) setState({ status: "ready" });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId]);
+
+  return (
+    <section
+      className="mt-6 border border-rule bg-paper"
+      data-testid="document-docx-preview"
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-rule px-5 py-3">
+        <div>
+          <h2 className="text-sm font-semibold text-ink">Original preview</h2>
+          <p className="mt-0.5 text-xs text-muted">
+            Word preview rendered from the audited original file proxy.
+          </p>
+        </div>
+        <span className="text-xs text-muted">{filename}</span>
+      </div>
+      {state.status === "loading" && (
+        <div className="border-b border-rule px-5 py-3">
+          <LoadingLine label="rendering Word document" />
+        </div>
+      )}
+      {state.status === "error" && (
+        <p className="border-b border-red-800 bg-red-50 px-5 py-3 text-sm text-red-900">
+          {state.message}
+        </p>
+      )}
+      <div className="max-h-[780px] overflow-auto bg-paper-sunken px-4 py-5">
+        <div
+          ref={containerRef}
+          aria-label={`Original Word preview for ${filename}`}
+          className="legalise-docx-preview"
+        />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds Word original-file preview to the document reader using a proven renderer package instead of a hand-built approximation.

- installs `docx-preview`
- adds `DocxOriginalPreview`, dynamically importing the renderer only when a DOCX preview is opened
- fetches original bytes through the audited backend proxy via `apiFetch`
- shows DOCX original preview in `DocumentDetail` when the original is a Word document
- keeps PDF preview path unchanged

## Scope

Frontend-only. No backend, schema, audit, or storage changes.

## Verification

- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run test -- DocumentDetail DocxOriginalPreview --run`
- `npm --prefix frontend run test -- --run` (223/223)
- `npm --prefix frontend run build`

## Bundle note

`docx-preview` is lazy-loaded into its own Vite chunk (`docx-preview-*.js`) so it does not inflate the primary app bundle for non-DOCX routes.