### PR TITLE
documents: polish Word reader preview

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -170,4 +170,18 @@
   .legalise-docx-preview .legalise-docx {
     box-shadow: 0 1px 2px rgba(24, 24, 24, 0.08);
   }
+
+  .legalise-docx-preview-wide {
+    align-items: stretch;
+  }
+
+  .legalise-docx-preview-wide .legalise-docx-wrapper {
+    width: 100%;
+  }
+
+  .legalise-docx-preview-wide .legalise-docx {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+  }
 }

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
@@ -41,6 +41,12 @@ describe("DocxOriginalPreview", () => {
     });
     expect(screen.getByText(/Rendered Word body/)).toBeInTheDocument();
     expect(api.fetchDocumentOriginalBlob).toHaveBeenCalledWith("doc-1");
+    expect(screen.getByRole("button", { name: "Paper" })).toHaveClass("bg-ink");
+    await userEvent.click(screen.getByRole("button", { name: "Wide" }));
+    expect(screen.getByRole("button", { name: "Wide" })).toHaveClass("bg-ink");
+    expect(screen.getByTestId("document-docx-reader-canvas").firstChild).toHaveClass(
+      "legalise-docx-preview-wide",
+    );
   });
 
   it("searches rendered Word text and turns a hit into a review note quote", async () => {

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
@@ -37,6 +37,7 @@ export function DocxOriginalPreview({
   const [state, setState] = useState<PreviewState>({ status: "loading" });
   const [renderedText, setRenderedText] = useState("");
   const [query, setQuery] = useState(sourceHighlight?.trim() ?? "");
+  const [viewMode, setViewMode] = useState<"paper" | "wide">("paper");
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const searchTerm = query.trim();
@@ -110,19 +111,43 @@ export function DocxOriginalPreview({
 
   return (
     <section
-      className="mt-6 border border-rule bg-paper"
+      className="border border-rule bg-paper"
       data-testid="document-docx-preview"
     >
-      <div className="flex items-center justify-between gap-3 border-b border-rule px-5 py-3">
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-rule px-5 py-4">
         <div>
-          <h2 className="text-sm font-semibold text-ink">Original preview</h2>
+          <h2 className="text-sm font-semibold text-ink">Word reader</h2>
           <p className="mt-0.5 text-xs text-muted">
             Word preview rendered from the audited original file proxy.
           </p>
         </div>
-        <div className="text-right">
-          <span className="block text-xs font-medium text-ink">{filename}</span>
-          <span className="mt-1 block text-[11px] uppercase tracking-track2 text-muted">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="mr-1 max-w-52 truncate text-xs font-medium text-muted">
+            {filename}
+          </span>
+          <button
+            type="button"
+            onClick={() => setViewMode("paper")}
+            className={`border px-3 py-2 text-xs font-medium ${
+              viewMode === "paper"
+                ? "border-ink bg-ink text-paper"
+                : "border-rule text-muted hover:border-ink hover:text-ink"
+            }`}
+          >
+            Paper
+          </button>
+          <button
+            type="button"
+            onClick={() => setViewMode("wide")}
+            className={`border px-3 py-2 text-xs font-medium ${
+              viewMode === "wide"
+                ? "border-ink bg-ink text-paper"
+                : "border-rule text-muted hover:border-ink hover:text-ink"
+            }`}
+          >
+            Wide
+          </button>
+          <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] uppercase tracking-track2 text-muted">
             {state.status === "ready"
               ? "Rendered"
               : state.status === "loading"
@@ -189,11 +214,16 @@ export function DocxOriginalPreview({
           <p className="mt-3 text-xs text-muted">No matches in the rendered Word text.</p>
         )}
       </div>
-      <div className="max-h-[780px] overflow-auto bg-paper-sunken px-4 py-5">
+      <div
+        className="max-h-[780px] overflow-auto bg-paper-sunken px-4 py-5"
+        data-testid="document-docx-reader-canvas"
+      >
         <div
           ref={containerRef}
           aria-label={`Original Word preview for ${filename}`}
-          className="legalise-docx-preview"
+          className={`legalise-docx-preview ${
+            viewMode === "wide" ? "legalise-docx-preview-wide" : ""
+          }`}
         />
       </div>
     </section>


### PR DESCRIPTION
## Summary

- renames the DOCX original surface to Word reader so it matches the PDF reader language
- adds Paper / Wide reader modes on top of docx-preview output
- removes the extra preview margin so the reader sits cleanly inside the document workbench

## Verification

- cd frontend && npm run typecheck
- cd frontend && npm test -- --run src/modules/document_preview/DocxOriginalPreview.test.tsx src/modules/document_preview/PdfDocumentViewer.test.tsx src/matter/DocumentDetail.test.tsx
- cd frontend && npm run build

## Scope

Frontend-only. Still uses docx-preview and the audited original-file proxy; no custom DOCX renderer, backend, or storage change.