### PR TITLE
documents: surface selected passage notes

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -679,7 +679,10 @@ describe("DocumentDetail", () => {
     } as unknown as Selection);
 
     fireEvent.mouseUp(content);
-    fireEvent.click(await screen.findByRole("button", { name: "Quote this passage" }));
+    expect(await screen.findByTestId("document-editor-selected-passage")).toHaveTextContent(
+      "single social-media post",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add review note" }));
     fireEvent.change(
       screen.getByPlaceholderText("What should be checked before relying on this document?"),
       {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -563,7 +563,15 @@ export function DocumentDetail({
       setSelectedAnchor(null);
     }
     requestAnimationFrame(() => {
-      notesRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+      notesRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
+    });
+  };
+  const startNoteFromCurrentSelection = () => {
+    const trimmed = selectedQuote.trim().replace(/\s+/g, " ");
+    if (!trimmed) return;
+    setCommentQuote(trimmed);
+    requestAnimationFrame(() => {
+      notesRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
     });
   };
   const submitVersionUpload = async () => {
@@ -866,6 +874,9 @@ export function DocumentDetail({
                   sourceLabel={editorSourceLabel}
                   sourceHighlight={currentReaderQuote}
                   noteHighlights={anchoredOpenNotes}
+                  selectedQuote={selectedQuote || undefined}
+                  selectedQuoteAnchored={Boolean(selectedAnchor)}
+                  onCreateNoteFromSelection={startNoteFromCurrentSelection}
                   onSaved={(version) => {
                     setSelectedVersionId(version.id);
                     getDocumentVersions(documentId)
@@ -1079,7 +1090,7 @@ export function DocumentDetail({
                 </button>
                 <button
                   type="button"
-                  onClick={() => notesRef.current?.scrollIntoView({ block: "start", behavior: "smooth" })}
+                  onClick={() => notesRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" })}
                   className="flex items-center justify-between border border-rule bg-paper-sunken px-3 py-2 text-left hover:border-ink"
                 >
                   <span>Open review notes</span>

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -267,4 +267,29 @@ describe("DocumentRichEditor surface", () => {
     fireEvent.keyDown(window, { key: "f", metaKey: true });
     expect(find).toHaveFocus();
   });
+
+  it("surfaces the selected passage as a review-note action", async () => {
+    const onCreateNoteFromSelection = vi.fn();
+    render(
+      <DocumentRichEditor
+        documentId="doc-1"
+        filename="draft.docx"
+        initialText="The dismissal letter mentioned a single social-media post."
+        sourceLabel="extracted · 60 chars"
+        selectedQuote="single social-media post"
+        selectedQuoteAnchored
+        onCreateNoteFromSelection={onCreateNoteFromSelection}
+        onSaved={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByTestId("document-editor-selected-passage")).toHaveTextContent(
+      "single social-media post",
+    );
+    expect(screen.getByTestId("document-editor-selected-passage")).toHaveTextContent(
+      "Anchored",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add review note" }));
+    expect(onCreateNoteFromSelection).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -301,6 +301,9 @@ export function DocumentRichEditor({
   sourceLabel,
   sourceHighlight,
   noteHighlights = [],
+  selectedQuote,
+  selectedQuoteAnchored,
+  onCreateNoteFromSelection,
   onSaved,
   onDirtyChange,
 }: {
@@ -312,6 +315,9 @@ export function DocumentRichEditor({
   sourceLabel: string;
   sourceHighlight?: string | null;
   noteHighlights?: DocumentNoteHighlight[];
+  selectedQuote?: string;
+  selectedQuoteAnchored?: boolean;
+  onCreateNoteFromSelection?: () => void;
   onSaved: (version: DocumentVersionRead) => void;
   onDirtyChange?: (dirty: boolean) => void;
 }) {
@@ -856,6 +862,33 @@ export function DocumentRichEditor({
                 </button>
               )}
             </div>
+            {selectedQuote && (
+              <div
+                className="border border-ink bg-paper p-3"
+                data-testid="document-editor-selected-passage"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-ink">
+                    Selected passage
+                  </p>
+                  <span className="border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
+                    {selectedQuoteAnchored ? "Anchored" : "Unanchored"}
+                  </span>
+                </div>
+                <p className="mt-2 max-h-28 overflow-hidden text-xs leading-5 text-muted">
+                  {selectedQuote}
+                </p>
+                {onCreateNoteFromSelection && (
+                  <button
+                    type="button"
+                    onClick={onCreateNoteFromSelection}
+                    className="mt-3 w-full border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
+                  >
+                    Add review note
+                  </button>
+                )}
+              </div>
+            )}
             <div>
               <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
                 Review notes


### PR DESCRIPTION
## Summary
- Shows selected document text inside the editor rail as a first-class selected passage.
- Adds an in-editor `Add review note` action that fills the existing anchored-note form and scrolls to the note composer.
- Keeps note persistence on the existing document comment API; no backend changes.

## Verification
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- --run src/modules/document_edit/DocumentRichEditor.test.tsx src/matter/DocumentDetail.test.tsx src/modules/document_preview/DocxOriginalPreview.test.tsx`
- `cd frontend && npm run build`

## Note
Reopened against `master` after the stacked PR base branch for #94 was merged/deleted.