### PR TITLE
documents: polish version comparison

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -275,6 +275,16 @@ describe("DocumentDetail", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Versions" }));
+    expect(screen.getByLabelText("Compare against")).toHaveValue("__extracted");
+    expect(screen.getByText("Added")).toBeInTheDocument();
+    expect(screen.getByText("Removed")).toBeInTheDocument();
+    expect(screen.getByText(/Before · Extracted text/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Compare against"), {
+      target: { value: "v-2" },
+    });
+    expect(screen.getByText(/Before · v2/)).toBeInTheDocument();
+    expect(screen.getByText("First saved body")).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "v2" }));
     await waitFor(() => {
       expect(screen.getByText(/Viewing saved version v2/)).toBeInTheDocument();

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -686,6 +686,25 @@ describe("DocumentDetail", () => {
       instruction_hash: "hash",
       parse_ok: true,
     });
+    vi.spyOn(api, "acceptAll").mockResolvedValue({
+      affected_count: 1,
+      new_version: {
+        id: "v-3",
+        document_id: "doc-1",
+        version_number: 3,
+        kind: "user_accept",
+        created_by_id: "u-1",
+        created_at: "2026-05-28T09:06:00",
+        storage_uri: null,
+        filename: "claim-form.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 45,
+        sha256: "b".repeat(64),
+        notes: "Accepted model edits",
+        resolved_text: "The agreement may terminate on written notice.",
+      },
+      resolved_text: "The agreement may terminate on written notice.",
+    });
 
     mount();
     await waitFor(() => {
@@ -706,6 +725,16 @@ describe("DocumentDetail", () => {
     expect(
       screen.getByText(/Proposed edits are ready in the document review area/i),
     ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Accept all" }));
+    const reviewSaved = await screen.findByRole("button", {
+      name: "Review saved version",
+    });
+    fireEvent.click(reviewSaved);
+
+    expect(screen.getByRole("heading", { name: "Version record" })).toBeInTheDocument();
+    expect(screen.getByText(/Before · Extracted text/)).toBeInTheDocument();
+    expect(screen.getByText(/After · v3/)).toBeInTheDocument();
   });
 
   it("shows an honest empty state when no extracted body exists", async () => {

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -377,6 +377,20 @@ describe("DocumentDetail", () => {
           resolved_at: null,
           resolved_by_id: null,
         },
+        {
+          id: "comment-resolved",
+          document_id: "doc-1",
+          author_id: "u-1",
+          quote_text: "Original body",
+          body_sha256: "a".repeat(64),
+          anchor_start: 0,
+          anchor_end: 13,
+          body: "Resolved note kept for the file record.",
+          status: "resolved",
+          created_at: "2026-06-03T09:00:00",
+          resolved_at: "2026-06-03T09:30:00",
+          resolved_by_id: "u-1",
+        },
       ])
       .mockResolvedValue([]);
     const create = vi.spyOn(api, "createDocumentComment").mockResolvedValue({
@@ -398,6 +412,12 @@ describe("DocumentDetail", () => {
     expect(await screen.findByTestId("document-comments")).toHaveTextContent(
       "Check the context before relying on this.",
     );
+    expect(screen.getByTestId("document-comments")).toHaveTextContent("Open");
+    expect(screen.getByTestId("document-comments")).toHaveTextContent("Anchored");
+    expect(screen.getByTestId("document-comments")).toHaveTextContent("Resolved");
+    fireEvent.click(screen.getByText("1 resolved"));
+    expect(screen.getByText("Resolved note kept for the file record.")).toBeInTheDocument();
+    expect(screen.getByText(/resolved 2026-06-03 09:30/)).toBeInTheDocument();
     expect(await screen.findByTestId("document-editor-note-rail")).toHaveTextContent(
       "Original body",
     );

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -365,6 +365,9 @@ export function DocumentDetail({
   const rejectedEdits = versions.reduce((total, v) => total + v.rejected_count, 0);
   const openComments = comments.filter((comment) => comment.status === "open");
   const resolvedComments = comments.filter((comment) => comment.status === "resolved");
+  const anchoredComments = comments.filter(
+    (comment) => comment.anchor_start !== null && comment.anchor_end !== null,
+  );
   const anchoredOpenNotes: DocumentNoteHighlight[] = openComments
     .filter(
       (comment) =>
@@ -1008,9 +1011,34 @@ export function DocumentDetail({
                   {openComments.length} open
                 </span>
               </div>
+              <dl className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+                <div className="border border-rule bg-paper-sunken p-2">
+                  <dt className="uppercase tracking-track2 text-muted">Open</dt>
+                  <dd className="mt-1 text-base font-semibold text-ink">
+                    {openComments.length}
+                  </dd>
+                </div>
+                <div className="border border-rule bg-paper-sunken p-2">
+                  <dt className="uppercase tracking-track2 text-muted">Anchored</dt>
+                  <dd className="mt-1 text-base font-semibold text-ink">
+                    {anchoredComments.length}
+                  </dd>
+                </div>
+                <div className="border border-rule bg-paper-sunken p-2">
+                  <dt className="uppercase tracking-track2 text-muted">Resolved</dt>
+                  <dd className="mt-1 text-base font-semibold text-ink">
+                    {resolvedComments.length}
+                  </dd>
+                </div>
+              </dl>
               <div className="mt-4 space-y-3">
                 {openComments.length === 0 && resolvedComments.length === 0 && (
                   <p className="text-sm text-muted">No review notes yet.</p>
+                )}
+                {openComments.length > 0 && (
+                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                    Open notes
+                  </p>
                 )}
                 {openComments.map((comment) => (
                   <article
@@ -1057,9 +1085,34 @@ export function DocumentDetail({
                     </summary>
                     <div className="mt-3 space-y-2">
                       {resolvedComments.map((comment) => (
-                        <p key={comment.id} className="text-sm leading-6 text-muted">
-                          {comment.body}
-                        </p>
+                        <article
+                          key={comment.id}
+                          className="border border-rule bg-paper p-3 text-sm"
+                        >
+                          {comment.quote_text && (
+                            <blockquote className="mb-2 border-l-2 border-rule pl-3 text-muted">
+                              {comment.quote_text}
+                            </blockquote>
+                          )}
+                          <p className="leading-6 text-muted">{comment.body}</p>
+                          <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
+                            <span>
+                              resolved{" "}
+                              {comment.resolved_at
+                                ? comment.resolved_at.replace("T", " ").slice(0, 16)
+                                : "without timestamp"}
+                            </span>
+                            {comment.quote_text && (
+                              <button
+                                type="button"
+                                onClick={() => jumpToCommentQuote(comment.quote_text ?? "")}
+                                className="font-medium text-ink underline underline-offset-4 hover:text-muted"
+                              >
+                                Find in document
+                              </button>
+                            )}
+                          </div>
+                        </article>
                       ))}
                     </div>
                   </details>

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -148,6 +148,7 @@ export function DocumentDetail({
   const [showDetails, setShowDetails] = useState(false);
   const [workbenchView, setWorkbenchView] = useState<WorkbenchView>("editor");
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(null);
+  const [compareVersionId, setCompareVersionId] = useState<string>(EXTRACTED_VERSION_ID);
   const [editorDirty, setEditorDirty] = useState(false);
   const [activeEditResult, setActiveEditResult] =
     useState<EditInstructionResponse | null>(null);
@@ -224,6 +225,7 @@ export function DocumentDetail({
     setActiveEditResult(null);
     setWorkbenchView("editor");
     setSelectedVersionId(null);
+    setCompareVersionId(EXTRACTED_VERSION_ID);
     setEditorDirty(false);
     loadBody();
     loadComments();
@@ -331,9 +333,19 @@ export function DocumentDetail({
   const selectedResolvedIndex = selectedResolvedVersion
     ? resolvedVersions.findIndex((v) => v.id === selectedResolvedVersion.id)
     : -1;
+  const effectiveCompareVersionId =
+    compareVersionId === selectedResolvedVersion?.id ? EXTRACTED_VERSION_ID : compareVersionId;
   const compareBeforeVersion =
-    selectedResolvedIndex > 0 ? resolvedVersions[selectedResolvedIndex - 1] : null;
-  const compareBeforeText = compareBeforeVersion?.resolved_text ?? body?.extracted_text ?? "";
+    effectiveCompareVersionId === EXTRACTED_VERSION_ID
+      ? null
+      : (resolvedVersions.find(
+          (v) => v.id === effectiveCompareVersionId && v.id !== selectedResolvedVersion?.id,
+        ) ??
+        (selectedResolvedIndex > 0 ? resolvedVersions[selectedResolvedIndex - 1] : null));
+  const compareBeforeText =
+    effectiveCompareVersionId === EXTRACTED_VERSION_ID
+      ? (body?.extracted_text ?? "")
+      : (compareBeforeVersion?.resolved_text ?? body?.extracted_text ?? "");
   const editorText =
     selectedResolvedVersion?.resolved_text ?? body?.extracted_text ?? "";
   const editorJson = selectedResolvedVersion?.resolved_json as TiptapNode | null | undefined;
@@ -447,6 +459,7 @@ export function DocumentDetail({
     if (!confirmDiscardEditorChanges()) return;
     setActiveReaderQuote(quote);
     setSelectedVersionId(null);
+    setCompareVersionId(EXTRACTED_VERSION_ID);
     setWorkbenchView("editor");
     requestAnimationFrame(() => {
       workbenchRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
@@ -469,6 +482,7 @@ export function DocumentDetail({
       setVersionUploadFile(null);
       setVersionUploadNotes("");
       setSelectedVersionId(uploaded.resolved_text ? uploaded.id : null);
+      setCompareVersionId(EXTRACTED_VERSION_ID);
       setActiveReaderQuote(null);
       setEditorDirty(false);
       await Promise.all([
@@ -488,6 +502,7 @@ export function DocumentDetail({
 
   const refreshAfterVersionRestore = async () => {
     setSelectedVersionId(null);
+    setCompareVersionId(EXTRACTED_VERSION_ID);
     setActiveReaderQuote(null);
     setEditorDirty(false);
     await Promise.all([
@@ -841,16 +856,41 @@ export function DocumentDetail({
                 onVersionRestored={refreshAfterVersionRestore}
               />
               {selectedResolvedVersion?.resolved_text && compareBeforeText && (
-                <VersionDiff
-                  before={{
-                    version: compareBeforeVersion,
-                    text: compareBeforeText,
-                  }}
-                  after={{
-                    version: selectedResolvedVersion,
-                    text: selectedResolvedVersion.resolved_text,
-                  }}
-                />
+                <>
+                  <div className="mt-5 flex flex-wrap items-end gap-3 border border-rule bg-paper-sunken p-4">
+                    <label className="grid gap-1 text-xs font-semibold text-muted">
+                      Compare against
+                      <select
+                        value={effectiveCompareVersionId}
+                        onChange={(event) => setCompareVersionId(event.target.value)}
+                        className="min-w-52 border border-rule bg-paper px-3 py-2 text-sm font-normal text-ink"
+                      >
+                        <option value={EXTRACTED_VERSION_ID}>Extracted text</option>
+                        {resolvedVersions
+                          .filter((version) => version.id !== selectedResolvedVersion.id)
+                          .map((version) => (
+                            <option key={version.id} value={version.id}>
+                              v{version.version_number}
+                            </option>
+                          ))}
+                      </select>
+                    </label>
+                    <p className="max-w-xl text-xs leading-5 text-muted">
+                      Use this to check how an uploaded or edited copy differs from the source
+                      text or another saved version before restoring, downloading, or relying on it.
+                    </p>
+                  </div>
+                  <VersionDiff
+                    before={{
+                      version: compareBeforeVersion,
+                      text: compareBeforeText,
+                    }}
+                    after={{
+                      version: selectedResolvedVersion,
+                      text: selectedResolvedVersion.resolved_text,
+                    }}
+                  />
+                </>
               )}
               {versions.length === 0 && (
                 <p className="mt-4 text-sm text-muted">No versions recorded.</p>

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -388,6 +388,23 @@ export function DocumentDetail({
     setSelectedVersionId(versionId);
     setWorkbenchView("editor");
   };
+  const reviewSavedVersion = (version: DocumentVersionSummary["version"]) => {
+    setVersions((current) => {
+      if (current.some((summary) => summary.version.id === version.id)) return current;
+      return [
+        ...current,
+        {
+          version,
+          pending_count: 0,
+          accepted_count: 0,
+          rejected_count: 0,
+        },
+      ];
+    });
+    setSelectedVersionId(version.id);
+    setCompareVersionId(EXTRACTED_VERSION_ID);
+    setWorkbenchView("versions");
+  };
   const submitComment = async () => {
     const trimmed = commentBody.trim();
     if (trimmed.length < 2) {
@@ -693,6 +710,7 @@ export function DocumentDetail({
                       .then(setVersions)
                       .catch(() => undefined);
                   }}
+                  onSavedVersion={reviewSavedVersion}
                 />
               </section>
             )}

--- a/frontend/src/modules/document_edit/TrackedChangesView.tsx
+++ b/frontend/src/modules/document_edit/TrackedChangesView.tsx
@@ -22,14 +22,15 @@ import { ErrorCallout } from "../../ui/primitives";
 type Props = {
   result: EditInstructionResponse;
   onResolved?: () => void;
+  onSavedVersion?: (version: DocumentVersionRead) => void;
 };
 
 type ResolvedBanner = {
-  versionNumber: number;
+  version: DocumentVersionRead;
   textLength: number;
 };
 
-export function TrackedChangesView({ result, onResolved }: Props) {
+export function TrackedChangesView({ result, onResolved, onSavedVersion }: Props) {
   const [edits, setEdits] = useState<DocumentEditRead[]>(result.pending_edits);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [bulkBusy, setBulkBusy] = useState<null | "accept" | "reject">(null);
@@ -53,7 +54,7 @@ export function TrackedChangesView({ result, onResolved }: Props) {
     );
 
   const flashBanner = (v: DocumentVersionRead, len: number) =>
-    setBanner({ versionNumber: v.version_number, textLength: len });
+    setBanner({ version: v, textLength: len });
 
   const handleResolve = async (
     edit: DocumentEditRead,
@@ -144,8 +145,19 @@ export function TrackedChangesView({ result, onResolved }: Props) {
       )}
 
       {banner && (
-        <div className="mb-3 border border-ink bg-wash p-2 text-[11px] text-ink font-mono">
-          Version v{banner.versionNumber} saved · {banner.textLength} chars
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3 border border-ink bg-wash p-3 text-[11px] text-ink">
+          <span className="font-mono">
+            Version v{banner.version.version_number} saved · {banner.textLength} chars
+          </span>
+          {onSavedVersion && (
+            <button
+              type="button"
+              onClick={() => onSavedVersion(banner.version)}
+              className="border border-ink bg-paper px-3 py-1.5 font-sans text-xs font-semibold text-ink hover:bg-ink hover:text-paper"
+            >
+              Review saved version
+            </button>
+          )}
         </div>
       )}
 

--- a/frontend/src/modules/document_edit/VersionDiff.test.tsx
+++ b/frontend/src/modules/document_edit/VersionDiff.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildVersionDiff } from "./VersionDiff";
+import { buildVersionDiff, buildVersionDiffSummary } from "./VersionDiff";
 
 describe("VersionDiff", () => {
   it("marks inserted and deleted text", () => {
@@ -12,5 +12,15 @@ describe("VersionDiff", () => {
     expect(
       parts.some((part) => part.type === "insert" && part.text.includes("acceptable")),
     ).toBe(true);
+  });
+
+  it("summarises changed and unchanged characters", () => {
+    const parts = buildVersionDiff("Alpha beta.", "Alpha beta and gamma.");
+    const summary = buildVersionDiffSummary(parts);
+
+    expect(summary.changed).toBe(true);
+    expect(summary.insertedChars).toBeGreaterThan(0);
+    expect(summary.deletedChars).toBe(0);
+    expect(summary.unchangedChars).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/modules/document_edit/VersionDiff.tsx
+++ b/frontend/src/modules/document_edit/VersionDiff.tsx
@@ -9,6 +9,13 @@ type DiffPart = {
   text: string;
 };
 
+type DiffSummary = {
+  insertedChars: number;
+  deletedChars: number;
+  unchangedChars: number;
+  changed: boolean;
+};
+
 export function buildVersionDiff(before: string, after: string): DiffPart[] {
   const diffs = dmp.diff_main(before, after);
   dmp.diff_cleanupSemantic(diffs);
@@ -20,9 +27,57 @@ export function buildVersionDiff(before: string, after: string): DiffPart[] {
     }));
 }
 
+export function buildVersionDiffSummary(parts: DiffPart[]): DiffSummary {
+  return parts.reduce<DiffSummary>(
+    (summary, part) => {
+      if (part.type === "insert") {
+        summary.insertedChars += part.text.length;
+        summary.changed = true;
+      } else if (part.type === "delete") {
+        summary.deletedChars += part.text.length;
+        summary.changed = true;
+      } else {
+        summary.unchangedChars += part.text.length;
+      }
+      return summary;
+    },
+    { insertedChars: 0, deletedChars: 0, unchangedChars: 0, changed: false },
+  );
+}
+
 function versionLabel(version: DocumentVersionRead | null): string {
   if (!version) return "Extracted text";
   return `v${version.version_number}`;
+}
+
+function renderPlainText(text: string) {
+  return text || "No text captured for this side.";
+}
+
+function renderInlineParts(parts: DiffPart[]) {
+  return parts.map((part, index) => {
+    if (part.type === "insert") {
+      return (
+        <ins
+          key={`${part.type}-${index}`}
+          className="bg-green-100 px-0.5 text-green-950 no-underline"
+        >
+          {part.text}
+        </ins>
+      );
+    }
+    if (part.type === "delete") {
+      return (
+        <del
+          key={`${part.type}-${index}`}
+          className="bg-red-100 px-0.5 text-red-950"
+        >
+          {part.text}
+        </del>
+      );
+    }
+    return <span key={`${part.type}-${index}`}>{part.text}</span>;
+  });
 }
 
 export function VersionDiff({
@@ -33,7 +88,7 @@ export function VersionDiff({
   after: { version: DocumentVersionRead; text: string };
 }) {
   const parts = buildVersionDiff(before.text, after.text);
-  const changed = parts.some((part) => part.type !== "same");
+  const summary = buildVersionDiffSummary(parts);
 
   return (
     <section className="mt-5 border border-rule bg-paper-sunken p-4" data-testid="version-diff">
@@ -45,34 +100,58 @@ export function VersionDiff({
           </p>
         </div>
         <span className="border border-rule bg-paper px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
-          {changed ? "Changes shown" : "No text changes"}
+          {summary.changed ? "Changes shown" : "No text changes"}
         </span>
       </div>
-      <div className="mt-4 max-h-[360px] overflow-auto border border-rule bg-paper p-4 text-sm leading-7">
-        {parts.map((part, index) => {
-          if (part.type === "insert") {
-            return (
-              <ins
-                key={`${part.type}-${index}`}
-                className="bg-green-100 px-0.5 text-green-950 no-underline"
-              >
-                {part.text}
-              </ins>
-            );
-          }
-          if (part.type === "delete") {
-            return (
-              <del
-                key={`${part.type}-${index}`}
-                className="bg-red-100 px-0.5 text-red-950"
-              >
-                {part.text}
-              </del>
-            );
-          }
-          return <span key={`${part.type}-${index}`}>{part.text}</span>;
-        })}
+
+      <dl className="mt-4 grid gap-2 text-xs sm:grid-cols-3">
+        <div className="border border-rule bg-paper p-3">
+          <dt className="font-mono uppercase tracking-track2 text-muted">Added</dt>
+          <dd className="mt-1 text-sm font-semibold text-green-900">
+            {summary.insertedChars.toLocaleString()} chars
+          </dd>
+        </div>
+        <div className="border border-rule bg-paper p-3">
+          <dt className="font-mono uppercase tracking-track2 text-muted">Removed</dt>
+          <dd className="mt-1 text-sm font-semibold text-red-900">
+            {summary.deletedChars.toLocaleString()} chars
+          </dd>
+        </div>
+        <div className="border border-rule bg-paper p-3">
+          <dt className="font-mono uppercase tracking-track2 text-muted">Unchanged</dt>
+          <dd className="mt-1 text-sm font-semibold text-ink">
+            {summary.unchangedChars.toLocaleString()} chars
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        <div className="border border-rule bg-paper">
+          <div className="border-b border-rule px-3 py-2 text-xs font-semibold text-muted">
+            Before · {versionLabel(before.version)}
+          </div>
+          <pre className="max-h-[260px] overflow-auto whitespace-pre-wrap p-4 font-sans text-sm leading-7 text-ink">
+            {renderPlainText(before.text)}
+          </pre>
+        </div>
+        <div className="border border-rule bg-paper">
+          <div className="border-b border-rule px-3 py-2 text-xs font-semibold text-muted">
+            After · {versionLabel(after.version)}
+          </div>
+          <pre className="max-h-[260px] overflow-auto whitespace-pre-wrap p-4 font-sans text-sm leading-7 text-ink">
+            {renderPlainText(after.text)}
+          </pre>
+        </div>
       </div>
+
+      <details className="mt-4 border border-rule bg-paper">
+        <summary className="cursor-pointer px-3 py-2 text-xs font-semibold text-ink">
+          Inline redline
+        </summary>
+        <div className="max-h-[360px] overflow-auto border-t border-rule p-4 text-sm leading-7">
+          {renderInlineParts(parts)}
+        </div>
+      </details>
     </section>
   );
 }

--- a/frontend/src/modules/document_edit/VersionTimeline.tsx
+++ b/frontend/src/modules/document_edit/VersionTimeline.tsx
@@ -12,8 +12,10 @@ const KIND_LABEL: Record<string, string> = {
   assistant_edit: "Assistant edit",
   user_accept: "User accept",
   user_reject: "User reject",
+  user_edit: "User edit",
   generated: "Generated",
   replicated: "Replicated",
+  restored: "Restored",
 };
 
 function fmt(ts: string): string {
@@ -65,7 +67,6 @@ export function VersionTimeline({
   }, [documentId, providedVersions, refreshKey]);
 
   const versions = providedVersions ?? fetchedVersions;
-  const latestVersionNumber = Math.max(...versions.map((s) => s.version.version_number));
 
   const restore = async (versionId: string) => {
     setRestoreError(null);
@@ -94,6 +95,7 @@ export function VersionTimeline({
     );
   }
   if (versions.length === 0) return null;
+  const latestVersionNumber = Math.max(...versions.map((s) => s.version.version_number));
 
   return (
     <div className="mt-5 border-t border-rule pt-4">


### PR DESCRIPTION
## Summary
- add explicit compare-against selection for document saved versions
- upgrade version diff into side-by-side before/after review with added/removed/unchanged counts
- keep inline redline available behind details and tidy version labels for user/restored versions

## Verification
- npm run test -- VersionDiff.test.tsx DocumentDetail.test.tsx
- npm run typecheck
- npm run build

Backend untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compare document versions against other saved versions or extracted text via dropdown selector
  * Diff view now displays character count statistics (Added, Removed, Unchanged)
  * Inline redline is now presented in a collapsible section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->