### PR TITLE
documents: polish original previews

### DIFF
--- a/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
@@ -72,7 +72,16 @@ export function DocxOriginalPreview({
             Word preview rendered from the audited original file proxy.
           </p>
         </div>
-        <span className="text-xs text-muted">{filename}</span>
+        <div className="text-right">
+          <span className="block text-xs font-medium text-ink">{filename}</span>
+          <span className="mt-1 block text-[11px] uppercase tracking-track2 text-muted">
+            {state.status === "ready"
+              ? "Rendered"
+              : state.status === "loading"
+                ? "Rendering"
+                : "Preview failed"}
+          </span>
+        </div>
       </div>
       {state.status === "loading" && (
         <div className="border-b border-rule px-5 py-3">
@@ -80,9 +89,10 @@ export function DocxOriginalPreview({
         </div>
       )}
       {state.status === "error" && (
-        <p className="border-b border-red-800 bg-red-50 px-5 py-3 text-sm text-red-900">
-          {state.message}
-        </p>
+        <div className="border-b border-red-800 bg-red-50 px-5 py-3 text-sm text-red-900">
+          <p>Could not render the Word preview.</p>
+          <p className="mt-1 text-xs">{state.message}</p>
+        </div>
       )}
       <div className="max-h-[780px] overflow-auto bg-paper-sunken px-4 py-5">
         <div

--- a/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
+++ b/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
@@ -127,6 +127,22 @@ export function PdfDocumentViewer({
           <span className="min-w-24 text-center text-xs text-muted">
             Page {pageNumber} / {numPages || "?"}
           </span>
+          <label className="sr-only" htmlFor={`pdf-page-${filename}`}>
+            Jump to page
+          </label>
+          <input
+            id={`pdf-page-${filename}`}
+            type="number"
+            min={1}
+            max={numPages || undefined}
+            value={pageNumber}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              if (!Number.isFinite(next)) return;
+              setPageNumber(Math.min(Math.max(1, next), numPages || next));
+            }}
+            className="h-10 w-20 border border-rule bg-paper px-2 text-center text-sm outline-none focus:border-ink"
+          />
           <button
             type="button"
             onClick={() => setPageNumber((v) => Math.min(numPages || v, v + 1))}
@@ -141,6 +157,13 @@ export function PdfDocumentViewer({
             className="border border-rule px-3 py-2"
           >
             -
+          </button>
+          <button
+            type="button"
+            onClick={() => setScale(1.15)}
+            className="min-w-16 border border-rule px-3 py-2 text-xs text-muted hover:border-ink hover:text-ink"
+          >
+            {Math.round(scale * 100)}%
           </button>
           <button
             type="button"
@@ -172,7 +195,7 @@ export function PdfDocumentViewer({
           </span>
         </div>
         {searchHits.length > 0 && (
-          <div className="mt-3 flex flex-wrap gap-2">
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
             {searchHits.slice(0, 8).map((hit) => (
               <button
                 key={`${hit.page}-${hit.preview}`}
@@ -181,10 +204,16 @@ export function PdfDocumentViewer({
                 className="border border-rule bg-paper px-3 py-2 text-left text-xs hover:border-ink"
                 title={hit.preview}
               >
-                Page {hit.page}
+                <span className="block font-semibold text-ink">Page {hit.page}</span>
+                <span className="mt-1 block max-h-10 overflow-hidden leading-5 text-muted">
+                  {hit.preview}
+                </span>
               </button>
             ))}
           </div>
+        )}
+        {searchTerm.length >= 3 && !loadingText && searchHits.length === 0 && (
+          <p className="mt-3 text-xs text-muted">No matches in the indexed PDF text.</p>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- improve the PDF reader controls with page jump, zoom readout/reset, and search snippets
- add explicit empty-search feedback for indexed PDF text
- clarify DOCX preview render state and failure copy

## Verification
- npm run typecheck
- npm run build

Frontend-only document workbench slice.