### PR TITLE
documents: import word originals into editor

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "diff-match-patch": "^1.0.5",
         "docx-preview": "^0.3.7",
         "lucide-react": "^0.460.0",
+        "mammoth": "^1.12.0",
         "pdfjs-dist": "^5.6.205",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3058,6 +3059,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3234,6 +3244,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.29",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
@@ -3269,6 +3299,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -3775,6 +3811,12 @@
       "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "license": "Apache-2.0"
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -3807,6 +3849,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4759,6 +4810,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4815,6 +4877,39 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/mdn-data": {
@@ -4997,6 +5092,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5093,6 +5194,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -6068,6 +6178,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6427,6 +6543,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.26.0",
@@ -6839,6 +6961,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "diff-match-patch": "^1.0.5",
     "docx-preview": "^0.3.7",
     "lucide-react": "^0.460.0",
+    "mammoth": "^1.12.0",
     "pdfjs-dist": "^5.6.205",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -992,6 +992,7 @@ export function DocumentDetail({
                   initialJson={editorJson}
                   latestVersionNumber={latestVersion?.version_number}
                   latestVersionId={latestVersion?.id ?? null}
+                  originalMimeType={doc.mime_type}
                   sourceLabel={editorSourceLabel}
                   sourceHighlight={currentReaderQuote}
                   noteHighlights={anchoredOpenNotes}

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -9,6 +9,7 @@ import {
   documentStatsFromText,
   findNormalizedRange,
   findNormalizedRanges,
+  isEditableWordDocument,
   readDocumentLocalDraft,
   type TiptapNode,
   textToEditorHtml,
@@ -201,6 +202,17 @@ describe("DocumentRichEditor text conversion", () => {
     expect(readDocumentLocalDraft("doc-1")?.plainText).toBe("Unsaved wording");
     clearDocumentLocalDraft("doc-1");
     expect(readDocumentLocalDraft("doc-1")).toBeNull();
+  });
+
+  it("detects editable Word originals by extension or MIME type", () => {
+    expect(isEditableWordDocument("lease.docx", null)).toBe(true);
+    expect(
+      isEditableWordDocument(
+        "lease",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ),
+    ).toBe(true);
+    expect(isEditableWordDocument("lease.pdf", "application/pdf")).toBe(false);
   });
 });
 

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -20,6 +20,7 @@ import type { Content, JSONContent } from "@tiptap/core";
 import {
   commitDocumentWorkingDraft,
   documentVersionDocxUrl,
+  fetchDocumentOriginalBlob,
   getDocumentWorkingDraft,
   saveDocumentWorkingDraft,
   type DocumentVersionRead,
@@ -40,6 +41,7 @@ type TextRange = { start: number; end: number };
 type OutlineItem = { id: string; label: string; query: string };
 type DocumentStats = { words: number; chars: number; blocks: number };
 type DocumentCanvasMode = "page" | "wide";
+type OriginalImportState = "idle" | "loading" | "ready" | "error";
 type DocumentLocalDraft = {
   documentId: string;
   filename: string;
@@ -145,6 +147,13 @@ function plainTextFromNode(node: TiptapNode): string {
 
 export function editorJsonToPlainText(json: TiptapNode): string {
   return plainTextFromNode(json).replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export function isEditableWordDocument(filename: string, mimeType?: string | null): boolean {
+  return (
+    /\.docx$/i.test(filename) ||
+    mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  );
 }
 
 function firstTextFromNode(node: TiptapNode): string {
@@ -309,6 +318,7 @@ export function DocumentRichEditor({
   initialJson,
   latestVersionNumber,
   latestVersionId,
+  originalMimeType,
   sourceLabel,
   sourceHighlight,
   noteHighlights = [],
@@ -324,6 +334,7 @@ export function DocumentRichEditor({
   initialJson?: TiptapNode | null;
   latestVersionNumber?: number;
   latestVersionId?: string | null;
+  originalMimeType?: string | null;
   sourceLabel: string;
   sourceHighlight?: string | null;
   noteHighlights?: DocumentNoteHighlight[];
@@ -345,6 +356,7 @@ export function DocumentRichEditor({
   const [serverDraft, setServerDraft] = useState<DocumentWorkingDraftRead | null>(null);
   const [draftLoadState, setDraftLoadState] = useState<"loading" | "ready" | "error">("loading");
   const [draftSaveState, setDraftSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [originalImportState, setOriginalImportState] = useState<OriginalImportState>("idle");
   const [canvasMode, setCanvasMode] = useState<DocumentCanvasMode>("page");
   const findInputRef = useRef<HTMLInputElement | null>(null);
   const draftSaveTimerRef = useRef<number | null>(null);
@@ -376,6 +388,31 @@ export function DocumentRichEditor({
     draftBaseVersionIdRef.current = draft.base_version_id;
     setDraftSaveState("saved");
     return draft;
+  }
+
+  async function importOriginalWordDraft(): Promise<boolean> {
+    if (!editor || !isEditableWordDocument(filename, originalMimeType)) return false;
+    setOriginalImportState("loading");
+    try {
+      const blob = await fetchDocumentOriginalBlob(documentId);
+      const arrayBuffer = await blob.arrayBuffer();
+      const mammoth = await import("mammoth");
+      const result = await mammoth.convertToHtml({ arrayBuffer });
+      const html = result.value.trim();
+      if (!html) throw new Error("Word import returned no editable content.");
+      editor.commands.setContent(html, { emitUpdate: false });
+      const editorJson = editor.getJSON() as TiptapNode;
+      const importedText = editorJsonToPlainText(editorJson);
+      await persistWorkingDraft(editorJson, importedText);
+      setDirty(true);
+      onDirtyChange?.(true);
+      setSavedMessage("Word structure imported. Save it to create an editable version.");
+      setOriginalImportState("ready");
+      return true;
+    } catch {
+      setOriginalImportState("error");
+      return false;
+    }
   }
 
   function scheduleWorkingDraftSave(editorJson: TiptapNode, plainText: string) {
@@ -450,6 +487,7 @@ export function DocumentRichEditor({
     setServerDraft(null);
     setDraftLoadState("loading");
     setDraftSaveState("idle");
+    setOriginalImportState("idle");
     draftBaseVersionIdRef.current = latestVersionId ?? null;
     if (draftSaveTimerRef.current !== null) {
       window.clearTimeout(draftSaveTimerRef.current);
@@ -462,10 +500,22 @@ export function DocumentRichEditor({
     let cancelled = false;
     setDraftLoadState("loading");
     getDocumentWorkingDraft(documentId)
-      .then((draft) => {
+      .then(async (draft) => {
         if (cancelled) return;
         setServerDraft(draft);
         draftBaseVersionIdRef.current = draft.base_version_id ?? latestVersionId ?? null;
+        const shouldImportWord =
+          draft.version_counter === 0 &&
+          !draft.editor_json &&
+          isEditableWordDocument(filename, originalMimeType);
+        if (shouldImportWord) {
+          const imported = await importOriginalWordDraft();
+          if (cancelled) return;
+          if (imported) {
+            setDraftLoadState("ready");
+            return;
+          }
+        }
         const draftContent = draft.editor_json ?? textToEditorHtml(draft.plain_text, sourceHighlight);
         editor.commands.setContent(draftContent as Content, { emitUpdate: false });
         const hasMutableDraft = draft.version_counter > 0;
@@ -483,7 +533,7 @@ export function DocumentRichEditor({
     return () => {
       cancelled = true;
     };
-  }, [documentId, editor, latestVersionId, onDirtyChange, sourceHighlight]);
+  }, [documentId, editor, filename, latestVersionId, onDirtyChange, originalMimeType, sourceHighlight]);
 
   useEffect(() => {
     return () => {
@@ -924,6 +974,27 @@ export function DocumentRichEditor({
         >
           Shared draft could not be saved. The browser copy is preserved locally; try saving
           again before leaving this file.
+        </p>
+      )}
+      {originalImportState === "loading" && (
+        <p className="border-b border-rule bg-paper-sunken px-5 py-2 text-xs text-muted">
+          Importing Word structure into the editable working copy...
+        </p>
+      )}
+      {originalImportState === "ready" && (
+        <p
+          className="border-b border-rule bg-paper-sunken px-5 py-2 text-xs text-muted"
+          data-testid="document-word-import-ready"
+        >
+          Word structure imported into the shared draft. Save a version when the edit is ready.
+        </p>
+      )}
+      {originalImportState === "error" && (
+        <p
+          className="border-b border-amber-300 bg-amber-50 px-5 py-2 text-xs leading-5 text-amber-900"
+          data-testid="document-word-import-fallback"
+        >
+          Word structure could not be imported here, so the editor is using extracted text.
         </p>
       )}
       {localDraft && (


### PR DESCRIPTION
## Summary
- add Mammoth as the proven DOCX-to-HTML conversion package for editable Word imports
- when a DOCX has no Legalise rich draft/version yet, import the original file into TipTap and persist it as a shared working draft
- keep extracted text as the fallback and surface honest import-ready/fallback copy in the editor

## Local checks
- `cd frontend && npm test -- --run src/modules/document_edit/DocumentRichEditor.test.tsx src/matter/DocumentDetail.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`