### PR TITLE
documents: include review notes in DOCX exports

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -469,7 +469,11 @@ def _docx_export_filename(filename: str, version_number: int) -> str:
     return f"{cleaned}-v{version_number}.docx"
 
 
-def _render_resolved_text_docx(title: str, body: str) -> bytes:
+def _render_resolved_text_docx(
+    title: str,
+    body: str,
+    comments: list[DocumentComment] | None = None,
+) -> bytes:
     document = DocxDocument()
     document.add_heading(title, level=0)
     for block in body.split("\n\n"):
@@ -482,8 +486,32 @@ def _render_resolved_text_docx(title: str, body: str) -> bytes:
             para.add_run().add_break()
             para.add_run(line)
     buf = io.BytesIO()
+    _append_document_comments_docx(document, comments or [])
     document.save(buf)
     return buf.getvalue()
+
+
+def _append_document_comments_docx(
+    document: DocxDocument,
+    comments: list[DocumentComment],
+) -> None:
+    if not comments:
+        return
+    document.add_page_break()
+    document.add_heading("Document review notes", level=1)
+    for index, comment in enumerate(comments, start=1):
+        status = "resolved" if comment.status == COMMENT_STATUS_RESOLVED else "open"
+        document.add_heading(f"Note {index} ({status})", level=2)
+        if comment.quote_text:
+            quote = document.add_paragraph(style="Intense Quote")
+            quote.add_run(comment.quote_text)
+        document.add_paragraph(comment.body)
+        meta = document.add_paragraph()
+        meta.add_run("Created: ").bold = True
+        meta.add_run(comment.created_at.isoformat())
+        if comment.resolved_at:
+            meta.add_run(" · Resolved: ").bold = True
+            meta.add_run(comment.resolved_at.isoformat())
 
 
 def _add_tiptap_inline_content(paragraph, nodes: list[dict[str, Any]] | None) -> None:
@@ -612,9 +640,14 @@ def _add_tiptap_table(document: DocxDocument, node: dict[str, Any]) -> None:
                         run.bold = True
 
 
-def _render_tiptap_docx(title: str, body_json: dict[str, Any], fallback_text: str) -> bytes:
+def _render_tiptap_docx(
+    title: str,
+    body_json: dict[str, Any],
+    fallback_text: str,
+    comments: list[DocumentComment] | None = None,
+) -> bytes:
     if body_json.get("type") != "doc" or not isinstance(body_json.get("content"), list):
-        return _render_resolved_text_docx(title, fallback_text)
+        return _render_resolved_text_docx(title, fallback_text, comments or [])
 
     document = DocxDocument()
     document.add_heading(title, level=0)
@@ -630,6 +663,7 @@ def _render_tiptap_docx(title: str, body_json: dict[str, Any], fallback_text: st
             _add_tiptap_list(document, node, "List Number")
         elif node_type == "table":
             _add_tiptap_table(document, node)
+    _append_document_comments_docx(document, comments or [])
     buf = io.BytesIO()
     document.save(buf)
     return buf.getvalue()
@@ -1576,10 +1610,22 @@ async def get_document_version_docx(
     if not version.resolved_text:
         raise HTTPException(422, "document version has no resolved text")
 
+    comments = (
+        await session.execute(
+            select(DocumentComment)
+            .where(DocumentComment.document_id == doc.id)
+            .order_by(DocumentComment.created_at.asc(), DocumentComment.id.asc())
+        )
+    ).scalars().all()
     data = (
-        _render_tiptap_docx(doc.filename, version.resolved_json, version.resolved_text)
+        _render_tiptap_docx(
+            doc.filename,
+            version.resolved_json,
+            version.resolved_text,
+            comments,
+        )
         if version.resolved_json
-        else _render_resolved_text_docx(doc.filename, version.resolved_text)
+        else _render_resolved_text_docx(doc.filename, version.resolved_text, comments)
     )
     filename = _docx_export_filename(doc.filename, version.version_number)
     await audit.log(
@@ -1597,6 +1643,7 @@ async def get_document_version_docx(
             "byte_count": len(data),
             "format": "docx",
             "rich_json": version.resolved_json is not None,
+            "review_note_count": len(comments),
         },
     )
     await session.commit()

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -545,6 +545,14 @@ async def test_get_manual_document_version_docx_returns_word_file(client) -> Non
     """Owner can download a saved editor version as a valid .docx."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
     _, doc_id = await _create_matter_and_upload(client)
+    note = await client.post(
+        f"/api/documents/{doc_id}/comments",
+        json={
+            "body": "Check limitation before relying on this draft.",
+            "quote_text": "Edited witness statement.",
+        },
+    )
+    assert note.status_code == 200, note.text
 
     save = await client.post(
         f"/api/documents/{doc_id}/versions/manual",
@@ -560,6 +568,11 @@ async def test_get_manual_document_version_docx_returns_word_file(client) -> Non
     )
     assert resp.headers.get("content-disposition", "").endswith('.docx"')
     assert zipfile.is_zipfile(io.BytesIO(resp.content))
+    docx = DocxDocument(io.BytesIO(resp.content))
+    all_text = "\n".join(paragraph.text for paragraph in docx.paragraphs)
+    assert "Document review notes" in all_text
+    assert "Check limitation before relying on this draft." in all_text
+    assert "Edited witness statement." in all_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- append document review notes to saved-version DOCX exports so notes travel with the working copy
- include quoted passages, note status, created/resolved timestamps, and note body in a Word appendix
- add review_note_count to the document.version.docx.exported audit payload
- extend the route ACL/docx test to prove the appendix appears in the generated Word file

## Verification
- python3 -m py_compile backend/app/api/documents.py backend/tests/test_route_acl_sweep.py
- npm run typecheck

Local note: pytest/uv are not installed on this PATH, so GitHub CI is the backend execution gate.