### PR TITLE
demo: route chat source chips to public reader

### DIFF
--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -138,6 +138,9 @@ export function DemoMatter() {
                   showDisabledFooter={false}
                   showContextRail={false}
                   onDisabledAction={() => setTabAndHash("workflows")}
+                  onDocumentChip={(documentId) =>
+                    navigate(`/demo/documents/${encodeURIComponent(documentId)}`)
+                  }
                 />
               </div>
             )}

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -20,7 +20,7 @@ import {
 } from "@tanstack/react-router";
 import { AssistantTab } from "./AssistantTab";
 import * as api from "../../lib/api";
-import type { Matter } from "../../lib/api";
+import type { AssistantMessage, Matter, MatterDocument } from "../../lib/api";
 
 const matter: Matter = {
   id: "m-1",
@@ -32,8 +32,14 @@ const matter: Matter = {
   default_model_id: null,
 } as never;
 
-function mountChat(overrides?: { setTabAndHash?: (k: string) => void }) {
+function mountChat(overrides?: {
+  setTabAndHash?: (k: string) => void;
+  docs?: MatterDocument[] | null;
+  initialMessages?: AssistantMessage[];
+  onDocumentChip?: (documentId: string) => void;
+}) {
   const setTabAndHash = overrides?.setTabAndHash ?? vi.fn();
+  const docs = overrides?.docs ?? [];
   const root = createRootRoute({ component: () => <Outlet /> });
   const tab = createRoute({
     getParentRoute: () => root,
@@ -41,11 +47,13 @@ function mountChat(overrides?: { setTabAndHash?: (k: string) => void }) {
     component: () => (
       <AssistantTab
         matter={matter}
-        docs={[]}
+        docs={docs}
         chronology={[]}
         setTabAndHash={setTabAndHash as never}
         auditCount={0}
         showPostureInPulse={false}
+        initialMessages={overrides?.initialMessages}
+        onDocumentChip={overrides?.onDocumentChip}
       />
     ),
   });
@@ -210,6 +218,40 @@ describe("AssistantTab — in-chat skill picker", () => {
     expect(
       await screen.findByTestId("generic-runner-demo.guided-skill-summarise"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("AssistantTab — source chips", () => {
+  it("lets public shells override document chip routing", async () => {
+    const onDocumentChip = vi.fn();
+    mountChat({
+      docs: [
+        {
+          id: "doc-public",
+          filename: "demo-note.txt",
+          sha256: "sha",
+          size_bytes: 99,
+          tag: "demo",
+          from_disclosure: false,
+          uploaded_at: "2026-01-01T00:00:00Z",
+          mime_type: "text/plain",
+        } as never,
+      ],
+      initialMessages: [
+        {
+          id: "a-1",
+          role: "assistant",
+          content: "The dismissal date is in [doc:doc-public].",
+          suggested_actions: [],
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      onDocumentChip,
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /Document.*demo-note\.txt/i }));
+
+    expect(onDocumentChip).toHaveBeenCalledWith("doc-public");
   });
 });
 

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -46,6 +46,9 @@ interface AssistantTabProps {
   showContextRail?: boolean;
   // Called when a Suggested Action chip is clicked in disabled (demo) mode.
   onDisabledAction?: () => void;
+  // Optional route override for read-only/public shells. Normal matters
+  // route source chips into the authenticated matter document reader.
+  onDocumentChip?: (documentId: string) => void;
 }
 
 // Three concrete first-actions per matter type. Per JOY.md "Suggested
@@ -89,6 +92,7 @@ export function AssistantTab({
   showDisabledFooter = true,
   showContextRail = true,
   onDisabledAction,
+  onDocumentChip,
   // back-compat — see AssistantTabProps; deliberately unused.
   auditCount: _auditCount,
   workflowsGrantedCount: _workflowsGrantedCount,
@@ -270,6 +274,10 @@ export function AssistantTab({
   // honest note that exact-passage anchoring isn't supported yet.
   const navigate = useNavigate();
   const dispatchDocChip = (documentId: string) => {
+    if (onDocumentChip) {
+      onDocumentChip(documentId);
+      return;
+    }
     void navigate({
       to: "/matters/$slug/documents/$documentId",
       params: { slug: matter.slug, documentId },


### PR DESCRIPTION
## Summary
- lets the shared Chat surface accept a document-chip routing override
- wires the public /demo Chat source chips to /demo/documents/:id
- keeps authenticated matter chat chips routing to /matters/:slug/documents/:id

## Verification
- npm --prefix frontend run test -- AssistantTab DemoLoop route --run
- npm --prefix frontend run typecheck
- npm --prefix frontend run test -- --run
- npm --prefix frontend run build
- local Chrome smoke: /demo source chip -> /demo/documents/33333333-3333-3333-3333-333333333303, reader shows synthetic-mutual-nda.docx extracted text
