### PR TITLE
documents: add heading and numbered-list editing

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -73,6 +73,34 @@
     margin-bottom: 0;
   }
 
+  .legalise-document-editor h2 {
+    font-size: 1.35rem;
+    font-weight: 700;
+    line-height: 1.35;
+    margin: 0 0 0.9rem;
+  }
+
+  .legalise-document-editor h3 {
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1.45;
+    margin: 0 0 0.75rem;
+  }
+
+  .legalise-document-editor p + h2,
+  .legalise-document-editor ul + h2,
+  .legalise-document-editor ol + h2,
+  .legalise-document-editor table + h2 {
+    margin-top: 1.6rem;
+  }
+
+  .legalise-document-editor p + h3,
+  .legalise-document-editor ul + h3,
+  .legalise-document-editor ol + h3,
+  .legalise-document-editor table + h3 {
+    margin-top: 1.25rem;
+  }
+
   .legalise-document-editor ul,
   .legalise-document-editor ol {
     margin: 0 0 1.1rem 1.25rem;

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -101,6 +101,12 @@ function versionSummary(
   };
 }
 
+async function expectEditorText(container: HTMLElement, text: string) {
+  await waitFor(() => {
+    expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(text);
+  });
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(api, "getDocumentVersions").mockResolvedValue([]);
@@ -184,9 +190,7 @@ describe("DocumentDetail", () => {
 
     const { container } = mount();
     await screen.findByText(/Viewing saved version v3/);
-    expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(
-      "Second saved body",
-    );
+    await expectEditorText(container, "Second saved body");
     expect(screen.getByTestId("document-download-edited-docx").getAttribute("href")).toContain(
       "/documents/doc-1/versions/v-3/docx",
     );
@@ -196,9 +200,7 @@ describe("DocumentDetail", () => {
     await waitFor(() => {
       expect(screen.getByText(/Viewing saved version v2/)).toBeInTheDocument();
     });
-    expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(
-      "First saved body",
-    );
+    await expectEditorText(container, "First saved body");
     expect(screen.getByTestId("document-download-edited-docx").getAttribute("href")).toContain(
       "/documents/doc-1/versions/v-2/docx",
     );
@@ -208,9 +210,7 @@ describe("DocumentDetail", () => {
     await waitFor(() => {
       expect(screen.getByText(/python-docx · 13 chars · 1 pages/)).toBeInTheDocument();
     });
-    expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(
-      "Original body",
-    );
+    await expectEditorText(container, "Original body");
     expect(screen.queryByTestId("document-download-edited-docx")).toBeNull();
   });
 

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -62,6 +62,38 @@ describe("DocumentRichEditor text conversion", () => {
     ).toBe("Line one\nline two\n\nNext");
   });
 
+  it("keeps headings and ordered lists readable in the plain-text fallback", () => {
+    expect(
+      editorJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "Issues" }],
+          },
+          {
+            type: "orderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  { type: "paragraph", content: [{ type: "text", text: "Limitation" }] },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  { type: "paragraph", content: [{ type: "text", text: "Disclosure" }] },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe("Issues\n\nLimitation\nDisclosure");
+  });
+
   it("keeps table cells legible in the plain-text fallback", () => {
     expect(
       editorJsonToPlainText({

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -166,7 +166,9 @@ export function DocumentRichEditor({
     {
       extensions: [
         StarterKit.configure({
-          heading: false,
+          heading: {
+            levels: [2, 3],
+          },
           codeBlock: false,
           horizontalRule: false,
         }),
@@ -250,6 +252,20 @@ export function DocumentRichEditor({
           {editor && (
             <>
               <ToolbarButton
+                label="Heading 2"
+                active={editor.isActive("heading", { level: 2 })}
+                onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+              >
+                H2
+              </ToolbarButton>
+              <ToolbarButton
+                label="Heading 3"
+                active={editor.isActive("heading", { level: 3 })}
+                onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+              >
+                H3
+              </ToolbarButton>
+              <ToolbarButton
                 label="Bold"
                 active={editor.isActive("bold")}
                 onClick={() => editor.chain().focus().toggleBold().run()}
@@ -283,6 +299,13 @@ export function DocumentRichEditor({
                 onClick={() => editor.chain().focus().toggleBulletList().run()}
               >
                 *
+              </ToolbarButton>
+              <ToolbarButton
+                label="Numbered list"
+                active={editor.isActive("orderedList")}
+                onClick={() => editor.chain().focus().toggleOrderedList().run()}
+              >
+                1.
               </ToolbarButton>
               <ToolbarButton
                 label="Insert table"


### PR DESCRIPTION
## Summary
- enable H2/H3 and numbered-list controls in the rich document editor
- add editor typography spacing for headings
- keep heading/ordered-list content readable in plain-text fallbacks
- de-flake a DocumentDetail editor assertion exposed by the full frontend suite

## Verification
- `npm --prefix frontend run test -- DocumentRichEditor --run`
- `npm --prefix frontend run test -- DocumentDetail --run`
- `npm --prefix frontend run test -- --run` (231/231)
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run build`

No backend or schema changes.