### PR TITLE
fix(matter): restore rail status footer + surface posture (Mobbin audit)

### DIFF
--- a/frontend/src/matter/MatterNav.tsx
+++ b/frontend/src/matter/MatterNav.tsx
@@ -132,17 +132,17 @@ function NavBody({
           {matter.slug}
         </div>
         {showPosture && (
-          <details className="mt-3">
-            <summary className="cursor-pointer text-[10px] uppercase tracking-widest text-muted hover:text-ink">
-              Project settings
-            </summary>
-            <div className="mt-2 flex items-center gap-2">
-              <span className="eyebrow">Privilege</span>
-              <span className="inline-flex items-center border border-rule px-1.5 py-0.5">
-                <PrivilegeControlInline value={matter.privilege_posture} onChange={onPostureChange} />
-              </span>
-            </div>
-          </details>
+          // Posture is surfaced inline, not hidden behind a disclosure: it
+          // gates every privileged action, so it stays visible in the matter
+          // card. Restores the P19 always-visible pattern (Mobbin audit
+          // 2026-06-03: no reference buries key record context behind a
+          // <details>).
+          <div className="mt-3 flex items-center gap-2">
+            <span className="eyebrow">Posture</span>
+            <span className="inline-flex items-center border border-rule px-1.5 py-0.5">
+              <PrivilegeControlInline value={matter.privilege_posture} onChange={onPostureChange} />
+            </span>
+          </div>
         )}
       </div>
 
@@ -170,6 +170,15 @@ function NavBody({
         })}
       </nav>
 
+      {/* Bottom utility zone — matter status. A persistent bottom strip is a
+          near-universal rail convention (Mobbin audit 2026-06-03); mt-auto
+          pins it to the foot of the flex-column rail. */}
+      <div className="mt-auto border-t border-rule px-4 py-3 flex items-center justify-between gap-2">
+        <span className="eyebrow text-muted">Status</span>
+        <span className="text-[10px] font-mono uppercase tracking-track2 text-muted truncate">
+          {matter.status}
+        </span>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
The small rail-fidelity follow-up to the merged Mobbin audit (#67). Two low-risk fixes to `MatterNav`, both within-spec — **no architecture touched**, no document-engine overlap.

## Changes (`frontend/src/matter/MatterNav.tsx` only)

1. **Surface posture.** Was collapsed behind a `<details>` "Project settings" disclosure (relabelled "Privilege"); now an always-visible eyebrow + chip ("Posture") in the matter card. Rationale: posture gates every privileged action, and the Mobbin pass found no reference app buries key record context behind an in-rail disclosure. Still gated by the existing `showPosture` prop — callers decide *whether* to show it; this only fixes *how* it shows.
2. **Restore the bottom utility zone.** A persistent bottom strip is a near-universal rail convention (present in all 14 audited references) that was dropped post-IA-reset. Re-added as an `mt-auto` status strip rendering `matter.status`, pinned to the foot of the flex-column rail.

## Evidence
Both fixes were the evidence-backed recommendations in `docs/design-research/LEFT_RAIL_MOBBIN_AUDIT_2026-06-03.md` (merged in #67) and the flagged decisions in P19 (#61).

## Verification
- `tsc --noEmit` clean (no `MatterNav` errors).
- `DemoMatter.test.tsx` — 2/2 pass (the component's only current consumer).
- The component isn't yet wired into the authed workspace, so this is visible today only in the demo rail; the fix makes the component spec-correct and ready for that wiring.

## Scope
Explicitly **not** the chat-direction question (that's a separate shell-pass decision, scoped from the audit doc). This is just the two low-risk fidelity fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)