### PR TITLE
documents: surface review-note docx exports

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -857,6 +857,22 @@ describe("DocumentDetail", () => {
   it("makes saved versions openable and downloadable from the version workspace", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc({ filename: "witness.docx" })]);
     vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "getDocumentComments").mockResolvedValue([
+      {
+        id: "comment-1",
+        document_id: "doc-1",
+        author_id: "u-1",
+        quote_text: "Edited",
+        body_sha256: "a".repeat(64),
+        anchor_start: null,
+        anchor_end: null,
+        body: "Check the edit before relying on it.",
+        status: "open",
+        created_at: "2026-06-03T10:00:00",
+        resolved_at: null,
+        resolved_by_id: null,
+      },
+    ]);
     vi.spyOn(api, "getDocumentVersions").mockResolvedValue([
       versionSummary("v-1", 1, null, "upload"),
       versionSummary("v-2", 2, "Edited body"),
@@ -870,6 +886,7 @@ describe("DocumentDetail", () => {
     expect(screen.getByRole("button", { name: "Open in editor" })).toBeInTheDocument();
     const download = screen.getByRole("link", { name: "Download DOCX" });
     expect(download.getAttribute("href")).toContain("/documents/doc-1/versions/v-2/docx");
+    expect(screen.getAllByText("Includes 1 review note.").length).toBeGreaterThan(0);
   });
 
   it("uploads a replacement file as the next active document version", async () => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -795,13 +795,21 @@ export function DocumentDetail({
             </div>
             <div className="flex flex-wrap items-start gap-2 text-sm" aria-label="Document commands">
               {selectedResolvedVersion && (
-                <a
-                  href={documentVersionDocxUrl(documentId, selectedResolvedVersion.id)}
-                  className="inline-flex items-center border border-ink bg-ink px-3 py-2 text-paper hover:bg-black"
-                  data-testid="document-download-edited-docx"
-                >
-                  Download edited DOCX
-                </a>
+                <div className="grid gap-1">
+                  <a
+                    href={documentVersionDocxUrl(documentId, selectedResolvedVersion.id)}
+                    className="inline-flex items-center border border-ink bg-ink px-3 py-2 text-paper hover:bg-black"
+                    data-testid="document-download-edited-docx"
+                  >
+                    Download edited DOCX
+                  </a>
+                  {comments.length > 0 && (
+                    <p className="text-[11px] leading-4 text-muted">
+                      Includes {comments.length} review{" "}
+                      {comments.length === 1 ? "note" : "notes"}.
+                    </p>
+                  )}
+                </div>
               )}
               <a
                 href={originalHref}
@@ -1137,6 +1145,7 @@ export function DocumentDetail({
                 documentId={documentId}
                 versions={versions}
                 selectedVersionId={selectedResolvedVersion?.id ?? null}
+                reviewNoteCount={comments.length}
                 onSelectVersion={(versionId) => openEditorVersion(versionId)}
                 onVersionRestored={refreshAfterVersionRestore}
               />

--- a/frontend/src/modules/document_edit/VersionTimeline.tsx
+++ b/frontend/src/modules/document_edit/VersionTimeline.tsx
@@ -42,6 +42,7 @@ type Props = {
   refreshKey?: number;
   versions?: DocumentVersionSummary[];
   selectedVersionId?: string | null;
+  reviewNoteCount?: number;
   onSelectVersion?: (versionId: string) => void;
   onVersionRestored?: () => void | Promise<void>;
 };
@@ -51,6 +52,7 @@ export function VersionTimeline({
   refreshKey = 0,
   versions: providedVersions,
   selectedVersionId,
+  reviewNoteCount = 0,
   onSelectVersion,
   onVersionRestored,
 }: Props) {
@@ -222,12 +224,20 @@ export function VersionTimeline({
                     </button>
                   )}
                   {hasEditableText && (
-                    <a
-                      href={documentVersionDocxUrl(documentId, s.version.id)}
-                      className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
-                    >
-                      Download DOCX
-                    </a>
+                    <div className="grid gap-1">
+                      <a
+                        href={documentVersionDocxUrl(documentId, s.version.id)}
+                        className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
+                      >
+                        Download DOCX
+                      </a>
+                      {reviewNoteCount > 0 && (
+                        <p className="text-[11px] leading-4 text-muted">
+                          Includes {reviewNoteCount} review{" "}
+                          {reviewNoteCount === 1 ? "note" : "notes"}.
+                        </p>
+                      )}
+                    </div>
                   )}
                   {hasOriginal && (
                     <>


### PR DESCRIPTION
## Summary
- show that edited DOCX downloads include document review notes
- carry the same note affordance into the saved-version timeline
- pin the behaviour in the document workbench test

## Local gates
- npm run typecheck
- npx vitest run src/matter/DocumentDetail.test.tsx src/modules/document_edit/VersionTimeline.test.tsx

## Scope
Frontend-only. Builds on PR #124, where the backend started including review notes in document-version DOCX exports.