### PR TITLE
documents: add review notes

### DIFF
--- a/backend/alembic/versions/0025_document_comments.py
+++ b/backend/alembic/versions/0025_document_comments.py
@@ -1,0 +1,43 @@
+"""Add document comments.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "document_comments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("document_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("author_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("quote_text", sa.Text(), nullable=True),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("resolved_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(["author_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["documents.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["resolved_by_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_document_comments_document_id", "document_comments", ["document_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_comments_document_id", table_name="document_comments")
+    op.drop_table("document_comments")

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import io
 import re
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 
 from typing import Any, Literal
 
@@ -23,7 +23,18 @@ from app.core.storage import get_storage_backend, StorageReadError
 from app.core.model_gateway import PrivilegePaused, gateway as model_gateway
 from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
 from app.core.api import audit, audit_failure
-from app.models import AuditEntry, Document, DocumentEdit, DocumentVersion, Matter, User, STATUS_ARCHIVED
+from app.models import (
+    AuditEntry,
+    COMMENT_STATUS_OPEN,
+    COMMENT_STATUS_RESOLVED,
+    Document,
+    DocumentComment,
+    DocumentEdit,
+    DocumentVersion,
+    Matter,
+    STATUS_ARCHIVED,
+    User,
+)
 from app.models.document_body import DocumentBody, BODY_KIND_EXTRACTED
 from app.models.document_edit import (
     EDIT_STATUS_ACCEPTED,
@@ -628,6 +639,25 @@ class ManualDocumentVersionRequest(BaseModel):
     notes: str | None = Field(default=None, max_length=500)
 
 
+class DocumentCommentRead(BaseModel):
+    id: uuid.UUID
+    document_id: uuid.UUID
+    author_id: uuid.UUID
+    quote_text: str | None
+    body: str
+    status: str
+    created_at: datetime
+    resolved_at: datetime | None
+    resolved_by_id: uuid.UUID | None
+
+    model_config = {"from_attributes": True}
+
+
+class DocumentCommentCreate(BaseModel):
+    body: str = Field(min_length=2, max_length=4000)
+    quote_text: str | None = Field(default=None, max_length=2000)
+
+
 async def _resolve_one(
     document_id_unused: None,
     edit_id: uuid.UUID,
@@ -915,6 +945,101 @@ async def _load_owned_document(
     if matter.created_by_id != user.id or matter.status == STATUS_ARCHIVED:
         raise HTTPException(404, "document not found")
     return doc, matter
+
+
+@router.get("/{document_id}/comments", response_model=list[DocumentCommentRead])
+async def get_document_comments(
+    document_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> list[DocumentCommentRead]:
+    """List review notes for an owned, live document."""
+    doc, _matter = await _load_owned_document(document_id, session, user)
+    comments = (
+        await session.scalars(
+            select(DocumentComment)
+            .where(DocumentComment.document_id == doc.id)
+            .order_by(DocumentComment.created_at.asc(), DocumentComment.id.asc())
+        )
+    ).all()
+    return [DocumentCommentRead.model_validate(comment) for comment in comments]
+
+
+@router.post("/{document_id}/comments", response_model=DocumentCommentRead)
+async def post_document_comment(
+    document_id: uuid.UUID,
+    body: DocumentCommentCreate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentCommentRead:
+    """Add a human review note to an owned document."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    comment_body = body.body.strip()
+    if len(comment_body) < 2:
+        raise HTTPException(422, "comment body is required")
+    quote_text = body.quote_text.strip() if body.quote_text else None
+    comment = DocumentComment(
+        document_id=doc.id,
+        author_id=user.id,
+        quote_text=quote_text or None,
+        body=comment_body,
+        status=COMMENT_STATUS_OPEN,
+    )
+    session.add(comment)
+    await session.flush()
+    await audit.log(
+        session,
+        "document.comment.created",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_comment",
+        resource_id=str(comment.id),
+        payload={
+            "document_id": str(doc.id),
+            "has_quote": bool(comment.quote_text),
+        },
+    )
+    await session.commit()
+    return DocumentCommentRead.model_validate(comment)
+
+
+@router.post(
+    "/{document_id}/comments/{comment_id}/resolve",
+    response_model=DocumentCommentRead,
+)
+async def post_resolve_document_comment(
+    document_id: uuid.UUID,
+    comment_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentCommentRead:
+    """Resolve a document review note."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    comment = await session.scalar(
+        select(DocumentComment).where(
+            DocumentComment.id == comment_id,
+            DocumentComment.document_id == doc.id,
+        )
+    )
+    if comment is None:
+        raise HTTPException(404, "document comment not found")
+    if comment.status != COMMENT_STATUS_RESOLVED:
+        comment.status = COMMENT_STATUS_RESOLVED
+        comment.resolved_at = datetime.now(UTC)
+        comment.resolved_by_id = user.id
+        await audit.log(
+            session,
+            "document.comment.resolved",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="document_editor",
+            resource_type="document_comment",
+            resource_id=str(comment.id),
+            payload={"document_id": str(doc.id)},
+        )
+    await session.commit()
+    return DocumentCommentRead.model_validate(comment)
 
 
 def _result_from_redacted(body: DocumentBody) -> AnonymisationResult:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -40,6 +40,12 @@ from app.models.audit import AuditEntry
 from app.models.document_body import DocumentBody, BODY_KIND_VALUES, EXTRACTION_METHOD_VALUES
 from app.models.document_version import DocumentVersion, VERSION_KIND_VALUES
 from app.models.document_edit import DocumentEdit, EDIT_STATUS_VALUES
+from app.models.document_comment import (
+    COMMENT_STATUS_OPEN,
+    COMMENT_STATUS_RESOLVED,
+    COMMENT_STATUS_VALUES,
+    DocumentComment,
+)
 from app.models.tabular_review import TabularReview, TabularReviewRow
 from app.models.workspace_skill import WorkspaceDisabledSkill
 from app.models.workspace_skill_capability_grant import (
@@ -145,6 +151,7 @@ __all__ = [
     "DocumentBody",
     "DocumentVersion",
     "DocumentEdit",
+    "DocumentComment",
     "TabularReview",
     "TabularReviewRow",
     "WorkspaceDisabledSkill",
@@ -179,6 +186,9 @@ __all__ = [
     "EXTRACTION_METHOD_VALUES",
     "VERSION_KIND_VALUES",
     "EDIT_STATUS_VALUES",
+    "COMMENT_STATUS_OPEN",
+    "COMMENT_STATUS_RESOLVED",
+    "COMMENT_STATUS_VALUES",
     # Matter context primitive.
     "MatterContextSchema",
     "MatterContextItem",

--- a/backend/app/models/document_comment.py
+++ b/backend/app/models/document_comment.py
@@ -1,0 +1,45 @@
+"""DocumentComment — owner-scoped review notes on a document."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+COMMENT_STATUS_OPEN = "open"
+COMMENT_STATUS_RESOLVED = "resolved"
+COMMENT_STATUS_VALUES = {COMMENT_STATUS_OPEN, COMMENT_STATUS_RESOLVED}
+
+
+class DocumentComment(Base):
+    __tablename__ = "document_comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    document_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("documents.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    author_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    quote_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(String(24), default=COMMENT_STATUS_OPEN, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    resolved_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+
+    def __repr__(self) -> str:
+        return f"<DocumentComment {self.document_id} status={self.status}>"

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -86,6 +86,64 @@ async def test_get_document_versions_cross_user_returns_404(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_document_comments_owner_can_create_list_and_resolve(client) -> None:
+    """Owner can leave and resolve review notes on a document."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+
+    created = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={
+            "quote_text": "single social-media post",
+            "body": "Check the source before relying on this.",
+        },
+    )
+    assert created.status_code == 200, created.text
+    comment = created.json()
+    assert comment["status"] == "open"
+    assert comment["quote_text"] == "single social-media post"
+    assert comment["body"] == "Check the source before relying on this."
+
+    listed = await client.get(f"/api/documents/{doc_id}/comments")
+    assert listed.status_code == 200, listed.text
+    assert [row["id"] for row in listed.json()] == [comment["id"]]
+
+    resolved = await client.post(
+        f"/api/documents/{doc_id}/comments/{comment['id']}/resolve",
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json()["status"] == "resolved"
+    assert resolved.json()["resolved_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_document_comments_cross_user_returns_404(client) -> None:
+    """User B cannot list, create, or resolve User A's document comments by UUID."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+    created = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={"body": "Owner note."},
+    )
+    assert created.status_code == 200, created.text
+    comment_id = created.json()["id"]
+    await client.post("/auth/logout")
+
+    await _signup_and_login(client, EMAIL_B, PASSWORD_B)
+    listed = await client.get(f"/api/documents/{doc_id}/comments")
+    assert listed.status_code == 404, listed.text
+    posted = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={"body": "Cross-user note."},
+    )
+    assert posted.status_code == 404, posted.text
+    resolved = await client.post(
+        f"/api/documents/{doc_id}/comments/{comment_id}/resolve",
+    )
+    assert resolved.status_code == 404, resolved.text
+
+
+@pytest.mark.asyncio
 async def test_post_manual_document_version_creates_user_edit_version(client) -> None:
     """Owner can save editor text as a new immutable document version."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
@@ -351,6 +409,34 @@ async def test_get_document_versions_archived_matter_returns_404(client) -> None
 
     resp = await client.get(f"/api/documents/{doc_id}/versions")
     assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_document_comments_archived_matter_returns_404(client) -> None:
+    """After the owning matter is archived, document comment endpoints 404."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    slug, doc_id = await _create_matter_and_upload(client)
+    created = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={"body": "Review note before archive."},
+    )
+    assert created.status_code == 200, created.text
+    comment_id = created.json()["id"]
+
+    del_resp = await client.delete(f"/api/matters/{slug}")
+    assert del_resp.status_code in (200, 204), del_resp.text
+
+    listed = await client.get(f"/api/documents/{doc_id}/comments")
+    assert listed.status_code == 404, listed.text
+    posted = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={"body": "Review note after archive."},
+    )
+    assert posted.status_code == 404, posted.text
+    resolved = await client.post(
+        f"/api/documents/{doc_id}/comments/{comment_id}/resolve",
+    )
+    assert resolved.status_code == 404, resolved.text
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1725,6 +1725,18 @@ export interface DocumentVersionSummary {
   rejected_count: number;
 }
 
