### PR TITLE
documents: deepen workbench parity

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -20,8 +20,24 @@ import * as anonApi from "../modules/anonymisation/api";
 import type { MatterDocument } from "../lib/api";
 
 vi.mock("../modules/document_preview/PdfDocumentViewer", () => ({
-  PdfDocumentViewer: ({ filename }: { filename: string }) => (
-    <div data-testid="pdf-document-viewer">PDF reader for {filename}</div>
+  PdfDocumentViewer: ({
+    filename,
+    onQuoteSelected,
+  }: {
+    filename: string;
+    onQuoteSelected?: (quote: string) => void;
+  }) => (
+    <div data-testid="pdf-document-viewer">
+      PDF reader for {filename}
+      {onQuoteSelected && (
+        <button
+          type="button"
+          onClick={() => onQuoteSelected("PDF quoted passage")}
+        >
+          Mock PDF quote
+        </button>
+      )}
+    </div>
   ),
 }));
 
@@ -120,6 +136,12 @@ async function expectEditorText(container: HTMLElement, text: string) {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.spyOn(api, "getModulesV2").mockResolvedValue({
+    modules: [],
+    ui_slots: [],
+  });
+  vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+  vi.spyOn(api, "listGrants").mockResolvedValue({ matter_id: "m-1", grants: [] });
   vi.spyOn(api, "getDocumentVersions").mockResolvedValue([]);
   vi.spyOn(api, "getDocumentComments").mockResolvedValue([]);
   vi.spyOn(api, "getDocumentEditSessions").mockResolvedValue([]);
@@ -358,6 +380,176 @@ describe("DocumentDetail", () => {
     expect(screen.getByTestId("document-history-workspace")).toBeInTheDocument();
     expect(screen.getByText("Version record")).toBeInTheDocument();
     expect(screen.getByText("Redaction")).toBeInTheDocument();
+  });
+
+  it("shows a review queue and honest live presence on the workbench", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "getDocumentVersions").mockResolvedValue([
+      {
+        ...versionSummary("v-1", 1, "Original body"),
+        pending_count: 2,
+      },
+    ]);
+    vi.spyOn(api, "getDocumentComments").mockResolvedValue([
+      {
+        id: "comment-1",
+        document_id: "doc-1",
+        author_id: "u-1",
+        quote_text: null,
+        body_sha256: null,
+        anchor_start: null,
+        anchor_end: null,
+        body: "Check this before signing.",
+        status: "open",
+        created_at: "2026-06-03T10:00:00",
+        resolved_at: null,
+        resolved_by_id: null,
+      },
+    ]);
+    vi.spyOn(api, "startDocumentEditSession").mockResolvedValue({
+      current: {
+        id: "edit-session-1",
+        document_id: "doc-1",
+        user_id: "u-1",
+        client_id: "client-1",
+        user_label: "Andy",
+        started_at: "2026-06-03T18:00:00",
+        last_seen_at: "2026-06-03T18:00:00",
+        ended_at: null,
+      },
+      active: [
+        {
+          id: "edit-session-1",
+          document_id: "doc-1",
+          user_id: "u-1",
+          client_id: "client-1",
+          user_label: "Andy",
+          started_at: "2026-06-03T18:00:00",
+          last_seen_at: "2026-06-03T18:00:00",
+          ended_at: null,
+        },
+        {
+          id: "edit-session-2",
+          document_id: "doc-1",
+          user_id: "u-2",
+          client_id: "client-2",
+          user_label: "Reviewer",
+          started_at: "2026-06-03T18:01:00",
+          last_seen_at: "2026-06-03T18:01:00",
+          ended_at: null,
+        },
+      ],
+    });
+
+    mount();
+
+    expect(await screen.findByTestId("document-review-queue")).toHaveTextContent(
+      "4 items need attention.",
+    );
+    expect(screen.getByTestId("document-review-queue")).toHaveTextContent(
+      "Proposed redlines",
+    );
+    expect(screen.getByTestId("document-presence-strip")).toHaveTextContent(
+      "2 people have this file open",
+    );
+    expect(screen.getByText(/Another session is active/i)).toBeInTheDocument();
+  });
+
+  it("turns a PDF search result into a quoted review note", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+
+    mount();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Original" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Mock PDF quote" }));
+
+    expect(screen.getByPlaceholderText("Optional quoted passage")).toHaveValue(
+      "PDF quoted passage",
+    );
+    expect(screen.getByTestId("document-selected-quote")).toHaveTextContent(
+      "PDF quoted passage",
+    );
+  });
+
+  it("runs ready document skills from the document workbench", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([
+      {
+        module_id: "demo.guided-skill",
+        version: "0.1.0",
+        publisher: "legalise",
+        visibility: "first_party",
+        signature_status: "verified",
+        enabled: true,
+        installed_at: "2026-01-01T00:00:00",
+        installed_by_user_id: null,
+      },
+    ]);
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({
+      modules: [
+        {
+          module_id: "demo.guided-skill",
+          source_kind: "v2",
+          manifest: {
+            name: "Demo skill",
+            description: "Summarises the selected file.",
+            capabilities: [
+              {
+                id: "summarise",
+                kind: "skill",
+                scope: "matter",
+                reads: ["document.body.read"],
+                writes: ["matter.artifact.write"],
+                model_access: "required",
+                ui: {
+                  label: "Plain-English Summary",
+                  default_request: "Summarise {filename}.",
+                },
+              },
+            ],
+          },
+          is_valid: true,
+          validation_errors: [],
+        },
+      ],
+      ui_slots: [],
+    });
+    vi.spyOn(api, "listGrants").mockResolvedValue({
+      matter_id: "m-1",
+      grants: [
+        {
+          id: "g-1",
+          plugin: "demo.guided-skill",
+          skill: "summarise",
+          capability: "document.body.read",
+          scope_type: "matter",
+          scope_id: "m-1",
+          granted_at: "2026-01-01T00:00:00",
+        },
+        {
+          id: "g-2",
+          plugin: "demo.guided-skill",
+          skill: "summarise",
+          capability: "matter.artifact.write",
+          scope_type: "matter",
+          scope_id: "m-1",
+          granted_at: "2026-01-01T00:00:00",
+        },
+      ],
+    });
+
+    mount();
+
+    expect(await screen.findByTestId("document-skill-runner")).toHaveTextContent(
+      "1 ready",
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Plain-English Summary/i }));
+
+    expect(screen.getByTestId("generic-runner-demo.guided-skill-summarise")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Summarise claim-form.pdf.")).toBeInTheDocument();
   });
 
   it("shows document review notes and lets the user add one", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -21,11 +21,14 @@ import {
   endDocumentEditSession,
   type EditInstructionResponse,
   getAnonymisation,
+  getModulesV2,
   getDocumentComments,
   getDocumentBody,
   getDocumentEditSessions,
   getDocumentVersions,
+  listGrants,
   listDocuments,
+  listInstalledModules,
   resolveDocumentComment,
   startDocumentEditSession,
   uploadDocumentVersion,
@@ -34,7 +37,10 @@ import {
   type DocumentBody,
   type DocumentEditSessionRead,
   type DocumentVersionSummary,
+  type GrantRow,
+  type InstalledModule,
   type MatterDocument,
+  type V2ManifestEntry,
 } from "../lib/api";
 import {
   DescItem,
@@ -53,6 +59,12 @@ import {
   type DocumentNoteHighlight,
   type TiptapNode,
 } from "../modules/document_edit/DocumentRichEditor";
+import { GenericSkillRunner } from "./GenericSkillRunner";
+import {
+  runnableMatterSkills,
+  shortCapabilityList,
+  type RunnableMatterSkill,
+} from "./skillRunnerModel";
 
 const DocxOriginalPreview = lazy(() =>
   import("../modules/document_preview/DocxOriginalPreview").then((mod) => ({
@@ -152,7 +164,18 @@ export function DocumentDetail({
   const [editorDirty, setEditorDirty] = useState(false);
   const [activeEditResult, setActiveEditResult] =
     useState<EditInstructionResponse | null>(null);
+  const [moduleEntries, setModuleEntries] = useState<V2ManifestEntry[]>([]);
+  const [installedModules, setInstalledModules] = useState<Map<string, InstalledModule>>(
+    new Map(),
+  );
+  const [grantRows, setGrantRows] = useState<GrantRow[] | null>(null);
+  const [skillLoadState, setSkillLoadState] =
+    useState<"loading" | "ready" | "error">("loading");
+  const [activeRunnerSkill, setActiveRunnerSkill] =
+    useState<RunnableMatterSkill | null>(null);
   const workbenchRef = useRef<HTMLDivElement | null>(null);
+  const notesRef = useRef<HTMLElement | null>(null);
+  const skillsRef = useRef<HTMLElement | null>(null);
   const editClientIdRef = useRef<string | null>(null);
 
   const sourceContext = useRouterState({
@@ -278,6 +301,31 @@ export function DocumentDetail({
     };
   }, [documentId]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setSkillLoadState("loading");
+    void Promise.all([
+      getModulesV2(),
+      listInstalledModules(),
+      listGrants(slug),
+    ])
+      .then(([moduleResponse, installedRows, grantsResponse]) => {
+        if (cancelled) return;
+        const installedIndex = new Map<string, InstalledModule>();
+        for (const row of installedRows) installedIndex.set(row.module_id, row);
+        setModuleEntries(moduleResponse.modules);
+        setInstalledModules(installedIndex);
+        setGrantRows(grantsResponse.grants);
+        setSkillLoadState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setSkillLoadState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
   if (q.status === "loading") {
     return (
       <div className="mx-auto max-w-3xl px-6 py-12">
@@ -368,6 +416,17 @@ export function DocumentDetail({
   const anchoredComments = comments.filter(
     (comment) => comment.anchor_start !== null && comment.anchor_end !== null,
   );
+  const runnableSkills = runnableMatterSkills({
+    modules: moduleEntries,
+    installed: installedModules,
+    grants: grantRows,
+  });
+  const documentSkills = runnableSkills.filter((skill) =>
+    skill.reads.includes("document.body.read"),
+  );
+  const reviewQueueTotal =
+    pendingEdits + openComments.length + (activeEditSessions.length > 1 ? 1 : 0);
+  const hasConcurrentSession = activeEditSessions.length > 1;
   const anchoredOpenNotes: DocumentNoteHighlight[] = openComments
     .filter(
       (comment) =>
@@ -483,6 +542,28 @@ export function DocumentDetail({
     setWorkbenchView("editor");
     requestAnimationFrame(() => {
       workbenchRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+    });
+  };
+  const startQuotedNote = (quote: string) => {
+    const trimmed = quote.trim().replace(/\s+/g, " ");
+    if (!trimmed) return;
+    setSelectedQuote(trimmed);
+    setCommentQuote(trimmed);
+    const range = findNormalizedRange(editorText, trimmed);
+    if (range) {
+      setSelectedAnchor({ quote: trimmed, start: range.start, end: range.end, bodySha256: null });
+      void sha256Hex(editorText).then((bodySha256) => {
+        setSelectedAnchor((current) =>
+          current?.quote === trimmed && current.start === range.start && current.end === range.end
+            ? { ...current, bodySha256 }
+            : current,
+        );
+      });
+    } else {
+      setSelectedAnchor(null);
+    }
+    requestAnimationFrame(() => {
+      notesRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
     });
   };
   const submitVersionUpload = async () => {
@@ -686,6 +767,34 @@ export function DocumentDetail({
           )}
         </nav>
 
+        <div
+          className="mt-4 flex flex-wrap items-center justify-between gap-3 border border-rule bg-paper px-4 py-3 text-sm"
+          data-testid="document-presence-strip"
+        >
+          <div>
+            <span className="font-semibold text-ink">
+              {activeEditSessions.length > 1
+                ? `${activeEditSessions.length} people have this file open`
+                : "You are working in this file"}
+            </span>
+            <span className="ml-2 text-muted">
+              Live presence is recorded; edits save as document versions.
+            </span>
+          </div>
+          {activeEditSessions.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              {activeEditSessions.slice(0, 4).map((session) => (
+                <span
+                  key={session.id}
+                  className="border border-rule bg-paper-sunken px-2 py-1 text-xs text-muted"
+                >
+                  {session.user_label}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
         <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_390px]">
           <main
             ref={workbenchRef}
@@ -782,6 +891,7 @@ export function DocumentDetail({
                     fileUrl={originalHref}
                     filename={doc.filename}
                     sourceHighlight={currentReaderQuote}
+                    onQuoteSelected={startQuotedNote}
                   />
                 ) : canPreviewDocx ? (
                   <DocxOriginalPreview documentId={documentId} filename={doc.filename} />
@@ -937,6 +1047,55 @@ export function DocumentDetail({
           </main>
 
           <aside className="space-y-4 lg:sticky lg:top-6 lg:self-start">
+            <section className="border border-ink bg-paper p-4" data-testid="document-review-queue">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                    Review queue
+                  </p>
+                  <h2 className="mt-1 text-lg font-semibold tracking-tight2 text-ink">
+                    {reviewQueueTotal === 0
+                      ? "Nothing waiting."
+                      : `${reviewQueueTotal} item${reviewQueueTotal === 1 ? "" : "s"} need attention.`}
+                  </h2>
+                </div>
+                <span className="border border-ink bg-ink px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-paper">
+                  Workbench
+                </span>
+              </div>
+              <div className="mt-4 grid gap-2 text-sm">
+                <button
+                  type="button"
+                  onClick={() => openWorkbenchView(activeEditResult ? "redlines" : "versions")}
+                  className="flex items-center justify-between border border-rule bg-paper-sunken px-3 py-2 text-left hover:border-ink"
+                >
+                  <span>Proposed redlines</span>
+                  <span className="font-semibold text-ink">{pendingEdits}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => notesRef.current?.scrollIntoView({ block: "start", behavior: "smooth" })}
+                  className="flex items-center justify-between border border-rule bg-paper-sunken px-3 py-2 text-left hover:border-ink"
+                >
+                  <span>Open review notes</span>
+                  <span className="font-semibold text-ink">{openComments.length}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => openWorkbenchView("versions")}
+                  className="flex items-center justify-between border border-rule bg-paper-sunken px-3 py-2 text-left hover:border-ink"
+                >
+                  <span>Saved versions</span>
+                  <span className="font-semibold text-ink">{versions.length}</span>
+                </button>
+                {activeEditSessions.length > 1 && (
+                  <p className="border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
+                    Another session is open. Coordinate before saving a new version.
+                  </p>
+                )}
+              </div>
+            </section>
+
             <section className="border border-rule bg-paper p-4">
               <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
                 Document intelligence
@@ -947,6 +1106,83 @@ export function DocumentDetail({
               <p className="mt-2 text-sm leading-6 text-muted">
                 Proposed edits, human notes, active sessions, and version status stay with this document.
               </p>
+            </section>
+
+            <section
+              ref={skillsRef}
+              className="border border-rule bg-paper p-4"
+              data-testid="document-skill-runner"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-ink">Run a skill on this file</h2>
+                  <p className="mt-1 text-sm leading-6 text-muted">
+                    Use the same project skills from Chat, preloaded with this document.
+                  </p>
+                </div>
+                <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                  {documentSkills.length} ready
+                </span>
+              </div>
+              {activeRunnerSkill ? (
+                <div className="mt-4">
+                  <GenericSkillRunner
+                    slug={slug}
+                    skill={activeRunnerSkill}
+                    documents={[doc]}
+                    initialDocumentIds={[documentId]}
+                    onClose={() => setActiveRunnerSkill(null)}
+                    compact
+                  />
+                </div>
+              ) : skillLoadState === "loading" ? (
+                <p className="mt-3 text-sm text-muted">Loading project skills...</p>
+              ) : skillLoadState === "error" ? (
+                <p className="mt-3 text-sm text-muted">
+                  Skills could not be loaded here. Open the project Skills page to check setup.
+                </p>
+              ) : documentSkills.length === 0 ? (
+                <div className="mt-3 text-sm text-muted">
+                  <p>No document-reading skills are ready for this file yet.</p>
+                  <Link
+                    to="/matters/$slug/$tab"
+                    params={{ slug, tab: "workflows" }}
+                    className="mt-2 inline-block underline underline-offset-4 hover:text-ink"
+                  >
+                    Open project Skills →
+                  </Link>
+                </div>
+              ) : (
+                <div className="mt-3 space-y-2">
+                  {documentSkills.slice(0, 4).map((skill) => (
+                    <button
+                      key={`${skill.moduleId}:${skill.capabilityId}`}
+                      type="button"
+                      onClick={() => {
+                        setActiveRunnerSkill(skill);
+                        requestAnimationFrame(() => {
+                          skillsRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+                        });
+                      }}
+                      className="w-full border border-rule bg-paper-sunken px-3 py-2 text-left hover:border-ink"
+                    >
+                      <span className="block text-sm font-semibold text-ink">{skill.title}</span>
+                      <span className="mt-1 block text-xs text-muted">
+                        Reads {shortCapabilityList(skill.reads)} · writes {shortCapabilityList(skill.writes)}
+                      </span>
+                    </button>
+                  ))}
+                  {documentSkills.length > 4 && (
+                    <Link
+                      to="/matters/$slug/$tab"
+                      params={{ slug, tab: "workflows" }}
+                      className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+                    >
+                      See all skills →
+                    </Link>
+                  )}
+                </div>
+              )}
             </section>
 
             <section className="border border-rule bg-paper p-4">
@@ -1001,7 +1237,7 @@ export function DocumentDetail({
                 <div>
                   <h2 className="text-sm font-semibold text-ink">Editing now</h2>
                   <p className="mt-1 text-sm leading-6 text-muted">
-                    Active document sessions are visible here. Real-time co-editing will use this same document session record.
+                    Active document sessions are visible here. Edits are preserved as versions so another person's save does not disappear into the file.
                   </p>
                 </div>
                 <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
@@ -1024,10 +1260,19 @@ export function DocumentDetail({
                 ) : (
                   <p className="text-sm text-muted">You are editing this document.</p>
                 )}
+                {hasConcurrentSession && (
+                  <p className="border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
+                    Another session is active. Agree who saves the next version before applying edits.
+                  </p>
+                )}
               </div>
             </section>
 
-            <section className="border border-rule bg-paper p-4" data-testid="document-comments">
+            <section
+              ref={notesRef}
+              className="border border-rule bg-paper p-4"
+              data-testid="document-comments"
+            >
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <h2 className="text-sm font-semibold text-ink">Review notes</h2>

--- a/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
+++ b/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
@@ -36,10 +36,12 @@ export function PdfDocumentViewer({
   fileUrl,
   filename,
   sourceHighlight,
+  onQuoteSelected,
 }: {
   fileUrl: string;
   filename: string;
   sourceHighlight?: string | null;
+  onQuoteSelected?: (quote: string) => void;
 }) {
   const [numPages, setNumPages] = useState(0);
   const [pageNumber, setPageNumber] = useState(1);
@@ -197,18 +199,31 @@ export function PdfDocumentViewer({
         {searchHits.length > 0 && (
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
             {searchHits.slice(0, 8).map((hit) => (
-              <button
+              <div
                 key={`${hit.page}-${hit.preview}`}
-                type="button"
-                onClick={() => setPageNumber(hit.page)}
-                className="border border-rule bg-paper px-3 py-2 text-left text-xs hover:border-ink"
-                title={hit.preview}
+                className="border border-rule bg-paper px-3 py-2 text-xs"
               >
-                <span className="block font-semibold text-ink">Page {hit.page}</span>
-                <span className="mt-1 block max-h-10 overflow-hidden leading-5 text-muted">
-                  {hit.preview}
-                </span>
-              </button>
+                <button
+                  type="button"
+                  onClick={() => setPageNumber(hit.page)}
+                  className="block w-full text-left hover:text-ink"
+                  title={hit.preview}
+                >
+                  <span className="block font-semibold text-ink">Page {hit.page}</span>
+                  <span className="mt-1 block max-h-10 overflow-hidden leading-5 text-muted">
+                    {hit.preview}
+                  </span>
+                </button>
+                {onQuoteSelected && (
+                  <button
+                    type="button"
+                    onClick={() => onQuoteSelected(hit.preview)}
+                    className="mt-2 font-medium text-ink underline underline-offset-4 hover:text-muted"
+                  >
+                    Quote in note
+                  </button>
+                )}
+              </div>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary

Pushes the document workbench further toward the Mike-calibre document surface using the stack already in the repo, without adding a parallel runner or new backend substrate.

- Adds PDF search-hit → review-note quoting, so source inspection can seed anchored notes from the original preview.
- Adds a workbench review queue that brings redlines, open notes, saved versions, and concurrent sessions into one scanable control surface.
- Makes document edit-session presence visible and honest: live presence is recorded; edits save as versions.
- Embeds the existing generic skill runner in the document workbench for document-reading skills, preloaded with the current file. No bespoke per-skill page path.
- Extends focused tests for queue/presence, PDF quote-to-note, and document-scoped skill running.

## Verification

- `npm run typecheck` in `frontend`
- `npm run build` in `frontend`
- `npm test -- --run src/matter/DocumentDetail.test.tsx src/modules/document_preview/PdfDocumentViewer.test.tsx src/matter/GenericSkillRunner.test.tsx` in `frontend`
- Local browser smoke: Vite home route loaded on `127.0.0.1:3000`; authenticated document data path covered by component tests.

## Notes

This deliberately reuses the canonical `GenericSkillRunner` and `runnableMatterSkills` derivation. The document page does not invent a separate document-skill model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added live presence indicator displaying active document editors
  * Introduced document skills interface for running analysis on files
  * Enabled quote selection from PDF documents for review notes
  * PDF search results now include "quote in note" action for direct note insertion
  * Enhanced review queue with concurrent editing session indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->