### PR TITLE
documents: add editor review map

### DIFF
--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 import {
   clearDocumentLocalDraft,
@@ -446,5 +446,43 @@ describe("DocumentRichEditor surface", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Add review note" }));
     expect(onCreateNoteFromSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows which review notes are located in the working copy", async () => {
+    render(
+      <DocumentRichEditor
+        documentId="doc-1"
+        filename="draft.docx"
+        initialText="The dismissal letter mentioned a single social-media post."
+        sourceLabel="extracted · 60 chars"
+        noteHighlights={[
+          {
+            id: "note-1",
+            label: "Open note",
+            quote: "single social-media post",
+            status: "open",
+          },
+          {
+            id: "note-2",
+            label: "Moved note",
+            quote: "holiday pay clause",
+            status: "open",
+          },
+        ]}
+        onSaved={() => undefined}
+      />,
+    );
+
+    const reviewMap = await screen.findByTestId("document-editor-review-map");
+    expect(reviewMap).toHaveTextContent("1 of 2 note anchors located");
+    expect(within(reviewMap).getByRole("button", { name: /Open note/ })).toHaveTextContent(
+      "Located",
+    );
+    expect(within(reviewMap).getByRole("button", { name: /Moved note/ })).toHaveTextContent(
+      "Not located",
+    );
+
+    fireEvent.click(within(reviewMap).getByRole("button", { name: /Open note/ }));
+    expect(screen.getByLabelText("Find")).toHaveValue("single social-media post");
   });
 });

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -524,6 +524,15 @@ export function DocumentRichEditor({
     () => findNormalizedRange(plainText, sourceHighlight),
     [plainText, sourceHighlight],
   );
+  const noteAnchorSummaries = useMemo(
+    () =>
+      noteHighlights.map((note) => ({
+        ...note,
+        located: Boolean(findNormalizedRange(plainText, note.quote)),
+      })),
+    [noteHighlights, plainText],
+  );
+  const locatedNoteCount = noteAnchorSummaries.filter((note) => note.located).length;
   const stats = useMemo(() => documentStatsFromText(plainText), [plainText]);
   const sharedDraftLabel =
     draftLoadState === "loading"
@@ -1012,6 +1021,49 @@ export function DocumentRichEditor({
         <p className="border-b border-red-800 bg-red-50 px-5 py-3 text-sm text-red-900">
           {error}
         </p>
+      )}
+      {noteAnchorSummaries.length > 0 && (
+        <div
+          className="border-b border-rule bg-paper px-5 py-3"
+          data-testid="document-editor-review-map"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                Review map
+              </p>
+              <p className="mt-1 text-sm text-ink">
+                {locatedNoteCount} of {noteAnchorSummaries.length} note anchor
+                {noteAnchorSummaries.length === 1 ? "" : "s"} located in this working copy.
+              </p>
+            </div>
+            <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+              Anchored notes
+            </span>
+          </div>
+          <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+            {noteAnchorSummaries.map((note) => (
+              <button
+                key={note.id}
+                type="button"
+                onClick={() => setFindQuery(note.quote)}
+                className={`min-w-[220px] max-w-[280px] border px-3 py-2 text-left text-xs leading-5 ${
+                  note.located
+                    ? "border-ink bg-paper text-ink"
+                    : "border-amber-300 bg-amber-50 text-amber-950"
+                }`}
+              >
+                <span className="block font-semibold">{note.label}</span>
+                <span className="mt-1 block max-h-10 overflow-hidden text-muted">
+                  {note.quote}
+                </span>
+                <span className="mt-2 block font-mono uppercase tracking-track2">
+                  {note.located ? "Located" : "Not located"}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
       )}
       <div className="grid min-h-[620px] lg:grid-cols-[240px_minmax(0,1fr)]">
         <aside className="border-b border-rule bg-paper-sunken px-5 py-5 lg:border-b-0 lg:border-r">


### PR DESCRIPTION
## Summary
- add a review-map layer above the document editor showing anchored review notes
- locate each note quote against the current working copy and distinguish located vs not located
- clicking a note pushes the quote into the editor find panel

## Local checks
- `cd frontend && npm test -- --run src/modules/document_edit/DocumentRichEditor.test.tsx src/matter/DocumentDetail.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`