### PR TITLE
documents: polish original preview search

### DIFF
--- a/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
@@ -66,7 +66,7 @@ describe("DocxOriginalPreview", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("1 match")).toBeInTheDocument();
+      expect(screen.getByText("1 match · 1 / 1")).toBeInTheDocument();
     });
     expect(screen.getAllByText(/dismissal facts/).length).toBeGreaterThan(0);
 
@@ -78,8 +78,10 @@ describe("DocxOriginalPreview", () => {
     await userEvent.clear(screen.getByPlaceholderText("Search text in this Word file"));
     await userEvent.type(screen.getByPlaceholderText("Search text in this Word file"), "limitation");
     await waitFor(() => {
-      expect(screen.getByText("1 match")).toBeInTheDocument();
+      expect(screen.getByText("1 match · 1 / 1")).toBeInTheDocument();
     });
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByText("1 match · 1 / 1")).toBeInTheDocument();
   });
 
   it("shows a useful error if the original cannot be loaded", async () => {

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 
 import { fetchDocumentOriginalBlob } from "../../lib/api";
 import { LoadingLine } from "../../ui/primitives";
@@ -38,6 +38,7 @@ export function DocxOriginalPreview({
   const [renderedText, setRenderedText] = useState("");
   const [query, setQuery] = useState(sourceHighlight?.trim() ?? "");
   const [viewMode, setViewMode] = useState<"paper" | "wide">("paper");
+  const [activeHitIndex, setActiveHitIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const searchTerm = query.trim();
@@ -62,6 +63,27 @@ export function DocxOriginalPreview({
   useEffect(() => {
     setQuery(sourceHighlight?.trim() ?? "");
   }, [sourceHighlight]);
+
+  useEffect(() => {
+    setActiveHitIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (activeHitIndex >= searchHits.length) setActiveHitIndex(0);
+  }, [activeHitIndex, searchHits.length]);
+
+  const moveSearchHit = (direction: 1 | -1) => {
+    if (searchHits.length === 0) return;
+    setActiveHitIndex((current) =>
+      (current + direction + searchHits.length) % searchHits.length,
+    );
+  };
+
+  const onSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    moveSearchHit(event.shiftKey ? -1 : 1);
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -175,6 +197,7 @@ export function DocxOriginalPreview({
           <input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={onSearchKeyDown}
             placeholder="Search text in this Word file"
             className="min-h-[40px] min-w-[260px] flex-1 border border-rule bg-paper px-3 text-sm outline-none focus:border-ink"
           />
@@ -182,7 +205,9 @@ export function DocxOriginalPreview({
             {state.status === "loading"
               ? "Indexing text..."
               : searchTerm.length >= 3
-                ? `${searchHits.length} match${searchHits.length === 1 ? "" : "es"}`
+                ? `${searchHits.length} match${searchHits.length === 1 ? "" : "es"}${
+                    searchHits.length > 0 ? ` · ${activeHitIndex + 1} / ${searchHits.length}` : ""
+                  }`
                 : "Type 3+ characters"}
           </span>
         </div>
@@ -191,7 +216,9 @@ export function DocxOriginalPreview({
             {searchHits.map((hit, index) => (
               <div
                 key={`${hit.index}-${hit.preview}`}
-                className="border border-rule bg-paper px-3 py-2 text-xs"
+                className={`border bg-paper px-3 py-2 text-xs ${
+                  index === activeHitIndex ? "border-ink" : "border-rule"
+                }`}
               >
                 <span className="block font-semibold text-ink">Match {index + 1}</span>
                 <span className="mt-1 block max-h-12 overflow-hidden leading-5 text-muted">
@@ -200,7 +227,10 @@ export function DocxOriginalPreview({
                 {onQuoteSelected && (
                   <button
                     type="button"
-                    onClick={() => onQuoteSelected(hit.preview)}
+                    onClick={() => {
+                      setActiveHitIndex(index);
+                      onQuoteSelected(hit.preview);
+                    }}
                     className="mt-2 font-medium text-ink underline underline-offset-4 hover:text-muted"
                   >
                     Quote in note

--- a/frontend/src/modules/document_preview/PdfDocumentViewer.test.tsx
+++ b/frontend/src/modules/document_preview/PdfDocumentViewer.test.tsx
@@ -68,13 +68,15 @@ describe("PdfDocumentViewer", () => {
     expect(screen.getByTestId("mock-pdf-page")).toHaveTextContent("Page 1");
 
     await waitFor(() => {
-      expect(screen.getByText("1 page")).toBeInTheDocument();
+      expect(screen.getByText("1 page · 1 / 1")).toBeInTheDocument();
     });
 
     await userEvent.clear(screen.getByPlaceholderText("Search text in this PDF"));
     await userEvent.type(screen.getByPlaceholderText("Search text in this PDF"), "dismissal");
     await waitFor(() => {
-      expect(screen.getByText("1 page")).toBeInTheDocument();
+      expect(screen.getByText("1 page · 1 / 1")).toBeInTheDocument();
     });
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByText("1 page · 1 / 1")).toBeInTheDocument();
   });
 });

--- a/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
+++ b/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -50,6 +50,7 @@ export function PdfDocumentViewer({
   const [pageTexts, setPageTexts] = useState<string[]>([]);
   const [query, setQuery] = useState(sourceHighlight?.trim() ?? "");
   const [loadingText, setLoadingText] = useState(false);
+  const [activeHitIndex, setActiveHitIndex] = useState(0);
 
   const file = useMemo(
     () => ({ url: fileUrl, withCredentials: true }),
@@ -75,6 +76,29 @@ export function PdfDocumentViewer({
   useEffect(() => {
     setQuery(sourceHighlight?.trim() ?? "");
   }, [sourceHighlight]);
+
+  useEffect(() => {
+    setActiveHitIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (activeHitIndex >= searchHits.length) setActiveHitIndex(0);
+  }, [activeHitIndex, searchHits.length]);
+
+  const moveSearchHit = (direction: 1 | -1) => {
+    if (searchHits.length === 0) return;
+    setActiveHitIndex((current) => {
+      const next = (current + direction + searchHits.length) % searchHits.length;
+      setPageNumber(searchHits[next].page);
+      return next;
+    });
+  };
+
+  const onSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    moveSearchHit(event.shiftKey ? -1 : 1);
+  };
 
   async function extractText(pdf: LoadedPdf) {
     setLoadingText(true);
@@ -185,6 +209,7 @@ export function PdfDocumentViewer({
           <input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={onSearchKeyDown}
             placeholder="Search text in this PDF"
             className="min-h-[40px] min-w-[260px] flex-1 border border-rule bg-paper px-3 text-sm outline-none focus:border-ink"
           />
@@ -192,20 +217,27 @@ export function PdfDocumentViewer({
             {loadingText
               ? "Indexing text..."
               : searchTerm.length >= 3
-                ? `${searchHits.length} page${searchHits.length === 1 ? "" : "s"}`
+                ? `${searchHits.length} page${searchHits.length === 1 ? "" : "s"}${
+                    searchHits.length > 0 ? ` · ${activeHitIndex + 1} / ${searchHits.length}` : ""
+                  }`
                 : "Type 3+ characters"}
           </span>
         </div>
         {searchHits.length > 0 && (
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            {searchHits.slice(0, 8).map((hit) => (
+            {searchHits.slice(0, 8).map((hit, index) => (
               <div
                 key={`${hit.page}-${hit.preview}`}
-                className="border border-rule bg-paper px-3 py-2 text-xs"
+                className={`border bg-paper px-3 py-2 text-xs ${
+                  index === activeHitIndex ? "border-ink" : "border-rule"
+                }`}
               >
                 <button
                   type="button"
-                  onClick={() => setPageNumber(hit.page)}
+                  onClick={() => {
+                    setActiveHitIndex(index);
+                    setPageNumber(hit.page);
+                  }}
                   className="block w-full text-left hover:text-ink"
                   title={hit.preview}
                 >
@@ -217,7 +249,11 @@ export function PdfDocumentViewer({
                 {onQuoteSelected && (
                   <button
                     type="button"
-                    onClick={() => onQuoteSelected(hit.preview)}
+                    onClick={() => {
+                      setActiveHitIndex(index);
+                      setPageNumber(hit.page);
+                      onQuoteSelected(hit.preview);
+                    }}
                     className="mt-2 font-medium text-ink underline underline-offset-4 hover:text-muted"
                   >
                     Quote in note


### PR DESCRIPTION
## Summary
- add Enter / Shift+Enter search cycling to Word and PDF original previews
- show active match position in preview search status
- keep quote-to-note flow tied to the active search hit

## Verification
- cd frontend && npm test -- --run src/modules/document_preview/DocxOriginalPreview.test.tsx src/modules/document_preview/PdfDocumentViewer.test.tsx src/modules/document_edit/DocumentRichEditor.test.tsx src/matter/DocumentDetail.test.tsx
- cd frontend && npm run typecheck
- cd frontend && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard navigation for search results: press Enter to move to next match, Shift+Enter for previous match
  * Enhanced search counter to display current match position (e.g., "1 / 5 matches")
  * Added visual highlighting to indicate the currently active search result

<!-- end of auto-generated comment: release notes by coderabbit.ai -->