### PR TITLE
documents: add library search filters

### DIFF
--- a/frontend/src/matter/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { DocumentsTab } from "./DocumentsTab";
 
@@ -23,25 +24,40 @@ vi.mock("@tanstack/react-router", () => ({
 afterEach(() => cleanup());
 
 describe("DocumentsTab — document ingress", () => {
+  const sampleDocs = [
+    {
+      id: "doc-1",
+      matter_id: "matter-1",
+      filename: "witness.docx",
+      mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      size_bytes: 1200,
+      sha256: "a".repeat(64),
+      tag: "draft",
+      from_disclosure: false,
+      uploaded_at: "2026-06-03T10:00:00",
+      uploaded_by_id: "u-1",
+      comment_count: 2,
+    },
+    {
+      id: "doc-2",
+      matter_id: "matter-1",
+      filename: "dismissal-letter.pdf",
+      mime_type: "application/pdf",
+      size_bytes: 2400,
+      sha256: "b".repeat(64),
+      tag: "disclosure",
+      from_disclosure: true,
+      uploaded_at: "2026-06-03T11:00:00",
+      uploaded_by_id: "u-1",
+      comment_count: 0,
+    },
+  ];
+
   it("surfaces review-note counts in the document list", () => {
     render(
       <DocumentsTab
         slug="khan"
-        docs={[
-          {
-            id: "doc-1",
-            matter_id: "matter-1",
-            filename: "witness.docx",
-            mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            size_bytes: 1200,
-            sha256: "a".repeat(64),
-            tag: "draft",
-            from_disclosure: false,
-            uploaded_at: "2026-06-03T10:00:00",
-            uploaded_by_id: "u-1",
-            comment_count: 2,
-          },
-        ]}
+        docs={[sampleDocs[0]]}
         onUpload={vi.fn()}
       />,
     );
@@ -52,6 +68,26 @@ describe("DocumentsTab — document ingress", () => {
     expect(screen.getByText("Open workbench")).toBeInTheDocument();
     expect(screen.getAllByText("Files")[0]).toBeInTheDocument();
     expect(screen.getAllByText("1K")[0]).toBeInTheDocument();
+  });
+
+  it("searches and filters the document library without opening files", async () => {
+    render(<DocumentsTab slug="khan" docs={sampleDocs} onUpload={vi.fn()} />);
+
+    expect(screen.getByText("Showing 2 of 2 documents.")).toBeInTheDocument();
+
+    await userEvent.type(screen.getByPlaceholderText("Filename, tag, hash, source"), "dismissal");
+    expect(screen.queryByText("witness.docx")).not.toBeInTheDocument();
+    expect(screen.getByText("dismissal-letter.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 documents.")).toBeInTheDocument();
+
+    await userEvent.clear(screen.getByPlaceholderText("Filename, tag, hash, source"));
+    await userEvent.click(screen.getByRole("button", { name: "With notes" }));
+    expect(screen.getByText("witness.docx")).toBeInTheDocument();
+    expect(screen.queryByText("dismissal-letter.pdf")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Disclosure" }));
+    expect(screen.queryByText("witness.docx")).not.toBeInTheDocument();
+    expect(screen.getByText("dismissal-letter.pdf")).toBeInTheDocument();
   });
 
   it("uploads multiple selected files through the existing per-document audit path", async () => {

--- a/frontend/src/matter/tabs/DocumentsTab.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.tsx
@@ -71,6 +71,9 @@ export function DocumentsTab({
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [ingress, setIngress] = useState<IngressStatus>({ kind: "idle" });
   const [dragging, setDragging] = useState(false);
+  const [documentQuery, setDocumentQuery] = useState("");
+  const [documentFilter, setDocumentFilter] =
+    useState<"all" | "disclosure" | "notes">("all");
 
   const uploadFiles = async (files: File[]) => {
     if (files.length === 0) return;
@@ -114,6 +117,27 @@ export function DocumentsTab({
   const totalBytes = docs?.reduce((total, d) => total + d.size_bytes, 0) ?? 0;
   const disclosureCount = docs?.filter((d) => d.from_disclosure).length ?? 0;
   const noteCount = docs?.reduce((total, d) => total + (d.comment_count ?? 0), 0) ?? 0;
+  const filteredDocs =
+    docs?.filter((d) => {
+      const query = documentQuery.trim().toLowerCase();
+      const matchesQuery =
+        !query ||
+        [
+          d.filename,
+          d.tag ?? "",
+          d.sha256,
+          d.from_disclosure ? "disclosure cpr 31" : "upload",
+          deriveType(d),
+        ]
+          .join(" ")
+          .toLowerCase()
+          .includes(query);
+      const matchesFilter =
+        documentFilter === "all" ||
+        (documentFilter === "disclosure" && d.from_disclosure) ||
+        (documentFilter === "notes" && (d.comment_count ?? 0) > 0);
+      return matchesQuery && matchesFilter;
+    }) ?? null;
 
   // Column template shared by the header row and each data row so columns
   // stay aligned. Document gets the largest fr; full SHA moves into the
@@ -244,6 +268,45 @@ export function DocumentsTab({
               as CPR 31 material.
             </p>
           )}
+          <div
+            className="mb-4 grid gap-3 border border-rule bg-paper px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto]"
+            data-testid="document-library-controls"
+          >
+            <label className="text-xs font-semibold uppercase tracking-track2 text-muted">
+              Search documents
+              <input
+                value={documentQuery}
+                onChange={(event) => setDocumentQuery(event.target.value)}
+                placeholder="Filename, tag, hash, source"
+                className="mt-1 min-h-[40px] w-full border border-rule bg-paper-sunken px-3 font-sans text-sm font-normal normal-case tracking-normal text-ink outline-none focus:border-ink"
+              />
+            </label>
+            <div className="flex flex-wrap items-end gap-2">
+              {[
+                ["all", "All"],
+                ["disclosure", "Disclosure"],
+                ["notes", "With notes"],
+              ].map(([value, label]) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() =>
+                    setDocumentFilter(value as "all" | "disclosure" | "notes")
+                  }
+                  className={`min-h-[40px] border px-3 text-sm font-medium ${
+                    documentFilter === value
+                      ? "border-ink bg-ink text-paper"
+                      : "border-rule bg-paper text-ink hover:border-ink"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+            <p className="text-xs text-muted md:col-span-2">
+              Showing {filteredDocs?.length ?? 0} of {docs.length} document{docs.length === 1 ? "" : "s"}.
+            </p>
+          </div>
           <div className="overflow-x-auto border-t border-rule">
           <div className="min-w-[720px]">
             <div
@@ -257,7 +320,7 @@ export function DocumentsTab({
               <span>Updated</span>
               <span className="text-right">Action</span>
             </div>
-            {docs.map((d) => {
+            {filteredDocs?.map((d) => {
               const typeLabel = deriveType(d);
               return (
                 <Link
@@ -300,6 +363,11 @@ export function DocumentsTab({
                 </Link>
               );
             })}
+            {filteredDocs?.length === 0 && (
+              <div className="border-b border-rule bg-paper px-4 py-6 text-sm text-muted">
+                No documents match this search. Clear the query or switch filters.
+              </div>
+            )}
           </div>
         </div>
         </div>


### PR DESCRIPTION
## Summary

Fourth document-engine parity slice. This makes the Documents tab behave more like a project file library before the user opens the full workbench.

- Adds document-library search across filename, tag, hash, source, and derived type.
- Adds quick filters for All, Disclosure, and With notes.
- Shows the filtered count so users know whether they are seeing the whole matter file.
- Keeps upload, audit, and workbench routing unchanged.

## Verification

- `npm run typecheck` in `frontend`
- `npm test -- --run src/matter/tabs/DocumentsTab.test.tsx src/matter/DocumentDetail.test.tsx src/modules/document_preview/DocxOriginalPreview.test.tsx src/modules/document_edit/DocumentRichEditor.test.tsx` in `frontend`
- `npm run build` in `frontend`

## Notes

Frontend-only. No backend, no schema, no document-storage changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to filter documents by filename, tag, hash, source, and type.
  * Added filter options for disclosure and notes status.
  * Display live count showing "X of Y documents" matched.
  * Added empty state message when no results match the search.

* **Tests**
  * Added comprehensive test coverage for search and filter UI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->