### PR TITLE
documents: preserve rich editor versions

### DIFF
--- a/backend/alembic/versions/0024_document_version_rich_json.py
+++ b/backend/alembic/versions/0024_document_version_rich_json.py
@@ -1,0 +1,29 @@
+"""Store rich editor JSON for document versions.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document_versions",
+        sa.Column("resolved_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("document_versions", "resolved_json")

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -7,11 +7,12 @@ import re
 import uuid
 from datetime import datetime
 
-from typing import Literal
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from docx import Document as DocxDocument
+from docx.enum.text import WD_COLOR_INDEX
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -138,6 +139,7 @@ class DocumentVersionRead(BaseModel):
     storage_uri: str | None
     notes: str | None
     resolved_text: str | None = None
+    resolved_json: dict[str, Any] | None = None
 
     model_config = {"from_attributes": True}
 
@@ -265,6 +267,89 @@ def _render_resolved_text_docx(title: str, body: str) -> bytes:
         for line in lines[1:]:
             para.add_run().add_break()
             para.add_run(line)
+    buf = io.BytesIO()
+    document.save(buf)
+    return buf.getvalue()
+
+
+def _add_tiptap_inline_content(paragraph, nodes: list[dict[str, Any]] | None) -> None:
+    for node in nodes or []:
+        node_type = node.get("type")
+        if node_type == "text":
+            run = paragraph.add_run(str(node.get("text") or ""))
+            mark_types = {
+                str(mark.get("type"))
+                for mark in node.get("marks") or []
+                if isinstance(mark, dict)
+            }
+            run.bold = "bold" in mark_types
+            run.italic = "italic" in mark_types
+            run.underline = "underline" in mark_types
+            if "highlight" in mark_types:
+                run.font.highlight_color = WD_COLOR_INDEX.YELLOW
+        elif node_type == "hardBreak":
+            paragraph.add_run().add_break()
+        elif isinstance(node.get("content"), list):
+            _add_tiptap_inline_content(paragraph, node.get("content"))
+
+
+def _add_tiptap_paragraph(
+    document: DocxDocument,
+    node: dict[str, Any],
+    style: str | None = None,
+) -> None:
+    if node.get("type") == "heading":
+        level = int((node.get("attrs") or {}).get("level") or 1)
+        paragraph = document.add_heading(level=max(1, min(level, 4)))
+    else:
+        paragraph = document.add_paragraph(style=style)
+    _add_tiptap_inline_content(paragraph, node.get("content"))
+
+
+def _add_tiptap_list_item(document: DocxDocument, item: dict[str, Any], style: str) -> None:
+    children = item.get("content") or []
+    wrote_paragraph = False
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        child_type = child.get("type")
+        if child_type in {"paragraph", "heading"}:
+            _add_tiptap_paragraph(
+                document,
+                child,
+                style=style if not wrote_paragraph else None,
+            )
+            wrote_paragraph = True
+        elif child_type == "bulletList":
+            _add_tiptap_list(document, child, "List Bullet")
+        elif child_type == "orderedList":
+            _add_tiptap_list(document, child, "List Number")
+    if not wrote_paragraph:
+        document.add_paragraph(style=style)
+
+
+def _add_tiptap_list(document: DocxDocument, node: dict[str, Any], style: str) -> None:
+    for child in node.get("content") or []:
+        if isinstance(child, dict) and child.get("type") == "listItem":
+            _add_tiptap_list_item(document, child, style)
+
+
+def _render_tiptap_docx(title: str, body_json: dict[str, Any], fallback_text: str) -> bytes:
+    if body_json.get("type") != "doc" or not isinstance(body_json.get("content"), list):
+        return _render_resolved_text_docx(title, fallback_text)
+
+    document = DocxDocument()
+    document.add_heading(title, level=0)
+    for node in body_json.get("content") or []:
+        if not isinstance(node, dict):
+            continue
+        node_type = node.get("type")
+        if node_type in {"paragraph", "heading"}:
+            _add_tiptap_paragraph(document, node)
+        elif node_type == "bulletList":
+            _add_tiptap_list(document, node, "List Bullet")
+        elif node_type == "orderedList":
+            _add_tiptap_list(document, node, "List Number")
     buf = io.BytesIO()
     document.save(buf)
     return buf.getvalue()
@@ -473,6 +558,7 @@ class DocumentVersionSummary(BaseModel):
 
 class ManualDocumentVersionRequest(BaseModel):
     resolved_text: str = Field(min_length=1, max_length=500_000)
+    resolved_json: dict[str, Any] | None = None
     notes: str | None = Field(default=None, max_length=500)
 
 
@@ -594,6 +680,7 @@ async def post_manual_document_version(
         kind=VERSION_KIND_USER_EDIT,
         created_by_id=user.id,
         resolved_text=body.resolved_text,
+        resolved_json=body.resolved_json,
         notes=body.notes or "Edited in Legalise document editor",
     )
     session.add(version)
@@ -611,6 +698,7 @@ async def post_manual_document_version(
             "version_number": version.version_number,
             "kind": version.kind,
             "char_count": len(body.resolved_text),
+            "rich_json": body.resolved_json is not None,
         },
     )
     await session.commit()
@@ -637,7 +725,11 @@ async def get_document_version_docx(
     if not version.resolved_text:
         raise HTTPException(422, "document version has no resolved text")
 
-    data = _render_resolved_text_docx(doc.filename, version.resolved_text)
+    data = (
+        _render_tiptap_docx(doc.filename, version.resolved_json, version.resolved_text)
+        if version.resolved_json
+        else _render_resolved_text_docx(doc.filename, version.resolved_text)
+    )
     filename = _docx_export_filename(doc.filename, version.version_number)
     await audit.log(
         session,
@@ -653,6 +745,7 @@ async def get_document_version_docx(
             "char_count": len(version.resolved_text),
             "byte_count": len(data),
             "format": "docx",
+            "rich_json": version.resolved_json is not None,
         },
     )
     await session.commit()

--- a/backend/app/models/document_version.py
+++ b/backend/app/models/document_version.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import datetime, UTC
 
 from sqlalchemy import String, DateTime, ForeignKey, Integer, Text, UniqueConstraint
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -61,6 +61,7 @@ class DocumentVersion(Base):
     storage_uri: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     resolved_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resolved_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     def __repr__(self) -> str:
         return f"<DocumentVersion {self.document_id} v{self.version_number} kind={self.kind}>"

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -15,6 +15,7 @@ import uuid
 import zipfile
 
 import pytest
+from docx import Document as DocxDocument
 
 
 EMAIL_A = "acl-sweep-a@example.com"
@@ -94,6 +95,19 @@ async def test_post_manual_document_version_creates_user_edit_version(client) ->
         f"/api/documents/{doc_id}/versions/manual",
         json={
             "resolved_text": "Edited witness statement.\n\nSecond paragraph.",
+            "resolved_json": {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "Edited witness statement."}],
+                    },
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "Second paragraph."}],
+                    },
+                ],
+            },
             "notes": "Manual edit from document editor",
         },
     )
@@ -102,6 +116,7 @@ async def test_post_manual_document_version_creates_user_edit_version(client) ->
     assert payload["kind"] == "user_edit"
     assert payload["version_number"] == 2
     assert payload["resolved_text"] == "Edited witness statement.\n\nSecond paragraph."
+    assert payload["resolved_json"]["type"] == "doc"
     assert payload["notes"] == "Manual edit from document editor"
 
     versions = await client.get(f"/api/documents/{doc_id}/versions")
@@ -109,6 +124,7 @@ async def test_post_manual_document_version_creates_user_edit_version(client) ->
     rows = versions.json()
     assert rows[-1]["version"]["kind"] == "user_edit"
     assert rows[-1]["version"]["resolved_text"] == "Edited witness statement.\n\nSecond paragraph."
+    assert rows[-1]["version"]["resolved_json"]["type"] == "doc"
 
 
 @pytest.mark.asyncio
@@ -131,6 +147,73 @@ async def test_get_manual_document_version_docx_returns_word_file(client) -> Non
     )
     assert resp.headers.get("content-disposition", "").endswith('.docx"')
     assert zipfile.is_zipfile(io.BytesIO(resp.content))
+
+
+@pytest.mark.asyncio
+async def test_get_manual_document_version_docx_preserves_rich_editor_marks(client) -> None:
+    """Rich editor saves keep basic formatting when exported as .docx."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+
+    save = await client.post(
+        f"/api/documents/{doc_id}/versions/manual",
+        json={
+            "resolved_text": "Important term\n\nListed point",
+            "resolved_json": {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Important",
+                                "marks": [{"type": "bold"}, {"type": "underline"}],
+                            },
+                            {"type": "text", "text": " term", "marks": [{"type": "italic"}]},
+                        ],
+                    },
+                    {
+                        "type": "bulletList",
+                        "content": [
+                            {
+                                "type": "listItem",
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [
+                                            {
+                                                "type": "text",
+                                                "text": "Listed point",
+                                                "marks": [{"type": "highlight"}],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        },
+    )
+    assert save.status_code == 200, save.text
+    version_id = save.json()["id"]
+
+    resp = await client.get(f"/api/documents/{doc_id}/versions/{version_id}/docx")
+    assert resp.status_code == 200, resp.text
+    docx = DocxDocument(io.BytesIO(resp.content))
+
+    first = docx.paragraphs[1]
+    assert first.runs[0].text == "Important"
+    assert first.runs[0].bold is True
+    assert first.runs[0].underline is True
+    assert first.runs[1].text == " term"
+    assert first.runs[1].italic is True
+
+    bullet = next(p for p in docx.paragraphs if p.text == "Listed point")
+    assert bullet.style.name.startswith("List Bullet")
+    assert bullet.runs[0].font.highlight_color is not None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1547,6 +1547,7 @@ export interface DocumentVersionRead {
   storage_uri: string | null;
   notes: string | null;
   resolved_text: string | null;
+  resolved_json?: Record<string, unknown> | null;
 }
 
 export interface DocumentEditRead {
@@ -1769,11 +1770,16 @@ export const saveDocumentVersion = (
   documentId: string,
   resolvedText: string,
   notes?: string,
+  resolvedJson?: Record<string, unknown> | null,
 ) =>
   apiFetch(`${API}/documents/${documentId}/versions/manual`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ resolved_text: resolvedText, notes }),
+    body: JSON.stringify({
+      resolved_text: resolvedText,
+      resolved_json: resolvedJson ?? null,
+      notes,
+    }),
   }).then((r) => resolutionJsonOrThrow<DocumentVersionRead>(r));
 
 // ----- Auth + user --------------------------------------------------------

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -33,6 +33,7 @@ import { VersionTimeline } from "../modules/document_edit/VersionTimeline";
 import {
   DocumentRichEditor,
   findNormalizedRange,
+  type TiptapNode,
 } from "../modules/document_edit/DocumentRichEditor";
 import { DocxOriginalPreview } from "../modules/document_preview/DocxOriginalPreview";
 
@@ -206,6 +207,7 @@ export function DocumentDetail({
         null);
   const editorText =
     selectedResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
+  const editorJson = selectedResolvedVersion?.resolved_json as TiptapNode | null | undefined;
   const sourceQuoteFoundInReader = sourceContext.quote
     ? Boolean(findNormalizedRange(editorText, sourceContext.quote))
     : null;
@@ -417,6 +419,7 @@ export function DocumentDetail({
                   documentId={documentId}
                   filename={doc.filename}
                   initialText={editorText}
+                  initialJson={editorJson}
                   latestVersionNumber={latestVersion?.version_number}
                   sourceLabel={editorSourceLabel}
                   sourceHighlight={sourceContext.quote}

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -4,17 +4,14 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
 import Highlight from "@tiptap/extension-highlight";
+import type { Content, JSONContent } from "@tiptap/core";
 
 import {
   saveDocumentVersion,
   type DocumentVersionRead,
 } from "../../lib/api";
 
-type TiptapNode = {
-  type?: string;
-  text?: string;
-  content?: TiptapNode[];
-};
+export type TiptapNode = JSONContent;
 
 function escapeHtml(value: string): string {
   return value
@@ -133,6 +130,7 @@ export function DocumentRichEditor({
   documentId,
   filename,
   initialText,
+  initialJson,
   latestVersionNumber,
   sourceLabel,
   sourceHighlight,
@@ -141,6 +139,7 @@ export function DocumentRichEditor({
   documentId: string;
   filename: string;
   initialText: string;
+  initialJson?: TiptapNode | null;
   latestVersionNumber?: number;
   sourceLabel: string;
   sourceHighlight?: string | null;
@@ -150,9 +149,9 @@ export function DocumentRichEditor({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedMessage, setSavedMessage] = useState<string | null>(null);
-  const content = useMemo(
-    () => textToEditorHtml(initialText, sourceHighlight),
-    [initialText, sourceHighlight],
+  const content = useMemo<Content>(
+    () => initialJson ?? textToEditorHtml(initialText, sourceHighlight),
+    [initialJson, initialText, sourceHighlight],
   );
   const editor = useEditor(
     {
@@ -200,10 +199,12 @@ export function DocumentRichEditor({
     setSaving(true);
     setError(null);
     try {
+      const editorJson = editor.getJSON() as TiptapNode;
       const version = await saveDocumentVersion(
         documentId,
         plainText,
         `Edited ${filename} in Legalise document editor`,
+        editorJson,
       );
       setDirty(false);
       setSavedMessage(`Saved v${version.version_number}`);


### PR DESCRIPTION
## Summary

Document engine slice: saved editor versions now preserve the Tiptap document JSON alongside the plain-text fallback, and edited DOCX export uses that rich JSON when present.

What changed:
- Adds nullable `document_versions.resolved_json` (migration 0024).
- Manual version saves accept/return `resolved_json` while keeping `resolved_text` for fallback/search/old data.
- DOCX export preserves the editor controls we already expose: paragraphs, hard breaks, bullet/number lists, bold, italic, underline, highlight.
- Reopening a saved version feeds the rich JSON back into the editor instead of only flattened text.
- Backend regression saves rich JSON and inspects the generated DOCX with `python-docx` to prove marks/list style survive.

## Local verification

- `npm --prefix frontend run typecheck` ✅
- `npm --prefix frontend run test -- DocumentDetail DocumentRichEditor --run --testTimeout=20000` ✅
- `npm --prefix frontend run build` ✅
- `python3 -m py_compile backend/app/api/documents.py backend/app/models/document_version.py backend/alembic/versions/0024_document_version_rich_json.py` ✅
- `npm --prefix frontend run test -- AppHome --run` ✅ after full-suite timing flake

Notes:
- Full frontend vitest hit one unrelated AppHome routing wait timeout under full-suite load, then that file passed in isolation.
- Local shell has no backend pytest/uv environment, so the DB-backed route test is left to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents now support rich text formatting, including bold, italic, underline, and highlighting.
  * Document exports to .docx now preserve rich formatting from the editor.
  * Rich editor content is saved and can be reloaded when editing documents.

* **Tests**
  * Added tests verifying rich text formatting is preserved in .docx exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->