### PR TITLE
documents: add edit session presence

### DIFF
--- a/backend/alembic/versions/0026_document_edit_sessions.py
+++ b/backend/alembic/versions/0026_document_edit_sessions.py
@@ -1,0 +1,51 @@
+"""Add document edit sessions.
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "document_edit_sessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("document_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("client_id", sa.String(length=96), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["document_id"], ["documents.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_document_edit_sessions_document_id",
+        "document_edit_sessions",
+        ["document_id"],
+    )
+    op.create_index(
+        "ix_document_edit_sessions_user_id",
+        "document_edit_sessions",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_edit_sessions_user_id", table_name="document_edit_sessions")
+    op.drop_index("ix_document_edit_sessions_document_id", table_name="document_edit_sessions")
+    op.drop_table("document_edit_sessions")
+

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -6,7 +6,7 @@ import io
 import hashlib
 import re
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from typing import Any, Literal
 
@@ -43,6 +43,7 @@ from app.models import (
     Document,
     DocumentComment,
     DocumentEdit,
+    DocumentEditSession,
     DocumentVersion,
     Matter,
     STATUS_ARCHIVED,
@@ -184,6 +185,26 @@ class DocumentEditRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class DocumentEditSessionStart(BaseModel):
+    client_id: str = Field(min_length=8, max_length=96)
+
+
+class DocumentEditSessionRead(BaseModel):
+    id: uuid.UUID
+    document_id: uuid.UUID
+    user_id: uuid.UUID
+    client_id: str
+    user_label: str
+    started_at: datetime
+    last_seen_at: datetime
+    ended_at: datetime | None
+
+
+class DocumentEditSessionResponse(BaseModel):
+    current: DocumentEditSessionRead
+    active: list[DocumentEditSessionRead]
+
+
 class EditInstructionResponse(BaseModel):
     version: DocumentVersionRead
     pending_edits: list[DocumentEditRead]
@@ -191,6 +212,41 @@ class EditInstructionResponse(BaseModel):
     model_notes: str
     instruction_hash: str
     parse_ok: bool
+
+
+def _active_session_cutoff() -> datetime:
+    return datetime.now(UTC) - timedelta(seconds=90)
+
+
+async def _active_edit_sessions(
+    session: AsyncSession,
+    document_id: uuid.UUID,
+) -> list[DocumentEditSessionRead]:
+    rows = (
+        await session.execute(
+            select(DocumentEditSession, User)
+            .join(User, User.id == DocumentEditSession.user_id)
+            .where(
+                DocumentEditSession.document_id == document_id,
+                DocumentEditSession.ended_at.is_(None),
+                DocumentEditSession.last_seen_at >= _active_session_cutoff(),
+            )
+            .order_by(DocumentEditSession.last_seen_at.desc())
+        )
+    ).all()
+    return [
+        DocumentEditSessionRead(
+            id=row.id,
+            document_id=row.document_id,
+            user_id=row.user_id,
+            client_id=row.client_id,
+            user_label=user.name or user.email,
+            started_at=row.started_at,
+            last_seen_at=row.last_seen_at,
+            ended_at=row.ended_at,
+        )
+        for row, user in rows
+    ]
 
 
 @router.post("/{document_id}/edit-instructions", response_model=EditInstructionResponse)
@@ -1133,6 +1189,111 @@ async def get_document_versions(
             )
         )
     return out
+
+
+@router.get("/{document_id}/edit-sessions", response_model=list[DocumentEditSessionRead])
+async def get_document_edit_sessions(
+    document_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> list[DocumentEditSessionRead]:
+    """List active editing sessions for this document."""
+    doc, _matter = await _load_owned_document(document_id, session, user)
+    return await _active_edit_sessions(session, doc.id)
+
+
+@router.post("/{document_id}/edit-sessions", response_model=DocumentEditSessionResponse)
+async def post_document_edit_session(
+    document_id: uuid.UUID,
+    body: DocumentEditSessionStart,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentEditSessionResponse:
+    """Start or heartbeat a document editing session for this browser client."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    now = datetime.now(UTC)
+    row = await session.scalar(
+        select(DocumentEditSession).where(
+            DocumentEditSession.document_id == doc.id,
+            DocumentEditSession.user_id == user.id,
+            DocumentEditSession.client_id == body.client_id,
+            DocumentEditSession.ended_at.is_(None),
+        )
+    )
+    started = False
+    if row is None:
+        row = DocumentEditSession(
+            document_id=doc.id,
+            user_id=user.id,
+            client_id=body.client_id,
+            started_at=now,
+            last_seen_at=now,
+        )
+        session.add(row)
+        started = True
+    else:
+        row.last_seen_at = now
+
+    await session.flush()
+    if started:
+        await audit.log(
+            session,
+            "document.edit_session.started",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="document_editor",
+            resource_type="document",
+            resource_id=str(doc.id),
+            payload={"session_id": str(row.id)},
+        )
+    await session.commit()
+    active = await _active_edit_sessions(session, doc.id)
+    current = next((item for item in active if item.id == row.id), None)
+    if current is None:
+        current = DocumentEditSessionRead(
+            id=row.id,
+            document_id=row.document_id,
+            user_id=row.user_id,
+            client_id=row.client_id,
+            user_label=user.name or user.email,
+            started_at=row.started_at,
+            last_seen_at=row.last_seen_at,
+            ended_at=row.ended_at,
+        )
+    return DocumentEditSessionResponse(current=current, active=active)
+
+
+@router.delete("/{document_id}/edit-sessions/{session_id}", status_code=204)
+async def delete_document_edit_session(
+    document_id: uuid.UUID,
+    session_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> Response:
+    """End this browser client's document editing session."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    row = await session.scalar(
+        select(DocumentEditSession).where(
+            DocumentEditSession.id == session_id,
+            DocumentEditSession.document_id == doc.id,
+            DocumentEditSession.user_id == user.id,
+        )
+    )
+    if row is not None and row.ended_at is None:
+        row.ended_at = datetime.now(UTC)
+        row.last_seen_at = row.ended_at
+        await audit.log(
+            session,
+            "document.edit_session.ended",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="document_editor",
+            resource_type="document",
+            resource_id=str(doc.id),
+            payload={"session_id": str(row.id)},
+        )
+        await session.commit()
+    return Response(status_code=204)
 
 
 # -- Anonymisation ---------------------------------------------------------

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -40,6 +40,7 @@ from app.models.audit import AuditEntry
 from app.models.document_body import DocumentBody, BODY_KIND_VALUES, EXTRACTION_METHOD_VALUES
 from app.models.document_version import DocumentVersion, VERSION_KIND_VALUES
 from app.models.document_edit import DocumentEdit, EDIT_STATUS_VALUES
+from app.models.document_edit_session import DocumentEditSession
 from app.models.document_comment import (
     COMMENT_STATUS_OPEN,
     COMMENT_STATUS_RESOLVED,
@@ -151,6 +152,7 @@ __all__ = [
     "DocumentBody",
     "DocumentVersion",
     "DocumentEdit",
+    "DocumentEditSession",
     "DocumentComment",
     "TabularReview",
     "TabularReviewRow",

--- a/backend/app/models/document_edit_session.py
+++ b/backend/app/models/document_edit_session.py
@@ -1,0 +1,45 @@
+"""Document edit sessions.
+
+Lightweight presence/locking substrate for the document workbench. This is not
+real-time CRDT collaboration; it records who has a document open for editing so
+the UI can show active editors and later co-editing can attach to the same
+document-scoped session primitive.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class DocumentEditSession(Base):
+    __tablename__ = "document_edit_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    document_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("documents.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+    client_id: Mapped[str] = mapped_column(String(96), nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<DocumentEditSession {self.document_id} user={self.user_id}>"
+

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -144,6 +144,39 @@ async def test_document_comments_cross_user_returns_404(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_document_edit_sessions_are_owner_scoped(client) -> None:
+    """Owner can heartbeat an edit session; another user cannot see it."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload(client)
+
+    started = await client.post(
+        f"/api/documents/{doc_id}/edit-sessions",
+        json={"client_id": "browser-client-a"},
+    )
+    assert started.status_code == 200, started.text
+    payload = started.json()
+    assert payload["current"]["client_id"] == "browser-client-a"
+    assert payload["active"][0]["user_label"] == EMAIL_A
+
+    listed = await client.get(f"/api/documents/{doc_id}/edit-sessions")
+    assert listed.status_code == 200, listed.text
+    assert [row["client_id"] for row in listed.json()] == ["browser-client-a"]
+
+    ended = await client.delete(
+        f"/api/documents/{doc_id}/edit-sessions/{payload['current']['id']}",
+    )
+    assert ended.status_code == 204, ended.text
+    listed_after = await client.get(f"/api/documents/{doc_id}/edit-sessions")
+    assert listed_after.status_code == 200, listed_after.text
+    assert listed_after.json() == []
+
+    await client.post("/auth/logout")
+    await _signup_and_login(client, EMAIL_B, PASSWORD_B)
+    cross_user = await client.get(f"/api/documents/{doc_id}/edit-sessions")
+    assert cross_user.status_code == 404, cross_user.text
+
+
+@pytest.mark.asyncio
 async def test_post_manual_document_version_creates_user_edit_version(client) -> None:
     """Owner can save editor text as a new immutable document version."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1738,6 +1738,22 @@ export interface DocumentCommentRead {
   resolved_by_id: string | null;
 }
 
+export interface DocumentEditSessionRead {
+  id: string;
+  document_id: string;
+  user_id: string;
+  client_id: string;
+  user_label: string;
+  started_at: string;
+  last_seen_at: string;
+  ended_at: string | null;
+}
+
+export interface DocumentEditSessionResponse {
+  current: DocumentEditSessionRead;
+  active: DocumentEditSessionRead[];
+}
+
 export class ConflictError extends Error {
   status = 409;
 }
@@ -1848,6 +1864,35 @@ export const getDocumentComments = (documentId: string) =>
   apiFetch(`${API}/documents/${documentId}/comments`).then((r) =>
     resolutionJsonOrThrow<DocumentCommentRead[]>(r),
   );
+
+export const getDocumentEditSessions = (documentId: string) =>
+  apiFetch(`${API}/documents/${documentId}/edit-sessions`).then((r) =>
+    resolutionJsonOrThrow<DocumentEditSessionRead[]>(r),
+  );
+
+export const startDocumentEditSession = (
+  documentId: string,
+  clientId: string,
+) =>
+  apiFetch(`${API}/documents/${documentId}/edit-sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_id: clientId }),
+  }).then((r) => resolutionJsonOrThrow<DocumentEditSessionResponse>(r));
+
+export const endDocumentEditSession = async (
+  documentId: string,
+  sessionId: string,
+): Promise<void> => {
+  const res = await apiFetch(
+    `${API}/documents/${documentId}/edit-sessions/${sessionId}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok && res.status !== 204) {
+    const text = await res.text();
+    throw new Error(`${res.status} ${res.statusText}: ${text}`);
+  }
+};
 
 export const createDocumentComment = (
   documentId: string,

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -117,6 +117,32 @@ beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(api, "getDocumentVersions").mockResolvedValue([]);
   vi.spyOn(api, "getDocumentComments").mockResolvedValue([]);
+  vi.spyOn(api, "getDocumentEditSessions").mockResolvedValue([]);
+  vi.spyOn(api, "startDocumentEditSession").mockResolvedValue({
+    current: {
+      id: "edit-session-1",
+      document_id: "doc-1",
+      user_id: "u-1",
+      client_id: "client-1",
+      user_label: "Andy",
+      started_at: "2026-06-03T18:00:00",
+      last_seen_at: "2026-06-03T18:00:00",
+      ended_at: null,
+    },
+    active: [
+      {
+        id: "edit-session-1",
+        document_id: "doc-1",
+        user_id: "u-1",
+        client_id: "client-1",
+        user_label: "Andy",
+        started_at: "2026-06-03T18:00:00",
+        last_seen_at: "2026-06-03T18:00:00",
+        ended_at: null,
+      },
+    ],
+  });
+  vi.spyOn(api, "endDocumentEditSession").mockResolvedValue(undefined);
   vi.spyOn(api, "getAnonymisation").mockRejectedValue(new Error("404"));
   // AnonymiseButton (child) fetches its own module's getAnonymisation on
   // mount — stub it so the test doesn't hit the network.

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -11,17 +11,21 @@ import {
   createDocumentComment,
   documentOriginalUrl,
   documentVersionDocxUrl,
+  endDocumentEditSession,
   type EditInstructionResponse,
   getAnonymisation,
   getDocumentComments,
   getDocumentBody,
+  getDocumentEditSessions,
   getDocumentVersions,
   listDocuments,
   resolveDocumentComment,
+  startDocumentEditSession,
   uploadDocumentVersion,
   type AnonymisationResult,
   type DocumentCommentRead,
   type DocumentBody,
+  type DocumentEditSessionRead,
   type DocumentVersionSummary,
   type MatterDocument,
 } from "../lib/api";
@@ -106,6 +110,7 @@ export function DocumentDetail({
   const [versionUploadNotes, setVersionUploadNotes] = useState("");
   const [versionUploadBusy, setVersionUploadBusy] = useState(false);
   const [versionUploadError, setVersionUploadError] = useState<string | null>(null);
+  const [activeEditSessions, setActiveEditSessions] = useState<DocumentEditSessionRead[]>([]);
   const [showDetails, setShowDetails] = useState(false);
   const [workbenchView, setWorkbenchView] = useState<WorkbenchView>("editor");
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
@@ -113,6 +118,7 @@ export function DocumentDetail({
   const [activeEditResult, setActiveEditResult] =
     useState<EditInstructionResponse | null>(null);
   const workbenchRef = useRef<HTMLDivElement | null>(null);
+  const editClientIdRef = useRef<string | null>(null);
 
   const sourceContext = useRouterState({
     select: (s) => {
@@ -192,6 +198,49 @@ export function DocumentDetail({
       .then(setAnon)
       .catch(() => setAnon(null));
   }, [documentId, loadBody, loadComments, loadVersions]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let currentSessionId: string | null = null;
+    const storageKey = "legalise.document_edit_client_id";
+    const ensureClientId = () => {
+      if (editClientIdRef.current) return editClientIdRef.current;
+      const existing = window.localStorage.getItem(storageKey);
+      if (existing) {
+        editClientIdRef.current = existing;
+        return existing;
+      }
+      const generated = window.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+      window.localStorage.setItem(storageKey, generated);
+      editClientIdRef.current = generated;
+      return generated;
+    };
+    const heartbeat = async () => {
+      try {
+        const response = await startDocumentEditSession(documentId, ensureClientId());
+        if (cancelled) return;
+        currentSessionId = response.current.id;
+        setActiveEditSessions(response.active);
+      } catch {
+        if (!cancelled) {
+          getDocumentEditSessions(documentId)
+            .then((rows) => {
+              if (!cancelled) setActiveEditSessions(rows);
+            })
+            .catch(() => undefined);
+        }
+      }
+    };
+    heartbeat();
+    const interval = window.setInterval(heartbeat, 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      if (currentSessionId) {
+        endDocumentEditSession(documentId, currentSessionId).catch(() => undefined);
+      }
+    };
+  }, [documentId]);
 
   if (q.status === "loading") {
     return (
@@ -770,6 +819,37 @@ export function DocumentDetail({
                   <dd className="mt-1 text-lg font-semibold text-ink">{rejectedEdits}</dd>
                 </div>
               </dl>
+            </section>
+
+            <section className="border border-rule bg-paper p-4" data-testid="document-edit-sessions">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-ink">Editing now</h2>
+                  <p className="mt-1 text-sm leading-6 text-muted">
+                    Active document sessions are visible here. Real-time co-editing will use this same document session record.
+                  </p>
+                </div>
+                <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                  {activeEditSessions.length || 1} active
+                </span>
+              </div>
+              <div className="mt-3 space-y-2">
+                {activeEditSessions.length > 0 ? (
+                  activeEditSessions.map((session) => (
+                    <div
+                      key={session.id}
+                      className="flex items-center justify-between gap-3 border border-rule bg-paper-sunken px-3 py-2 text-sm"
+                    >
+                      <span className="font-medium text-ink">{session.user_label}</span>
+                      <span className="text-xs text-muted">
+                        {session.last_seen_at.replace("T", " ").slice(0, 16)}
+                      </span>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted">You are editing this document.</p>
+                )}
+              </div>
             </section>
 
             <section className="border border-rule bg-paper p-4" data-testid="document-comments">


### PR DESCRIPTION
## Summary

Document engine collaboration-ready slice:

- add `document_edit_sessions` model + migration for document-scoped editing presence
- add owner-gated APIs to list, start/heartbeat, and end document edit sessions
- audit session start/end, not every heartbeat
- add frontend API helpers and a stable browser client id
- show an `Editing now` panel in the document workbench right rail
- add route-level test coverage for owner scope + active/end behavior

## Verification

- `python3 -m py_compile backend/app/models/document_edit_session.py backend/app/api/documents.py backend/alembic/versions/0026_document_edit_sessions.py backend/tests/test_route_acl_sweep.py`
- `npm run test -- DocumentDetail.test.tsx` (16/16)
- `npm run build` (frontend; existing PDF/docx bundle-size warning)

Local backend pytest could not run because this machine's Python lacks pytest; GitHub CI is the backend gate.

## Notes

This is not CRDT/live-cursor co-editing yet. It is the document-scoped session/presence primitive needed before real-time co-editing can be added cleanly.
