### PR TITLE
documents: guard shared draft conflicts

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -232,11 +232,13 @@ class DocumentWorkingDraftUpsert(BaseModel):
     editor_json: dict[str, Any] | None = None
     base_version_id: uuid.UUID | None = None
     client_id: str | None = Field(default=None, max_length=96)
+    expected_version_counter: int | None = Field(default=None, ge=0)
 
 
 class DocumentWorkingDraftCommitRequest(BaseModel):
     notes: str | None = Field(default=None, max_length=500)
     clear_draft: bool = True
+    expected_version_counter: int | None = Field(default=None, ge=0)
 
 
 class EditInstructionResponse(BaseModel):
@@ -1021,6 +1023,16 @@ async def put_document_working_draft(
         select(DocumentWorkingDraft).where(DocumentWorkingDraft.document_id == doc.id)
     )
     if draft is None:
+        if body.expected_version_counter not in (None, 0):
+            raise HTTPException(
+                409,
+                {
+                    "error": "working_draft_conflict",
+                    "message": "The shared draft changed before this save. Reload the document before saving again.",
+                    "current_version_counter": 0,
+                    "current_client_id": None,
+                },
+            )
         draft = DocumentWorkingDraft(
             document_id=doc.id,
             updated_by_id=user.id,
@@ -1033,6 +1045,19 @@ async def put_document_working_draft(
         )
         session.add(draft)
     else:
+        if (
+            body.expected_version_counter is not None
+            and body.expected_version_counter != draft.version_counter
+        ):
+            raise HTTPException(
+                409,
+                {
+                    "error": "working_draft_conflict",
+                    "message": "The shared draft changed before this save. Reload the document before saving again.",
+                    "current_version_counter": draft.version_counter,
+                    "current_client_id": draft.client_id,
+                },
+            )
         draft.updated_by_id = user.id
         draft.updated_at = now
         draft.plain_text = body.plain_text
@@ -1063,6 +1088,19 @@ async def post_document_working_draft_commit(
             {
                 "error": "working_draft_empty",
                 "message": "There is no working draft text to save as a version.",
+            },
+        )
+    if (
+        body.expected_version_counter is not None
+        and body.expected_version_counter != draft.version_counter
+    ):
+        raise HTTPException(
+            409,
+            {
+                "error": "working_draft_conflict",
+                "message": "The shared draft changed before this version save. Reload the document before saving again.",
+                "current_version_counter": draft.version_counter,
+                "current_client_id": draft.client_id,
             },
         )
 

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -364,6 +364,43 @@ async def test_document_working_draft_base_version_must_belong_to_document(clien
 
 
 @pytest.mark.asyncio
+async def test_document_working_draft_rejects_stale_counter(client) -> None:
+    """Autosave and commit reject stale shared-draft counters."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload_text(client, "Original extracted text.")
+
+    first = await client.put(
+        f"/api/documents/{doc_id}/draft",
+        json={
+            "plain_text": "First working draft.",
+            "client_id": "client-a",
+            "expected_version_counter": 0,
+        },
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["version_counter"] == 1
+
+    stale_save = await client.put(
+        f"/api/documents/{doc_id}/draft",
+        json={
+            "plain_text": "Stale overwrite attempt.",
+            "client_id": "client-b",
+            "expected_version_counter": 0,
+        },
+    )
+    assert stale_save.status_code == 409, stale_save.text
+    assert stale_save.json()["detail"]["error"] == "working_draft_conflict"
+    assert stale_save.json()["detail"]["current_version_counter"] == 1
+
+    stale_commit = await client.post(
+        f"/api/documents/{doc_id}/draft/commit",
+        json={"expected_version_counter": 0},
+    )
+    assert stale_commit.status_code == 409, stale_commit.text
+    assert stale_commit.json()["detail"]["error"] == "working_draft_conflict"
+
+
+@pytest.mark.asyncio
 async def test_post_upload_document_version_updates_active_document_and_body(client) -> None:
     """Owner can upload a replacement binary as the next active document version."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1783,12 +1783,32 @@ export interface DocumentWorkingDraftRead {
 
 export class ConflictError extends Error {
   status = 409;
+  detail: unknown;
+  constructor(message = "edit already resolved", detail: unknown = null) {
+    super(message);
+    this.name = "ConflictError";
+    this.detail = detail;
+  }
 }
 
 async function resolutionJsonOrThrow<T>(res: Response): Promise<T> {
   if (res.status === 409) {
     const text = await res.text();
-    throw new ConflictError(text || "edit already resolved");
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      const detail =
+        parsed && typeof parsed === "object" && "detail" in parsed
+          ? (parsed as { detail?: unknown }).detail
+          : parsed;
+      const message =
+        detail && typeof detail === "object" && "message" in detail
+          ? String((detail as { message?: unknown }).message || "")
+          : "";
+      throw new ConflictError(message || "edit already resolved", detail);
+    } catch (err) {
+      if (err instanceof ConflictError) throw err;
+      throw new ConflictError(text || "edit already resolved");
+    }
   }
   if (!res.ok) {
     const text = await res.text();
@@ -1834,6 +1854,7 @@ export const saveDocumentWorkingDraft = (
     editor_json?: Record<string, unknown> | null;
     base_version_id?: string | null;
     client_id?: string | null;
+    expected_version_counter?: number | null;
   },
 ) =>
   apiFetch(`${API}/documents/${documentId}/draft`, {
@@ -1846,11 +1867,16 @@ export const commitDocumentWorkingDraft = (
   documentId: string,
   notes?: string,
   clearDraft = true,
+  expectedVersionCounter?: number | null,
 ) =>
   apiFetch(`${API}/documents/${documentId}/draft/commit`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ notes: notes?.trim() || null, clear_draft: clearDraft }),
+    body: JSON.stringify({
+      notes: notes?.trim() || null,
+      clear_draft: clearDraft,
+      expected_version_counter: expectedVersionCounter ?? null,
+    }),
   }).then((r) => resolutionJsonOrThrow<DocumentVersionRead>(r));
 
 export const saveDocumentVersion = (

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -358,6 +358,91 @@ describe("DocumentRichEditor surface", () => {
     expect(calledUrls.some((call) => call.url.endsWith("/versions/manual"))).toBe(false);
   });
 
+  it("surfaces shared-draft conflicts when saving a version", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/documents/doc-1/draft") && !init?.method) {
+        return Promise.resolve(
+          jsonResponse({
+            document_id: "doc-1",
+            updated_by_id: "user-1",
+            updated_at: "2026-06-04T02:30:00Z",
+            plain_text: "Server draft wording.",
+            editor_json: {
+              type: "doc",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Server draft wording." }],
+                },
+              ],
+            },
+            base_version_id: "version-1",
+            version_counter: 3,
+            client_id: "client-1",
+          }),
+        );
+      }
+      if (url.endsWith("/documents/doc-1/draft") && init?.method === "PUT") {
+        return Promise.resolve(
+          jsonResponse({
+            document_id: "doc-1",
+            updated_by_id: "user-1",
+            updated_at: "2026-06-04T02:31:00Z",
+            plain_text: "Server draft wording.",
+            editor_json: {
+              type: "doc",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Server draft wording." }],
+                },
+              ],
+            },
+            base_version_id: "version-1",
+            version_counter: 4,
+            client_id: "document-editor-test",
+          }),
+        );
+      }
+      if (url.endsWith("/documents/doc-1/draft/commit") && init?.method === "POST") {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              detail: {
+                error: "working_draft_conflict",
+                message: "The shared draft changed before this version save.",
+                current_version_counter: 5,
+                current_client_id: "client-2",
+              },
+            },
+            409,
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({ detail: "not found" }, 404));
+    });
+
+    render(
+      <DocumentRichEditor
+        documentId="doc-1"
+        filename="draft.docx"
+        initialText="Extracted fallback."
+        latestVersionNumber={2}
+        latestVersionId="version-1"
+        sourceLabel="extracted · 19 chars"
+        onSaved={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("Server draft wording.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Save version" }));
+
+    expect(await screen.findByTestId("document-server-draft-error")).toHaveTextContent(
+      "The shared draft changed before this version save.",
+    );
+  });
+
   it("renders grouped document editing controls on a page canvas", async () => {
     Object.assign(window.navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -19,6 +19,7 @@ import type { Content, JSONContent } from "@tiptap/core";
 
 import {
   commitDocumentWorkingDraft,
+  ConflictError,
   documentVersionDocxUrl,
   fetchDocumentOriginalBlob,
   getDocumentWorkingDraft,
@@ -384,12 +385,14 @@ export function DocumentRichEditor({
   const [serverDraft, setServerDraft] = useState<DocumentWorkingDraftRead | null>(null);
   const [draftLoadState, setDraftLoadState] = useState<"loading" | "ready" | "error">("loading");
   const [draftSaveState, setDraftSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [draftConflict, setDraftConflict] = useState<string | null>(null);
   const [originalImportState, setOriginalImportState] = useState<OriginalImportState>("idle");
   const [draftBaselineText, setDraftBaselineText] = useState(initialText);
   const [canvasMode, setCanvasMode] = useState<DocumentCanvasMode>("page");
   const findInputRef = useRef<HTMLInputElement | null>(null);
   const draftSaveTimerRef = useRef<number | null>(null);
   const draftBaseVersionIdRef = useRef<string | null>(latestVersionId ?? null);
+  const draftVersionCounterRef = useRef<number>(0);
   const draftClientIdRef = useRef<string>("");
   if (!draftClientIdRef.current) {
     const suffix =
@@ -412,9 +415,12 @@ export function DocumentRichEditor({
       editor_json: editorJson as Record<string, unknown>,
       base_version_id: draftBaseVersionIdRef.current,
       client_id: draftClientIdRef.current,
+      expected_version_counter: draftVersionCounterRef.current,
     });
     setServerDraft(draft);
     draftBaseVersionIdRef.current = draft.base_version_id;
+    draftVersionCounterRef.current = draft.version_counter;
+    setDraftConflict(null);
     setDraftSaveState("saved");
     return draft;
   }
@@ -452,8 +458,13 @@ export function DocumentRichEditor({
     setDraftSaveState("saving");
     draftSaveTimerRef.current = window.setTimeout(() => {
       draftSaveTimerRef.current = null;
-      persistWorkingDraft(editorJson, plainText).catch(() => {
+      persistWorkingDraft(editorJson, plainText).catch((err) => {
         setDraftSaveState("error");
+        setDraftConflict(
+          err instanceof ConflictError
+            ? err.message
+            : null,
+        );
       });
     }, 900);
   }
@@ -517,9 +528,11 @@ export function DocumentRichEditor({
     setServerDraft(null);
     setDraftLoadState("loading");
     setDraftSaveState("idle");
+    setDraftConflict(null);
     setOriginalImportState("idle");
     setDraftBaselineText(initialText);
     draftBaseVersionIdRef.current = latestVersionId ?? null;
+    draftVersionCounterRef.current = 0;
     if (draftSaveTimerRef.current !== null) {
       window.clearTimeout(draftSaveTimerRef.current);
       draftSaveTimerRef.current = null;
@@ -535,6 +548,7 @@ export function DocumentRichEditor({
         if (cancelled) return;
         setServerDraft(draft);
         draftBaseVersionIdRef.current = draft.base_version_id ?? latestVersionId ?? null;
+        draftVersionCounterRef.current = draft.version_counter;
         const shouldImportWord =
           draft.version_counter === 0 &&
           !draft.editor_json &&
@@ -561,6 +575,7 @@ export function DocumentRichEditor({
         if (cancelled) return;
         setDraftLoadState("error");
         setDraftSaveState("error");
+        setDraftConflict(null);
       });
     return () => {
       cancelled = true;
@@ -666,6 +681,8 @@ export function DocumentRichEditor({
       const version = await commitDocumentWorkingDraft(
         documentId,
         `Edited ${filename} in Legalise document editor`,
+        true,
+        draftVersionCounterRef.current,
       );
       setDirty(false);
       onDirtyChange?.(false);
@@ -673,12 +690,23 @@ export function DocumentRichEditor({
       setServerDraft(null);
       setDraftBaselineText(plainText);
       draftBaseVersionIdRef.current = version.id;
+      draftVersionCounterRef.current = 0;
       setDraftSaveState("idle");
+      setDraftConflict(null);
       clearDocumentLocalDraft(documentId);
       setLocalDraft(null);
       onSaved(version);
       return version;
     } catch (err) {
+      if (err instanceof ConflictError) {
+        const message =
+          err.message ||
+          "The shared draft changed in another editor. Reload this document before saving again.";
+        setDraftSaveState("error");
+        setDraftConflict(message);
+        setError(message);
+        return null;
+      }
       setError(err instanceof Error ? err.message : String(err));
       return null;
     } finally {
@@ -713,6 +741,7 @@ export function DocumentRichEditor({
     onDirtyChange?.(false);
     setError(null);
     setSavedMessage(null);
+    setDraftConflict(null);
     setDraftBaselineText(initialText);
     clearDocumentLocalDraft(documentId);
     setLocalDraft(null);
@@ -1016,8 +1045,8 @@ export function DocumentRichEditor({
           className="border-b border-amber-300 bg-amber-50 px-5 py-2 text-xs leading-5 text-amber-900"
           data-testid="document-server-draft-error"
         >
-          Shared draft could not be saved. The browser copy is preserved locally; try saving
-          again before leaving this file.
+          {draftConflict ??
+            "Shared draft could not be saved. The browser copy is preserved locally; try saving again before leaving this file."}
         </p>
       )}
       {originalImportState === "loading" && (


### PR DESCRIPTION
## Summary
- add optimistic version-counter checks to shared document draft autosave and commit
- return structured 409 working_draft_conflict responses for stale saves
- surface draft conflicts in the rich editor instead of silently overwriting or pretending the version saved

## Tests
- cd frontend && npm test -- --run src/modules/document_edit/DocumentRichEditor.test.tsx
- cd frontend && npm run typecheck
- cd frontend && npm run build
- python -m py_compile backend/app/api/documents.py backend/tests/test_route_acl_sweep.py
- python -m pytest backend/tests/test_route_acl_sweep.py -k "working_draft" -q (not run locally: pytest is not installed in this Python environment)

## Document-engine phase
This is the first real shared-editing guard: multiple open editors can still work through the server draft, but stale saves/commits now fail visibly instead of overwriting another user's newer draft.