### PR TITLE
documents: edit open review notes

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -905,6 +905,10 @@ class DocumentCommentCreate(BaseModel):
     anchor_end: int | None = Field(default=None, ge=0)
 
 
+class DocumentCommentUpdate(BaseModel):
+    body: str = Field(min_length=2, max_length=4000)
+
+
 async def _resolve_one(
     document_id_unused: None,
     edit_id: uuid.UUID,
@@ -2043,6 +2047,59 @@ async def post_document_comment(
             "anchor_end": comment.anchor_end,
         },
     )
+    await session.commit()
+    return DocumentCommentRead.model_validate(comment)
+
+
+@router.patch(
+    "/{document_id}/comments/{comment_id}",
+    response_model=DocumentCommentRead,
+)
+async def patch_document_comment(
+    document_id: uuid.UUID,
+    comment_id: uuid.UUID,
+    body: DocumentCommentUpdate,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentCommentRead:
+    """Update the body of an open document review note."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    comment = await session.scalar(
+        select(DocumentComment).where(
+            DocumentComment.id == comment_id,
+            DocumentComment.document_id == doc.id,
+        )
+    )
+    if comment is None:
+        raise HTTPException(404, "document comment not found")
+    if comment.status == COMMENT_STATUS_RESOLVED:
+        raise HTTPException(
+            409,
+            {
+                "error": "document_comment_resolved",
+                "message": "Resolved review notes cannot be edited.",
+            },
+        )
+    next_body = body.body.strip()
+    if len(next_body) < 2:
+        raise HTTPException(422, "comment body is required")
+    if next_body != comment.body:
+        previous_length = len(comment.body)
+        comment.body = next_body
+        await audit.log(
+            session,
+            "document.comment.updated",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="document_editor",
+            resource_type="document_comment",
+            resource_id=str(comment.id),
+            payload={
+                "document_id": str(doc.id),
+                "previous_length": previous_length,
+                "next_length": len(next_body),
+            },
+        )
     await session.commit()
     return DocumentCommentRead.model_validate(comment)
 

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -128,12 +128,25 @@ async def test_document_comments_owner_can_create_list_and_resolve(client) -> No
     assert listed.status_code == 200, listed.text
     assert [row["id"] for row in listed.json()] == [comment["id"]]
 
+    updated = await client.patch(
+        f"/api/documents/{doc_id}/comments/{comment['id']}",
+        json={"body": "Checked against the source and updated for clarity."},
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["body"] == "Checked against the source and updated for clarity."
+
     resolved = await client.post(
         f"/api/documents/{doc_id}/comments/{comment['id']}/resolve",
     )
     assert resolved.status_code == 200, resolved.text
     assert resolved.json()["status"] == "resolved"
     assert resolved.json()["resolved_at"] is not None
+
+    edit_resolved = await client.patch(
+        f"/api/documents/{doc_id}/comments/{comment['id']}",
+        json={"body": "Too late to edit."},
+    )
+    assert edit_resolved.status_code == 409, edit_resolved.text
 
 
 @pytest.mark.asyncio
@@ -198,6 +211,11 @@ async def test_document_comments_cross_user_returns_404(client) -> None:
         f"/api/documents/{doc_id}/comments/{comment_id}/resolve",
     )
     assert resolved.status_code == 404, resolved.text
+    updated = await client.patch(
+        f"/api/documents/{doc_id}/comments/{comment_id}",
+        json={"body": "Cross-user edit."},
+    )
+    assert updated.status_code == 404, updated.text
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2005,6 +2005,22 @@ export const createDocumentComment = (
     body: JSON.stringify(payload),
   }).then((r) => resolutionJsonOrThrow<DocumentCommentRead>(r));
 
+export const updateDocumentComment = (
+  documentId: string,
+  commentId: string,
+  payload: { body: string },
+) =>
+  apiFetch(
+    `${API}/documents/${encodeURIComponent(documentId)}/comments/${encodeURIComponent(
+      commentId,
+    )}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  ).then((r) => resolutionJsonOrThrow<DocumentCommentRead>(r));
+
 export const resolveDocumentComment = (documentId: string, commentId: string) =>
   apiFetch(
     `${API}/documents/${encodeURIComponent(documentId)}/comments/${encodeURIComponent(

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -828,6 +828,22 @@ describe("DocumentDetail", () => {
         resolved_by_id: null,
       },
     ]);
+    const update = vi
+      .spyOn(api, "updateDocumentComment")
+      .mockResolvedValue({
+        id: "comment-1",
+        document_id: "doc-1",
+        author_id: "u-1",
+        quote_text: null,
+        body_sha256: null,
+        anchor_start: null,
+        anchor_end: null,
+        body: "Edited after checking the source.",
+        status: "open",
+        created_at: "2026-06-03T10:00:00",
+        resolved_at: null,
+        resolved_by_id: null,
+      });
     const resolve = vi
       .spyOn(api, "resolveDocumentComment")
       .mockResolvedValue({
@@ -847,6 +863,16 @@ describe("DocumentDetail", () => {
 
     mount();
     await screen.findByText("Resolve after checking the source.");
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText("Edit note"), {
+      target: { value: "Edited after checking the source." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith("doc-1", "comment-1", {
+        body: "Edited after checking the source.",
+      });
+    });
     fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
 
     await waitFor(() => {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -33,6 +33,7 @@ import {
   readArtifact,
   resolveDocumentComment,
   startDocumentEditSession,
+  updateDocumentComment,
   uploadDocumentVersion,
   type ArtifactRead,
   type AnonymisationResult,
@@ -199,6 +200,8 @@ export function DocumentDetail({
   const [activeReaderQuote, setActiveReaderQuote] = useState<string | null>(null);
   const [commentError, setCommentError] = useState<string | null>(null);
   const [commentBusy, setCommentBusy] = useState(false);
+  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
+  const [editingCommentBody, setEditingCommentBody] = useState("");
   const [versionUploadFile, setVersionUploadFile] = useState<File | null>(null);
   const [versionUploadNotes, setVersionUploadNotes] = useState("");
   const [versionUploadBusy, setVersionUploadBusy] = useState(false);
@@ -608,6 +611,34 @@ export function DocumentDetail({
       loadComments();
     } catch (err) {
       setCommentError(err instanceof Error ? err.message : "Could not resolve note.");
+    } finally {
+      setCommentBusy(false);
+    }
+  };
+  const startEditingComment = (comment: DocumentCommentRead) => {
+    setEditingCommentId(comment.id);
+    setEditingCommentBody(comment.body);
+    setCommentError(null);
+  };
+  const cancelEditingComment = () => {
+    setEditingCommentId(null);
+    setEditingCommentBody("");
+  };
+  const submitCommentEdit = async (commentId: string) => {
+    const trimmed = editingCommentBody.trim();
+    if (trimmed.length < 2) {
+      setCommentError("Add a note before saving.");
+      return;
+    }
+    setCommentBusy(true);
+    setCommentError(null);
+    try {
+      await updateDocumentComment(documentId, commentId, { body: trimmed });
+      setEditingCommentId(null);
+      setEditingCommentBody("");
+      loadComments();
+    } catch (err) {
+      setCommentError(err instanceof Error ? err.message : "Could not update note.");
     } finally {
       setCommentBusy(false);
     }
@@ -1860,17 +1891,59 @@ export function DocumentDetail({
                         </button>
                       </div>
                     )}
-                    <p className="leading-6 text-ink">{comment.body}</p>
+                    {editingCommentId === comment.id ? (
+                      <div className="space-y-2">
+                        <label className="grid gap-1 text-xs font-semibold uppercase tracking-track2 text-muted">
+                          Edit note
+                          <textarea
+                            value={editingCommentBody}
+                            onChange={(event) => setEditingCommentBody(event.target.value)}
+                            rows={3}
+                            className="w-full resize-y border border-rule bg-paper px-3 py-2 font-sans text-sm font-normal normal-case tracking-normal text-ink outline-none focus:border-ink"
+                          />
+                        </label>
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            disabled={commentBusy}
+                            onClick={() => submitCommentEdit(comment.id)}
+                            className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            Save changes
+                          </button>
+                          <button
+                            type="button"
+                            disabled={commentBusy}
+                            onClick={cancelEditingComment}
+                            className="border border-rule px-3 py-2 text-xs font-semibold text-muted hover:border-ink hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="leading-6 text-ink">{comment.body}</p>
+                    )}
                     <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted">
                       <span>{comment.created_at.replace("T", " ").slice(0, 16)}</span>
-                      <button
-                        type="button"
-                        disabled={commentBusy}
-                        onClick={() => resolveComment(comment.id)}
-                        className="underline underline-offset-4 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        Resolve
-                      </button>
+                      <div className="flex items-center gap-3">
+                        <button
+                          type="button"
+                          disabled={commentBusy}
+                          onClick={() => startEditingComment(comment)}
+                          className="underline underline-offset-4 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          disabled={commentBusy}
+                          onClick={() => resolveComment(comment.id)}
+                          className="underline underline-offset-4 hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Resolve
+                        </button>
+                      </div>
                     </div>
                   </article>
                 ))}


### PR DESCRIPTION
## Summary
- add owner-scoped PATCH /api/documents/{id}/comments/{comment_id} for open review-note body edits
- reject edits to resolved notes and audit body updates without storing note text in the audit payload
- add inline edit controls for open document review notes

## Local gates
- python3 -m py_compile backend/app/api/documents.py backend/tests/test_route_acl_sweep.py
- npm run typecheck
- npx vitest run src/matter/DocumentDetail.test.tsx

## Scope
No anchor mutation, no quote mutation, no resolved-note editing, no document schema migration.