### PR TITLE
demo: lead document reader with workbench

### DIFF
--- a/frontend/src/demo/DemoMatter.test.tsx
+++ b/frontend/src/demo/DemoMatter.test.tsx
@@ -64,6 +64,12 @@ describe("DemoMatter document search", () => {
     expect(screen.getByTestId("demo-document-workbench-rail")).toHaveTextContent(
       "This file is ready to use.",
     );
+    expect(screen.getByTestId("demo-document-workbench-rail").closest("aside")).toHaveClass(
+      "order-1",
+    );
+    expect(screen.getByTestId("demo-document-reader").closest("section")).toHaveClass(
+      "order-2",
+    );
     expect(screen.getByRole("link", { name: /Run a skill with this file/i })).toHaveAttribute(
       "href",
       "/demo/workflows",

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -742,7 +742,7 @@ export function DemoDocumentReader({
       </header>
 
       <main className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <section className="min-h-[680px] border border-rule bg-paper">
+        <section className="order-2 min-h-[680px] border border-rule bg-paper lg:order-1">
           <div className="border-b border-rule px-5 py-3">
             <div className="flex flex-wrap items-end justify-between gap-3">
               <div>
@@ -790,7 +790,7 @@ export function DemoDocumentReader({
           </div>
         </section>
 
-        <aside className="space-y-4">
+        <aside className="order-1 space-y-4 lg:order-2">
           <section className="border border-ink bg-paper p-4" data-testid="demo-document-workbench-rail">
             <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
               Document workbench


### PR DESCRIPTION
## Summary

- puts the public demo document workbench rail before extracted text on narrow screens
- keeps the desktop reader + rail split unchanged
- adds a regression assertion for the mobile ordering

## Verification

- cd frontend && npm run typecheck
- cd frontend && npm test -- --run src/demo/DemoMatter.test.tsx
- cd frontend && npm run build
- browser preview at /demo/documents/:id confirmed the workbench card appears first in the narrow viewport

## Scope

Frontend-only demo flow polish. No backend, auth, or real document workbench changes.