### PR TITLE
documents: show anchored notes in editor rail

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -357,10 +357,10 @@ describe("DocumentDetail", () => {
           id: "comment-1",
           document_id: "doc-1",
           author_id: "u-1",
-          quote_text: "single social-media post",
-          body_sha256: null,
-          anchor_start: null,
-          anchor_end: null,
+          quote_text: "Original body",
+          body_sha256: "a".repeat(64),
+          anchor_start: 0,
+          anchor_end: 13,
           body: "Check the context before relying on this.",
           status: "open",
           created_at: "2026-06-03T10:00:00",
@@ -387,6 +387,9 @@ describe("DocumentDetail", () => {
     mount();
     expect(await screen.findByTestId("document-comments")).toHaveTextContent(
       "Check the context before relying on this.",
+    );
+    expect(await screen.findByTestId("document-editor-note-rail")).toHaveTextContent(
+      "Original body",
     );
     fireEvent.change(
       screen.getByPlaceholderText("Quoted passage; select text in the document or type one"),

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -50,6 +50,7 @@ import { VersionDiff } from "../modules/document_edit/VersionDiff";
 import {
   DocumentRichEditor,
   findNormalizedRange,
+  type DocumentNoteHighlight,
   type TiptapNode,
 } from "../modules/document_edit/DocumentRichEditor";
 
@@ -352,6 +353,17 @@ export function DocumentDetail({
   const rejectedEdits = versions.reduce((total, v) => total + v.rejected_count, 0);
   const openComments = comments.filter((comment) => comment.status === "open");
   const resolvedComments = comments.filter((comment) => comment.status === "resolved");
+  const anchoredOpenNotes: DocumentNoteHighlight[] = openComments
+    .filter(
+      (comment) =>
+        comment.quote_text && comment.anchor_start !== null && comment.anchor_end !== null,
+    )
+    .map((comment, index) => ({
+      id: comment.id,
+      label: `Note ${index + 1}`,
+      quote: comment.quote_text ?? "",
+      status: comment.status,
+    }));
   const confirmDiscardEditorChanges = () =>
     !editorDirty || window.confirm("Discard unsaved document edits?");
   const openWorkbenchView = (next: WorkbenchView) => {
@@ -692,6 +704,7 @@ export function DocumentDetail({
                   latestVersionNumber={latestVersion?.version_number}
                   sourceLabel={editorSourceLabel}
                   sourceHighlight={currentReaderQuote}
+                  noteHighlights={anchoredOpenNotes}
                   onSaved={(version) => {
                     setSelectedVersionId(version.id);
                     getDocumentVersions(documentId)

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -27,6 +27,12 @@ function escapeHtml(value: string): string {
 
 type TextRange = { start: number; end: number };
 type OutlineItem = { id: string; label: string; query: string };
+export type DocumentNoteHighlight = {
+  id: string;
+  label: string;
+  quote: string;
+  status: "open" | "resolved";
+};
 
 export function findNormalizedRanges(
   text: string,
@@ -172,6 +178,7 @@ export function DocumentRichEditor({
   latestVersionNumber,
   sourceLabel,
   sourceHighlight,
+  noteHighlights = [],
   onSaved,
   onDirtyChange,
 }: {
@@ -182,6 +189,7 @@ export function DocumentRichEditor({
   latestVersionNumber?: number;
   sourceLabel: string;
   sourceHighlight?: string | null;
+  noteHighlights?: DocumentNoteHighlight[];
   onSaved: (version: DocumentVersionRead) => void;
   onDirtyChange?: (dirty: boolean) => void;
 }) {
@@ -502,6 +510,28 @@ export function DocumentRichEditor({
                 >
                   Search cited text
                 </button>
+              )}
+            </div>
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                Review notes
+              </p>
+              {noteHighlights.length > 0 ? (
+                <div className="mt-2 space-y-2" data-testid="document-editor-note-rail">
+                  {noteHighlights.map((note) => (
+                    <button
+                      key={note.id}
+                      type="button"
+                      onClick={() => setFindQuery(note.quote)}
+                      className="block w-full border border-rule bg-paper px-3 py-2 text-left text-xs leading-5 text-muted hover:border-ink hover:text-ink"
+                    >
+                      <span className="block font-medium text-ink">{note.label}</span>
+                      <span className="mt-1 block max-h-10 overflow-hidden">{note.quote}</span>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-2 text-sm text-muted">No anchored notes yet.</p>
               )}
             </div>
             <div>


### PR DESCRIPTION
## Summary

Makes anchored review notes visible inside the document workbench instead of only in the review-note side panel.

- adds a Review notes rail inside DocumentRichEditor
- shows open anchored notes beside the document and lets the user search that quoted passage
- passes anchored open notes from DocumentDetail into the editor
- keeps resolved/history notes in the existing review-note panel

## Verification

- npm run test -- DocumentDetail.test.tsx DocumentRichEditor.test.tsx
- npm run typecheck
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Review notes" section in the document editor sidebar displaying all anchored review notes.
  * Users can click on review notes to quickly locate and navigate to their corresponding location in the document.

* **Tests**
  * Updated test coverage to verify anchored review notes rendering with proper anchor data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->