### PR TITLE
documents: show review note counts

### DIFF
--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -20,7 +20,7 @@ from datetime import date, datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile, File, Form, status
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.adapters import plugin_bridge as plugin_bridge_module
@@ -47,6 +47,7 @@ from app.core.api import audit
 from app.models import (
     AuditEntry,
     Document,
+    DocumentComment,
     Job,
     Matter,
     User,
@@ -192,6 +193,7 @@ class DocumentRead(BaseModel):
     from_disclosure: bool
     uploaded_at: datetime
     uploaded_by_id: uuid.UUID
+    comment_count: int = 0
 
     model_config = {"from_attributes": True}
 
@@ -533,16 +535,25 @@ async def list_documents(
     slug: str,
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_user),  # noqa: ARG001
-) -> list[Document]:
+) -> list[DocumentRead]:
     matter = await session.scalar(
         select(Matter).where(Matter.slug == slug, Matter.created_by_id == user.id)
     )
     if matter is None:
         raise HTTPException(404, f"matter not found: {slug}")
-    rows = await session.scalars(
-        select(Document).where(Document.matter_id == matter.id).order_by(Document.uploaded_at.desc())
+    rows = await session.execute(
+        select(Document, func.count(DocumentComment.id).label("comment_count"))
+        .outerjoin(DocumentComment, DocumentComment.document_id == Document.id)
+        .where(Document.matter_id == matter.id)
+        .group_by(Document.id)
+        .order_by(Document.uploaded_at.desc())
     )
-    return list(rows.all())
+    return [
+        DocumentRead.model_validate(doc).model_copy(
+            update={"comment_count": int(comment_count or 0)}
+        )
+        for doc, comment_count in rows.all()
+    ]
 
 
 @router.patch("/{slug}/privilege", response_model=MatterRead)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,6 +34,7 @@ export interface MatterDocument {
   from_disclosure: boolean;
   uploaded_at: string;
   uploaded_by_id: string;
+  comment_count?: number;
 }
 
 export interface MatterCreate {

--- a/frontend/src/matter/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.test.tsx
@@ -3,9 +3,53 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 
 import { DocumentsTab } from "./DocumentsTab";
 
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, params, ...props }: any) => (
+    <a
+      href={
+        typeof to === "string"
+          ? to
+              .replace("$slug", params?.slug ?? "")
+              .replace("$documentId", params?.documentId ?? "")
+          : "#"
+      }
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+
 afterEach(() => cleanup());
 
 describe("DocumentsTab — document ingress", () => {
+  it("surfaces review-note counts in the document list", () => {
+    render(
+      <DocumentsTab
+        slug="khan"
+        docs={[
+          {
+            id: "doc-1",
+            matter_id: "matter-1",
+            filename: "witness.docx",
+            mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            size_bytes: 1200,
+            sha256: "a".repeat(64),
+            tag: "draft",
+            from_disclosure: false,
+            uploaded_at: "2026-06-03T10:00:00",
+            uploaded_by_id: "u-1",
+            comment_count: 2,
+          },
+        ]}
+        onUpload={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(screen.getByText("2 notes")).toBeInTheDocument();
+  });
+
   it("uploads multiple selected files through the existing per-document audit path", async () => {
     const onUpload = vi.fn().mockResolvedValue(undefined);
     render(<DocumentsTab slug="khan" docs={[]} onUpload={onUpload} />);

--- a/frontend/src/matter/tabs/DocumentsTab.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.tsx
@@ -117,7 +117,7 @@ export function DocumentsTab({
   // expand drawer (short hash still shown as muted secondary line under
   // the filename) so the primary scan path is workflow-shaped.
   const gridCols =
-    "grid grid-cols-[1.5fr_110px_90px_110px_130px_72px] gap-4 px-4 py-3";
+    "grid grid-cols-[1.5fr_110px_90px_110px_90px_130px_72px] gap-4 px-4 py-3";
 
   return (
     <div className="max-w-4xl">
@@ -218,6 +218,7 @@ export function DocumentsTab({
               <span>Type</span>
               <span>Size</span>
               <span>Disclosure</span>
+              <span>Notes</span>
               <span>Updated</span>
               <span className="text-right">Action</span>
             </div>
@@ -251,6 +252,9 @@ export function DocumentsTab({
                     ) : (
                       <span className="text-xs text-muted">Upload</span>
                     )}
+                  </span>
+                  <span className="text-xs text-ink">
+                    {d.comment_count ? `${d.comment_count} note${d.comment_count === 1 ? "" : "s"}` : "None"}
                   </span>
                   <span className="text-xs text-ink">
                     {formatDate(d.uploaded_at)}


### PR DESCRIPTION
## Summary
- add `comment_count` to matter document list responses
- compute counts from document review notes on the backend
- show a quiet Notes column in the matter Documents table

## Verification
- `python3 -m py_compile backend/app/api/matters.py`
- `npm --prefix frontend run test -- DocumentsTab --run`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run build`
- `git diff --check`

## Notes
- no migration; reads the existing `document_comments` table
- upload responses default `comment_count` to 0