### PR TITLE
documents: copy selected passage

### DIFF
--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -714,6 +714,9 @@ describe("DocumentRichEditor surface", () => {
   });
 
   it("surfaces the selected passage as a review-note action", async () => {
+    Object.assign(window.navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
     const onCreateNoteFromSelection = vi.fn();
     render(
       <DocumentRichEditor
@@ -733,6 +736,15 @@ describe("DocumentRichEditor surface", () => {
     );
     expect(screen.getByTestId("document-editor-selected-passage")).toHaveTextContent(
       "Anchored",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Copy passage" }));
+    await waitFor(() => {
+      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "single social-media post",
+      );
+    });
+    expect(screen.getByTestId("document-editor-copy-status")).toHaveTextContent(
+      "Copied selected passage",
     );
     fireEvent.click(screen.getByRole("button", { name: "Add review note" }));
     expect(onCreateNoteFromSelection).toHaveBeenCalledTimes(1);

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -965,6 +965,13 @@ export function DocumentRichEditor({
     window.setTimeout(() => setCopiedMessage(null), 2000);
   }
 
+  async function copySelectedQuote() {
+    if (!selectedQuote?.trim()) return;
+    await window.navigator.clipboard.writeText(selectedQuote.trim());
+    setCopiedMessage("Copied selected passage");
+    window.setTimeout(() => setCopiedMessage(null), 2000);
+  }
+
   function downloadWorkingText() {
     const blob = new Blob([plainText], { type: "text/plain;charset=utf-8" });
     const url = window.URL.createObjectURL(blob);
@@ -1523,11 +1530,18 @@ export function DocumentRichEditor({
                 <p className="mt-2 max-h-28 overflow-hidden text-xs leading-5 text-muted">
                   {selectedQuote}
                 </p>
+                <button
+                  type="button"
+                  onClick={() => void copySelectedQuote()}
+                  className="mt-3 w-full border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
+                >
+                  Copy passage
+                </button>
                 {onCreateNoteFromSelection && (
                   <button
                     type="button"
                     onClick={onCreateNoteFromSelection}
-                    className="mt-3 w-full border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
+                    className="mt-2 w-full border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
                   >
                     Add review note
                   </button>


### PR DESCRIPTION
## Summary
- add a Copy passage action to the selected-passage rail in the document editor
- reuse the existing copy-status feedback state
- pin the selected-passage copy behaviour in the editor test

## Local gates
- npm run typecheck
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx

## Scope
Frontend-only. This improves the document workbench selection flow without changing storage, comments, skills, or audit behaviour.