### PR TITLE
documents: surface proposed redlines in reader

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -223,6 +223,72 @@ describe("DocumentDetail", () => {
     expect(screen.getByText("Redaction")).toBeInTheDocument();
   });
 
+  it("moves proposed redlines into the main document review area", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue({
+      document_id: "doc-1",
+      kind: "extracted",
+      extracted_text: "The agreement may terminate immediately.",
+      extraction_method: "pypdf",
+      extracted_at: "2026-05-28T09:01:00",
+      char_count: 40,
+      page_count: 1,
+      error_reason: null,
+    });
+    vi.spyOn(api, "postEditInstruction").mockResolvedValue({
+      version: {
+        id: "v-2",
+        document_id: "doc-1",
+        version_number: 2,
+        kind: "model_edit",
+        created_by_id: "u-1",
+        created_at: "2026-05-28T09:05:00",
+        storage_uri: null,
+        notes: null,
+        resolved_text: null,
+      },
+      pending_edits: [
+        {
+          id: "edit-1",
+          document_version_id: "v-2",
+          change_id: "c1",
+          correlation_id: null,
+          deleted_text: "may terminate immediately",
+          inserted_text: "may terminate on written notice",
+          context_before: "The agreement ",
+          context_after: ".",
+          rationale: "Avoids abrupt termination language.",
+          status: "pending",
+          created_at: "2026-05-28T09:05:00",
+        },
+      ],
+      model_used: "stub-echo",
+      model_notes: "One edit proposed.",
+      instruction_hash: "hash",
+      parse_ok: true,
+    });
+
+    mount();
+    await waitFor(() => {
+      expect(screen.getByTestId("document-editor")).toBeInTheDocument();
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText(/type an edit instruction/i),
+      {
+        target: { value: "Tighten termination wording." },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Propose edits" }));
+
+    const redlines = await screen.findByTestId("document-inline-redlines");
+    expect(redlines).toBeInTheDocument();
+    expect(screen.getByText(/Review suggested changes/i)).toBeInTheDocument();
+    expect(redlines).toHaveTextContent(/on written notice/i);
+    expect(
+      screen.getByText(/Proposed edits are ready in the document review area/i),
+    ).toBeInTheDocument();
+  });
+
   it("shows an honest empty state when no extracted body exists", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
     vi.spyOn(api, "getDocumentBody").mockRejectedValue(new Error("404"));

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -10,6 +10,7 @@ import { MATTER_TAB_LABELS, isTabKey } from "./tabs/types";
 import {
   documentOriginalUrl,
   documentVersionDocxUrl,
+  type EditInstructionResponse,
   getAnonymisation,
   getDocumentBody,
   getDocumentVersions,
@@ -26,6 +27,7 @@ import {
   LoadingLine,
 } from "../ui/primitives";
 import { EditPanel } from "../modules/document_edit/EditPanel";
+import { TrackedChangesView } from "../modules/document_edit/TrackedChangesView";
 import { AnonymiseButton } from "../modules/anonymisation/AnonymiseButton";
 import { VersionTimeline } from "../modules/document_edit/VersionTimeline";
 import {
@@ -59,6 +61,8 @@ export function DocumentDetail({
   const [versions, setVersions] = useState<DocumentVersionSummary[]>([]);
   const [anon, setAnon] = useState<AnonymisationResult | null>(null);
   const [showDetails, setShowDetails] = useState(false);
+  const [activeEditResult, setActiveEditResult] =
+    useState<EditInstructionResponse | null>(null);
 
   const sourceContext = useRouterState({
     select: (s) => {
@@ -109,6 +113,7 @@ export function DocumentDetail({
   }, [documentId]);
 
   useEffect(() => {
+    setActiveEditResult(null);
     loadBody();
     getDocumentVersions(documentId).then(setVersions).catch(() => undefined);
     getAnonymisation(documentId)
@@ -280,6 +285,43 @@ export function DocumentDetail({
 
         <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_390px]">
           <main className="min-w-0">
+            {activeEditResult && (
+              <section
+                className="mb-6 border border-rule bg-paper p-5"
+                data-testid="document-inline-redlines"
+              >
+                <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+                      Proposed redlines
+                    </p>
+                    <h2 className="mt-1 text-xl font-semibold tracking-tight2 text-ink">
+                      Review suggested changes in this document.
+                    </h2>
+                    <p className="mt-1 text-sm leading-6 text-muted">
+                      Accepting edits creates a new version; rejected edits stay in the record.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setActiveEditResult(null)}
+                    className="border border-rule px-3 py-2 text-sm text-muted hover:border-ink hover:text-ink"
+                  >
+                    Hide redlines
+                  </button>
+                </div>
+                <TrackedChangesView
+                  result={activeEditResult}
+                  onResolved={() => {
+                    loadBody();
+                    getDocumentVersions(documentId)
+                      .then(setVersions)
+                      .catch(() => undefined);
+                  }}
+                />
+              </section>
+            )}
+
             <div data-testid="document-content">
               {bodyMissing && !latestResolvedVersion ? (
                 <div className="p-6">
@@ -362,13 +404,15 @@ export function DocumentDetail({
                 Document tools
               </h2>
               <p className="mt-1 text-sm leading-6 text-muted">
-                Propose edits against the extracted text. You choose which suggestions become a new version.
+                Propose edits against the extracted text. Suggested changes appear in the document review area.
               </p>
               <div className="mt-4" data-testid="document-redline-workspace">
                 <EditPanel
                   documentId={documentId}
                   filename={doc.filename}
+                  showResult={false}
                   showTimeline={false}
+                  onResult={setActiveEditResult}
                   onResolved={() => {
                     loadBody();
                     getDocumentVersions(documentId)

--- a/frontend/src/modules/document_edit/EditPanel.tsx
+++ b/frontend/src/modules/document_edit/EditPanel.tsx
@@ -48,6 +48,8 @@ type EditPanelProps = {
   filename: string;
   onClose?: () => void;
   onResolved?: () => void;
+  onResult?: (result: EditInstructionResponse) => void;
+  showResult?: boolean;
   showTimeline?: boolean;
 };
 
@@ -56,6 +58,8 @@ export function EditPanel({
   filename,
   onClose,
   onResolved,
+  onResult,
+  showResult = true,
   showTimeline = true,
 }: EditPanelProps) {
   const [instruction, setInstruction] = useState("");
@@ -76,6 +80,7 @@ export function EditPanel({
     try {
       const res = await postEditInstruction(documentId, instruction.trim(), mode);
       setResult(res);
+      onResult?.(res);
       setTimelineKey((k) => k + 1);
     } catch (e: unknown) {
       if (e instanceof ProviderUpstreamError) {
@@ -160,7 +165,13 @@ export function EditPanel({
         </div>
       )}
 
-      {result && (
+      {result && !showResult && (
+        <p className="border border-rule bg-paper-sunken px-3 py-2 text-[12px] text-muted">
+          Proposed edits are ready in the document review area.
+        </p>
+      )}
+
+      {result && showResult && (
         <TrackedChangesView
           result={result}
           onResolved={() => {


### PR DESCRIPTION
## Summary

Moves active proposed redlines into the main document reader, while preserving the existing edit-instruction backend and accept/reject endpoints.

- `EditPanel` can hand proposed edits up to the page and optionally suppress its own embedded result list
- `DocumentDetail` renders proposed redlines above the editor in the main document column
- the right tool rail stays focused on asking for edits
- accepting/rejecting still flows through `TrackedChangesView` and the existing version APIs

## Scope

Frontend-only. No backend, schema, audit, or document-resolution changes.

## Verification

- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run test -- DocumentDetail --run`
- `npm --prefix frontend run test -- --run` (224/224, rerun alone after parallel contention)
- `npm --prefix frontend run build`

## Note

A parallel full Vitest run timed out in unrelated tests while typecheck/build were also running. Rerunning Vitest alone passed 224/224.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proposed edits now appear in an inline review panel within the document for convenient review
  * Added "Proposed redlines" section displaying suggested changes with confirmation messaging when edits are ready

* **Tests**
  * Added test coverage verifying the proposed redlines workflow and user confirmation messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->