### PR TITLE
documents: scroll active find match

### DIFF
--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -661,6 +661,14 @@ describe("DocumentRichEditor surface", () => {
   });
 
   it("lets the reader move through find results", async () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        callback(0);
+        return 1;
+      });
     render(
       <DocumentRichEditor
         documentId="doc-1"
@@ -680,12 +688,14 @@ describe("DocumentRichEditor surface", () => {
       expect(document.querySelectorAll('[data-find-match="true"]')).toHaveLength(2);
       expect(document.querySelector('[data-find-match="active"]')).toHaveTextContent("Clause");
     });
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", inline: "nearest" });
     fireEvent.click(screen.getByRole("button", { name: "Next" }));
     expect(screen.getByTestId("document-editor-find-position")).toHaveTextContent("2 / 3");
     await waitFor(() => {
       expect(document.querySelectorAll('[data-find-match="true"]')).toHaveLength(2);
       expect(document.querySelector('[data-find-match="active"]')).toHaveTextContent("Clause");
     });
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
     fireEvent.click(screen.getByRole("button", { name: "Previous" }));
     expect(screen.getByTestId("document-editor-find-position")).toHaveTextContent("1 / 3");
     expect(screen.getByTestId("document-editor-find-preview")).toHaveTextContent(
@@ -695,6 +705,7 @@ describe("DocumentRichEditor surface", () => {
     expect(screen.getByTestId("document-editor-find-position")).toHaveTextContent("2 / 3");
     fireEvent.keyDown(screen.getByLabelText("Find"), { key: "Enter", shiftKey: true });
     expect(screen.getByTestId("document-editor-find-position")).toHaveTextContent("1 / 3");
+    requestAnimationFrame.mockRestore();
   });
 
   it("focuses document find with Cmd/Ctrl+F", async () => {

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -855,6 +855,13 @@ export function DocumentRichEditor({
         activeIndex,
       } satisfies FindDecorationState),
     );
+    if (findQuery.trim().length >= 3 && findMatches.length > 0) {
+      window.requestAnimationFrame(() => {
+        editor.view.dom
+          .querySelector('[data-find-match="active"]')
+          ?.scrollIntoView({ block: "center", inline: "nearest" });
+      });
+    }
   }, [activeFindIndex, editor, findMatches.length, findQuery]);
 
   async function save(): Promise<DocumentVersionRead | null> {


### PR DESCRIPTION
## Summary
- scroll the active document Find match into view when search results or active index changes
- pin the behaviour in the existing editor find test

## Local gates
- npm run typecheck
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx

## Scope
Frontend-only. Builds on the ProseMirror find-highlighting work and keeps search usable in long documents.