### PR TITLE
demo: strengthen document reader flow

### DIFF
--- a/frontend/src/demo/DemoMatter.test.tsx
+++ b/frontend/src/demo/DemoMatter.test.tsx
@@ -1,6 +1,7 @@
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { demoDocumentMatches, splitSearchMatches } from "./DemoMatter";
+import { DemoDocumentReader, demoDocumentMatches, splitSearchMatches } from "./DemoMatter";
 
 describe("DemoMatter document search", () => {
   it("splits all case-insensitive matches without changing source text", () => {
@@ -39,5 +40,38 @@ describe("DemoMatter document search", () => {
     expect(demoDocumentMatches(doc, "cpr 31")).toBe(true);
     expect(demoDocumentMatches(doc, "abc123")).toBe(true);
     expect(demoDocumentMatches(doc, "witness")).toBe(false);
+  });
+
+  it("shows a no-sign-in document workbench rail in the public reader", () => {
+    const docs = [
+      {
+        id: "doc-1",
+        matter_id: "matter-1",
+        filename: "dismissal-letter.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 2048,
+        sha256: "abc123".padEnd(64, "0"),
+        tag: "disclosure",
+        from_disclosure: true,
+        uploaded_at: "2026-06-03T10:00:00",
+        uploaded_by_id: "user-1",
+      },
+    ];
+
+    render(<DemoDocumentReader documentId="doc-1" docs={docs} />);
+
+    expect(screen.getByRole("heading", { name: "dismissal-letter.pdf" })).toBeInTheDocument();
+    expect(screen.getByTestId("demo-document-workbench-rail")).toHaveTextContent(
+      "This file is ready to use.",
+    );
+    expect(screen.getByRole("link", { name: /Run a skill with this file/i })).toHaveAttribute(
+      "href",
+      "/demo/workflows",
+    );
+    expect(screen.getByRole("link", { name: /View the Record/i })).toHaveAttribute(
+      "href",
+      "/demo/audit",
+    );
+    expect(screen.queryByText(/sign in/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -662,7 +662,7 @@ function DemoDocumentsTab({
   );
 }
 
-function DemoDocumentReader({
+export function DemoDocumentReader({
   documentId,
   docs,
 }: {
@@ -791,16 +791,54 @@ function DemoDocumentReader({
         </section>
 
         <aside className="space-y-4">
-          <section className="border border-rule bg-paper p-4">
-            <h2 className="text-sm font-semibold text-ink">How this is used</h2>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              Skills and chat answers cite project documents. In the live workspace,
-              source chips open the reader, proposed edits create versions, and
-              document access is recorded.
+          <section className="border border-ink bg-paper p-4" data-testid="demo-document-workbench-rail">
+            <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+              Document workbench
             </p>
+            <h2 className="mt-1 text-sm font-semibold text-ink">This file is ready to use.</h2>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              In the product, chat and skills use this reader as their source surface.
+              Source chips come back here so a solicitor can check the text before
+              relying on output.
+            </p>
+            <div className="mt-4 grid gap-2 text-sm">
+              <a
+                href="/demo/workflows"
+                className="flex items-center justify-between border border-ink bg-ink px-3 py-2 font-semibold text-paper hover:bg-black"
+              >
+                <span>Run a skill with this file</span>
+                <span aria-hidden="true">→</span>
+              </a>
+              <a
+                href="/demo/audit"
+                className="flex items-center justify-between border border-rule bg-paper-sunken px-3 py-2 font-semibold text-ink hover:border-ink"
+              >
+                <span>View the Record</span>
+                <span aria-hidden="true">→</span>
+              </a>
+              <a
+                href="/demo/documents"
+                className="flex items-center justify-between border border-rule bg-paper-sunken px-3 py-2 font-semibold text-ink hover:border-ink"
+              >
+                <span>Open other files</span>
+                <span aria-hidden="true">→</span>
+              </a>
+            </div>
           </section>
           <section className="border border-rule bg-paper p-4">
-            <h2 className="text-sm font-semibold text-ink">Document facts</h2>
+            <h2 className="text-sm font-semibold text-ink">What happens in the workspace</h2>
+            <ol className="mt-3 space-y-2 text-sm leading-6 text-muted">
+              <li><span className="font-semibold text-ink">1.</span> Read or search the document.</li>
+              <li><span className="font-semibold text-ink">2.</span> Run a skill with the file selected.</li>
+              <li><span className="font-semibold text-ink">3.</span> Review and sign the output.</li>
+              <li><span className="font-semibold text-ink">4.</span> Export the working pack record.</li>
+            </ol>
+          </section>
+          <section className="border border-rule bg-paper p-4">
+            <details>
+              <summary className="cursor-pointer text-sm font-semibold text-ink">
+                Document facts
+              </summary>
             <dl className="mt-3 space-y-3 text-sm">
               <DemoReaderFact label="Type" value={doc.mime_type} />
               <DemoReaderFact
@@ -809,6 +847,7 @@ function DemoDocumentReader({
               />
               <DemoReaderFact label="SHA-256" value={doc.sha256} mono />
             </dl>
+            </details>
           </section>
         </aside>
       </main>


### PR DESCRIPTION
## Summary
- Makes the public demo document reader feel like the document workbench, with a right-rail action panel for skills, Record, and other files.
- Hides metadata behind a `Document facts` disclosure.
- Keeps the public path no-sign-in and links directly to `/demo/workflows`, `/demo/audit`, and `/demo/documents`.

## Verification
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- --run src/demo/DemoMatter.test.tsx`
- `cd frontend && npm run build`

## Scope
Frontend-only P5 demo document flow slice. No backend or auth changes.