### PR TITLE
documents: compare saved versions

### DIFF
--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -34,6 +34,7 @@ import { EditPanel } from "../modules/document_edit/EditPanel";
 import { TrackedChangesView } from "../modules/document_edit/TrackedChangesView";
 import { AnonymiseButton } from "../modules/anonymisation/AnonymiseButton";
 import { VersionTimeline } from "../modules/document_edit/VersionTimeline";
+import { VersionDiff } from "../modules/document_edit/VersionDiff";
 import {
   DocumentRichEditor,
   findNormalizedRange,
@@ -223,6 +224,12 @@ export function DocumentDetail({
       : (resolvedVersions.find((v) => v.id === selectedVersionId) ??
         latestResolvedVersion ??
         null);
+  const selectedResolvedIndex = selectedResolvedVersion
+    ? resolvedVersions.findIndex((v) => v.id === selectedResolvedVersion.id)
+    : -1;
+  const compareBeforeVersion =
+    selectedResolvedIndex > 0 ? resolvedVersions[selectedResolvedIndex - 1] : null;
+  const compareBeforeText = compareBeforeVersion?.resolved_text ?? body?.extracted_text ?? "";
   const editorText =
     selectedResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
   const editorJson = selectedResolvedVersion?.resolved_json as TiptapNode | null | undefined;
@@ -586,6 +593,18 @@ export function DocumentDetail({
                 selectedVersionId={selectedResolvedVersion?.id ?? null}
                 onSelectVersion={(versionId) => openEditorVersion(versionId)}
               />
+              {selectedResolvedVersion?.resolved_text && compareBeforeText && (
+                <VersionDiff
+                  before={{
+                    version: compareBeforeVersion,
+                    text: compareBeforeText,
+                  }}
+                  after={{
+                    version: selectedResolvedVersion,
+                    text: selectedResolvedVersion.resolved_text,
+                  }}
+                />
+              )}
               {versions.length === 0 && (
                 <p className="mt-4 text-sm text-muted">No versions recorded.</p>
               )}

--- a/frontend/src/modules/document_edit/VersionDiff.test.tsx
+++ b/frontend/src/modules/document_edit/VersionDiff.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { buildVersionDiff } from "./VersionDiff";
+
+describe("VersionDiff", () => {
+  it("marks inserted and deleted text", () => {
+    const parts = buildVersionDiff("The clause is risky.", "The clause is acceptable.");
+
+    expect(parts.some((part) => part.type === "delete" && part.text.includes("risky"))).toBe(
+      true,
+    );
+    expect(
+      parts.some((part) => part.type === "insert" && part.text.includes("acceptable")),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/modules/document_edit/VersionDiff.tsx
+++ b/frontend/src/modules/document_edit/VersionDiff.tsx
@@ -1,0 +1,78 @@
+import { diff_match_patch as DiffMatchPatch } from "diff-match-patch";
+
+import type { DocumentVersionRead } from "../../lib/api";
+
+const dmp = new DiffMatchPatch();
+
+type DiffPart = {
+  type: "same" | "insert" | "delete";
+  text: string;
+};
+
+export function buildVersionDiff(before: string, after: string): DiffPart[] {
+  const diffs = dmp.diff_main(before, after);
+  dmp.diff_cleanupSemantic(diffs);
+  return diffs
+    .filter(([, text]) => text.length > 0)
+    .map(([op, text]) => ({
+      type: op === 1 ? "insert" : op === -1 ? "delete" : "same",
+      text,
+    }));
+}
+
+function versionLabel(version: DocumentVersionRead | null): string {
+  if (!version) return "Extracted text";
+  return `v${version.version_number}`;
+}
+
+export function VersionDiff({
+  before,
+  after,
+}: {
+  before: { version: DocumentVersionRead | null; text: string };
+  after: { version: DocumentVersionRead; text: string };
+}) {
+  const parts = buildVersionDiff(before.text, after.text);
+  const changed = parts.some((part) => part.type !== "same");
+
+  return (
+    <section className="mt-5 border border-rule bg-paper-sunken p-4" data-testid="version-diff">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-ink">Compare version</h3>
+          <p className="mt-1 text-xs text-muted">
+            {versionLabel(before.version)} → {versionLabel(after.version)}
+          </p>
+        </div>
+        <span className="border border-rule bg-paper px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+          {changed ? "Changes shown" : "No text changes"}
+        </span>
+      </div>
+      <div className="mt-4 max-h-[360px] overflow-auto border border-rule bg-paper p-4 text-sm leading-7">
+        {parts.map((part, index) => {
+          if (part.type === "insert") {
+            return (
+              <ins
+                key={`${part.type}-${index}`}
+                className="bg-green-100 px-0.5 text-green-950 no-underline"
+              >
+                {part.text}
+              </ins>
+            );
+          }
+          if (part.type === "delete") {
+            return (
+              <del
+                key={`${part.type}-${index}`}
+                className="bg-red-100 px-0.5 text-red-950"
+              >
+                {part.text}
+              </del>
+            );
+          }
+          return <span key={`${part.type}-${index}`}>{part.text}</span>;
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `VersionDiff` component using the existing `diff-match-patch` dependency
- show a compact compare panel in the Versions workspace for the selected saved version
- compare first saved version against extracted text, later saved versions against the previous saved version

## Verification
- `npm --prefix frontend run test -- VersionDiff DocumentDetail --run`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run build`

## Notes
- frontend-only
- no new dependency added