### PR TITLE
skills: clarify runner output next steps

### DIFF
--- a/frontend/src/matter/GenericSkillRunner.test.tsx
+++ b/frontend/src/matter/GenericSkillRunner.test.tsx
@@ -90,6 +90,10 @@ describe("GenericSkillRunner", () => {
 
     expect(await screen.findByTestId("generic-runner-result")).toBeInTheDocument();
     expect(screen.getByText(/The witness statement says X/i)).toBeInTheDocument();
+    expect(screen.getByTestId("generic-runner-next-steps-artifact-1")).toHaveTextContent(
+      "Review the output, sign it if you stand behind it",
+    );
+    expect(screen.getByRole("link", { name: "Review & sign" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Close run/i }));
 

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -343,27 +343,39 @@ function RunnerResult({
                 kindHint={artifact.kind}
                 matterSlug={slug}
               />
-              <div className="mt-3 flex flex-wrap gap-3 text-xs">
-                <Link
-                  to="/matters/$slug/artifacts/$artifactId"
-                  params={{ slug, artifactId: artifact.id }}
-                  className="underline underline-offset-4 hover:text-ink"
-                >
-                  Open output →
-                </Link>
-                <Link
-                  to="/matters/$slug/artifacts/$artifactId/sign"
-                  params={{ slug, artifactId: artifact.id }}
-                  className="underline underline-offset-4 hover:text-ink"
-                >
-                  Review & sign →
-                </Link>
-                <a
-                  href={`/matters/${encodeURIComponent(slug)}/audit?invocation_id=${encodeURIComponent(response.invocation_id)}`}
-                  className="underline underline-offset-4 hover:text-ink"
-                >
-                  View Record for this run →
-                </a>
+              <div
+                className="mt-3 border border-ink bg-paper-sunken p-3"
+                data-testid={`generic-runner-next-steps-${artifact.id}`}
+              >
+                <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
+                  Next step
+                </p>
+                <p className="mt-1 text-sm font-semibold text-ink">
+                  Review the output, sign it if you stand behind it, then use the Record as
+                  the receipt.
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                  <Link
+                    to="/matters/$slug/artifacts/$artifactId/sign"
+                    params={{ slug, artifactId: artifact.id }}
+                    className="border border-ink bg-ink px-3 py-2 font-semibold text-paper hover:bg-black"
+                  >
+                    Review & sign
+                  </Link>
+                  <Link
+                    to="/matters/$slug/artifacts/$artifactId"
+                    params={{ slug, artifactId: artifact.id }}
+                    className="border border-rule bg-paper px-3 py-2 font-semibold text-ink hover:border-ink"
+                  >
+                    Open output
+                  </Link>
+                  <a
+                    href={`/matters/${encodeURIComponent(slug)}/audit?invocation_id=${encodeURIComponent(response.invocation_id)}`}
+                    className="border border-rule bg-paper px-3 py-2 font-semibold text-ink hover:border-ink"
+                  >
+                    View Record
+                  </a>
+                </div>
               </div>
             </section>
           ))}


### PR DESCRIPTION
## Summary
- Replaces the plain post-run output links with a clear next-step panel.
- Makes `Review & sign` the primary action after a skill writes an output.
- Keeps `Open output` and `View Record` available as secondary actions.

## Verification
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- --run src/matter/GenericSkillRunner.test.tsx src/matter/DocumentDetail.test.tsx src/matter/tabs/AssistantTab.test.tsx`
- `cd frontend && npm run build`

## Scope
Frontend-only generic runner completion polish. No invocation/backend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to verify post-run "next steps" UI elements and link interactions.

* **Style**
  * Redesigned the "next steps" interface displayed after successful skill completion. Replaced the action row of underlined links with a bordered "Next step" panel featuring styled buttons and updated instructional guidance, improving visual hierarchy and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->