### PR TITLE
documents: anchor review notes to source text

### DIFF
--- a/backend/alembic/versions/0028_document_comment_anchors.py
+++ b/backend/alembic/versions/0028_document_comment_anchors.py
@@ -1,0 +1,29 @@
+"""Add source anchors to document comments.
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("document_comments", sa.Column("body_sha256", sa.String(length=64), nullable=True))
+    op.add_column("document_comments", sa.Column("anchor_start", sa.Integer(), nullable=True))
+    op.add_column("document_comments", sa.Column("anchor_end", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("document_comments", "anchor_end")
+    op.drop_column("document_comments", "anchor_start")
+    op.drop_column("document_comments", "body_sha256")

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -49,7 +49,7 @@ from app.models import (
     STATUS_ARCHIVED,
     User,
 )
-from app.models.document_body import DocumentBody, BODY_KIND_EXTRACTED
+from app.models.document_body import DocumentBody, BODY_KIND_EXTRACTED, extracted_body_for
 from app.models.document_edit import (
     EDIT_STATUS_ACCEPTED,
     EDIT_STATUS_PENDING,
@@ -725,6 +725,9 @@ class DocumentCommentRead(BaseModel):
     document_id: uuid.UUID
     author_id: uuid.UUID
     quote_text: str | None
+    body_sha256: str | None
+    anchor_start: int | None
+    anchor_end: int | None
     body: str
     status: str
     created_at: datetime
@@ -737,6 +740,9 @@ class DocumentCommentRead(BaseModel):
 class DocumentCommentCreate(BaseModel):
     body: str = Field(min_length=2, max_length=4000)
     quote_text: str | None = Field(default=None, max_length=2000)
+    body_sha256: str | None = Field(default=None, max_length=64)
+    anchor_start: int | None = Field(default=None, ge=0)
+    anchor_end: int | None = Field(default=None, ge=0)
 
 
 async def _resolve_one(
@@ -1668,10 +1674,56 @@ async def post_document_comment(
     if len(comment_body) < 2:
         raise HTTPException(422, "comment body is required")
     quote_text = body.quote_text.strip() if body.quote_text else None
+    anchor_start = body.anchor_start
+    anchor_end = body.anchor_end
+    body_sha256: str | None = None
+    has_anchor = anchor_start is not None or anchor_end is not None
+    if has_anchor:
+        if anchor_start is None or anchor_end is None or anchor_end <= anchor_start:
+            raise HTTPException(
+                422,
+                {
+                    "error": "invalid_comment_anchor",
+                    "message": "Comment anchors require start and end positions.",
+                },
+            )
+        extracted = await extracted_body_for(session, doc.id)
+        if extracted is None:
+            raise HTTPException(
+                422,
+                {
+                    "error": "document_body_unavailable",
+                    "message": "The document text is not available for anchoring.",
+                },
+            )
+        source_text = extracted.extracted_text
+        body_sha256 = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
+        if body.body_sha256 and body.body_sha256 != body_sha256:
+            raise HTTPException(
+                409,
+                {
+                    "error": "document_body_changed",
+                    "message": "The document text changed before the note was saved.",
+                },
+            )
+        if anchor_end > len(source_text):
+            raise HTTPException(
+                422,
+                {
+                    "error": "invalid_comment_anchor",
+                    "message": "The selected range is outside the document text.",
+                },
+            )
+        anchored_quote = source_text[anchor_start:anchor_end].strip()
+        if not quote_text and anchored_quote:
+            quote_text = anchored_quote[:2000]
     comment = DocumentComment(
         document_id=doc.id,
         author_id=user.id,
         quote_text=quote_text or None,
+        body_sha256=body_sha256,
+        anchor_start=anchor_start if has_anchor else None,
+        anchor_end=anchor_end if has_anchor else None,
         body=comment_body,
         status=COMMENT_STATUS_OPEN,
     )
@@ -1688,6 +1740,10 @@ async def post_document_comment(
         payload={
             "document_id": str(doc.id),
             "has_quote": bool(comment.quote_text),
+            "has_anchor": has_anchor,
+            "body_sha256": comment.body_sha256,
+            "anchor_start": comment.anchor_start,
+            "anchor_end": comment.anchor_end,
         },
     )
     await session.commit()

--- a/backend/app/models/document_comment.py
+++ b/backend/app/models/document_comment.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -31,6 +31,9 @@ class DocumentComment(Base):
         UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
     )
     quote_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    body_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    anchor_start: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    anchor_end: Mapped[int | None] = mapped_column(Integer, nullable=True)
     body: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(24), default=COMMENT_STATUS_OPEN, nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -10,6 +10,7 @@ DB-backed; skips when Postgres is unreachable (see conftest.py).
 
 from __future__ import annotations
 
+import hashlib
 import io
 import uuid
 import zipfile
@@ -49,6 +50,25 @@ async def _create_matter_and_upload(client) -> tuple[str, str]:
     resp = await client.post(
         f"/api/matters/{slug}/documents",
         files={"file": ("test.pdf", io.BytesIO(_PDF_MAGIC), "application/pdf")},
+        data={"tag": "draft"},
+    )
+    assert resp.status_code == 201, resp.text
+    doc_id = resp.json()["id"]
+    return slug, doc_id
+
+
+async def _create_matter_and_upload_text(client, text: str) -> tuple[str, str]:
+    """Returns (matter_slug, document_id) for an extracted text/plain document."""
+    create = await client.post(
+        "/api/matters",
+        json={"title": "ACL Sweep Text Matter"},
+    )
+    assert create.status_code == 201, create.text
+    slug = create.json()["slug"]
+
+    resp = await client.post(
+        f"/api/matters/{slug}/documents",
+        files={"file": ("note.txt", io.BytesIO(text.encode("utf-8")), "text/plain")},
         data={"tag": "draft"},
     )
     assert resp.status_code == 201, resp.text
@@ -114,6 +134,43 @@ async def test_document_comments_owner_can_create_list_and_resolve(client) -> No
     assert resolved.status_code == 200, resolved.text
     assert resolved.json()["status"] == "resolved"
     assert resolved.json()["resolved_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_document_comments_owner_can_anchor_note_to_extracted_text(client) -> None:
+    """Owner-created notes can pin a selected passage to the extracted body hash."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    source_text = "Alpha beta gamma"
+    _, doc_id = await _create_matter_and_upload_text(client, source_text)
+    current_hash = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
+
+    created = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={
+            "body": "Check this anchored passage.",
+            "quote_text": "beta",
+            "body_sha256": current_hash,
+            "anchor_start": 6,
+            "anchor_end": 10,
+        },
+    )
+    assert created.status_code == 200, created.text
+    comment = created.json()
+    assert comment["quote_text"] == "beta"
+    assert comment["body_sha256"] == current_hash
+    assert comment["anchor_start"] == 6
+    assert comment["anchor_end"] == 10
+
+    stale = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={
+            "body": "This should not attach to stale text.",
+            "body_sha256": "0" * 64,
+            "anchor_start": 0,
+            "anchor_end": 5,
+        },
+    )
+    assert stale.status_code == 409, stale.text
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1744,6 +1744,9 @@ export interface DocumentCommentRead {
   document_id: string;
   author_id: string;
   quote_text: string | null;
+  body_sha256: string | null;
+  anchor_start: number | null;
+  anchor_end: number | null;
   body: string;
   status: "open" | "resolved";
   created_at: string;
@@ -1920,7 +1923,13 @@ export const endDocumentEditSession = async (
 
 export const createDocumentComment = (
   documentId: string,
-  payload: { body: string; quote_text?: string | null },
+  payload: {
+    body: string;
+    quote_text?: string | null;
+    body_sha256?: string | null;
+    anchor_start?: number | null;
+    anchor_end?: number | null;
+  },
 ) =>
   apiFetch(`${API}/documents/${documentId}/comments`, {
     method: "POST",

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -358,6 +358,9 @@ describe("DocumentDetail", () => {
           document_id: "doc-1",
           author_id: "u-1",
           quote_text: "single social-media post",
+          body_sha256: null,
+          anchor_start: null,
+          anchor_end: null,
           body: "Check the context before relying on this.",
           status: "open",
           created_at: "2026-06-03T10:00:00",
@@ -371,6 +374,9 @@ describe("DocumentDetail", () => {
       document_id: "doc-1",
       author_id: "u-1",
       quote_text: null,
+      body_sha256: null,
+      anchor_start: null,
+      anchor_end: null,
       body: "Ask client for policy copy.",
       status: "open",
       created_at: "2026-06-03T10:05:00",
@@ -394,10 +400,16 @@ describe("DocumentDetail", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save note" }));
 
     await waitFor(() => {
-      expect(create).toHaveBeenCalledWith("doc-1", {
-        body: "Ask client for policy copy.",
-        quote_text: "policy breach",
-      });
+      expect(create).toHaveBeenCalledWith(
+        "doc-1",
+        expect.objectContaining({
+          body: "Ask client for policy copy.",
+          quote_text: "policy breach",
+          body_sha256: null,
+          anchor_start: null,
+          anchor_end: null,
+        }),
+      );
     });
   });
 
@@ -415,6 +427,9 @@ describe("DocumentDetail", () => {
       document_id: "doc-1",
       author_id: "u-1",
       quote_text: "single social-media post",
+      body_sha256: "b".repeat(64),
+      anchor_start: 33,
+      anchor_end: 57,
       body: "Check this passage.",
       status: "open",
       created_at: "2026-06-03T10:05:00",
@@ -440,10 +455,15 @@ describe("DocumentDetail", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save note" }));
 
     await waitFor(() => {
-      expect(create).toHaveBeenCalledWith("doc-1", {
-        body: "Check this passage.",
-        quote_text: "single social-media post",
-      });
+      expect(create).toHaveBeenCalledWith(
+        "doc-1",
+        expect.objectContaining({
+          body: "Check this passage.",
+          quote_text: "single social-media post",
+          anchor_start: 33,
+          anchor_end: 57,
+        }),
+      );
     });
   });
 
@@ -456,6 +476,9 @@ describe("DocumentDetail", () => {
         document_id: "doc-1",
         author_id: "u-1",
         quote_text: null,
+        body_sha256: null,
+        anchor_start: null,
+        anchor_end: null,
         body: "Resolve after checking the source.",
         status: "open",
         created_at: "2026-06-03T10:00:00",
@@ -470,6 +493,9 @@ describe("DocumentDetail", () => {
         document_id: "doc-1",
         author_id: "u-1",
         quote_text: null,
+        body_sha256: null,
+        anchor_start: null,
+        anchor_end: null,
         body: "Resolve after checking the source.",
         status: "resolved",
         created_at: "2026-06-03T10:00:00",

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -79,6 +79,21 @@ type DocQuery =
 
 const EXTRACTED_VERSION_ID = "__extracted";
 type WorkbenchView = "editor" | "redlines" | "original" | "versions";
+type SelectedAnchor = {
+  quote: string;
+  start: number;
+  end: number;
+  bodySha256: string | null;
+};
+
+async function sha256Hex(text: string): Promise<string | null> {
+  if (!window.crypto?.subtle) return null;
+  const bytes = new TextEncoder().encode(text);
+  const digest = await window.crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
 
 function WorkbenchTab({
   active,
@@ -120,6 +135,7 @@ export function DocumentDetail({
   const [commentBody, setCommentBody] = useState("");
   const [commentQuote, setCommentQuote] = useState("");
   const [selectedQuote, setSelectedQuote] = useState("");
+  const [selectedAnchor, setSelectedAnchor] = useState<SelectedAnchor | null>(null);
   const [activeReaderQuote, setActiveReaderQuote] = useState<string | null>(null);
   const [commentError, setCommentError] = useState<string | null>(null);
   const [commentBusy, setCommentBusy] = useState(false);
@@ -356,14 +372,21 @@ export function DocumentDetail({
     }
     setCommentBusy(true);
     setCommentError(null);
+    const normalizedQuote = commentQuote.trim().replace(/\s+/g, " ");
+    const anchor =
+      selectedAnchor && normalizedQuote === selectedAnchor.quote ? selectedAnchor : null;
     try {
       await createDocumentComment(documentId, {
         body: trimmed,
         quote_text: commentQuote.trim() || null,
+        body_sha256: anchor?.bodySha256 ?? null,
+        anchor_start: anchor?.start ?? null,
+        anchor_end: anchor?.end ?? null,
       });
       setCommentBody("");
       setCommentQuote("");
       setSelectedQuote("");
+      setSelectedAnchor(null);
       loadComments();
     } catch (err) {
       setCommentError(err instanceof Error ? err.message : "Could not save note.");
@@ -380,7 +403,21 @@ export function DocumentDetail({
     const root = workbenchRef.current;
     if (!root || !anchorNode || !focusNode) return;
     if (!root.contains(anchorNode) || !root.contains(focusNode)) return;
-    setSelectedQuote(selected.slice(0, 1200));
+    const quote = selected.slice(0, 1200);
+    const range = findNormalizedRange(editorText, quote);
+    setSelectedQuote(quote);
+    if (!range) {
+      setSelectedAnchor(null);
+      return;
+    }
+    setSelectedAnchor({ quote, start: range.start, end: range.end, bodySha256: null });
+    void sha256Hex(editorText).then((bodySha256) => {
+      setSelectedAnchor((current) =>
+        current?.quote === quote && current.start === range.start && current.end === range.end
+          ? { ...current, bodySha256 }
+          : current,
+      );
+    });
   };
   const resolveComment = async (commentId: string) => {
     setCommentBusy(true);
@@ -911,7 +948,14 @@ export function DocumentDetail({
                   >
                     {comment.quote_text && (
                       <div className="mb-2 border-l-2 border-rule pl-3 text-muted">
-                        <blockquote>{comment.quote_text}</blockquote>
+                        <div className="flex items-start justify-between gap-3">
+                          <blockquote>{comment.quote_text}</blockquote>
+                          {comment.anchor_start !== null && comment.anchor_end !== null && (
+                            <span className="shrink-0 border border-rule bg-paper px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
+                              Anchored
+                            </span>
+                          )}
+                        </div>
                         <button
                           type="button"
                           onClick={() => jumpToCommentQuote(comment.quote_text ?? "")}
@@ -961,6 +1005,11 @@ export function DocumentDetail({
                     </p>
                     <p className="mt-2 max-h-24 overflow-hidden leading-6 text-muted">
                       {selectedQuote}
+                    </p>
+                    <p className="mt-2 text-xs text-muted">
+                      {selectedAnchor
+                        ? "This note will stay anchored to the current document text."
+                        : "This passage can be quoted, but its exact text position was not found."}
                     </p>
                     <button
                       type="button"


### PR DESCRIPTION
## Summary

Adds anchored review notes to the document workbench so notes created from selected text pin to the extracted source body instead of being loose quoted text only.

- adds document_comment anchor columns: body_sha256, anchor_start, anchor_end
- validates anchor ranges against the extracted DocumentBody only and rejects stale body hashes
- sends anchored selections from DocumentDetail and labels anchored notes in the review panel
- keeps manually typed quotes and old comments working as loose quote notes

## Verification

- python3 -m py_compile backend/app/models/document_comment.py backend/app/api/documents.py backend/alembic/versions/0028_document_comment_anchors.py backend/tests/test_route_acl_sweep.py
- npm run test -- DocumentDetail.test.tsx
- npm run typecheck
- npm run build

Local note: ruff is not installed in the local Python env, so CI remains the lint/full backend gate.