### PR TITLE
documents: make saved versions selectable

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -63,6 +63,44 @@ function mount(documentId = "doc-1", search = "") {
   return render(<RouterProvider router={router} />);
 }
 
+function body(over: Partial<api.DocumentBody> = {}): api.DocumentBody {
+  return {
+    document_id: "doc-1",
+    kind: "extracted",
+    extracted_text: "Original body",
+    extraction_method: "python-docx",
+    extracted_at: "2026-05-28T09:01:00",
+    char_count: 13,
+    page_count: 1,
+    error_reason: null,
+    ...over,
+  };
+}
+
+function versionSummary(
+  id: string,
+  versionNumber: number,
+  resolvedText: string | null,
+  kind = "user_edit",
+): api.DocumentVersionSummary {
+  return {
+    version: {
+      id,
+      document_id: "doc-1",
+      version_number: versionNumber,
+      kind,
+      created_by_id: "u-1",
+      created_at: `2026-05-28T09:0${versionNumber}:00`,
+      storage_uri: null,
+      notes: null,
+      resolved_text: resolvedText,
+    },
+    pending_count: 0,
+    accepted_count: 0,
+    rejected_count: 0,
+  };
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(api, "getDocumentVersions").mockResolvedValue([]);
@@ -119,56 +157,56 @@ describe("DocumentDetail", () => {
 
   it("offers edited DOCX download when a saved resolved version exists", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc({ filename: "witness.docx" })]);
-    vi.spyOn(api, "getDocumentBody").mockResolvedValue({
-      document_id: "doc-1",
-      kind: "extracted",
-      extracted_text: "Original body",
-      extraction_method: "python-docx",
-      extracted_at: "2026-05-28T09:01:00",
-      char_count: 13,
-      page_count: 1,
-      error_reason: null,
-    });
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
     vi.spyOn(api, "getDocumentVersions").mockResolvedValue([
-      {
-        version: {
-          id: "v-1",
-          document_id: "doc-1",
-          version_number: 1,
-          kind: "upload",
-          created_by_id: "u-1",
-          created_at: "2026-05-28T09:00:00",
-          storage_uri: null,
-          notes: null,
-          resolved_text: null,
-        },
-        pending_count: 0,
-        accepted_count: 0,
-        rejected_count: 0,
-      },
-      {
-        version: {
-          id: "v-2",
-          document_id: "doc-1",
-          version_number: 2,
-          kind: "user_edit",
-          created_by_id: "u-1",
-          created_at: "2026-05-28T09:02:00",
-          storage_uri: null,
-          notes: "Edited",
-          resolved_text: "Edited body",
-        },
-        pending_count: 0,
-        accepted_count: 0,
-        rejected_count: 0,
-      },
+      versionSummary("v-1", 1, null, "upload"),
+      versionSummary("v-2", 2, "Edited body"),
     ]);
 
     mount();
     const link = await screen.findByTestId("document-download-edited-docx");
     expect(link).toHaveTextContent("Download edited DOCX");
     expect(link.getAttribute("href")).toContain("/documents/doc-1/versions/v-2/docx");
-    expect(screen.getByText(/Editing saved version v2/)).toBeInTheDocument();
+    expect(screen.getByText(/Viewing saved version v2/)).toBeInTheDocument();
+  });
+
+  it("lets the reader switch between saved versions and extracted text", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc({ filename: "witness.docx" })]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "getDocumentVersions").mockResolvedValue([
+      versionSummary("v-1", 1, null, "upload"),
+      versionSummary("v-2", 2, "First saved body"),
+      versionSummary("v-3", 3, "Second saved body"),
+    ]);
+
+    const { container } = mount();
+    await screen.findByText(/Viewing saved version v3/);
+    expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(
+      "Second saved body",
+    );
+    expect(screen.getByTestId("document-download-edited-docx").getAttribute("href")).toContain(
+      "/documents/doc-1/versions/v-3/docx",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "v2" }));
+    await waitFor(() => {
+      expect(screen.getByText(/Viewing saved version v2/)).toBeInTheDocument();
+    });
+    expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(
+      "First saved body",
+    );
+    expect(screen.getByTestId("document-download-edited-docx").getAttribute("href")).toContain(
+      "/documents/doc-1/versions/v-2/docx",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Extracted text" }));
+    await waitFor(() => {
+      expect(screen.getByText(/python-docx · 13 chars · 1 pages/)).toBeInTheDocument();
+    });
+    expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(
+      "Original body",
+    );
+    expect(screen.queryByTestId("document-download-edited-docx")).toBeNull();
   });
 
   it("surfaces full metadata once the Details disclosure is opened", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -48,6 +48,8 @@ type DocQuery =
   | { status: "not_found" }
   | { status: "error"; message: string };
 
+const EXTRACTED_VERSION_ID = "__extracted";
+
 export function DocumentDetail({
   slug,
   documentId,
@@ -61,6 +63,7 @@ export function DocumentDetail({
   const [versions, setVersions] = useState<DocumentVersionSummary[]>([]);
   const [anon, setAnon] = useState<AnonymisationResult | null>(null);
   const [showDetails, setShowDetails] = useState(false);
+  const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
   const [activeEditResult, setActiveEditResult] =
     useState<EditInstructionResponse | null>(null);
 
@@ -114,6 +117,7 @@ export function DocumentDetail({
 
   useEffect(() => {
     setActiveEditResult(null);
+    setSelectedVersionId(null);
     loadBody();
     getDocumentVersions(documentId).then(setVersions).catch(() => undefined);
     getAnonymisation(documentId)
@@ -161,15 +165,25 @@ export function DocumentDetail({
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
     doc.filename.toLowerCase().endsWith(".docx");
   const latestVersion = versions.at(-1)?.version;
-  const latestResolvedVersion = [...versions]
+  const resolvedVersions = versions
+    .map((v) => v.version)
+    .filter((v) => Boolean(v.resolved_text));
+  const latestResolvedVersion = [...resolvedVersions]
     .reverse()
-    .find((v) => v.version.resolved_text)?.version;
-  const editorText = latestResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
+    .at(0);
+  const selectedResolvedVersion =
+    selectedVersionId === EXTRACTED_VERSION_ID
+      ? null
+      : (resolvedVersions.find((v) => v.id === selectedVersionId) ??
+        latestResolvedVersion ??
+        null);
+  const editorText =
+    selectedResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
   const sourceQuoteFoundInReader = sourceContext.quote
     ? Boolean(findNormalizedRange(editorText, sourceContext.quote))
     : null;
-  const editorSourceLabel = latestResolvedVersion
-    ? `Editing saved version v${latestResolvedVersion.version_number}`
+  const editorSourceLabel = selectedResolvedVersion
+    ? `Viewing saved version v${selectedResolvedVersion.version_number}`
     : body
       ? `${body.extraction_method} · ${body.char_count.toLocaleString()} chars${
           body.page_count ? ` · ${body.page_count} pages` : ""
@@ -223,7 +237,7 @@ export function DocumentDetail({
                     v{latestVersion.version_number}
                   </span>
                 )}
-                {latestResolvedVersion && (
+                {selectedResolvedVersion && (
                   <span className="border border-rule bg-paper-sunken px-2 py-1">
                     editable
                   </span>
@@ -231,9 +245,9 @@ export function DocumentDetail({
               </div>
             </div>
             <div className="flex flex-wrap items-start gap-2 text-sm">
-              {latestResolvedVersion && (
+              {selectedResolvedVersion && (
                 <a
-                  href={documentVersionDocxUrl(documentId, latestResolvedVersion.id)}
+                  href={documentVersionDocxUrl(documentId, selectedResolvedVersion.id)}
                   className="inline-flex items-center border border-ink bg-ink px-3 py-2 text-paper hover:bg-black"
                   data-testid="document-download-edited-docx"
                 >
@@ -323,14 +337,14 @@ export function DocumentDetail({
             )}
 
             <div data-testid="document-content">
-              {bodyMissing && !latestResolvedVersion ? (
+              {bodyMissing && !selectedResolvedVersion ? (
                 <div className="p-6">
                   <EmptyState
                     title="No extracted text"
                     body="No extracted body is available for this document (extraction may have failed or not run). The original file is still available."
                   />
                 </div>
-              ) : !body && !latestResolvedVersion ? (
+              ) : !body && !selectedResolvedVersion ? (
                 <div className="border border-rule bg-paper p-6">
                   <LoadingLine label="loading document text" />
                 </div>
@@ -342,7 +356,8 @@ export function DocumentDetail({
                   latestVersionNumber={latestVersion?.version_number}
                   sourceLabel={editorSourceLabel}
                   sourceHighlight={sourceContext.quote}
-                  onSaved={() => {
+                  onSaved={(version) => {
+                    setSelectedVersionId(version.id);
                     getDocumentVersions(documentId)
                       .then(setVersions)
                       .catch(() => undefined);
@@ -389,9 +404,43 @@ export function DocumentDetail({
                 Version record
               </h2>
               <p className="mt-1 text-sm leading-relaxed text-muted">
-                Accepted edits create new versions. Rejected edits stay in the document record.
+                Accepted edits and manual saves create new versions. Open a saved version to review or download it.
               </p>
-              <VersionTimeline documentId={documentId} />
+              {resolvedVersions.length > 0 && (
+                <div className="mt-4 flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedVersionId(EXTRACTED_VERSION_ID)}
+                    className={`border px-3 py-2 text-sm ${
+                      selectedVersionId === EXTRACTED_VERSION_ID
+                        ? "border-ink bg-ink text-paper"
+                        : "border-rule text-ink hover:border-ink"
+                    }`}
+                  >
+                    Extracted text
+                  </button>
+                  {resolvedVersions.map((version) => (
+                    <button
+                      key={version.id}
+                      type="button"
+                      onClick={() => setSelectedVersionId(version.id)}
+                      className={`border px-3 py-2 text-sm ${
+                        selectedResolvedVersion?.id === version.id
+                          ? "border-ink bg-ink text-paper"
+                          : "border-rule text-ink hover:border-ink"
+                      }`}
+                    >
+                      v{version.version_number}
+                    </button>
+                  ))}
+                </div>
+              )}
+              <VersionTimeline
+                documentId={documentId}
+                versions={versions}
+                selectedVersionId={selectedResolvedVersion?.id ?? null}
+                onSelectVersion={setSelectedVersionId}
+              />
               {versions.length === 0 && (
                 <p className="mt-4 text-sm text-muted">No versions recorded.</p>
               )}

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -229,7 +229,7 @@ export function DocumentRichEditor({
           <h2 className="text-sm font-semibold text-ink">Document editor</h2>
           <p className="mt-0.5 text-xs text-muted">
             {sourceLabel}
-            {latestVersionNumber ? ` · current v${latestVersionNumber}` : ""}
+            {latestVersionNumber ? ` · latest v${latestVersionNumber}` : ""}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/modules/document_edit/VersionTimeline.tsx
+++ b/frontend/src/modules/document_edit/VersionTimeline.tsx
@@ -27,17 +27,27 @@ function fmt(ts: string): string {
 type Props = {
   documentId: string;
   refreshKey?: number;
+  versions?: DocumentVersionSummary[];
+  selectedVersionId?: string | null;
+  onSelectVersion?: (versionId: string) => void;
 };
 
-export function VersionTimeline({ documentId, refreshKey = 0 }: Props) {
-  const [versions, setVersions] = useState<DocumentVersionSummary[]>([]);
+export function VersionTimeline({
+  documentId,
+  refreshKey = 0,
+  versions: providedVersions,
+  selectedVersionId,
+  onSelectVersion,
+}: Props) {
+  const [fetchedVersions, setFetchedVersions] = useState<DocumentVersionSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (providedVersions) return undefined;
     let cancelled = false;
     getDocumentVersions(documentId)
       .then((vs) => {
-        if (!cancelled) setVersions(vs);
+        if (!cancelled) setFetchedVersions(vs);
       })
       .catch((e: unknown) => {
         if (!cancelled) {
@@ -48,7 +58,9 @@ export function VersionTimeline({ documentId, refreshKey = 0 }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [documentId, refreshKey]);
+  }, [documentId, providedVersions, refreshKey]);
+
+  const versions = providedVersions ?? fetchedVersions;
 
   if (error) {
     return (
@@ -68,7 +80,9 @@ export function VersionTimeline({ documentId, refreshKey = 0 }: Props) {
         {versions.map((s) => (
           <li
             key={s.version.id}
-            className="flex items-baseline gap-3 text-[12px] border-l-2 border-rule pl-3"
+            className={`flex items-baseline gap-3 border-l-2 pl-3 text-[12px] ${
+              selectedVersionId === s.version.id ? "border-ink" : "border-rule"
+            }`}
           >
             <span className="font-mono text-[11px] text-ink">
               v{s.version.version_number}
@@ -80,6 +94,15 @@ export function VersionTimeline({ documentId, refreshKey = 0 }: Props) {
             <span className="ml-auto font-mono text-[10px] text-muted">
               {s.pending_count} pending · {s.accepted_count} accepted · {s.rejected_count} rejected
             </span>
+            {s.version.resolved_text && onSelectVersion && (
+              <button
+                type="button"
+                onClick={() => onSelectVersion(s.version.id)}
+                className="font-mono text-[10px] uppercase tracking-track2 text-muted underline underline-offset-4 hover:text-ink"
+              >
+                {selectedVersionId === s.version.id ? "Open" : "Open version"}
+              </button>
+            )}
           </li>
         ))}
       </ol>


### PR DESCRIPTION
## Summary
- make saved document versions selectable from the reader instead of implicitly hiding behind the latest version
- keep edited DOCX download tied to the active saved version
- render the version timeline from the document page's already-loaded version state, with direct open-version actions

## Verification
- npm --prefix frontend run test -- DocumentDetail --run
- npm --prefix frontend run typecheck
- npm --prefix frontend run test -- --run
- npm --prefix frontend run build

Backend untouched.