### PR TITLE
documents: add server working drafts

### DIFF
--- a/backend/alembic/versions/0029_document_working_drafts.py
+++ b/backend/alembic/versions/0029_document_working_drafts.py
@@ -1,0 +1,52 @@
+"""Add document working drafts.
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "document_working_drafts",
+        sa.Column("document_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("updated_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("plain_text", sa.Text(), nullable=False),
+        sa.Column("editor_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("base_version_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("version_counter", sa.Integer(), nullable=False),
+        sa.Column("client_id", sa.String(length=96), nullable=True),
+        sa.ForeignKeyConstraint(["base_version_id"], ["document_versions.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["document_id"], ["documents.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["updated_by_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("document_id"),
+    )
+    op.create_index(
+        "ix_document_working_drafts_base_version_id",
+        "document_working_drafts",
+        ["base_version_id"],
+    )
+    op.create_index(
+        "ix_document_working_drafts_updated_by_id",
+        "document_working_drafts",
+        ["updated_by_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_document_working_drafts_updated_by_id", table_name="document_working_drafts")
+    op.drop_index("ix_document_working_drafts_base_version_id", table_name="document_working_drafts")
+    op.drop_table("document_working_drafts")

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -45,6 +45,7 @@ from app.models import (
     DocumentEdit,
     DocumentEditSession,
     DocumentVersion,
+    DocumentWorkingDraft,
     Matter,
     STATUS_ARCHIVED,
     User,
@@ -213,6 +214,31 @@ class DocumentEditSessionResponse(BaseModel):
     active: list[DocumentEditSessionRead]
 
 
+class DocumentWorkingDraftRead(BaseModel):
+    document_id: uuid.UUID
+    updated_by_id: uuid.UUID | None
+    updated_at: datetime | None
+    plain_text: str
+    editor_json: dict[str, Any] | None = None
+    base_version_id: uuid.UUID | None = None
+    version_counter: int
+    client_id: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class DocumentWorkingDraftUpsert(BaseModel):
+    plain_text: str = Field(max_length=500_000)
+    editor_json: dict[str, Any] | None = None
+    base_version_id: uuid.UUID | None = None
+    client_id: str | None = Field(default=None, max_length=96)
+
+
+class DocumentWorkingDraftCommitRequest(BaseModel):
+    notes: str | None = Field(default=None, max_length=500)
+    clear_draft: bool = True
+
+
 class EditInstructionResponse(BaseModel):
     version: DocumentVersionRead
     pending_edits: list[DocumentEditRead]
@@ -255,6 +281,104 @@ async def _active_edit_sessions(
         )
         for row, user in rows
     ]
+
+
+async def _latest_text_version(
+    session: AsyncSession,
+    document_id: uuid.UUID,
+) -> DocumentVersion | None:
+    return await session.scalar(
+        select(DocumentVersion)
+        .where(
+            DocumentVersion.document_id == document_id,
+            DocumentVersion.resolved_text.is_not(None),
+        )
+        .order_by(DocumentVersion.version_number.desc(), DocumentVersion.created_at.desc())
+        .limit(1)
+    )
+
+
+async def _initial_working_draft(
+    session: AsyncSession,
+    doc: Document,
+) -> DocumentWorkingDraftRead:
+    latest = await _latest_text_version(session, doc.id)
+    if latest is not None:
+        return DocumentWorkingDraftRead(
+            document_id=doc.id,
+            updated_by_id=None,
+            updated_at=None,
+            plain_text=latest.resolved_text or "",
+            editor_json=latest.resolved_json,
+            base_version_id=latest.id,
+            version_counter=0,
+            client_id=None,
+        )
+
+    body = await extracted_body_for(session, doc.id)
+    return DocumentWorkingDraftRead(
+        document_id=doc.id,
+        updated_by_id=None,
+        updated_at=None,
+        plain_text=body.extracted_text if body is not None else "",
+        editor_json=None,
+        base_version_id=None,
+        version_counter=0,
+        client_id=None,
+    )
+
+
+async def _create_user_edit_version(
+    session: AsyncSession,
+    *,
+    doc: Document,
+    matter: Matter,
+    user: User,
+    resolved_text: str,
+    resolved_json: dict[str, Any] | None,
+    notes: str | None,
+    audit_source: str = "manual",
+) -> DocumentVersion:
+    next_version = (
+        await session.scalar(
+            select(func.coalesce(func.max(DocumentVersion.version_number), 0) + 1)
+            .where(DocumentVersion.document_id == doc.id)
+        )
+        or 1
+    )
+    version = DocumentVersion(
+        document_id=doc.id,
+        version_number=int(next_version),
+        kind=VERSION_KIND_USER_EDIT,
+        created_by_id=user.id,
+        filename=doc.filename,
+        mime_type="text/plain",
+        size_bytes=len(resolved_text.encode("utf-8")),
+        sha256=hashlib.sha256(resolved_text.encode("utf-8")).hexdigest(),
+        resolved_text=resolved_text,
+        resolved_json=resolved_json,
+        notes=notes or "Edited in Legalise document editor",
+    )
+    session.add(version)
+    await session.flush()
+    await audit.log(
+        session,
+        "document.version.saved",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_version",
+        resource_id=str(version.id),
+        payload={
+            "document_id": str(doc.id),
+            "version_number": version.version_number,
+            "kind": version.kind,
+            "char_count": len(resolved_text),
+            "rich_json": resolved_json is not None,
+            "source": audit_source,
+        },
+    )
+    return version
 
 
 @router.post("/{document_id}/edit-instructions", response_model=EditInstructionResponse)
@@ -841,6 +965,123 @@ async def post_reject_all(
     return await _resolve_all(version_id, "reject_all", session, user)
 
 
+@router.get("/{document_id}/draft", response_model=DocumentWorkingDraftRead)
+async def get_document_working_draft(
+    document_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentWorkingDraftRead:
+    """Return the shared working draft for the document editor.
+
+    If no mutable draft exists yet, return an initial draft derived from the
+    latest saved text version or the extracted document body. This keeps
+    initialisation server-owned without creating audit noise.
+    """
+    doc, _matter = await _load_owned_document(document_id, session, user)
+    draft = await session.scalar(
+        select(DocumentWorkingDraft).where(DocumentWorkingDraft.document_id == doc.id)
+    )
+    if draft is None:
+        return await _initial_working_draft(session, doc)
+    return DocumentWorkingDraftRead.model_validate(draft)
+
+
+@router.put("/{document_id}/draft", response_model=DocumentWorkingDraftRead)
+async def put_document_working_draft(
+    document_id: uuid.UUID,
+    body: DocumentWorkingDraftUpsert,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentWorkingDraftRead:
+    """Autosave the mutable working draft for a document.
+
+    Draft writes are intentionally not audit rows. The matter record should
+    show saved versions and professional decisions, not keystroke persistence.
+    """
+    doc, _matter = await _load_owned_document(document_id, session, user)
+    base_version_id = body.base_version_id
+    if base_version_id is not None:
+        exists = await session.scalar(
+            select(DocumentVersion.id).where(
+                DocumentVersion.id == base_version_id,
+                DocumentVersion.document_id == doc.id,
+            )
+        )
+        if exists is None:
+            raise HTTPException(
+                422,
+                {
+                    "error": "invalid_base_version",
+                    "message": "The draft base version does not belong to this document.",
+                },
+            )
+
+    now = datetime.now(UTC)
+    draft = await session.scalar(
+        select(DocumentWorkingDraft).where(DocumentWorkingDraft.document_id == doc.id)
+    )
+    if draft is None:
+        draft = DocumentWorkingDraft(
+            document_id=doc.id,
+            updated_by_id=user.id,
+            updated_at=now,
+            plain_text=body.plain_text,
+            editor_json=body.editor_json,
+            base_version_id=base_version_id,
+            version_counter=1,
+            client_id=body.client_id,
+        )
+        session.add(draft)
+    else:
+        draft.updated_by_id = user.id
+        draft.updated_at = now
+        draft.plain_text = body.plain_text
+        draft.editor_json = body.editor_json
+        draft.base_version_id = base_version_id
+        draft.client_id = body.client_id
+        draft.version_counter += 1
+
+    await session.commit()
+    return DocumentWorkingDraftRead.model_validate(draft)
+
+
+@router.post("/{document_id}/draft/commit", response_model=DocumentVersionRead)
+async def post_document_working_draft_commit(
+    document_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+    body: DocumentWorkingDraftCommitRequest = DocumentWorkingDraftCommitRequest(),
+) -> DocumentVersionRead:
+    """Commit the mutable working draft as an immutable document version."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    draft = await session.scalar(
+        select(DocumentWorkingDraft).where(DocumentWorkingDraft.document_id == doc.id)
+    )
+    if draft is None or not draft.plain_text.strip():
+        raise HTTPException(
+            422,
+            {
+                "error": "working_draft_empty",
+                "message": "There is no working draft text to save as a version.",
+            },
+        )
+
+    version = await _create_user_edit_version(
+        session,
+        doc=doc,
+        matter=matter,
+        user=user,
+        resolved_text=draft.plain_text,
+        resolved_json=draft.editor_json,
+        notes=body.notes or "Saved working draft from Legalise document editor",
+        audit_source="working_draft",
+    )
+    if body.clear_draft:
+        await session.delete(draft)
+    await session.commit()
+    return DocumentVersionRead.model_validate(version)
+
+
 @router.post("/{document_id}/versions/manual", response_model=DocumentVersionRead)
 async def post_manual_document_version(
     document_id: uuid.UUID,
@@ -850,43 +1091,14 @@ async def post_manual_document_version(
 ) -> DocumentVersionRead:
     """Save user-edited text as a new immutable document version."""
     doc, matter = await _load_owned_document(document_id, session, user)
-    next_version = (
-        await session.scalar(
-            select(func.coalesce(func.max(DocumentVersion.version_number), 0) + 1)
-            .where(DocumentVersion.document_id == doc.id)
-        )
-        or 1
-    )
-    version = DocumentVersion(
-        document_id=doc.id,
-        version_number=int(next_version),
-        kind=VERSION_KIND_USER_EDIT,
-        created_by_id=user.id,
-        filename=doc.filename,
-        mime_type="text/plain",
-        size_bytes=len(body.resolved_text.encode("utf-8")),
-        sha256=hashlib.sha256(body.resolved_text.encode("utf-8")).hexdigest(),
+    version = await _create_user_edit_version(
+        session,
+        doc=doc,
+        matter=matter,
+        user=user,
         resolved_text=body.resolved_text,
         resolved_json=body.resolved_json,
-        notes=body.notes or "Edited in Legalise document editor",
-    )
-    session.add(version)
-    await session.flush()
-    await audit.log(
-        session,
-        "document.version.saved",
-        actor_id=user.id,
-        matter_id=matter.id,
-        module="document_editor",
-        resource_type="document_version",
-        resource_id=str(version.id),
-        payload={
-            "document_id": str(doc.id),
-            "version_number": version.version_number,
-            "kind": version.kind,
-            "char_count": len(body.resolved_text),
-            "rich_json": body.resolved_json is not None,
-        },
+        notes=body.notes,
     )
     await session.commit()
     return DocumentVersionRead.model_validate(version)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -41,6 +41,7 @@ from app.models.document_body import DocumentBody, BODY_KIND_VALUES, EXTRACTION_
 from app.models.document_version import DocumentVersion, VERSION_KIND_VALUES
 from app.models.document_edit import DocumentEdit, EDIT_STATUS_VALUES
 from app.models.document_edit_session import DocumentEditSession
+from app.models.document_working_draft import DocumentWorkingDraft
 from app.models.document_comment import (
     COMMENT_STATUS_OPEN,
     COMMENT_STATUS_RESOLVED,
@@ -153,6 +154,7 @@ __all__ = [
     "DocumentVersion",
     "DocumentEdit",
     "DocumentEditSession",
+    "DocumentWorkingDraft",
     "DocumentComment",
     "TabularReview",
     "TabularReviewRow",

--- a/backend/app/models/document_working_draft.py
+++ b/backend/app/models/document_working_draft.py
@@ -1,0 +1,46 @@
+"""Server-backed working draft for the document editor.
+
+The editor can autosave many times before a user decides to create an
+immutable ``DocumentVersion``. This row is intentionally mutable and
+document-scoped; the durable record remains the version history.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class DocumentWorkingDraft(Base):
+    __tablename__ = "document_working_drafts"
+
+    document_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("documents.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    updated_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    plain_text: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    editor_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    base_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("document_versions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    version_counter: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    client_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<DocumentWorkingDraft {self.document_id} v{self.version_counter}>"

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -276,6 +276,94 @@ async def test_post_manual_document_version_creates_user_edit_version(client) ->
 
 
 @pytest.mark.asyncio
+async def test_document_working_draft_round_trip_and_commit(client) -> None:
+    """Owner can autosave a mutable draft and commit it as an immutable version."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload_text(client, "Original extracted text.")
+
+    initial = await client.get(f"/api/documents/{doc_id}/draft")
+    assert initial.status_code == 200, initial.text
+    initial_payload = initial.json()
+    assert initial_payload["plain_text"] == "Original extracted text."
+    assert initial_payload["version_counter"] == 0
+    assert initial_payload["base_version_id"] is None
+
+    saved = await client.put(
+        f"/api/documents/{doc_id}/draft",
+        json={
+            "plain_text": "Working draft text.\n\nSecond paragraph.",
+            "editor_json": {
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "Working draft text."}],
+                    },
+                ],
+            },
+            "client_id": "client-draft-1",
+        },
+    )
+    assert saved.status_code == 200, saved.text
+    draft = saved.json()
+    assert draft["plain_text"] == "Working draft text.\n\nSecond paragraph."
+    assert draft["editor_json"]["type"] == "doc"
+    assert draft["version_counter"] == 1
+    assert draft["client_id"] == "client-draft-1"
+
+    listed = await client.get(f"/api/documents/{doc_id}/draft")
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["plain_text"] == "Working draft text.\n\nSecond paragraph."
+
+    committed = await client.post(
+        f"/api/documents/{doc_id}/draft/commit",
+        json={"notes": "Commit shared working draft"},
+    )
+    assert committed.status_code == 200, committed.text
+    version = committed.json()
+    assert version["kind"] == "user_edit"
+    assert version["version_number"] == 2
+    assert version["resolved_text"] == "Working draft text.\n\nSecond paragraph."
+    assert version["resolved_json"]["type"] == "doc"
+    assert version["notes"] == "Commit shared working draft"
+
+    after_commit = await client.get(f"/api/documents/{doc_id}/draft")
+    assert after_commit.status_code == 200, after_commit.text
+    derived = after_commit.json()
+    assert derived["plain_text"] == "Working draft text.\n\nSecond paragraph."
+    assert derived["base_version_id"] == version["id"]
+    assert derived["version_counter"] == 0
+
+    versions = await client.get(f"/api/documents/{doc_id}/versions")
+    assert versions.status_code == 200, versions.text
+    rows = versions.json()
+    assert rows[-1]["version"]["notes"] == "Commit shared working draft"
+
+
+@pytest.mark.asyncio
+async def test_document_working_draft_base_version_must_belong_to_document(client) -> None:
+    """Draft base_version_id cannot point at another document's version."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id_a = await _create_matter_and_upload_text(client, "Document A.")
+    _, doc_id_b = await _create_matter_and_upload_text(client, "Document B.")
+    version_b = await client.post(
+        f"/api/documents/{doc_id_b}/versions/manual",
+        json={"resolved_text": "Document B saved version."},
+    )
+    assert version_b.status_code == 200, version_b.text
+
+    resp = await client.put(
+        f"/api/documents/{doc_id_a}/draft",
+        json={
+            "plain_text": "Invalid base pointer.",
+            "base_version_id": version_b.json()["id"],
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["error"] == "invalid_base_version"
+
+
+@pytest.mark.asyncio
 async def test_post_upload_document_version_updates_active_document_and_body(client) -> None:
     """Owner can upload a replacement binary as the next active document version."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
