### PR TITLE
documents: link outputs that cite file

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -142,6 +142,8 @@ beforeEach(() => {
   });
   vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
   vi.spyOn(api, "listGrants").mockResolvedValue({ matter_id: "m-1", grants: [] });
+  vi.spyOn(api, "listArtifacts").mockResolvedValue([]);
+  vi.spyOn(api, "readArtifact").mockRejectedValue(new Error("not found"));
   vi.spyOn(api, "getDocumentVersions").mockResolvedValue([]);
   vi.spyOn(api, "getDocumentComments").mockResolvedValue([]);
   vi.spyOn(api, "getDocumentEditSessions").mockResolvedValue([]);
@@ -205,6 +207,9 @@ describe("DocumentDetail", () => {
     expect(screen.getByTestId("document-next-step")).toHaveTextContent(
       "Start by reading or selecting text.",
     );
+    expect(await screen.findByTestId("document-output-links")).toHaveTextContent(
+      "No outputs cite this file yet.",
+    );
     expect(screen.getByText("Suggested edits")).toBeInTheDocument();
     expect(screen.getByTestId("document-workbench-tabs")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Read / edit" })).toBeInTheDocument();
@@ -244,6 +249,55 @@ describe("DocumentDetail", () => {
     expect(link).toHaveTextContent("Download edited DOCX");
     expect(link.getAttribute("href")).toContain("/documents/doc-1/versions/v-2/docx");
     expect(screen.getByText(/Viewing saved version v2/)).toBeInTheDocument();
+  });
+
+  it("links signed outputs that cite this document", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "listArtifacts").mockResolvedValue([
+      {
+        id: "art-1",
+        matter_id: "m-1",
+        module_id: "demo.guided-skill",
+        capability_id: "summarise",
+        invocation_id: "inv-1",
+        kind: "skill_response",
+        created_by_id: "u-1",
+        created_at: "2026-06-03T10:00:00",
+        size_bytes: 123,
+      },
+    ]);
+    vi.spyOn(api, "readArtifact").mockResolvedValue({
+      id: "art-1",
+      matter_id: "m-1",
+      module_id: "demo.guided-skill",
+      capability_id: "summarise",
+      invocation_id: "inv-1",
+      kind: "skill_response",
+      created_by_id: "u-1",
+      created_at: "2026-06-03T10:00:00",
+      size_bytes: 123,
+      payload: {
+        output: "Summary",
+        source_anchors: [
+          {
+            id: "a1",
+            source_type: "document",
+            document_id: "doc-1",
+            filename: "claim-form.pdf",
+          },
+        ],
+      },
+    });
+
+    mount();
+
+    const links = await screen.findByTestId("document-output-links");
+    expect(links).toHaveTextContent("1 output cites this file.");
+    expect(screen.getByRole("link", { name: /skill response/i })).toHaveAttribute(
+      "href",
+      "/matters/khan/artifacts/art-1",
+    );
   });
 
   it("shows original file actions for uploaded versions in the version record", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -27,11 +27,14 @@ import {
   getDocumentEditSessions,
   getDocumentVersions,
   listGrants,
+  listArtifacts,
   listDocuments,
   listInstalledModules,
+  readArtifact,
   resolveDocumentComment,
   startDocumentEditSession,
   uploadDocumentVersion,
+  type ArtifactRead,
   type AnonymisationResult,
   type DocumentCommentRead,
   type DocumentBody,
@@ -132,6 +135,50 @@ function WorkbenchTab({
   );
 }
 
+function artifactReferencesDocument(artifact: ArtifactRead, documentId: string): boolean {
+  const payload = artifact.payload;
+  const documentRef = payload.document_id;
+  if (documentRef === documentId) return true;
+  const documentRefs = payload.document_ids;
+  if (Array.isArray(documentRefs) && documentRefs.includes(documentId)) return true;
+
+  const input = payload.input;
+  if (input && typeof input === "object") {
+    const inputRecord = input as Record<string, unknown>;
+    if (inputRecord.document_id === documentId) return true;
+    if (
+      Array.isArray(inputRecord.document_ids) &&
+      inputRecord.document_ids.includes(documentId)
+    ) {
+      return true;
+    }
+  }
+
+  const anchors = payload.source_anchors;
+  if (
+    Array.isArray(anchors) &&
+    anchors.some(
+      (anchor) =>
+        anchor &&
+        typeof anchor === "object" &&
+        (anchor as Record<string, unknown>).document_id === documentId,
+    )
+  ) {
+    return true;
+  }
+
+  const evidence = payload.evidence;
+  return (
+    Array.isArray(evidence) &&
+    evidence.some(
+      (row) =>
+        row &&
+        typeof row === "object" &&
+        (row as Record<string, unknown>).document_id === documentId,
+    )
+  );
+}
+
 export function DocumentDetail({
   slug,
   documentId,
@@ -173,6 +220,7 @@ export function DocumentDetail({
     useState<"loading" | "ready" | "error">("loading");
   const [activeRunnerSkill, setActiveRunnerSkill] =
     useState<RunnableMatterSkill | null>(null);
+  const [documentArtifacts, setDocumentArtifacts] = useState<ArtifactRead[] | null>(null);
   const workbenchRef = useRef<HTMLDivElement | null>(null);
   const notesRef = useRef<HTMLElement | null>(null);
   const skillsRef = useRef<HTMLElement | null>(null);
@@ -326,6 +374,33 @@ export function DocumentDetail({
     };
   }, [slug]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setDocumentArtifacts(null);
+    void listArtifacts(slug)
+      .then((rows) =>
+        Promise.all(
+          rows.slice(0, 40).map((row) =>
+            readArtifact(slug, row.id).catch(() => null),
+          ),
+        ),
+      )
+      .then((rows) => {
+        if (cancelled) return;
+        setDocumentArtifacts(
+          rows.filter((row): row is ArtifactRead =>
+            Boolean(row && artifactReferencesDocument(row, documentId)),
+          ),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setDocumentArtifacts([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, documentId]);
+
   if (q.status === "loading") {
     return (
       <div className="mx-auto max-w-3xl px-6 py-12">
@@ -428,6 +503,7 @@ export function DocumentDetail({
   const secondaryDocumentSkills = documentSkills.slice(1, 4);
   const reviewQueueTotal =
     pendingEdits + openComments.length + (activeEditSessions.length > 1 ? 1 : 0);
+  const citedOutputCount = documentArtifacts?.length ?? 0;
   const hasConcurrentSession = activeEditSessions.length > 1;
   const anchoredOpenNotes: DocumentNoteHighlight[] = openComments
     .filter(
@@ -1131,6 +1207,62 @@ export function DocumentDetail({
               >
                 View Record
               </a>
+            </section>
+
+            <section
+              className="border border-rule bg-paper p-4"
+              data-testid="document-output-links"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                    Outputs using this file
+                  </p>
+                  <h2 className="mt-1 text-sm font-semibold text-ink">
+                    {documentArtifacts === null
+                      ? "Checking signed outputs..."
+                      : citedOutputCount === 0
+                        ? "No outputs cite this file yet."
+                        : `${citedOutputCount} output${citedOutputCount === 1 ? "" : "s"} ${
+                            citedOutputCount === 1 ? "cites" : "cite"
+                          } this file.`}
+                  </h2>
+                </div>
+                <a
+                  href={`/matters/${encodeURIComponent(slug)}/artifacts`}
+                  className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+                >
+                  Signed outputs
+                </a>
+              </div>
+              {documentArtifacts && documentArtifacts.length > 0 ? (
+                <div className="mt-3 space-y-2">
+                  {documentArtifacts.slice(0, 3).map((artifact) => (
+                    <a
+                      key={artifact.id}
+                      href={`/matters/${encodeURIComponent(slug)}/artifacts/${encodeURIComponent(artifact.id)}`}
+                      className="block border border-rule bg-paper-sunken px-3 py-2 text-sm hover:border-ink"
+                    >
+                      <span className="block font-semibold text-ink">
+                        {artifact.kind.replace(/_/g, " ")}
+                      </span>
+                      <span className="mt-1 block text-xs text-muted">
+                        {artifact.module_id} · {artifact.created_at.replace("T", " ").slice(0, 16)}
+                      </span>
+                    </a>
+                  ))}
+                  {documentArtifacts.length > 3 && (
+                    <p className="text-xs text-muted">
+                      {documentArtifacts.length - 3} more in Signed outputs.
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <p className="mt-3 text-sm leading-6 text-muted">
+                  Run a document skill, then sign the output. When the output cites this
+                  file, it appears here and in the matter Record.
+                </p>
+              )}
             </section>
 
             <section className="border border-ink bg-paper p-4" data-testid="document-review-queue">


### PR DESCRIPTION
## Summary

- loads existing matter artifacts and detects whether their payload references the current document
- adds an Outputs using this file rail to the document workbench
- links cited outputs back to Signed outputs / artifact detail so a file connects to the governed loop

## Verification

- cd frontend && npm run typecheck
- cd frontend && npm test -- --run src/matter/DocumentDetail.test.tsx src/matter/ArtifactPreview.test.tsx src/matter/GenericSkillRunner.test.tsx
- cd frontend && npm run build

## Scope

Frontend-only. Uses existing listArtifacts/readArtifact payloads; no backend query, schema, audit, or artifact mutation.