### PR TITLE
documents: disable DOCX download until a version exists

### DIFF
--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -648,7 +648,7 @@ describe("DocumentRichEditor surface", () => {
     expect(screen.getByTestId("document-editor-stats")).toHaveTextContent("words");
     expect(screen.getByRole("button", { name: "Copy text" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download text" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Download DOCX" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download DOCX" })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Copy text" }));
     await waitFor(() => {
       expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -710,7 +710,13 @@ export function DocumentRichEditor({
   const plainText = editor ? editorJsonToPlainText(editor.getJSON() as TiptapNode) : "";
   const currentEditorJson = editor ? editor.getJSON() as TiptapNode : null;
   const canSave = Boolean(editor && dirty && plainText.trim() && !saving && !downloadingDocx);
-  const canDownloadDocx = Boolean(editor && plainText.trim() && !saving && !downloadingDocx);
+  const canDownloadDocx = Boolean(
+    editor &&
+      plainText.trim() &&
+      !saving &&
+      !downloadingDocx &&
+      (dirty || latestVersionId),
+  );
   const findMatches = useMemo(
     () => findNormalizedRanges(plainText, findQuery),
     [plainText, findQuery],


### PR DESCRIPTION
## Summary
- prevent the editor DOCX download action from being enabled when there is no saved version URL yet
- keep Save & download DOCX enabled for dirty working copies, where saving can create the version first
- pin the clean extracted-text state so it cannot regress to an enabled button that only errors after click

## Verification
- npm test -- --run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run typecheck
- npm run build