### PR TITLE
documents: add Word preview search

### DIFF
--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -894,7 +894,12 @@ export function DocumentDetail({
                     onQuoteSelected={startQuotedNote}
                   />
                 ) : canPreviewDocx ? (
-                  <DocxOriginalPreview documentId={documentId} filename={doc.filename} />
+                  <DocxOriginalPreview
+                    documentId={documentId}
+                    filename={doc.filename}
+                    sourceHighlight={currentReaderQuote}
+                    onQuoteSelected={startQuotedNote}
+                  />
                 ) : (
                   <section className="border border-rule bg-paper p-6">
                     <EmptyState

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderAsync } from "docx-preview";
 
 import { DocxOriginalPreview } from "./DocxOriginalPreview";
@@ -7,7 +8,8 @@ import * as api from "../../lib/api";
 
 vi.mock("docx-preview", () => ({
   renderAsync: vi.fn(async (_blob: Blob, container: HTMLElement) => {
-    container.innerHTML = "<article>Rendered Word body</article>";
+    container.innerHTML =
+      "<article>Rendered Word body with dismissal facts and a limitation point.</article>";
   }),
 }));
 
@@ -37,8 +39,41 @@ describe("DocxOriginalPreview", () => {
         }),
       );
     });
-    expect(screen.getByText("Rendered Word body")).toBeInTheDocument();
+    expect(screen.getByText(/Rendered Word body/)).toBeInTheDocument();
     expect(api.fetchDocumentOriginalBlob).toHaveBeenCalledWith("doc-1");
