### PR TITLE
documents: define parity plan and compose workbench rail

### DIFF
--- a/docs/handovers/DOCUMENT_ENGINE_PARITY_PLAN_2026_06_04.md
+++ b/docs/handovers/DOCUMENT_ENGINE_PARITY_PLAN_2026_06_04.md
@@ -1,0 +1,183 @@
+# Document Engine Parity Plan — 2026-06-04
+
+## North Star
+
+Legalise needs a first-class document workspace: open a project, open a document, read it, search it, edit it, comment on it, run a skill against it, sign the output, and export the record.
+
+The target is Mike-calibre document experience, but built from proven packages and Legalise primitives:
+
+- TipTap / ProseMirror for rich editing.
+- `docx-preview` for Word original preview.
+- `react-pdf` / PDF.js for PDF original preview and text layer.
+- Existing Legalise document versions, redlines, review notes, skills, sign-off, record, and export.
+
+Do not vendor Mike code. Do not build a weak clone by hand. Assemble a professional document product from stable packages, then wrap it in Legalise governance.
+
+## Product Contract
+
+The document engine is not a side page. It is the working surface for a matter.
+
+The happy path:
+
+1. Open a project.
+2. Open Documents.
+3. Find or upload a file.
+4. Open the document workbench.
+5. Read/search the original or extracted text.
+6. Edit or annotate with review notes.
+7. Run a ready skill on the selected document.
+8. Open the produced output.
+9. Sign it or leave it as draft.
+10. View the Record / Working Pack.
+
+If the path above is not clearer after a change, the change waits.
+
+## Non-Negotiables
+
+- The surface must feel like a document app, not an admin panel.
+- Metadata is available, but never the first thing a user sees.
+- Search, comments, versions, and redlines stay on the document surface.
+- Skills run from the document context using the generic runner.
+- Audit/Record is the receipt, not the product.
+- Capability IDs, grant rows, manifests, and raw audit jargon stay behind details.
+- Demo users must be able to open and inspect sample documents without signing in.
+- Do not add bespoke first-party workflow pages as the main experience.
+
+## Existing Foundation
+
+Already shipped:
+
+- Document library upload and search/filter.
+- Routed document detail/workbench.
+- Original file open/download through audited backend proxy.
+- PDF original preview/search and quote-to-note.
+- Word original preview/search and quote-to-note.
+- TipTap editor with formatting, tables, outline, find, copy/download text, keyboard shortcuts, local draft recovery, save as version.
+- Version history, version upload, restore, compare, DOCX download from saved versions.
+- AI suggested redlines with accept/reject into saved versions.
+- Review notes with selected-quote anchoring.
+- Honest active-session presence.
+- Document-scoped generic skill runner.
+- Record links and source-anchor arrival notes.
+
+## Build Sequence
+
+### P1 — Workbench Composition
+
+Goal: one calm workspace, not stacked panels.
+
+Deliver:
+
+- Header answers: what document, what status, what primary action.
+- Main canvas defaults to the editor/reader.
+- Right rail has three compact groups:
+  - Review: notes, redlines, active sessions.
+  - Skills: ready document skills and current run.
+  - Versions: current version, save/export shortcuts.
+- Metadata moves fully behind details.
+- Reduce repeated boxes and counters.
+
+Acceptance:
+
+- A fresh user can say: "I am reading/editing this document, with review and skills beside it."
+- No raw capability or audit language in the primary view.
+
+### P2 — Reader / Editor Quality
+
+Goal: the editor and preview behave like a real document surface.
+
+Deliver:
+
+- One stable command bar for editor actions.
+- Find status and outline feel integrated, not bolted on.
+- Original preview search mirrors editor search where possible.
+- Save/version/download actions are predictable.
+- Keyboard shortcuts shown quietly.
+
+Acceptance:
+
+- User can search, edit, save, and download without hunting through panels.
+
+### P3 — Review Notes and Redlines
+
+Goal: comments and suggested edits feel native.
+
+Deliver:
+
+- Review queue in the rail is the entry point.
+- Notes list is compact and anchored.
+- Redlines are opened in the main canvas, not buried.
+- Resolve/accept/reject actions are obvious.
+
+Acceptance:
+
+- User can create a note from selected text or a source hit, find it again, and resolve it.
+
+### P4 — Document-Scoped Skills
+
+Goal: skills feel like document actions, not a separate module product.
+
+Deliver:
+
+- Ready skills appear in the rail.
+- Running a skill keeps the user on the document.
+- Output links go to artifact/sign-off/record.
+- Empty state explains setup in plain English.
+
+Acceptance:
+
+- User can run a skill on this document and understand what was produced.
+
+### P5 — Demo Document Flow
+
+Goal: public demo shows the document product without sign-in.
+
+Deliver:
+
+- Demo Documents shows a realistic file list.
+- Demo document reader has search and source-ready copy.
+- Demo Skills links back to documents where relevant.
+- No sign-in dead ends in the demo path.
+
+Acceptance:
+
+- Someone sent `legalise.dev` can click Demo → Documents → open a file → search/read → understand that skills use these files.
+
+### P6 — Visual Excellence Pass
+
+Goal: Mike-class calm, not admin-table utility.
+
+Deliver:
+
+- More deliberate spacing and type scale.
+- Clear active surface.
+- Softer rail hierarchy.
+- Stronger document canvas.
+- Consistent buttons and control density.
+
+Acceptance:
+
+- Browser walkthrough feels like a polished document workspace, not a set of backend features.
+
+## Deferred Unless Needed
+
+- True multiplayer CRDT editing.
+- Native DOCX pagination fidelity beyond `docx-preview`.
+- PDF annotation persistence.
+- Full track-changes import/export parity with Word.
+- Mike integration or plugin layer.
+- New backend document format abstractions.
+
+These are important, but they are not required before the document workspace feels coherent.
+
+## Review Gate
+
+For every PR in this track:
+
+1. Does it improve the happy path?
+2. Does it hide plumbing unless requested?
+3. Does it use an existing package or Legalise primitive where possible?
+4. Does it avoid bespoke first-party workflow pages?
+5. Does it keep the demo path free of sign-in dead ends?
+
+If not, stop and cut scope.

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -201,12 +201,12 @@ describe("DocumentDetail", () => {
     // editable document surface without metadata disclosure first.
     expect(screen.getByTestId("document-editor")).toBeInTheDocument();
     expect(screen.getByText(/pypdf · 23 chars · 3 pages/)).toBeInTheDocument();
-    expect(screen.getByText("Document intelligence")).toBeInTheDocument();
+    expect(screen.getByTestId("document-state-rail")).toBeInTheDocument();
     expect(screen.getByText("Suggested edits")).toBeInTheDocument();
     expect(screen.getByTestId("document-workbench-tabs")).toBeInTheDocument();
     expect(screen.queryByText("Version record")).toBeNull();
-    // Admin-ish document facts sit behind Details; the primary scan
-    // path is filename, text, original actions, and document tools.
+    // Admin-ish document facts sit behind File details; the primary scan
+    // path is filename, text, original actions, review, skills, and versions.
     expect(screen.queryByText("application/pdf")).toBeNull();
     expect(screen.queryByText(/a{8}/)).toBeNull();
     // Original-file actions are still present (secondary).
@@ -328,7 +328,7 @@ describe("DocumentDetail", () => {
     expect(screen.queryByTestId("document-download-edited-docx")).toBeNull();
   });
 
-  it("surfaces full metadata once the Details disclosure is opened", async () => {
+  it("surfaces full metadata once File details is opened", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
     vi.spyOn(api, "getDocumentBody").mockResolvedValue({
       document_id: "doc-1",

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1101,18 +1101,6 @@ export function DocumentDetail({
               </div>
             </section>
 
-            <section className="border border-rule bg-paper p-4">
-              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
-                Document intelligence
-              </p>
-              <h2 className="mt-1 text-lg font-semibold tracking-tight2 text-ink">
-                Review, edit, and preserve the file.
-              </h2>
-              <p className="mt-2 text-sm leading-6 text-muted">
-                Proposed edits, human notes, active sessions, and version status stay with this document.
-              </p>
-            </section>
-
             <section
               ref={skillsRef}
               className="border border-rule bg-paper p-4"
@@ -1217,11 +1205,21 @@ export function DocumentDetail({
               </div>
             </section>
 
-            <section className="border border-rule bg-paper p-4">
-              <h2 className="text-sm font-semibold text-ink">
-                Version state
-              </h2>
-              <dl className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+            <section className="border border-rule bg-paper p-4" data-testid="document-state-rail">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                    Document state
+                  </p>
+                  <h2 className="mt-1 text-sm font-semibold text-ink">
+                    Versions, people, redaction, and file details.
+                  </h2>
+                </div>
+                <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                  v{latestVersion?.version_number ?? 1}
+                </span>
+              </div>
+              <dl className="mt-4 grid grid-cols-3 gap-2 text-center text-xs">
                 <div className="border border-rule bg-paper-sunken p-2">
                   <dt className="uppercase tracking-track2 text-muted">Pending</dt>
                   <dd className="mt-1 text-lg font-semibold text-ink">{pendingEdits}</dd>
@@ -1235,41 +1233,87 @@ export function DocumentDetail({
                   <dd className="mt-1 text-lg font-semibold text-ink">{rejectedEdits}</dd>
                 </div>
               </dl>
-            </section>
+              <div className="mt-4 space-y-3 text-sm">
+                <details className="border border-rule bg-paper-sunken p-3" open={hasConcurrentSession}>
+                  <summary className="cursor-pointer font-medium text-ink">
+                    Editing now · {activeEditSessions.length || 1} active
+                  </summary>
+                  <div className="mt-3 space-y-2">
+                    {activeEditSessions.length > 0 ? (
+                      activeEditSessions.map((session) => (
+                        <div
+                          key={session.id}
+                          className="flex items-center justify-between gap-3 border border-rule bg-paper px-3 py-2 text-sm"
+                        >
+                          <span className="font-medium text-ink">{session.user_label}</span>
+                          <span className="text-xs text-muted">
+                            {session.last_seen_at.replace("T", " ").slice(0, 16)}
+                          </span>
+                        </div>
+                      ))
+                    ) : (
+                      <p className="text-sm text-muted">You are editing this document.</p>
+                    )}
+                    {hasConcurrentSession && (
+                      <p className="border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
+                        Another session is active. Agree who saves the next version before applying edits.
+                      </p>
+                    )}
+                  </div>
+                </details>
 
-            <section className="border border-rule bg-paper p-4" data-testid="document-edit-sessions">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <h2 className="text-sm font-semibold text-ink">Editing now</h2>
-                  <p className="mt-1 text-sm leading-6 text-muted">
-                    Active document sessions are visible here. Edits are preserved as versions so another person's save does not disappear into the file.
+                <details className="border border-rule bg-paper-sunken p-3">
+                  <summary className="cursor-pointer font-medium text-ink">
+                    Redaction
+                  </summary>
+                  <p className="mt-3 text-sm text-muted">
+                    {anon
+                      ? `Redacted body available · ${anon.entity_count} entities via ${anon.engine}, ${anon.anonymised_at.replace("T", " ").slice(0, 16)}.`
+                      : "No redacted body yet."}
                   </p>
-                </div>
-                <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
-                  {activeEditSessions.length || 1} active
-                </span>
-              </div>
-              <div className="mt-3 space-y-2">
-                {activeEditSessions.length > 0 ? (
-                  activeEditSessions.map((session) => (
-                    <div
-                      key={session.id}
-                      className="flex items-center justify-between gap-3 border border-rule bg-paper-sunken px-3 py-2 text-sm"
-                    >
-                      <span className="font-medium text-ink">{session.user_label}</span>
-                      <span className="text-xs text-muted">
-                        {session.last_seen_at.replace("T", " ").slice(0, 16)}
-                      </span>
+                  <div className="mt-3">
+                    <AnonymiseButton
+                      documentId={documentId}
+                      onResult={(r) => setAnon(r)}
+                    />
+                  </div>
+                </details>
+
+                <div className="border border-rule bg-paper-sunken p-3">
+                  <button
+                    type="button"
+                    onClick={() => setShowDetails((v) => !v)}
+                    aria-expanded={showDetails}
+                    data-testid="document-details-toggle"
+                    className="flex w-full items-center justify-between text-left font-medium text-ink"
+                  >
+                    <span>File details</span>
+                    <span aria-hidden="true" className="text-xs text-muted">
+                      {showDetails ? "Hide" : "Show"}
+                    </span>
+                  </button>
+                  {showDetails && (
+                    <div className="mt-4 space-y-4">
+                      {body && !bodyMissing && body.error_reason && (
+                        <p className="text-xs text-muted">{body.error_reason}</p>
+                      )}
+                      <dl className="space-y-3 text-sm">
+                        <DescItem label="Type">
+                          <span className="font-mono text-xs">{doc.mime_type}</span>
+                        </DescItem>
+                        <DescItem label="Uploaded">
+                          {doc.uploaded_at.replace("T", " ").slice(0, 19)}
+                        </DescItem>
+                        <DescItem label="SHA-256">
+                          <span className="font-mono text-xs break-all">{doc.sha256}</span>
+                        </DescItem>
+                      </dl>
+                      <p className="text-xs text-muted">
+                        Original file access is recorded.
+                      </p>
                     </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-muted">You are editing this document.</p>
-                )}
-                {hasConcurrentSession && (
-                  <p className="border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
-                    Another session is active. Agree who saves the next version before applying edits.
-                  </p>
-                )}
+                  )}
+                </div>
               </div>
             </section>
 
@@ -1475,57 +1519,6 @@ export function DocumentDetail({
               </div>
             </section>
 
-            <section className="border border-rule bg-paper p-4">
-              <h2 className="text-sm font-semibold text-ink">Redaction</h2>
-              <p className="mt-2 text-sm text-muted">
-                {anon
-                  ? `Redacted body available — ${anon.entity_count} entities via ${anon.engine}, ${anon.anonymised_at.replace("T", " ").slice(0, 16)}.`
-                  : "No redacted body yet."}
-              </p>
-              <div className="mt-3">
-                <AnonymiseButton
-                  documentId={documentId}
-                  onResult={(r) => setAnon(r)}
-                />
-              </div>
-            </section>
-
-            <section className="border border-rule bg-paper p-4">
-              <button
-                type="button"
-                onClick={() => setShowDetails((v) => !v)}
-                aria-expanded={showDetails}
-                data-testid="document-details-toggle"
-                className="flex w-full items-center justify-between text-left"
-              >
-                <h2 className="text-sm font-semibold text-ink">Details</h2>
-                <span aria-hidden="true" className="text-xs text-muted">
-                  {showDetails ? "Hide" : "Show"}
-                </span>
-              </button>
-
-              {showDetails && (
-                <div className="mt-4 space-y-4">
-                  {body && !bodyMissing && body.error_reason && (
-                    <p className="text-xs text-muted">{body.error_reason}</p>
-                  )}
-                  <dl className="space-y-3 text-sm">
-                    <DescItem label="Type">
-                      <span className="font-mono text-xs">{doc.mime_type}</span>
-                    </DescItem>
-                    <DescItem label="Uploaded">
-                      {doc.uploaded_at.replace("T", " ").slice(0, 19)}
-                    </DescItem>
-                    <DescItem label="SHA-256">
-                      <span className="font-mono text-xs break-all">{doc.sha256}</span>
-                    </DescItem>
-                  </dl>
-                  <p className="text-xs text-muted">
-                    Original file access is audited.
-                  </p>
-                </div>
-              )}
-            </section>
           </aside>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Document-engine parity pass, now with an explicit plan in-repo so the build stops feeling ad hoc.

- Adds `DOCUMENT_ENGINE_PARITY_PLAN_2026_06_04.md` with the north star, non-negotiables, existing foundation, build sequence, and review gate.
- Starts P1 Workbench Composition: removes the redundant "Document intelligence" rail card and consolidates version state, live editing, redaction, and file metadata into one `Document state` rail group.
- Keeps review queue, document-scoped skills, suggested edits, review notes, and metadata access intact.
- Keeps file metadata behind a disclosure instead of putting admin facts in the primary scan path.

## Verification

- `npm run typecheck` in `frontend`
- `npm test -- --run src/matter/DocumentDetail.test.tsx src/matter/tabs/DocumentsTab.test.tsx src/modules/document_edit/DocumentRichEditor.test.tsx src/modules/document_preview/DocxOriginalPreview.test.tsx` in `frontend`
- `npm run build` in `frontend`

## Notes

Frontend/docs only. No backend, no schema, no route changes. This is the first composition pass, not the final visual polish.