### PR TITLE
documents: mark review notes inline

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -120,6 +120,18 @@
     padding: 0 0.1em;
   }
 
+  .legalise-document-editor .legalise-review-note-open {
+    background: #EAF4F4;
+    box-shadow: inset 0 -2px 0 #2F6F6D;
+    padding: 0 0.08em;
+  }
+
+  .legalise-document-editor .legalise-review-note-resolved {
+    background: #F1F1ED;
+    box-shadow: inset 0 -2px 0 #9CA3AF;
+    padding: 0 0.08em;
+  }
+
   .legalise-document-editor table {
     border-collapse: collapse;
     margin: 0 0 1.25rem;

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -580,6 +580,16 @@ describe("DocumentRichEditor surface", () => {
     expect(within(reviewMap).getByRole("button", { name: /Moved note/ })).toHaveTextContent(
       "Not located",
     );
+    expect(
+      screen
+        .getByTestId("document-editor-canvas")
+        .querySelector('[data-review-note-id="note-1"]'),
+    ).toHaveTextContent("single social-media post");
+    expect(
+      screen
+        .getByTestId("document-editor-canvas")
+        .querySelector('[data-review-note-id="note-2"]'),
+    ).toBeNull();
 
     fireEvent.click(within(reviewMap).getByRole("button", { name: /Open note/ }));
     expect(screen.getByLabelText("Find")).toHaveValue("single social-media post");

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -6,6 +6,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
+import { Extension, type Content, type JSONContent } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
@@ -15,7 +16,8 @@ import { Table } from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
-import type { Content, JSONContent } from "@tiptap/core";
+import { Plugin, PluginKey } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
 
 import {
   commitDocumentWorkingDraft,
@@ -58,6 +60,42 @@ export type DocumentNoteHighlight = {
   quote: string;
   status: "open" | "resolved";
 };
+
+function reviewNoteDecorationsExtension(noteHighlights: DocumentNoteHighlight[]) {
+  return Extension.create({
+    name: "legaliseReviewNotes",
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey("legaliseReviewNotes"),
+          props: {
+            decorations(state) {
+              const decorations: Decoration[] = [];
+              state.doc.descendants((node, position) => {
+                if (!node.isText || !node.text) return;
+                noteHighlights.forEach((note) => {
+                  findNormalizedRanges(node.text ?? "", note.quote).forEach((range) => {
+                    decorations.push(
+                      Decoration.inline(position + range.start, position + range.end, {
+                        class:
+                          note.status === "resolved"
+                            ? "legalise-review-note-resolved"
+                            : "legalise-review-note-open",
+                        "data-review-note-id": note.id,
+                        title: note.label,
+                      }),
+                    );
+                  });
+                });
+              });
+              return DecorationSet.create(state.doc, decorations);
+            },
+          },
+        }),
+      ];
+    },
+  });
+}
 
 export function findNormalizedRanges(
   text: string,
@@ -405,6 +443,19 @@ export function DocumentRichEditor({
     () => initialJson ?? textToEditorHtml(initialText, sourceHighlight),
     [initialJson, initialText, sourceHighlight],
   );
+  const noteHighlightsKey = useMemo(
+    () =>
+      noteHighlights
+        .map((note) => `${note.id}:${note.status}:${note.quote}`)
+        .join("|"),
+    [noteHighlights],
+  );
+  const reviewNoteExtension = useMemo(
+    () => reviewNoteDecorationsExtension(noteHighlights),
+    // The key keeps the editor extension stable unless the actual anchor inputs change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [noteHighlightsKey],
+  );
   async function persistWorkingDraft(
     editorJson: TiptapNode,
     plainText: string,
@@ -484,6 +535,7 @@ export function DocumentRichEditor({
         }),
         Typography,
         Highlight.configure({ multicolor: false }),
+        reviewNoteExtension,
         Underline,
         Table.configure({ resizable: true }),
         TableRow,
@@ -514,7 +566,7 @@ export function DocumentRichEditor({
       },
       immediatelyRender: false,
     },
-    [documentId],
+    [documentId, reviewNoteExtension],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- marks located document review-note quotes inline in the TipTap editor with ProseMirror decorations
- keeps the saved document content clean; decorations are view-only and derived from existing anchored notes
- adds open/resolved styling and a regression assertion that located notes render in the canvas while moved notes do not

## Gates
- npm test -- --run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run typecheck
- npm run build

## Notes
Frontend-only document-engine slice. No backend, schema, audit, or saved-content changes.