+  });
+
+  it("searches rendered Word text and turns a hit into a review note quote", async () => {
+    const blob = new Blob(["docx"], {
+      type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    });
+    vi.spyOn(api, "fetchDocumentOriginalBlob").mockResolvedValue(blob);
+    const onQuoteSelected = vi.fn();
+
+    render(
+      <DocxOriginalPreview
+        documentId="doc-1"
+        filename="witness.docx"
+        sourceHighlight="dismissal facts"
+        onQuoteSelected={onQuoteSelected}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("1 match")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText(/dismissal facts/).length).toBeGreaterThan(0);
+
+    await userEvent.click(screen.getByRole("button", { name: "Quote in note" }));
+    expect(onQuoteSelected).toHaveBeenCalledWith(
+      expect.stringContaining("dismissal facts"),
+    );
+
+    await userEvent.clear(screen.getByPlaceholderText("Search text in this Word file"));
+    await userEvent.type(screen.getByPlaceholderText("Search text in this Word file"), "limitation");
+    await waitFor(() => {
+      expect(screen.getByText("1 match")).toBeInTheDocument();
+    });
   });
 
   it("shows a useful error if the original cannot be loaded", async () => {

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
@@ -8,15 +8,59 @@ type PreviewState =
   | { status: "ready" }
   | { status: "error"; message: string };
 
+type DocxSearchHit = {
+  index: number;
+  preview: string;
+};
+
+function normalise(value: string): string {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function previewAround(text: string, index: number, length: number): string {
+  const start = Math.max(0, index - 80);
+  const end = Math.min(text.length, index + length + 120);
+  return text.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
 export function DocxOriginalPreview({
   documentId,
   filename,
+  sourceHighlight,
+  onQuoteSelected,
 }: {
   documentId: string;
   filename: string;
+  sourceHighlight?: string | null;
+  onQuoteSelected?: (quote: string) => void;
 }) {
   const [state, setState] = useState<PreviewState>({ status: "loading" });
+  const [renderedText, setRenderedText] = useState("");
+  const [query, setQuery] = useState(sourceHighlight?.trim() ?? "");
   const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const searchTerm = query.trim();
+  const searchHits = (() => {
+    const needle = normalise(searchTerm);
+    const haystack = normalise(renderedText);
+    if (needle.length < 3 || !haystack) return [] as DocxSearchHit[];
+    const hits: DocxSearchHit[] = [];
+    let from = 0;
+    while (from < haystack.length && hits.length < 8) {
+      const index = haystack.indexOf(needle, from);
+      if (index === -1) break;
+      hits.push({
+        index,
+        preview: previewAround(renderedText, index, needle.length),
+      });
+      from = index + Math.max(needle.length, 1);
+    }
+    return hits;
+  })();
+
+  useEffect(() => {
+    setQuery(sourceHighlight?.trim() ?? "");
+  }, [sourceHighlight]);
 
   useEffect(() => {
     let cancelled = false;
@@ -24,6 +68,7 @@ export function DocxOriginalPreview({
     if (!container) return;
     container.innerHTML = "";
     setState({ status: "loading" });
+    setRenderedText("");
 
     fetchDocumentOriginalBlob(documentId)
       .then(async (blob) => {
@@ -45,7 +90,10 @@ export function DocxOriginalPreview({
           renderChanges: false,
           useBase64URL: true,
         });
-        if (!cancelled) setState({ status: "ready" });
+        if (!cancelled) {
+          setRenderedText(containerRef.current?.textContent ?? "");
+          setState({ status: "ready" });
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -94,6 +142,53 @@ export function DocxOriginalPreview({
           <p className="mt-1 text-xs">{state.message}</p>
         </div>
       )}
+      <div className="border-b border-rule bg-paper-sunken px-5 py-4">
+        <label className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+          Find in Word
+        </label>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search text in this Word file"
+            className="min-h-[40px] min-w-[260px] flex-1 border border-rule bg-paper px-3 text-sm outline-none focus:border-ink"
+          />
+          <span className="text-xs text-muted">
+            {state.status === "loading"
+              ? "Indexing text..."
+              : searchTerm.length >= 3
+                ? `${searchHits.length} match${searchHits.length === 1 ? "" : "es"}`
+                : "Type 3+ characters"}
+          </span>
+        </div>
+        {searchHits.length > 0 && (
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {searchHits.map((hit, index) => (
+              <div
+                key={`${hit.index}-${hit.preview}`}
+                className="border border-rule bg-paper px-3 py-2 text-xs"
+              >
+                <span className="block font-semibold text-ink">Match {index + 1}</span>
+                <span className="mt-1 block max-h-12 overflow-hidden leading-5 text-muted">
+                  {hit.preview}
+                </span>
+                {onQuoteSelected && (
+                  <button
+                    type="button"
+                    onClick={() => onQuoteSelected(hit.preview)}
+                    className="mt-2 font-medium text-ink underline underline-offset-4 hover:text-muted"
+                  >
+                    Quote in note
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        {searchTerm.length >= 3 && state.status === "ready" && searchHits.length === 0 && (
+          <p className="mt-3 text-xs text-muted">No matches in the rendered Word text.</p>
+        )}
+      </div>
       <div className="max-h-[780px] overflow-auto bg-paper-sunken px-4 py-5">
         <div
           ref={containerRef}


### PR DESCRIPTION
## Summary

Third document-engine parity slice after #88 and #89. This closes the mismatch between PDF and DOCX original previews.

- Adds rendered-text search to the Word original preview that is powered by the existing `docx-preview` render output.
- Seeds Word search from source-anchor text when arriving from Chat or a cited output.
- Adds `Quote in note` from Word search hits, wired into the same document review-note flow as PDF search hits.
- Keeps the original audited file proxy and existing `docx-preview` package; no new backend, no schema change, no new document stack.

## Verification

- `npm run typecheck` in `frontend`
- `npm test -- --run src/modules/document_preview/DocxOriginalPreview.test.tsx src/modules/document_preview/PdfDocumentViewer.test.tsx src/matter/DocumentDetail.test.tsx src/modules/document_edit/DocumentRichEditor.test.tsx src/matter/GenericSkillRunner.test.tsx` in `frontend`
- `npm run build` in `frontend`

## Notes

This does not claim perfect Word-native editing or collaboration. It makes the existing Word original reader behave like a review surface: find text, inspect context, and turn a passage into a workbench note.