@@ -588,6 +676,30 @@ async def test_post_manual_document_version_cross_user_returns_404(client) -> No
 
 
 @pytest.mark.asyncio
+async def test_document_working_draft_cross_user_returns_404(client) -> None:
+    """User B cannot read, write, or commit User A's working draft by UUID."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload_text(client, "Owned draft source.")
+    saved = await client.put(
+        f"/api/documents/{doc_id}/draft",
+        json={"plain_text": "Owned working draft."},
+    )
+    assert saved.status_code == 200, saved.text
+    await client.post("/auth/logout")
+
+    await _signup_and_login(client, EMAIL_B, PASSWORD_B)
+    get_resp = await client.get(f"/api/documents/{doc_id}/draft")
+    assert get_resp.status_code == 404, get_resp.text
+    put_resp = await client.put(
+        f"/api/documents/{doc_id}/draft",
+        json={"plain_text": "Cross-user draft should not land."},
+    )
+    assert put_resp.status_code == 404, put_resp.text
+    commit_resp = await client.post(f"/api/documents/{doc_id}/draft/commit")
+    assert commit_resp.status_code == 404, commit_resp.text
+
+
+@pytest.mark.asyncio
 async def test_get_document_version_docx_cross_user_returns_404(client) -> None:
     """User B cannot download User A's saved editor version."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
