### PR TITLE
documents: add active version lifecycle

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import io
+import hashlib
 import re
 import uuid
 from datetime import UTC, datetime
 
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from fastapi.responses import StreamingResponse
 from docx import Document as DocxDocument
 from docx.enum.text import WD_COLOR_INDEX
@@ -19,7 +20,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_user
 from app.core.db import get_session
-from app.core.storage import get_storage_backend, StorageReadError
+from app.core.document_uploads import (
+    ALLOWED_UPLOAD_MIMES,
+    MAX_UPLOAD_BYTES,
+    MIME_TO_FORMAT,
+    sniff_format,
+)
+from app.core.storage import (
+    get_storage_backend,
+    StorageReadError,
+    StorageWriteError,
+    uploaded_key,
+)
+from app.core.text_extraction import extract as extract_text
 from app.core.model_gateway import PrivilegePaused, gateway as model_gateway
 from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
 from app.core.api import audit, audit_failure
@@ -41,7 +54,7 @@ from app.models.document_edit import (
     EDIT_STATUS_PENDING,
     EDIT_STATUS_REJECTED,
 )
-from app.models.document_version import VERSION_KIND_USER_EDIT
+from app.models.document_version import VERSION_KIND_UPLOAD, VERSION_KIND_USER_EDIT
 from app.modules.document_edit import EDIT_MODES, propose_edits
 from app.modules.document_edit.resolver import (
     EditAlreadyResolved,
@@ -795,6 +808,207 @@ async def post_manual_document_version(
             "kind": version.kind,
             "char_count": len(body.resolved_text),
             "rich_json": body.resolved_json is not None,
+        },
+    )
+    await session.commit()
+    return DocumentVersionRead.model_validate(version)
+
+
+@router.post("/{document_id}/versions/upload", response_model=DocumentVersionRead)
+async def post_upload_document_version(
+    document_id: uuid.UUID,
+    file: UploadFile = File(...),
+    notes: str | None = Form(default=None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentVersionRead:
+    """Upload a replacement binary and make it the active document version.
+
+    This is the binary counterpart to manual editor saves: the document keeps
+    its identity, but the active original file, hash, extracted body, and
+    version history move forward together.
+    """
+    doc, matter = await _load_owned_document(document_id, session, user)
+
+    if file.content_type not in ALLOWED_UPLOAD_MIMES:
+        raise HTTPException(
+            415,
+            detail={
+                "error": "unsupported_mime",
+                "got": file.content_type,
+                "allowed": sorted(ALLOWED_UPLOAD_MIMES),
+            },
+        )
+
+    contents = await file.read()
+    if len(contents) > MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            413,
+            detail={
+                "error": "upload_too_large",
+                "max_bytes": MAX_UPLOAD_BYTES,
+                "got_bytes": len(contents),
+            },
+        )
+
+    declared_format = MIME_TO_FORMAT[file.content_type or ""]
+    inferred_format = sniff_format(contents[:1024])
+    if inferred_format is None or declared_format != inferred_format:
+        raise HTTPException(
+            415,
+            detail={
+                "error": "magic_byte_mismatch",
+                "declared_mime": file.content_type,
+                "declared_format": declared_format,
+                "inferred_format": inferred_format,
+            },
+        )
+
+    sha = hashlib.sha256(contents).hexdigest()
+    filename = file.filename or doc.filename or "untitled"
+    obj_key = uploaded_key(
+        user_id=user.id,
+        matter_id=matter.id,
+        document_id=doc.id,
+        sha256=sha,
+    )
+    storage = get_storage_backend()
+    try:
+        storage.put_bytes(
+            obj_key,
+            contents,
+            content_type=file.content_type or "application/octet-stream",
+            metadata={
+                "filename": filename[:200],
+                "sha256": sha,
+                "document_id": str(doc.id),
+            },
+        )
+    except StorageWriteError as exc:
+        await audit_failure(
+            session,
+            "storage.put_bytes.failed",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="storage",
+            resource_type="document",
+            resource_id=str(doc.id),
+            payload={
+                "storage_key": obj_key,
+                "backend": exc.backend,
+                "error_code": exc.error_code,
+                "version_upload": True,
+            },
+        )
+        raise HTTPException(
+            502,
+            detail={
+                "error": "storage_write_failed",
+                "message": "Failed to write document version to object storage.",
+                "storage_key": obj_key,
+                "backend": exc.backend,
+            },
+        ) from exc
+
+    next_version = (
+        await session.scalar(
+            select(func.coalesce(func.max(DocumentVersion.version_number), 0) + 1)
+            .where(DocumentVersion.document_id == doc.id)
+        )
+        or 1
+    )
+    extract_result = extract_text(
+        contents,
+        file.content_type or "application/octet-stream",
+        filename,
+    )
+    version = DocumentVersion(
+        document_id=doc.id,
+        version_number=int(next_version),
+        kind=VERSION_KIND_UPLOAD,
+        created_by_id=user.id,
+        storage_uri=obj_key,
+        notes=notes or f"Uploaded replacement file: {filename}",
+        resolved_text=(
+            extract_result.extracted_text
+            if extract_result.extraction_method != "failed"
+            else None
+        ),
+    )
+    session.add(version)
+
+    doc.filename = filename
+    doc.mime_type = file.content_type or "application/octet-stream"
+    doc.size_bytes = len(contents)
+    doc.sha256 = sha
+    doc.storage_uri = obj_key
+    doc.uploaded_at = datetime.now(UTC)
+    doc.uploaded_by_id = user.id
+
+    body = await session.scalar(
+        select(DocumentBody).where(
+            DocumentBody.document_id == doc.id,
+            DocumentBody.kind == BODY_KIND_EXTRACTED,
+        )
+    )
+    body_payload = {
+        "extracted_text": extract_result.extracted_text,
+        "extraction_method": extract_result.extraction_method,
+        "char_count": extract_result.char_count,
+        "page_count": extract_result.page_count,
+        "error_reason": extract_result.error_reason,
+        "extracted_at": datetime.now(UTC),
+    }
+    if body is None:
+        session.add(
+            DocumentBody(
+                document_id=doc.id,
+                kind=BODY_KIND_EXTRACTED,
+                **body_payload,
+            )
+        )
+    else:
+        for key, value in body_payload.items():
+            setattr(body, key, value)
+
+    await session.flush()
+    await audit.log(
+        session,
+        "document.version.uploaded",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_version",
+        resource_id=str(version.id),
+        payload={
+            "document_id": str(doc.id),
+            "version_number": version.version_number,
+            "filename": filename,
+            "sha256": sha,
+            "mime_type": doc.mime_type,
+            "size_bytes": doc.size_bytes,
+        },
+    )
+    await audit.log(
+        session,
+        (
+            "document.text_extraction_failed"
+            if extract_result.extraction_method == "failed"
+            else "document.text_extracted"
+        ),
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_ingestion",
+        resource_type="document",
+        resource_id=str(doc.id),
+        payload={
+            "version_id": str(version.id),
+            "version_number": version.version_number,
+            "method": extract_result.extraction_method,
+            "char_count": extract_result.char_count,
+            "page_count": extract_result.page_count,
+            "mime_type": doc.mime_type,
+            "reason": extract_result.error_reason,
         },
     )
     await session.commit()

--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -1,15 +1,4 @@
-"""Matters API — create, list, fetch, attach documents.
-
-v0.1 endpoints:
-    POST   /api/matters                     create a matter
-    GET    /api/matters                     list all matters for the user
-    GET    /api/matters/{slug}              fetch a matter by slug
-    POST   /api/matters/{slug}/documents    register a document on the matter
-    GET    /api/matters/{slug}/documents    list documents on the matter
-
-Document upload is metadata-only for v0.1; binary upload to MinIO/R2 lands
-later in the build window (Week 1 Day 5+).
-"""
+"""Matters API — create, list, fetch, attach documents."""
 
 from __future__ import annotations
 
@@ -28,6 +17,12 @@ from app.adapters.plugin_bridge import SkillDisabled
 from app.core.auth import current_user
 from app.core.db import get_session
 from app.core.limits import check_matter_create, check_document_upload
+from app.core.document_uploads import (
+    ALLOWED_UPLOAD_MIMES,
+    MAX_UPLOAD_BYTES,
+    MIME_TO_FORMAT,
+    sniff_format,
+)
 from app.core.matter_fs import (
     append_history,
     materialise_matter,
@@ -66,59 +61,6 @@ from app.models.document_body import DocumentBody, BODY_KIND_EXTRACTED
 from app.models.document_version import DocumentVersion, VERSION_KIND_UPLOAD
 
 router = APIRouter()
-
-
-# Upload validation. Pre-launch hardening: cap binary size, restrict
-# accepted MIME types, and require the body's magic bytes to match the
-# declared MIME so a fake `application/pdf` cannot reach the pdf
-# parser. Extraction downstream (`extract_text`) only knows pdf / docx
-# / doc / txt / md / rtf; the allowlist mirrors what we actually
-# process.
-MAX_UPLOAD_BYTES = 25 * 1024 * 1024  # 25 MB
-
-# Declared MIME → canonical format key. The format key is what we
-# compare against the inferred-from-bytes format below. Single source
-# of truth for the allowlist; `ALLOWED_UPLOAD_MIMES` is derived.
-_MIME_TO_FORMAT: dict[str, str] = {
-    "application/pdf": "pdf",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
-    "application/msword": "doc",
-    "text/plain": "text",
-    "text/markdown": "text",
-    "application/rtf": "rtf",
-    "text/rtf": "rtf",
-}
-ALLOWED_UPLOAD_MIMES = frozenset(_MIME_TO_FORMAT.keys())
-
-
-def _sniff_format(head: bytes) -> str | None:
-    """Infer canonical format key from the first ~1KB of a file body.
-
-    Returns one of the format keys used in `_MIME_TO_FORMAT.values()`
-    or None when no signature matches and the bytes are not valid UTF-8
-    (in which case calling the file `text/plain` would also be a lie).
-
-    Empty bytes is treated as text — the size cap is the emptiness
-    guard, not this function. The magic check is a "lying about file
-    type" defence, not a content quality check.
-    """
-    if head.startswith(b"%PDF-"):
-        return "pdf"
-    if head.startswith(b"PK\x03\x04"):
-        # Zip-based — could be any Office Open XML or generic zip, but
-        # the MIME allowlist only permits docx, so we report docx and
-        # let the parser reject malformed packages downstream.
-        return "docx"
-    if head.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"):
-        # OLE2 compound binary format used by legacy .doc / .xls / .ppt.
-        return "doc"
-    if head.startswith(b"{\\rtf"):
-        return "rtf"
-    try:
-        head.decode("utf-8")
-        return "text"
-    except UnicodeDecodeError:
-        return None
 
 
 # ---------- schemas ---------------------------------------------------------
@@ -369,8 +311,8 @@ async def upload_document(
     # data; the document is not yet inserted at this point.
     await check_document_upload(user.id, matter.id, len(contents), session)
 
-    declared_format = _MIME_TO_FORMAT[file.content_type or ""]
-    inferred_format = _sniff_format(contents[:1024])
+    declared_format = MIME_TO_FORMAT[file.content_type or ""]
+    inferred_format = sniff_format(contents[:1024])
     if inferred_format is None or declared_format != inferred_format:
         raise HTTPException(
             415,

--- a/backend/app/core/document_uploads.py
+++ b/backend/app/core/document_uploads.py
@@ -1,0 +1,41 @@
+"""Shared document-upload validation.
+
+Both first uploads and replacement-version uploads accept the same file
+formats and enforce the same size / magic-byte checks. Keep that policy out
+of route modules so the document engine does not drift by endpoint.
+"""
+
+from __future__ import annotations
+
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024  # 25 MB
+
+# Declared MIME -> canonical format key. The format key is what callers compare
+# against the inferred-from-bytes format below.
+MIME_TO_FORMAT: dict[str, str] = {
+    "application/pdf": "pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+    "application/msword": "doc",
+    "text/plain": "text",
+    "text/markdown": "text",
+    "application/rtf": "rtf",
+    "text/rtf": "rtf",
+}
+ALLOWED_UPLOAD_MIMES = frozenset(MIME_TO_FORMAT.keys())
+
+
+def sniff_format(head: bytes) -> str | None:
+    """Infer canonical format key from the first ~1KB of a file body."""
+    if head.startswith(b"%PDF-"):
+        return "pdf"
+    if head.startswith(b"PK\x03\x04"):
+        return "docx"
+    if head.startswith(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"):
+        return "doc"
+    if head.startswith(b"{\\rtf"):
+        return "rtf"
+    try:
+        head.decode("utf-8")
+        return "text"
+    except UnicodeDecodeError:
+        return None
+

--- a/backend/app/core/limits.py
+++ b/backend/app/core/limits.py
@@ -58,9 +58,9 @@ class Limits:
     documents_per_matter: int = field(
         default_factory=lambda: int(os.environ.get("LEGALISE_LIMIT_DOCUMENTS_PER_MATTER", "50"))
     )
-    # max_file_bytes re-uses the constant from matters.py via env-override.
+    # max_file_bytes re-uses the canonical upload helper via env-override.
     # Do not duplicate the 25 MB literal here — import MAX_UPLOAD_BYTES from
-    # app.api.matters at call sites that need the raw value.
+    # app.core.document_uploads at call sites that need the raw value.
     total_storage_bytes_per_user: int = field(
         default_factory=lambda: int(
             os.environ.get("LEGALISE_LIMIT_TOTAL_STORAGE_BYTES_PER_USER", str(500 * 1024 * 1024))

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -186,6 +186,50 @@ async def test_post_manual_document_version_creates_user_edit_version(client) ->
 
 
 @pytest.mark.asyncio
+async def test_post_upload_document_version_updates_active_document_and_body(client) -> None:
+    """Owner can upload a replacement binary as the next active document version."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    slug, doc_id = await _create_matter_and_upload(client)
+
+    resp = await client.post(
+        f"/api/documents/{doc_id}/versions/upload",
+        files={
+            "file": (
+                "replacement.txt",
+                io.BytesIO(b"Replacement document text."),
+                "text/plain",
+            )
+        },
+        data={"notes": "Clean text replacement"},
+    )
+    assert resp.status_code == 200, resp.text
+    version = resp.json()
+    assert version["kind"] == "upload"
+    assert version["version_number"] == 2
+    assert version["storage_uri"]
+    assert version["resolved_text"] == "Replacement document text."
+    assert version["notes"] == "Clean text replacement"
+
+    body = await client.get(f"/api/documents/{doc_id}/body")
+    assert body.status_code == 200, body.text
+    assert body.json()["extracted_text"] == "Replacement document text."
+
+    docs = await client.get(f"/api/matters/{slug}/documents")
+    assert docs.status_code == 200, docs.text
+    active = next(row for row in docs.json() if row["id"] == doc_id)
+    assert active["filename"] == "replacement.txt"
+    assert active["mime_type"] == "text/plain"
+    assert active["size_bytes"] == len(b"Replacement document text.")
+
+    versions = await client.get(f"/api/documents/{doc_id}/versions")
+    assert versions.status_code == 200, versions.text
+    rows = versions.json()
+    assert [row["version"]["version_number"] for row in rows] == [1, 2]
+    assert rows[-1]["version"]["kind"] == "upload"
+    assert rows[-1]["version"]["resolved_text"] == "Replacement document text."
+
+
+@pytest.mark.asyncio
 async def test_get_manual_document_version_docx_returns_word_file(client) -> None:
     """Owner can download a saved editor version as a valid .docx."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1795,6 +1795,55 @@ export const saveDocumentVersion = (
     }),
   }).then((r) => resolutionJsonOrThrow<DocumentVersionRead>(r));
 
+export const uploadDocumentVersion = async (
+  documentId: string,
+  file: File,
+  notes?: string,
+): Promise<DocumentVersionRead> => {
+  const fd = new FormData();
+  fd.append("file", file);
+  if (notes?.trim()) fd.append("notes", notes.trim());
+  const res = await apiFetch(`${API}/documents/${documentId}/versions/upload`, {
+    method: "POST",
+    body: fd,
+  });
+  if (res.status === 413 || res.status === 415) {
+    let detail: Record<string, unknown> | null = null;
+    try {
+      const body = (await res.json()) as { detail?: Record<string, unknown> };
+      detail = body?.detail ?? null;
+    } catch {
+      detail = null;
+    }
+    if (res.status === 415) {
+      const errKind = (detail?.error as string | undefined) ?? "unsupported_mime";
+      if (errKind === "magic_byte_mismatch") {
+        const declared = (detail?.declared_mime as string | null) || file.type || "the declared type";
+        const inferred = (detail?.inferred_format as string | null) ?? "something else";
+        throw new UploadError(
+          "magic_byte_mismatch",
+          415,
+          `File contents do not match its declared type. Declared as ${declared}; the bytes look like ${inferred}. Re-export from the source app and try again.`,
+        );
+      }
+      const got = (detail?.got as string | null) || file.type || "unknown";
+      throw new UploadError(
+        "unsupported_mime",
+        415,
+        `That file type is not supported (${got}). Upload a PDF, DOCX, DOC, TXT, MD, or RTF.`,
+      );
+    }
+    const maxBytes = Number(detail?.max_bytes ?? 25 * 1024 * 1024);
+    const gotBytes = Number(detail?.got_bytes ?? file.size);
+    throw new UploadError(
+      "upload_too_large",
+      413,
+      `File is too large (${formatMb(gotBytes)}). The limit is ${formatMb(maxBytes)} per document.`,
+    );
+  }
+  return resolutionJsonOrThrow<DocumentVersionRead>(res);
+};
+
 export const getDocumentComments = (documentId: string) =>
   apiFetch(`${API}/documents/${documentId}/comments`).then((r) =>
     resolutionJsonOrThrow<DocumentCommentRead[]>(r),

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -432,6 +432,49 @@ describe("DocumentDetail", () => {
     expect(download.getAttribute("href")).toContain("/documents/doc-1/versions/v-2/docx");
   });
 
+  it("uploads a replacement file as the next active document version", async () => {
+    vi.spyOn(api, "listDocuments")
+      .mockResolvedValueOnce([doc({ filename: "draft-v1.txt", mime_type: "text/plain" })])
+      .mockResolvedValueOnce([doc({ filename: "draft-v2.txt", mime_type: "text/plain", sha256: "b".repeat(64) })]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body({ extracted_text: "Updated body" }));
+    vi.spyOn(api, "getDocumentVersions")
+      .mockResolvedValueOnce([versionSummary("v-1", 1, null, "upload")])
+      .mockResolvedValueOnce([
+        versionSummary("v-1", 1, null, "upload"),
+        versionSummary("v-2", 2, "Updated body", "upload"),
+      ]);
+    const upload = vi.spyOn(api, "uploadDocumentVersion").mockResolvedValue({
+      id: "v-2",
+      document_id: "doc-1",
+      version_number: 2,
+      kind: "upload",
+      created_by_id: "u-1",
+      created_at: "2026-05-28T09:06:00",
+      storage_uri: "users/u/matters/m/documents/doc-1/b",
+      notes: "Clean copy",
+      resolved_text: "Updated body",
+    });
+
+    mount();
+    await screen.findByRole("heading", { name: "draft-v1.txt" });
+    fireEvent.click(screen.getByRole("button", { name: "Versions" }));
+    const input = screen.getByTestId("document-version-file-input");
+    const file = new File(["Updated body"], "draft-v2.txt", { type: "text/plain" });
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.change(screen.getByPlaceholderText("Optional version note"), {
+      target: { value: "Clean copy" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Upload version" }));
+
+    await waitFor(() => {
+      expect(upload).toHaveBeenCalledWith("doc-1", file, "Clean copy");
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "draft-v2.txt" })).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Viewing saved version v2/)).toBeInTheDocument();
+  });
+
   it("moves proposed redlines into the main document review area", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
     vi.spyOn(api, "getDocumentBody").mockResolvedValue({

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -18,6 +18,7 @@ import {
   getDocumentVersions,
   listDocuments,
   resolveDocumentComment,
+  uploadDocumentVersion,
   type AnonymisationResult,
   type DocumentCommentRead,
   type DocumentBody,
@@ -98,8 +99,13 @@ export function DocumentDetail({
   const [commentBody, setCommentBody] = useState("");
   const [commentQuote, setCommentQuote] = useState("");
   const [selectedQuote, setSelectedQuote] = useState("");
+  const [activeReaderQuote, setActiveReaderQuote] = useState<string | null>(null);
   const [commentError, setCommentError] = useState<string | null>(null);
   const [commentBusy, setCommentBusy] = useState(false);
+  const [versionUploadFile, setVersionUploadFile] = useState<File | null>(null);
+  const [versionUploadNotes, setVersionUploadNotes] = useState("");
+  const [versionUploadBusy, setVersionUploadBusy] = useState(false);
+  const [versionUploadError, setVersionUploadError] = useState<string | null>(null);
   const [showDetails, setShowDetails] = useState(false);
   const [workbenchView, setWorkbenchView] = useState<WorkbenchView>("editor");
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
@@ -129,23 +135,31 @@ export function DocumentDetail({
       : "← Documents";
   const arrivedFromChat = fromTab === "assistant";
 
+  const refreshDocumentMetadata = useCallback(
+    (cancelledRef?: { cancelled: boolean }) =>
+      listDocuments(slug)
+      .then((docs) => {
+        if (cancelledRef?.cancelled) return null;
+        const doc = docs.find((d) => d.id === documentId);
+        setQ(doc ? { status: "ready", doc } : { status: "not_found" });
+        return doc ?? null;
+      })
+      .catch((err: unknown) => {
+        if (!cancelledRef?.cancelled) setQ({ status: "error", message: String(err) });
+        return null;
+      }),
+    [slug, documentId],
+  );
+
   // Metadata: there's no single-document GET; the matter document list
   // is the authoritative source. Find the row by id.
   useEffect(() => {
-    let cancelled = false;
-    listDocuments(slug)
-      .then((docs) => {
-        if (cancelled) return;
-        const doc = docs.find((d) => d.id === documentId);
-        setQ(doc ? { status: "ready", doc } : { status: "not_found" });
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) setQ({ status: "error", message: String(err) });
-      });
+    const cancelledRef = { cancelled: false };
+    refreshDocumentMetadata(cancelledRef);
     return () => {
-      cancelled = true;
+      cancelledRef.cancelled = true;
     };
-  }, [slug, documentId]);
+  }, [refreshDocumentMetadata]);
 
   const loadBody = useCallback(() => {
     getDocumentBody(documentId)
@@ -162,6 +176,10 @@ export function DocumentDetail({
       .catch(() => setComments([]));
   }, [documentId]);
 
+  const loadVersions = useCallback(() => {
+    getDocumentVersions(documentId).then(setVersions).catch(() => undefined);
+  }, [documentId]);
+
   useEffect(() => {
     setActiveEditResult(null);
     setWorkbenchView("editor");
@@ -169,11 +187,11 @@ export function DocumentDetail({
     setEditorDirty(false);
     loadBody();
     loadComments();
-    getDocumentVersions(documentId).then(setVersions).catch(() => undefined);
+    loadVersions();
     getAnonymisation(documentId)
       .then(setAnon)
       .catch(() => setAnon(null));
-  }, [documentId, loadBody, loadComments]);
+  }, [documentId, loadBody, loadComments, loadVersions]);
 
   if (q.status === "loading") {
     return (
@@ -236,8 +254,9 @@ export function DocumentDetail({
   const editorText =
     selectedResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
   const editorJson = selectedResolvedVersion?.resolved_json as TiptapNode | null | undefined;
-  const sourceQuoteFoundInReader = sourceContext.quote
-    ? Boolean(findNormalizedRange(editorText, sourceContext.quote))
+  const currentReaderQuote = activeReaderQuote ?? sourceContext.quote;
+  const sourceQuoteFoundInReader = currentReaderQuote
+    ? Boolean(findNormalizedRange(editorText, currentReaderQuote))
     : null;
   const editorSourceLabel = selectedResolvedVersion
     ? `Viewing saved version v${selectedResolvedVersion.version_number}`
@@ -307,6 +326,48 @@ export function DocumentDetail({
       setCommentError(err instanceof Error ? err.message : "Could not resolve note.");
     } finally {
       setCommentBusy(false);
+    }
+  };
+  const jumpToCommentQuote = (quote: string) => {
+    if (!confirmDiscardEditorChanges()) return;
+    setActiveReaderQuote(quote);
+    setSelectedVersionId(null);
+    setWorkbenchView("editor");
+    requestAnimationFrame(() => {
+      workbenchRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+    });
+  };
+  const submitVersionUpload = async () => {
+    if (!versionUploadFile) {
+      setVersionUploadError("Choose a file to upload as the next version.");
+      return;
+    }
+    if (!confirmDiscardEditorChanges()) return;
+    setVersionUploadBusy(true);
+    setVersionUploadError(null);
+    try {
+      const uploaded = await uploadDocumentVersion(
+        documentId,
+        versionUploadFile,
+        versionUploadNotes,
+      );
+      setVersionUploadFile(null);
+      setVersionUploadNotes("");
+      setSelectedVersionId(uploaded.resolved_text ? uploaded.id : null);
+      setActiveReaderQuote(null);
+      setEditorDirty(false);
+      await Promise.all([
+        refreshDocumentMetadata(),
+        Promise.resolve(loadBody()),
+        Promise.resolve(loadVersions()),
+      ]);
+      setWorkbenchView("editor");
+    } catch (err) {
+      setVersionUploadError(
+        err instanceof Error ? err.message : "Could not upload this document version.",
+      );
+    } finally {
+      setVersionUploadBusy(false);
     }
   };
 
@@ -515,7 +576,7 @@ export function DocumentDetail({
                   initialJson={editorJson}
                   latestVersionNumber={latestVersion?.version_number}
                   sourceLabel={editorSourceLabel}
-                  sourceHighlight={sourceContext.quote}
+                  sourceHighlight={currentReaderQuote}
                   onSaved={(version) => {
                     setSelectedVersionId(version.id);
                     getDocumentVersions(documentId)
@@ -534,7 +595,7 @@ export function DocumentDetail({
               <PdfDocumentViewer
                 fileUrl={originalHref}
                 filename={doc.filename}
-                sourceHighlight={sourceContext.quote}
+                sourceHighlight={currentReaderQuote}
               />
               ) : canPreviewDocx ? (
               <DocxOriginalPreview documentId={documentId} filename={doc.filename} />
@@ -560,6 +621,55 @@ export function DocumentDetail({
               <p className="mt-1 text-sm leading-relaxed text-muted">
                 Accepted edits and manual saves create new versions. Open a saved version to review or download it.
               </p>
+              <div
+                className="mt-5 border border-rule bg-paper-sunken p-4"
+                data-testid="document-version-upload"
+              >
+                <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+                  <div>
+                    <h3 className="text-sm font-semibold text-ink">
+                      Upload next version
+                    </h3>
+                    <p className="mt-1 text-sm leading-6 text-muted">
+                      Replace the active original file while keeping this document's version history and review notes together.
+                    </p>
+                    <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                      <input
+                        type="file"
+                        accept=".pdf,.doc,.docx,.txt,.md,.rtf,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/plain,text/markdown,application/rtf,text/rtf"
+                        onChange={(event) =>
+                          setVersionUploadFile(event.currentTarget.files?.[0] ?? null)
+                        }
+                        className="w-full border border-rule bg-paper px-3 py-2 text-sm"
+                        data-testid="document-version-file-input"
+                      />
+                      <input
+                        type="text"
+                        value={versionUploadNotes}
+                        onChange={(event) => setVersionUploadNotes(event.target.value)}
+                        placeholder="Optional version note"
+                        className="w-full border border-rule bg-paper px-3 py-2 text-sm outline-none focus:border-ink"
+                      />
+                    </div>
+                    {versionUploadFile && (
+                      <p className="mt-2 text-xs text-muted">
+                        Next version: {versionUploadFile.name} · {formatBytes(versionUploadFile.size)}
+                      </p>
+                    )}
+                    {versionUploadError && (
+                      <p className="mt-2 text-xs text-red-700">{versionUploadError}</p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    disabled={versionUploadBusy}
+                    onClick={submitVersionUpload}
+                    className="border border-ink bg-ink px-4 py-2 text-sm font-medium text-paper hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {versionUploadBusy ? "Uploading..." : "Upload version"}
+                  </button>
+                </div>
+              </div>
               {resolvedVersions.length > 0 && (
                 <div className="mt-4 flex flex-wrap items-center gap-2">
                   <button
@@ -684,9 +794,16 @@ export function DocumentDetail({
                     className="border border-rule bg-paper-sunken p-3 text-sm"
                   >
                     {comment.quote_text && (
-                      <blockquote className="mb-2 border-l-2 border-rule pl-3 text-muted">
-                        {comment.quote_text}
-                      </blockquote>
+                      <div className="mb-2 border-l-2 border-rule pl-3 text-muted">
+                        <blockquote>{comment.quote_text}</blockquote>
+                        <button
+                          type="button"
+                          onClick={() => jumpToCommentQuote(comment.quote_text ?? "")}
+                          className="mt-2 text-xs font-medium text-ink underline underline-offset-4 hover:text-muted"
+                        >
+                          Find in document
+                        </button>
+                      </div>
                     )}
                     <p className="leading-6 text-ink">{comment.body}</p>
                     <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted">

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -26,6 +26,7 @@ function escapeHtml(value: string): string {
 }
 
 type TextRange = { start: number; end: number };
+type OutlineItem = { id: string; label: string; query: string };
 
 export function findNormalizedRanges(
   text: string,
@@ -118,6 +119,21 @@ function plainTextFromNode(node: TiptapNode): string {
 
 export function editorJsonToPlainText(json: TiptapNode): string {
   return plainTextFromNode(json).replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function documentOutlineFromText(text: string): OutlineItem[] {
+  const blocks = text
+    .split(/\n{2,}/)
+    .map((block) => block.replace(/\s+/g, " ").trim())
+    .filter((block) => block.length >= 12);
+  return blocks.slice(0, 12).map((block, index) => {
+    const compact = block.length > 76 ? `${block.slice(0, 73).trimEnd()}...` : block;
+    return {
+      id: `${index}-${compact}`,
+      label: compact,
+      query: block.slice(0, 96),
+    };
+  });
 }
 
 function ToolbarButton({
@@ -241,6 +257,14 @@ export function DocumentRichEditor({
           .replace(/\s+/g, " ")
           .trim()
       : null;
+  const outlineItems = useMemo(
+    () => documentOutlineFromText(plainText),
+    [plainText],
+  );
+  const sourceRange = useMemo(
+    () => findNormalizedRange(plainText, sourceHighlight),
+    [plainText, sourceHighlight],
+  );
 
   async function save() {
     if (!editor || !canSave) return;
@@ -456,7 +480,55 @@ export function DocumentRichEditor({
           {error}
         </p>
       )}
-      <EditorContent editor={editor} />
+      <div className="grid min-h-[620px] lg:grid-cols-[240px_minmax(0,1fr)]">
+        <aside className="border-b border-rule bg-paper-sunken px-5 py-5 lg:border-b-0 lg:border-r">
+          <div className="space-y-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                Source passage
+              </p>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                {sourceHighlight
+                  ? sourceRange
+                    ? "Located in this version."
+                    : "Not located in this version."
+                  : "No cited passage selected."}
+              </p>
+              {sourceHighlight && (
+                <button
+                  type="button"
+                  onClick={() => setFindQuery(sourceHighlight)}
+                  className="mt-2 text-xs font-medium text-ink underline underline-offset-4 hover:text-muted"
+                >
+                  Search cited text
+                </button>
+              )}
+            </div>
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                Outline
+              </p>
+              {outlineItems.length > 0 ? (
+                <nav className="mt-2 space-y-1" aria-label="Document outline">
+                  {outlineItems.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => setFindQuery(item.query)}
+                      className="block w-full border-l border-transparent py-1 pl-2 text-left text-xs leading-5 text-muted hover:border-ink hover:text-ink"
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </nav>
+              ) : (
+                <p className="mt-2 text-sm text-muted">No outline yet.</p>
+              )}
+            </div>
+          </div>
+        </aside>
+        <EditorContent editor={editor} />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Mike-parity document engine slice:

- add shared document upload validation so first uploads and replacement-version uploads use the same MIME, size, and magic-byte policy
- add `POST /api/documents/{document_id}/versions/upload` to upload a replacement binary as the next immutable document version
- replacement uploads update the active document metadata/original bytes, refresh extracted text, and audit `document.version.uploaded` plus extraction result
- add a Versions-panel upload flow in `DocumentDetail` that refreshes the active document, body, and version list after upload
- add review-note quote navigation (`Find in document`) so quoted notes jump back into the reader/editor
- add a persistent editor outline/source rail for document-map style navigation

## Verification

- `python3 -m py_compile backend/app/core/document_uploads.py backend/app/api/matters.py backend/app/api/documents.py backend/tests/test_route_acl_sweep.py`
- `npm run typecheck` (frontend)
- `npm run test -- DocumentDetail.test.tsx` (16/16)
- `npm run build` (frontend; existing PDF/docx bundle-size warning)

Local backend pytest could not run because this machine's Python lacks pytest (`No module named pytest`); GitHub CI is the backend gate.

## Notes

No schema migration. New uploaded versions use existing `document_versions.storage_uri`; the active `documents.storage_uri` moves to the latest uploaded binary so Open/Download original reads the current version.