### PR TITLE
documents: expose version originals

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1125,6 +1125,88 @@ async def get_document_version_docx(
     )
 
 
+@router.get("/{document_id}/versions/{version_id}/original")
+async def get_document_version_original(
+    document_id: uuid.UUID,
+    version_id: uuid.UUID,
+    download: int = Query(0),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> StreamingResponse:
+    """Stream the original uploaded bytes for a saved upload version."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    version = await session.scalar(
+        select(DocumentVersion).where(
+            DocumentVersion.id == version_id,
+            DocumentVersion.document_id == doc.id,
+        )
+    )
+    if version is None:
+        raise HTTPException(404, "document version not found")
+    if not version.storage_uri:
+        raise HTTPException(404, "version original file not available")
+
+    storage = get_storage_backend()
+    try:
+        data = storage.get_bytes(version.storage_uri)
+    except KeyError:
+        raise HTTPException(404, "version original file not available")
+    except StorageReadError as exc:
+        await audit_failure(
+            session,
+            "storage.get_bytes.failed",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="storage",
+            resource_type="document_version",
+            resource_id=str(version.id),
+            payload={
+                "document_id": str(doc.id),
+                "storage_key": version.storage_uri,
+                "backend": exc.backend,
+                "error_code": exc.error_code,
+            },
+        )
+        raise HTTPException(
+            502,
+            detail={
+                "error": "storage_read_failed",
+                "message": "Failed to read the version original from object storage.",
+                "storage_key": version.storage_uri,
+                "backend": exc.backend,
+            },
+        ) from exc
+
+    is_download = bool(download)
+    await audit.log(
+        session,
+        "document.version.original.accessed",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_version",
+        resource_id=str(version.id),
+        payload={
+            "document_id": str(doc.id),
+            "version_number": version.version_number,
+            "storage_key": version.storage_uri,
+            "download": is_download,
+        },
+    )
+    await session.commit()
+
+    filename = _safe_filename(doc.filename, str(version.id))
+    disposition = "attachment" if is_download else "inline"
+    return StreamingResponse(
+        iter([data]),
+        media_type=doc.mime_type or "application/octet-stream",
+        headers={
+            "Content-Disposition": f'{disposition}; filename="{filename}"',
+            "Content-Length": str(len(data)),
+        },
+    )
+
+
 @router.get("/{document_id}/versions", response_model=list[DocumentVersionSummary])
 async def get_document_versions(
     document_id: uuid.UUID,

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -261,6 +261,18 @@ async def test_post_upload_document_version_updates_active_document_and_body(cli
     assert rows[-1]["version"]["kind"] == "upload"
     assert rows[-1]["version"]["resolved_text"] == "Replacement document text."
 
+    version_original = await client.get(
+        f"/api/documents/{doc_id}/versions/{version['id']}/original"
+    )
+    assert version_original.status_code == 200, version_original.text
+    assert version_original.content == b"Replacement document text."
+    assert version_original.headers["content-type"].startswith("text/plain")
+
+    legacy_original = await client.get(
+        f"/api/documents/{doc_id}/versions/{rows[0]['version']['id']}/original"
+    )
+    assert legacy_original.status_code == 404, legacy_original.text
+
 
 @pytest.mark.asyncio
 async def test_get_manual_document_version_docx_returns_word_file(client) -> None:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1608,6 +1608,15 @@ export const documentVersionDocxUrl = (
     versionId,
   )}/docx`;
 
+export const documentVersionOriginalUrl = (
+  documentId: string,
+  versionId: string,
+  opts?: { download?: boolean },
+): string =>
+  `${API}/documents/${encodeURIComponent(documentId)}/versions/${encodeURIComponent(
+    versionId,
+  )}/original${opts?.download ? "?download=1" : ""}`;
+
 // ---------------------------------------------------------------------------
 // Matter lifecycle + export (LMF UX v1) — over the stable LMF endpoints
 // ---------------------------------------------------------------------------

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -88,6 +88,7 @@ function versionSummary(
   versionNumber: number,
   resolvedText: string | null,
   kind = "user_edit",
+  storageUri: string | null = null,
 ): api.DocumentVersionSummary {
   return {
     version: {
@@ -97,7 +98,7 @@ function versionSummary(
       kind,
       created_by_id: "u-1",
       created_at: `2026-05-28T09:0${versionNumber}:00`,
-      storage_uri: null,
+      storage_uri: storageUri,
       notes: null,
       resolved_text: resolvedText,
     },
@@ -210,6 +211,47 @@ describe("DocumentDetail", () => {
     expect(link).toHaveTextContent("Download edited DOCX");
     expect(link.getAttribute("href")).toContain("/documents/doc-1/versions/v-2/docx");
     expect(screen.getByText(/Viewing saved version v2/)).toBeInTheDocument();
+  });
+
+  it("shows original file actions for uploaded versions in the version record", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc({ filename: "witness.docx" })]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "getDocumentVersions").mockResolvedValue([
+      versionSummary("v-1", 1, null, "upload"),
+      versionSummary(
+        "v-2",
+        2,
+        "Replacement body",
+        "upload",
+        "users/u/matters/m/documents/doc-1/v2/replacement.docx",
+      ),
+      versionSummary("v-3", 3, "Edited body", "user_edit"),
+    ]);
+
+    mount();
+    fireEvent.click(await screen.findByRole("button", { name: "Versions" }));
+
+    const openOriginal = screen
+      .getAllByRole("link", { name: "Open original" })
+      .find((link) =>
+        link.getAttribute("href")?.includes("/documents/doc-1/versions/v-2/original"),
+      );
+    const downloadOriginal = screen.getByRole("link", { name: "Download original" });
+    if (!openOriginal) throw new Error("version original link not found");
+    expect(openOriginal.getAttribute("href")).toContain(
+      "/documents/doc-1/versions/v-2/original",
+    );
+    expect(openOriginal.getAttribute("href")).not.toContain("download=1");
+    expect(downloadOriginal.getAttribute("href")).toContain(
+      "/documents/doc-1/versions/v-2/original?download=1",
+    );
+    const editedDocx = screen
+      .getAllByRole("link", { name: "Download DOCX" })
+      .find((link) => link.getAttribute("href")?.includes("/versions/v-3/docx"));
+    if (!editedDocx) throw new Error("edited version DOCX link not found");
+    expect(editedDocx.getAttribute("href")).toContain(
+      "/documents/doc-1/versions/v-3/docx",
+    );
   });
 
   it("lets the reader switch between saved versions and extracted text", async () => {

--- a/frontend/src/modules/document_edit/VersionTimeline.tsx
+++ b/frontend/src/modules/document_edit/VersionTimeline.tsx
@@ -1,13 +1,8 @@
-// VersionTimeline - vertical list of document versions with edit counts.
-//
-// Fetches `getDocumentVersions(documentId)` on mount + whenever `refreshKey`
-// changes. Renders nothing if no versions exist (invariant: every
-// document has at least a v1 upload).
-
 import { useEffect, useState } from "react";
 import {
   DocumentVersionSummary,
   documentVersionDocxUrl,
+  documentVersionOriginalUrl,
   getDocumentVersions,
 } from "../../lib/api";
 
@@ -80,36 +75,43 @@ export function VersionTimeline({
       <div className="mb-3">
         <h3 className="text-sm font-semibold text-ink">Saved versions</h3>
         <p className="mt-1 text-xs leading-5 text-muted">
-          Open a saved version in the editor, or download it as an audited DOCX.
+          Open prior uploads, review saved edits, or download an audited copy.
         </p>
       </div>
       <ol className="space-y-2">
-        {versions.map((s) => (
-          <li
-            key={s.version.id}
-            className={`border bg-paper p-3 text-sm ${
-              selectedVersionId === s.version.id
-                ? "border-ink"
-                : "border-rule"
-            }`}
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <p className="font-semibold text-ink">
-                  v{s.version.version_number}{" "}
-                  <span className="font-normal text-muted">
-                    {KIND_LABEL[s.version.kind] || s.version.kind}
-                  </span>
-                </p>
-                <p className="mt-1 text-xs text-muted">{fmt(s.version.created_at)}</p>
-                <p className="mt-2 text-xs text-muted">
-                  {s.pending_count} pending · {s.accepted_count} accepted ·{" "}
-                  {s.rejected_count} rejected
-                </p>
-              </div>
-              {s.version.resolved_text && (
+        {versions.map((s) => {
+          const hasOriginal = Boolean(s.version.storage_uri);
+          const hasEditableText = Boolean(s.version.resolved_text);
+          return (
+            <li
+              key={s.version.id}
+              className={`border bg-paper p-3 text-sm ${
+                selectedVersionId === s.version.id
+                  ? "border-ink"
+                  : "border-rule"
+              }`}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold text-ink">
+                    v{s.version.version_number}{" "}
+                    <span className="font-normal text-muted">
+                      {KIND_LABEL[s.version.kind] || s.version.kind}
+                    </span>
+                  </p>
+                  <p className="mt-1 text-xs text-muted">{fmt(s.version.created_at)}</p>
+                  {s.version.notes && (
+                    <p className="mt-2 max-w-xl text-xs leading-5 text-ink">
+                      {s.version.notes}
+                    </p>
+                  )}
+                  <p className="mt-2 text-xs text-muted">
+                    {s.pending_count} pending · {s.accepted_count} accepted ·{" "}
+                    {s.rejected_count} rejected
+                  </p>
+                </div>
                 <div className="flex flex-wrap gap-2">
-                  {onSelectVersion && (
+                  {hasEditableText && onSelectVersion && (
                     <button
                       type="button"
                       onClick={() => onSelectVersion(s.version.id)}
@@ -118,17 +120,44 @@ export function VersionTimeline({
                       {selectedVersionId === s.version.id ? "Open in editor" : "Open version"}
                     </button>
                   )}
-                  <a
-                    href={documentVersionDocxUrl(documentId, s.version.id)}
-                    className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
-                  >
-                    Download DOCX
-                  </a>
+                  {hasEditableText && (
+                    <a
+                      href={documentVersionDocxUrl(documentId, s.version.id)}
+                      className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
+                    >
+                      Download DOCX
+                    </a>
+                  )}
+                  {hasOriginal && (
+                    <>
+                      <a
+                        href={documentVersionOriginalUrl(documentId, s.version.id)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
+                      >
+                        Open original
+                      </a>
+                      <a
+                        href={documentVersionOriginalUrl(documentId, s.version.id, {
+                          download: true,
+                        })}
+                        className="border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
+                      >
+                        Download original
+                      </a>
+                    </>
+                  )}
+                  {!hasOriginal && !hasEditableText && (
+                    <span className="border border-rule px-3 py-2 text-xs font-semibold text-muted">
+                      No file available
+                    </span>
+                  )}
                 </div>
-              )}
-            </div>
-          </li>
-        ))}
+              </div>
+            </li>
+          );
+        })}
       </ol>
     </div>
   );


### PR DESCRIPTION
## Summary

- add an owner-scoped streamed proxy for original bytes attached to saved document versions
- audit successful version-original access as document.version.original.accessed
- show Open original / Download original actions on upload versions in the version record while keeping DOCX export for editable versions

## Checks

- python3 -m py_compile backend/app/api/documents.py backend/tests/test_route_acl_sweep.py
- npm run test -- DocumentDetail.test.tsx
- npm run typecheck
- npm run build

Full backend pytest will run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to download original uploaded files from specific document versions
  * Version timeline now displays "Open original" and "Download original" action links for saved versions
  * Improved document version interface to distinguish between original uploaded files and edited versions for download

<!-- end of auto-generated comment: release notes by coderabbit.ai -->