+export interface DocumentCommentRead {
+  id: string;
+  document_id: string;
+  author_id: string;
+  quote_text: string | null;
+  body: string;
+  status: "open" | "resolved";
+  created_at: string;
+  resolved_at: string | null;
+  resolved_by_id: string | null;
+}
+
 export class ConflictError extends Error {
   status = 409;
 }
@@ -1781,6 +1793,29 @@ export const saveDocumentVersion = (
       notes,
     }),
   }).then((r) => resolutionJsonOrThrow<DocumentVersionRead>(r));
+
+export const getDocumentComments = (documentId: string) =>
+  apiFetch(`${API}/documents/${documentId}/comments`).then((r) =>
+    resolutionJsonOrThrow<DocumentCommentRead[]>(r),
+  );
+
+export const createDocumentComment = (
+  documentId: string,
+  payload: { body: string; quote_text?: string | null },
+) =>
+  apiFetch(`${API}/documents/${documentId}/comments`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  }).then((r) => resolutionJsonOrThrow<DocumentCommentRead>(r));
+
+export const resolveDocumentComment = (documentId: string, commentId: string) =>
+  apiFetch(
+    `${API}/documents/${encodeURIComponent(documentId)}/comments/${encodeURIComponent(
+      commentId,
+    )}/resolve`,
+    { method: "POST" },
+  ).then((r) => resolutionJsonOrThrow<DocumentCommentRead>(r));
 
 // ----- Auth + user --------------------------------------------------------
 // Auth endpoints live in `./api/auth` (sit at backend origin, NOT under

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -110,6 +110,7 @@ async function expectEditorText(container: HTMLElement, text: string) {
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(api, "getDocumentVersions").mockResolvedValue([]);
+  vi.spyOn(api, "getDocumentComments").mockResolvedValue([]);
   vi.spyOn(api, "getAnonymisation").mockRejectedValue(new Error("404"));
   // AnonymiseButton (child) fetches its own module's getAnonymisation on
   // mount — stub it so the test doesn't hit the network.
@@ -266,6 +267,96 @@ describe("DocumentDetail", () => {
     expect(screen.getByTestId("document-history-workspace")).toBeInTheDocument();
     expect(screen.getByText("Version record")).toBeInTheDocument();
     expect(screen.getByText("Redaction")).toBeInTheDocument();
+  });
+
+  it("shows document review notes and lets the user add one", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    const getComments = vi.spyOn(api, "getDocumentComments");
+    getComments
+      .mockResolvedValueOnce([
+        {
+          id: "comment-1",
+          document_id: "doc-1",
+          author_id: "u-1",
+          quote_text: "single social-media post",
+          body: "Check the context before relying on this.",
+          status: "open",
+          created_at: "2026-06-03T10:00:00",
+          resolved_at: null,
+          resolved_by_id: null,
+        },
+      ])
+      .mockResolvedValue([]);
+    const create = vi.spyOn(api, "createDocumentComment").mockResolvedValue({
+      id: "comment-2",
+      document_id: "doc-1",
+      author_id: "u-1",
+      quote_text: null,
+      body: "Ask client for policy copy.",
+      status: "open",
+      created_at: "2026-06-03T10:05:00",
+      resolved_at: null,
+      resolved_by_id: null,
+    });
+
+    mount();
+    expect(await screen.findByTestId("document-comments")).toHaveTextContent(
+      "Check the context before relying on this.",
+    );
+    fireEvent.change(screen.getByPlaceholderText("Quoted passage (optional)"), {
+      target: { value: "policy breach" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Add a review note"), {
+      target: { value: "Ask client for policy copy." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save note" }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith("doc-1", {
+        body: "Ask client for policy copy.",
+        quote_text: "policy breach",
+      });
+    });
+  });
+
+  it("resolves open document review notes", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "getDocumentComments").mockResolvedValue([
+      {
+        id: "comment-1",
+        document_id: "doc-1",
+        author_id: "u-1",
+        quote_text: null,
+        body: "Resolve after checking the source.",
+        status: "open",
+        created_at: "2026-06-03T10:00:00",
+        resolved_at: null,
+        resolved_by_id: null,
+      },
+    ]);
+    const resolve = vi
+      .spyOn(api, "resolveDocumentComment")
+      .mockResolvedValue({
+        id: "comment-1",
+        document_id: "doc-1",
+        author_id: "u-1",
+        quote_text: null,
+        body: "Resolve after checking the source.",
+        status: "resolved",
+        created_at: "2026-06-03T10:00:00",
+        resolved_at: "2026-06-03T10:10:00",
+        resolved_by_id: "u-1",
+      });
+
+    mount();
+    await screen.findByText("Resolve after checking the source.");
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
+
+    await waitFor(() => {
+      expect(resolve).toHaveBeenCalledWith("doc-1", "comment-1");
+    });
   });
 
   it("makes saved versions openable and downloadable from the version workspace", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -8,14 +8,18 @@ import { Link, useRouterState } from "@tanstack/react-router";
 import type { TabKey } from "./tabs/types";
 import { MATTER_TAB_LABELS, isTabKey } from "./tabs/types";
 import {
+  createDocumentComment,
   documentOriginalUrl,
   documentVersionDocxUrl,
   type EditInstructionResponse,
   getAnonymisation,
+  getDocumentComments,
   getDocumentBody,
   getDocumentVersions,
   listDocuments,
+  resolveDocumentComment,
   type AnonymisationResult,
+  type DocumentCommentRead,
   type DocumentBody,
   type DocumentVersionSummary,
   type MatterDocument,
@@ -88,6 +92,11 @@ export function DocumentDetail({
   const [bodyMissing, setBodyMissing] = useState(false);
   const [versions, setVersions] = useState<DocumentVersionSummary[]>([]);
   const [anon, setAnon] = useState<AnonymisationResult | null>(null);
+  const [comments, setComments] = useState<DocumentCommentRead[]>([]);
+  const [commentBody, setCommentBody] = useState("");
+  const [commentQuote, setCommentQuote] = useState("");
+  const [commentError, setCommentError] = useState<string | null>(null);
+  const [commentBusy, setCommentBusy] = useState(false);
   const [showDetails, setShowDetails] = useState(false);
   const [workbenchView, setWorkbenchView] = useState<WorkbenchView>("editor");
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
@@ -143,17 +152,24 @@ export function DocumentDetail({
       .catch(() => setBodyMissing(true));
   }, [documentId]);
 
+  const loadComments = useCallback(() => {
+    getDocumentComments(documentId)
+      .then(setComments)
+      .catch(() => setComments([]));
+  }, [documentId]);
+
   useEffect(() => {
     setActiveEditResult(null);
     setWorkbenchView("editor");
     setSelectedVersionId(null);
     setEditorDirty(false);
     loadBody();
+    loadComments();
     getDocumentVersions(documentId).then(setVersions).catch(() => undefined);
     getAnonymisation(documentId)
       .then(setAnon)
       .catch(() => setAnon(null));
-  }, [documentId, loadBody]);
+  }, [documentId, loadBody, loadComments]);
 
   if (q.status === "loading") {
     return (
@@ -223,6 +239,8 @@ export function DocumentDetail({
   const pendingEdits = versions.reduce((total, v) => total + v.pending_count, 0);
   const acceptedEdits = versions.reduce((total, v) => total + v.accepted_count, 0);
   const rejectedEdits = versions.reduce((total, v) => total + v.rejected_count, 0);
+  const openComments = comments.filter((comment) => comment.status === "open");
+  const resolvedComments = comments.filter((comment) => comment.status === "resolved");
   const confirmDiscardEditorChanges = () =>
     !editorDirty || window.confirm("Discard unsaved document edits?");
   const openWorkbenchView = (next: WorkbenchView) => {
@@ -234,6 +252,40 @@ export function DocumentDetail({
     if (!confirmDiscardEditorChanges()) return;
     setSelectedVersionId(versionId);
     setWorkbenchView("editor");
+  };
+  const submitComment = async () => {
+    const trimmed = commentBody.trim();
+    if (trimmed.length < 2) {
+      setCommentError("Add a note before saving.");
+      return;
+    }
+    setCommentBusy(true);
+    setCommentError(null);
+    try {
+      await createDocumentComment(documentId, {
+        body: trimmed,
+        quote_text: commentQuote.trim() || null,
+      });
+      setCommentBody("");
+      setCommentQuote("");
+      loadComments();
+    } catch (err) {
+      setCommentError(err instanceof Error ? err.message : "Could not save note.");
+    } finally {
+      setCommentBusy(false);
+    }
+  };
+  const resolveComment = async (commentId: string) => {
+    setCommentBusy(true);
+    setCommentError(null);
+    try {
+      await resolveDocumentComment(documentId, commentId);
+      loadComments();
+    } catch (err) {
+      setCommentError(err instanceof Error ? err.message : "Could not resolve note.");
+    } finally {
+      setCommentBusy(false);
+    }
   };
 
   return (
@@ -587,6 +639,88 @@ export function DocumentDetail({
                   <dd className="mt-1 text-lg font-semibold text-ink">{rejectedEdits}</dd>
                 </div>
               </dl>
+            </section>
+
+            <section className="border border-rule bg-paper p-4" data-testid="document-comments">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-ink">Review notes</h2>
+                  <p className="mt-1 text-sm leading-6 text-muted">
+                    Leave human notes on the file. Notes are recorded against this document.
+                  </p>
+                </div>
+                <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                  {openComments.length} open
+                </span>
+              </div>
+              <div className="mt-4 space-y-3">
+                {openComments.length === 0 && resolvedComments.length === 0 && (
+                  <p className="text-sm text-muted">No review notes yet.</p>
+                )}
+                {openComments.map((comment) => (
+                  <article
+                    key={comment.id}
+                    className="border border-rule bg-paper-sunken p-3 text-sm"
+                  >
+                    {comment.quote_text && (
+                      <blockquote className="mb-2 border-l-2 border-rule pl-3 text-muted">
+                        {comment.quote_text}
+                      </blockquote>
+                    )}
+                    <p className="leading-6 text-ink">{comment.body}</p>
+                    <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted">
+                      <span>{comment.created_at.replace("T", " ").slice(0, 16)}</span>
+                      <button
+                        type="button"
+                        disabled={commentBusy}
+                        onClick={() => resolveComment(comment.id)}
+                        className="underline underline-offset-4 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Resolve
+                      </button>
+                    </div>
+                  </article>
+                ))}
+                {resolvedComments.length > 0 && (
+                  <details className="border border-rule bg-paper-sunken p-3">
+                    <summary className="cursor-pointer text-sm font-medium text-muted">
+                      {resolvedComments.length} resolved
+                    </summary>
+                    <div className="mt-3 space-y-2">
+                      {resolvedComments.map((comment) => (
+                        <p key={comment.id} className="text-sm leading-6 text-muted">
+                          {comment.body}
+                        </p>
+                      ))}
+                    </div>
+                  </details>
+                )}
+              </div>
+              <div className="mt-4 space-y-2">
+                <textarea
+                  value={commentQuote}
+                  onChange={(event) => setCommentQuote(event.target.value)}
+                  placeholder="Quoted passage (optional)"
+                  rows={2}
+                  className="w-full resize-y border border-rule bg-paper px-3 py-2 text-sm outline-none focus:border-ink"
+                />
+                <textarea
+                  value={commentBody}
+                  onChange={(event) => setCommentBody(event.target.value)}
+                  placeholder="Add a review note"
+                  rows={3}
+                  className="w-full resize-y border border-rule bg-paper px-3 py-2 text-sm outline-none focus:border-ink"
+                />
+                {commentError && <p className="text-xs text-red-700">{commentError}</p>}
+                <button
+                  type="button"
+                  disabled={commentBusy}
+                  onClick={submitComment}
+                  className="w-full border border-ink bg-ink px-3 py-2 text-sm font-medium text-paper hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Save note
+                </button>
+              </div>
             </section>
 
             <section className="border border-rule bg-paper p-4">


### PR DESCRIPTION
## Summary
- add owner-scoped `document_comments` with migration 0025
- expose list/create/resolve document comment endpoints with document.comment.* audit rows
- add a Review notes panel to the document workbench, with open/resolved notes and optional quoted passage

## Verification
- `python3 -m py_compile backend/app/models/document_comment.py backend/app/models/__init__.py backend/app/api/documents.py backend/tests/test_route_acl_sweep.py`
- `npm --prefix frontend run test -- DocumentDetail --run`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run build`

## Notes
- owner-only document policy preserved; no superuser/admin document-read shortcut
- backend full pytest and alembic migration gate left to CI