@@ -683,6 +795,31 @@ async def test_post_manual_document_version_archived_matter_returns_404(client) 
         json={"resolved_text": "Archived matter edit should not land."},
     )
     assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_document_working_draft_archived_matter_returns_404(client) -> None:
+    """After archive, draft read/write/commit 404s."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    slug, doc_id = await _create_matter_and_upload_text(client, "Archive draft source.")
+    saved = await client.put(
+        f"/api/documents/{doc_id}/draft",
+        json={"plain_text": "Archive working draft."},
+    )
+    assert saved.status_code == 200, saved.text
+
+    del_resp = await client.delete(f"/api/matters/{slug}")
+    assert del_resp.status_code == 204, del_resp.text
+
+    get_resp = await client.get(f"/api/documents/{doc_id}/draft")
+    assert get_resp.status_code == 404, get_resp.text
+    put_resp = await client.put(
+        f"/api/documents/{doc_id}/draft",
+        json={"plain_text": "Archived matter draft should not land."},
+    )
+    assert put_resp.status_code == 404, put_resp.text
+    commit_resp = await client.post(f"/api/documents/{doc_id}/draft/commit")
+    assert commit_resp.status_code == 404, commit_resp.text
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1770,6 +1770,17 @@ export interface DocumentEditSessionResponse {
   active: DocumentEditSessionRead[];
 }
 
+export interface DocumentWorkingDraftRead {
+  document_id: string;
+  updated_by_id: string | null;
+  updated_at: string | null;
+  plain_text: string;
+  editor_json: Record<string, unknown> | null;
+  base_version_id: string | null;
+  version_counter: number;
+  client_id: string | null;
+}
+
 export class ConflictError extends Error {
   status = 409;
 }
@@ -1810,6 +1821,37 @@ export const getDocumentVersions = (documentId: string) =>
   apiFetch(`${API}/documents/${documentId}/versions`).then((r) =>
     resolutionJsonOrThrow<DocumentVersionSummary[]>(r),
   );
+
+export const getDocumentWorkingDraft = (documentId: string) =>
+  apiFetch(`${API}/documents/${documentId}/draft`).then((r) =>
+    resolutionJsonOrThrow<DocumentWorkingDraftRead>(r),
+  );
+
+export const saveDocumentWorkingDraft = (
+  documentId: string,
+  body: {
+    plain_text: string;
+    editor_json?: Record<string, unknown> | null;
+    base_version_id?: string | null;
+    client_id?: string | null;
+  },
+) =>
+  apiFetch(`${API}/documents/${documentId}/draft`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).then((r) => resolutionJsonOrThrow<DocumentWorkingDraftRead>(r));
+
+export const commitDocumentWorkingDraft = (
+  documentId: string,
+  notes?: string,
+  clearDraft = true,
+) =>
+  apiFetch(`${API}/documents/${documentId}/draft/commit`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ notes: notes?.trim() || null, clear_draft: clearDraft }),
+  }).then((r) => resolutionJsonOrThrow<DocumentVersionRead>(r));
 
 export const saveDocumentVersion = (
   documentId: string,

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -991,6 +991,7 @@ export function DocumentDetail({
                   initialText={editorText}
                   initialJson={editorJson}
                   latestVersionNumber={latestVersion?.version_number}
+                  latestVersionId={latestVersion?.id ?? null}
                   sourceLabel={editorSourceLabel}
                   sourceHighlight={currentReaderQuote}
                   noteHighlights={anchoredOpenNotes}

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -22,7 +22,15 @@ const tableCell = (type: "tableCell" | "tableHeader", text: string): TiptapNode 
 
 afterEach(() => {
   window.localStorage.clear();
+  vi.restoreAllMocks();
 });
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 describe("DocumentRichEditor text conversion", () => {
   it("turns plain paragraphs into editor-safe HTML", () => {
@@ -197,6 +205,145 @@ describe("DocumentRichEditor text conversion", () => {
 });
 
 describe("DocumentRichEditor surface", () => {
+  it("loads a shared server draft into the editor", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        document_id: "doc-1",
+        updated_by_id: "user-1",
+        updated_at: "2026-06-04T02:30:00Z",
+        plain_text: "Server draft wording.",
+        editor_json: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Server draft wording." }],
+            },
+          ],
+        },
+        base_version_id: "version-1",
+        version_counter: 3,
+        client_id: "client-1",
+      }),
+    );
+
+    render(
+      <DocumentRichEditor
+        documentId="doc-1"
+        filename="draft.docx"
+        initialText="Extracted fallback."
+        latestVersionNumber={2}
+        latestVersionId="version-1"
+        sourceLabel="extracted · 19 chars"
+        onSaved={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("Server draft wording.")).toBeInTheDocument();
+    expect(screen.getByTestId("document-editor")).toHaveTextContent("Shared draft saved · r3");
+  });
+
+  it("saves by committing the shared working draft", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/documents/doc-1/draft") && !init?.method) {
+        return Promise.resolve(
+          jsonResponse({
+            document_id: "doc-1",
+            updated_by_id: "user-1",
+            updated_at: "2026-06-04T02:30:00Z",
+            plain_text: "Server draft wording.",
+            editor_json: {
+              type: "doc",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Server draft wording." }],
+                },
+              ],
+            },
+            base_version_id: "version-1",
+            version_counter: 3,
+            client_id: "client-1",
+          }),
+        );
+      }
+      if (url.endsWith("/documents/doc-1/draft") && init?.method === "PUT") {
+        return Promise.resolve(
+          jsonResponse({
+            document_id: "doc-1",
+            updated_by_id: "user-1",
+            updated_at: "2026-06-04T02:31:00Z",
+            plain_text: "Server draft wording.",
+            editor_json: {
+              type: "doc",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Server draft wording." }],
+                },
+              ],
+            },
+            base_version_id: "version-1",
+            version_counter: 4,
+            client_id: "document-editor-test",
+          }),
+        );
+      }
+      if (url.endsWith("/documents/doc-1/draft/commit") && init?.method === "POST") {
+        return Promise.resolve(
+          jsonResponse({
+            id: "version-2",
+            document_id: "doc-1",
+            version_number: 3,
+            kind: "user_edit",
+            created_by_id: "user-1",
+            created_at: "2026-06-04T02:32:00Z",
+            storage_uri: null,
+            filename: "draft.docx",
+            mime_type: "text/plain",
+            size_bytes: 21,
+            sha256: "abc",
+            notes: "Edited draft.docx in Legalise document editor",
+            resolved_text: "Server draft wording.",
+            resolved_json: null,
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({ detail: "not found" }, 404));
+    });
+    const onSaved = vi.fn();
+
+    render(
+      <DocumentRichEditor
+        documentId="doc-1"
+        filename="draft.docx"
+        initialText="Extracted fallback."
+        latestVersionNumber={2}
+        latestVersionId="version-1"
+        sourceLabel="extracted · 19 chars"
+        onSaved={onSaved}
+      />,
+    );
+
+    expect(await screen.findByText("Server draft wording.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Save version" }));
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledWith(expect.objectContaining({ id: "version-2" }));
+    });
+    const calledUrls = fetchMock.mock.calls.map(([input, init]) => ({
+      url: String(input),
+      method: init?.method ?? "GET",
+    }));
+    expect(calledUrls).toContainEqual({ url: "/api/documents/doc-1/draft", method: "PUT" });
+    expect(calledUrls).toContainEqual({
+      url: "/api/documents/doc-1/draft/commit",
+      method: "POST",
+    });
+    expect(calledUrls.some((call) => call.url.endsWith("/versions/manual"))).toBe(false);
+  });
+
   it("renders grouped document editing controls on a page canvas", async () => {
     Object.assign(window.navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -18,8 +18,11 @@ import TableRow from "@tiptap/extension-table-row";
 import type { Content, JSONContent } from "@tiptap/core";
 
 import {
-  saveDocumentVersion,
+  commitDocumentWorkingDraft,
+  getDocumentWorkingDraft,
+  saveDocumentWorkingDraft,
   type DocumentVersionRead,
+  type DocumentWorkingDraftRead,
 } from "../../lib/api";
 
 export type TiptapNode = JSONContent;
@@ -304,6 +307,7 @@ export function DocumentRichEditor({
   initialText,
   initialJson,
   latestVersionNumber,
+  latestVersionId,
   sourceLabel,
   sourceHighlight,
   noteHighlights = [],
@@ -318,6 +322,7 @@ export function DocumentRichEditor({
   initialText: string;
   initialJson?: TiptapNode | null;
   latestVersionNumber?: number;
+  latestVersionId?: string | null;
   sourceLabel: string;
   sourceHighlight?: string | null;
   noteHighlights?: DocumentNoteHighlight[];
@@ -335,12 +340,55 @@ export function DocumentRichEditor({
   const [findQuery, setFindQuery] = useState("");
   const [activeFindIndex, setActiveFindIndex] = useState(0);
   const [localDraft, setLocalDraft] = useState<DocumentLocalDraft | null>(null);
+  const [serverDraft, setServerDraft] = useState<DocumentWorkingDraftRead | null>(null);
+  const [draftLoadState, setDraftLoadState] = useState<"loading" | "ready" | "error">("loading");
+  const [draftSaveState, setDraftSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [canvasMode, setCanvasMode] = useState<DocumentCanvasMode>("page");
   const findInputRef = useRef<HTMLInputElement | null>(null);
+  const draftSaveTimerRef = useRef<number | null>(null);
+  const draftBaseVersionIdRef = useRef<string | null>(latestVersionId ?? null);
+  const draftClientIdRef = useRef<string>("");
+  if (!draftClientIdRef.current) {
+    const suffix =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    draftClientIdRef.current = `document-editor-${suffix}`;
+  }
   const content = useMemo<Content>(
     () => initialJson ?? textToEditorHtml(initialText, sourceHighlight),
     [initialJson, initialText, sourceHighlight],
   );
+  async function persistWorkingDraft(
+    editorJson: TiptapNode,
+    plainText: string,
+  ): Promise<DocumentWorkingDraftRead> {
+    setDraftSaveState("saving");
+    const draft = await saveDocumentWorkingDraft(documentId, {
+      plain_text: plainText,
+      editor_json: editorJson as Record<string, unknown>,
+      base_version_id: draftBaseVersionIdRef.current,
+      client_id: draftClientIdRef.current,
+    });
+    setServerDraft(draft);
+    draftBaseVersionIdRef.current = draft.base_version_id;
+    setDraftSaveState("saved");
+    return draft;
+  }
+
+  function scheduleWorkingDraftSave(editorJson: TiptapNode, plainText: string) {
+    if (draftSaveTimerRef.current !== null) {
+      window.clearTimeout(draftSaveTimerRef.current);
+    }
+    setDraftSaveState("saving");
+    draftSaveTimerRef.current = window.setTimeout(() => {
+      draftSaveTimerRef.current = null;
+      persistWorkingDraft(editorJson, plainText).catch(() => {
+        setDraftSaveState("error");
+      });
+    }, 900);
+  }
+
   const editor = useEditor(
     {
       extensions: [
@@ -379,6 +427,7 @@ export function DocumentRichEditor({
           plainText,
           json,
         });
+        scheduleWorkingDraftSave(json, plainText);
         setDirty(true);
         onDirtyChange?.(true);
         setSavedMessage(null);
@@ -396,7 +445,51 @@ export function DocumentRichEditor({
     setError(null);
     setSavedMessage(null);
     setLocalDraft(readDocumentLocalDraft(documentId));
-  }, [content, documentId, editor, onDirtyChange]);
+    setServerDraft(null);
+    setDraftLoadState("loading");
+    setDraftSaveState("idle");
+    draftBaseVersionIdRef.current = latestVersionId ?? null;
+    if (draftSaveTimerRef.current !== null) {
+      window.clearTimeout(draftSaveTimerRef.current);
+      draftSaveTimerRef.current = null;
+    }
+  }, [content, documentId, editor, latestVersionId, onDirtyChange]);
+
+  useEffect(() => {
+    if (!editor) return;
+    let cancelled = false;
+    setDraftLoadState("loading");
+    getDocumentWorkingDraft(documentId)
+      .then((draft) => {
+        if (cancelled) return;
+        setServerDraft(draft);
+        draftBaseVersionIdRef.current = draft.base_version_id ?? latestVersionId ?? null;
+        const draftContent = draft.editor_json ?? textToEditorHtml(draft.plain_text, sourceHighlight);
+        editor.commands.setContent(draftContent as Content, { emitUpdate: false });
+        const hasMutableDraft = draft.version_counter > 0;
+        setDirty(hasMutableDraft);
+        onDirtyChange?.(hasMutableDraft);
+        setDraftLoadState("ready");
+        setDraftSaveState(hasMutableDraft ? "saved" : "idle");
+        setSavedMessage(hasMutableDraft ? "Shared draft loaded" : null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDraftLoadState("error");
+        setDraftSaveState("error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId, editor, latestVersionId, onDirtyChange, sourceHighlight]);
+
+  useEffect(() => {
+    return () => {
+      if (draftSaveTimerRef.current !== null) {
+        window.clearTimeout(draftSaveTimerRef.current);
+      }
+    };
+  }, []);
 
   const plainText = editor ? editorJsonToPlainText(editor.getJSON() as TiptapNode) : "";
   const currentEditorJson = editor ? editor.getJSON() as TiptapNode : null;
@@ -429,8 +522,18 @@ export function DocumentRichEditor({
     [plainText, sourceHighlight],
   );
   const stats = useMemo(() => documentStatsFromText(plainText), [plainText]);
+  const sharedDraftLabel =
+    draftLoadState === "loading"
+      ? "Loading shared draft"
+      : draftSaveState === "saving"
+        ? "Saving shared draft"
+        : draftSaveState === "saved"
+          ? `Shared draft saved${serverDraft ? ` · r${serverDraft.version_counter}` : ""}`
+          : draftSaveState === "error"
+            ? "Local fallback active"
+            : "Shared draft ready";
   const editorStatusLabel = dirty
-    ? "Unsaved local draft"
+    ? sharedDraftLabel
     : savedMessage
       ? savedMessage
       : latestVersionNumber
@@ -452,15 +555,21 @@ export function DocumentRichEditor({
     setError(null);
     try {
       const editorJson = editor.getJSON() as TiptapNode;
-      const version = await saveDocumentVersion(
+      if (draftSaveTimerRef.current !== null) {
+        window.clearTimeout(draftSaveTimerRef.current);
+        draftSaveTimerRef.current = null;
+      }
+      await persistWorkingDraft(editorJson, plainText);
+      const version = await commitDocumentWorkingDraft(
         documentId,
-        plainText,
         `Edited ${filename} in Legalise document editor`,
-        editorJson,
       );
       setDirty(false);
       onDirtyChange?.(false);
       setSavedMessage(`Saved v${version.version_number}`);
+      setServerDraft(null);
+      draftBaseVersionIdRef.current = version.id;
+      setDraftSaveState("idle");
       clearDocumentLocalDraft(documentId);
       setLocalDraft(null);
       onSaved(version);
@@ -486,6 +595,7 @@ export function DocumentRichEditor({
     editor.commands.setContent(localDraft.json, { emitUpdate: false });
     setDirty(true);
     onDirtyChange?.(true);
+    scheduleWorkingDraftSave(localDraft.json, localDraft.plainText);
     setSavedMessage("Local draft restored. Save it to create a document version.");
     setLocalDraft(null);
   }
@@ -611,7 +721,13 @@ export function DocumentRichEditor({
         <div className="flex flex-wrap items-center justify-between gap-2 border-t border-rule bg-paper-sunken px-5 py-2 text-xs text-muted">
           <span className="inline-flex items-center gap-2">
             <span
-              className={`h-2 w-2 rounded-full ${dirty ? "bg-amber-500" : "bg-emerald-700"}`}
+              className={`h-2 w-2 rounded-full ${
+                draftSaveState === "error"
+                  ? "bg-red-700"
+                  : dirty
+                    ? "bg-amber-500"
+                    : "bg-emerald-700"
+              }`}
               aria-hidden="true"
             />
             {editorStatusLabel}. Every save creates a new version.
@@ -756,6 +872,15 @@ export function DocumentRichEditor({
           data-testid="document-editor-copy-status"
         >
           {copiedMessage}
+        </p>
+      )}
+      {draftSaveState === "error" && (
+        <p
+          className="border-b border-amber-300 bg-amber-50 px-5 py-2 text-xs leading-5 text-amber-900"
+          data-testid="document-server-draft-error"
+        >
+          Shared draft could not be saved. The browser copy is preserved locally; try saving
+          again before leaving this file.
         </p>
       )}
       {localDraft && (


### PR DESCRIPTION
## Summary
- add `document_working_drafts` as the mutable server-owned editor draft for each document
- add GET/PUT/commit draft endpoints, with draft commit creating the same immutable `user_edit` version shape as manual saves
- add ACL/lifecycle coverage for owner, cross-user, archived matter, invalid base version, and commit flow
- expose typed frontend API helpers for draft load/save/commit

## Local checks
- `python -m py_compile backend/app/models/document_working_draft.py backend/app/api/documents.py`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`

Note: local shell has no `pytest`/`uv` available; DB-backed route tests are added for CI to run in the project environment.