### PR TITLE
documents: reopen resolved review notes

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -2142,6 +2142,44 @@ async def post_resolve_document_comment(
     return DocumentCommentRead.model_validate(comment)
 
 
+@router.post(
+    "/{document_id}/comments/{comment_id}/reopen",
+    response_model=DocumentCommentRead,
+)
+async def post_reopen_document_comment(
+    document_id: uuid.UUID,
+    comment_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentCommentRead:
+    """Reopen a resolved document review note."""
+    doc, matter = await _load_owned_document(document_id, session, user)
+    comment = await session.scalar(
+        select(DocumentComment).where(
+            DocumentComment.id == comment_id,
+            DocumentComment.document_id == doc.id,
+        )
+    )
+    if comment is None:
+        raise HTTPException(404, "document comment not found")
+    if comment.status == COMMENT_STATUS_RESOLVED:
+        comment.status = COMMENT_STATUS_OPEN
+        comment.resolved_at = None
+        comment.resolved_by_id = None
+        await audit.log(
+            session,
+            "document.comment.reopened",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="document_editor",
+            resource_type="document_comment",
+            resource_id=str(comment.id),
+            payload={"document_id": str(doc.id)},
+        )
+    await session.commit()
+    return DocumentCommentRead.model_validate(comment)
+
+
 def _result_from_redacted(body: DocumentBody) -> AnonymisationResult:
     """Reconstruct an AnonymisationResult from the persisted redacted body."""
     tokens: list[TokenMapping] = []

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -106,8 +106,8 @@ async def test_get_document_versions_cross_user_returns_404(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_document_comments_owner_can_create_list_and_resolve(client) -> None:
-    """Owner can leave and resolve review notes on a document."""
+async def test_document_comments_owner_can_create_list_resolve_and_reopen(client) -> None:
+    """Owner can leave, resolve, and reopen review notes on a document."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
     _, doc_id = await _create_matter_and_upload(client)
 
@@ -147,6 +147,21 @@ async def test_document_comments_owner_can_create_list_and_resolve(client) -> No
         json={"body": "Too late to edit."},
     )
     assert edit_resolved.status_code == 409, edit_resolved.text
+
+    reopened = await client.post(
+        f"/api/documents/{doc_id}/comments/{comment['id']}/reopen",
+    )
+    assert reopened.status_code == 200, reopened.text
+    assert reopened.json()["status"] == "open"
+    assert reopened.json()["resolved_at"] is None
+    assert reopened.json()["resolved_by_id"] is None
+
+    edit_reopened = await client.patch(
+        f"/api/documents/{doc_id}/comments/{comment['id']}",
+        json={"body": "Reopened and edited."},
+    )
+    assert edit_reopened.status_code == 200, edit_reopened.text
+    assert edit_reopened.json()["body"] == "Reopened and edited."
 
 
 @pytest.mark.asyncio
@@ -211,6 +226,10 @@ async def test_document_comments_cross_user_returns_404(client) -> None:
         f"/api/documents/{doc_id}/comments/{comment_id}/resolve",
     )
     assert resolved.status_code == 404, resolved.text
+    reopened = await client.post(
+        f"/api/documents/{doc_id}/comments/{comment_id}/reopen",
+    )
+    assert reopened.status_code == 404, reopened.text
     updated = await client.patch(
         f"/api/documents/{doc_id}/comments/{comment_id}",
         json={"body": "Cross-user edit."},
@@ -847,6 +866,10 @@ async def test_document_comments_archived_matter_returns_404(client) -> None:
         f"/api/documents/{doc_id}/comments/{comment_id}/resolve",
     )
     assert resolved.status_code == 404, resolved.text
+    reopened = await client.post(
+        f"/api/documents/{doc_id}/comments/{comment_id}/reopen",
+    )
+    assert reopened.status_code == 404, reopened.text
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2029,6 +2029,14 @@ export const resolveDocumentComment = (documentId: string, commentId: string) =>
     { method: "POST" },
   ).then((r) => resolutionJsonOrThrow<DocumentCommentRead>(r));
 
+export const reopenDocumentComment = (documentId: string, commentId: string) =>
+  apiFetch(
+    `${API}/documents/${encodeURIComponent(documentId)}/comments/${encodeURIComponent(
+      commentId,
+    )}/reopen`,
+    { method: "POST" },
+  ).then((r) => resolutionJsonOrThrow<DocumentCommentRead>(r));
+
 // ----- Auth + user --------------------------------------------------------
 // Auth endpoints live in `./api/auth` (sit at backend origin, NOT under
 // /api). Re-exported here so `../lib/api` consumers keep working.

--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -860,7 +860,6 @@ describe("DocumentDetail", () => {
         resolved_at: "2026-06-03T10:10:00",
         resolved_by_id: "u-1",
       });
-
     mount();
     await screen.findByText("Resolve after checking the source.");
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
@@ -877,6 +876,54 @@ describe("DocumentDetail", () => {
 
     await waitFor(() => {
       expect(resolve).toHaveBeenCalledWith("doc-1", "comment-1");
+    });
+  });
+
+  it("reopens resolved document review notes", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
+    vi.spyOn(api, "getDocumentComments").mockResolvedValue([
+      {
+        id: "comment-1",
+        document_id: "doc-1",
+        author_id: "u-1",
+        quote_text: null,
+        body_sha256: null,
+        anchor_start: null,
+        anchor_end: null,
+        body: "Resolve after checking the source.",
+        status: "resolved",
+        created_at: "2026-06-03T10:00:00",
+        resolved_at: "2026-06-03T10:10:00",
+        resolved_by_id: "u-1",
+      },
+    ]);
+    const reopen = vi
+      .spyOn(api, "reopenDocumentComment")
+      .mockResolvedValue({
+        id: "comment-1",
+        document_id: "doc-1",
+        author_id: "u-1",
+        quote_text: null,
+        body_sha256: null,
+        anchor_start: null,
+        anchor_end: null,
+        body: "Resolve after checking the source.",
+        status: "open",
+        created_at: "2026-06-03T10:00:00",
+        resolved_at: null,
+        resolved_by_id: null,
+      });
+
+    mount();
+    await waitFor(() => {
+      expect(screen.getByText(/Resolved notes \(1\)/)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText(/Resolved notes \(1\)/));
+    fireEvent.click(screen.getByRole("button", { name: "Reopen" }));
+
+    await waitFor(() => {
+      expect(reopen).toHaveBeenCalledWith("doc-1", "comment-1");
     });
   });
 

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -31,6 +31,7 @@ import {
   listDocuments,
   listInstalledModules,
   readArtifact,
+  reopenDocumentComment,
   resolveDocumentComment,
   startDocumentEditSession,
   updateDocumentComment,
@@ -611,6 +612,18 @@ export function DocumentDetail({
       loadComments();
     } catch (err) {
       setCommentError(err instanceof Error ? err.message : "Could not resolve note.");
+    } finally {
+      setCommentBusy(false);
+    }
+  };
+  const reopenComment = async (commentId: string) => {
+    setCommentBusy(true);
+    setCommentError(null);
+    try {
+      await reopenDocumentComment(documentId, commentId);
+      loadComments();
+    } catch (err) {
+      setCommentError(err instanceof Error ? err.message : "Could not reopen note.");
     } finally {
       setCommentBusy(false);
     }
@@ -1980,6 +1993,14 @@ export function DocumentDetail({
                                 Find in document
                               </button>
                             )}
+                            <button
+                              type="button"
+                              disabled={commentBusy}
+                              onClick={() => reopenComment(comment.id)}
+                              className="font-medium text-ink underline underline-offset-4 hover:text-muted disabled:cursor-not-allowed disabled:text-muted"
+                            >
+                              Reopen
+                            </button>
                           </div>
                         </article>
                       ))}


### PR DESCRIPTION
## Summary
- add an owner-scoped POST /api/documents/{document_id}/comments/{comment_id}/reopen endpoint
- audit document.comment.reopened without exposing note body text
- add a Reopen action to resolved review notes in the document workbench

## Validation
- python3 -m py_compile backend/app/api/documents.py backend/tests/test_route_acl_sweep.py
- npm run typecheck
- npx vitest run src/matter/DocumentDetail.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now reopen previously resolved document review comments, enabling them to revisit, modify, or add additional feedback to closed reviews. This provides flexibility in the review workflow.

* **Tests**
  * Expanded test coverage to verify the reopen functionality works correctly and properly enforces access control permissions across different user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->