### PR TITLE
documents: refresh cited outputs after file runs

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -601,6 +601,35 @@ describe("DocumentDetail", () => {
         },
       ],
     });
+    vi.spyOn(api, "invokeCapability").mockResolvedValue({
+      invocation_id: "inv-1",
+      module_id: "demo.guided-skill",
+      capability_id: "summarise",
+      matter_id: "m-1",
+      result: { artifact_id: "art-1" },
+    });
+    vi.spyOn(api, "readArtifact").mockResolvedValue({
+      id: "art-1",
+      matter_id: "m-1",
+      module_id: "demo.guided-skill",
+      capability_id: "summarise",
+      invocation_id: "inv-1",
+      kind: "skill_response",
+      created_by_id: "u-1",
+      created_at: "2026-06-03T10:00:00",
+      size_bytes: 123,
+      payload: {
+        output: "Summary",
+        source_anchors: [
+          {
+            id: "a1",
+            source_type: "document",
+            document_id: "doc-1",
+            filename: "claim-form.pdf",
+          },
+        ],
+      },
+    });
 
     mount();
 
@@ -617,6 +646,12 @@ describe("DocumentDetail", () => {
 
     expect(screen.getByTestId("generic-runner-demo.guided-skill-summarise")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Summarise claim-form.pdf.")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("generic-run-demo.guided-skill-summarise"));
+
+    expect(await screen.findByTestId("generic-runner-result")).toHaveTextContent("Output written");
+    expect(screen.getByTestId("document-output-links")).toHaveTextContent(
+      "1 signed output cites this file",
+    );
   });
 
   it("shows document review notes and lets the user add one", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1395,6 +1395,19 @@ export function DocumentDetail({
                     skill={activeRunnerSkill}
                     documents={[doc]}
                     initialDocumentIds={[documentId]}
+                    onRunComplete={(_response, artifacts) => {
+                      const related = artifacts.filter((artifact) =>
+                        artifactReferencesDocument(artifact, documentId),
+                      );
+                      if (related.length === 0) return;
+                      setDocumentArtifacts((current) => {
+                        const existing = new Set((current ?? []).map((artifact) => artifact.id));
+                        return [
+                          ...related.filter((artifact) => !existing.has(artifact.id)),
+                          ...(current ?? []),
+                        ];
+                      });
+                    }}
                     onClose={() => setActiveRunnerSkill(null)}
                     compact
                   />

--- a/frontend/src/matter/GenericSkillRunner.test.tsx
+++ b/frontend/src/matter/GenericSkillRunner.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
 import * as api from "../lib/api";
 import { artifactIdsFromResult, GenericSkillRunner } from "./GenericSkillRunner";
 import type { RunnableMatterSkill } from "./skillRunnerModel";
@@ -37,9 +38,18 @@ const docs = [
   },
 ];
 
-function renderRunner(skill: RunnableMatterSkill = baseSkill) {
+function renderRunner(
+  skill: RunnableMatterSkill = baseSkill,
+  props: Partial<ComponentProps<typeof GenericSkillRunner>> = {},
+) {
   return render(
-    <GenericSkillRunner slug="khan-v-acme" skill={skill} documents={docs} compact />,
+    <GenericSkillRunner
+      slug="khan-v-acme"
+      skill={skill}
+      documents={docs}
+      compact
+      {...props}
+    />,
   );
 }
 
@@ -99,6 +109,31 @@ describe("GenericSkillRunner", () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId("generic-runner-result")).toBeNull();
+    });
+  });
+
+  it("notifies the parent surface when a run completes", async () => {
+    const onRunComplete = vi.fn();
+    vi.spyOn(api, "invokeCapability").mockResolvedValue({
+      invocation_id: "inv-1",
+      result: { artifact_id: "artifact-1" },
+    } as never);
+    vi.spyOn(api, "readArtifact").mockResolvedValue({
+      id: "artifact-1",
+      kind: "skill_response",
+      payload: { output: "The witness statement says X." },
+      invocation_id: "inv-1",
+      created_at: "2026-01-01T00:00:00",
+    } as never);
+    renderRunner(baseSkill, { onRunComplete });
+
+    fireEvent.click(screen.getByTestId("generic-run-demo.guided-skill-summarise"));
+
+    await waitFor(() => {
+      expect(onRunComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ invocation_id: "inv-1" }),
+        [expect.objectContaining({ id: "artifact-1" })],
+      );
     });
   });
 

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -33,6 +33,7 @@ export function GenericSkillRunner({
   initialDocumentIds,
   initialInput,
   onClose,
+  onRunComplete,
   compact = false,
 }: {
   slug: string;
@@ -41,6 +42,7 @@ export function GenericSkillRunner({
   initialDocumentIds?: string[];
   initialInput?: string;
   onClose?: () => void;
+  onRunComplete?: (response: InvocationResponse, artifacts: ArtifactRead[]) => void;
   compact?: boolean;
 }) {
   const availableDocs = documents ?? [];
@@ -120,6 +122,7 @@ export function GenericSkillRunner({
         artifactIds.map((artifactId) => readArtifact(slug, artifactId)),
       );
       setState({ kind: "success", response, artifacts });
+      onRunComplete?.(response, artifacts);
     } catch (err) {
       setState(errorToState(err));
     }


### PR DESCRIPTION
## Summary
- add a reusable completion callback to the generic skill runner
- update the document workbench after a file-scoped skill run so cited outputs appear immediately
- prove the document golden path: select file skill, run it, artifact appears in the file's cited-output panel

## Tests
- cd frontend && npm test -- --run src/matter/GenericSkillRunner.test.tsx src/matter/DocumentDetail.test.tsx
- cd frontend && npm run typecheck
- cd frontend && npm run build

## Document-engine phase
This tightens the file-centric loop: open a document, run a document-reading skill, and see the output relationship on the same file page without a refresh.