### PR TITLE
documents: run skills on selected passages

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -128,10 +128,86 @@ function versionSummary(
   };
 }
 
+function mockReadyDocumentSkill() {
+  vi.spyOn(api, "listInstalledModules").mockResolvedValue([
+    {
+      module_id: "demo.guided-skill",
+      version: "0.1.0",
+      publisher: "legalise",
+      visibility: "first_party",
+      signature_status: "verified",
+      enabled: true,
+      installed_at: "2026-01-01T00:00:00",
+      installed_by_user_id: null,
+    },
+  ]);
+  vi.spyOn(api, "getModulesV2").mockResolvedValue({
+    modules: [
+      {
+        module_id: "demo.guided-skill",
+        source_kind: "v2",
+        manifest: {
+          name: "Demo skill",
+          description: "Summarises the selected file.",
+          capabilities: [
+            {
+              id: "summarise",
+              kind: "skill",
+              scope: "matter",
+              reads: ["document.body.read"],
+              writes: ["matter.artifact.write"],
+              model_access: "required",
+              ui: {
+                label: "Plain-English Summary",
+                default_request: "Summarise {filename}.",
+              },
+            },
+          ],
+        },
+        is_valid: true,
+        validation_errors: [],
+      },
+    ],
+    ui_slots: [],
+  });
+  vi.spyOn(api, "listGrants").mockResolvedValue({
+    matter_id: "m-1",
+    grants: [
+      {
+        id: "g-1",
+        plugin: "demo.guided-skill",
+        skill: "summarise",
+        capability: "document.body.read",
+        scope_type: "matter",
+        scope_id: "m-1",
+        granted_at: "2026-01-01T00:00:00",
+      },
+      {
+        id: "g-2",
+        plugin: "demo.guided-skill",
+        skill: "summarise",
+        capability: "matter.artifact.write",
+        scope_type: "matter",
+        scope_id: "m-1",
+        granted_at: "2026-01-01T00:00:00",
+      },
+    ],
+  });
+}
+
 async function expectEditorText(container: HTMLElement, text: string) {
   await waitFor(() => {
     expect(container.querySelector(".legalise-document-editor")).toHaveTextContent(text);
   });
+}
+
+async function editorTextNode(content: HTMLElement): Promise<ChildNode> {
+  let node: ChildNode | undefined;
+  await waitFor(() => {
+    node = content.querySelector(".legalise-document-editor")?.firstChild ?? undefined;
+    expect(node).toBeTruthy();
+  });
+  return node as ChildNode;
 }
 
 beforeEach(() => {
@@ -540,70 +616,7 @@ describe("DocumentDetail", () => {
   it("runs ready document skills from the document workbench", async () => {
     vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
     vi.spyOn(api, "getDocumentBody").mockResolvedValue(body());
-    vi.spyOn(api, "listInstalledModules").mockResolvedValue([
-      {
-        module_id: "demo.guided-skill",
-        version: "0.1.0",
-        publisher: "legalise",
-        visibility: "first_party",
-        signature_status: "verified",
-        enabled: true,
-        installed_at: "2026-01-01T00:00:00",
-        installed_by_user_id: null,
-      },
-    ]);
-    vi.spyOn(api, "getModulesV2").mockResolvedValue({
-      modules: [
-        {
-          module_id: "demo.guided-skill",
-          source_kind: "v2",
-          manifest: {
-            name: "Demo skill",
-            description: "Summarises the selected file.",
-            capabilities: [
-              {
-                id: "summarise",
-                kind: "skill",
-                scope: "matter",
-                reads: ["document.body.read"],
-                writes: ["matter.artifact.write"],
-                model_access: "required",
-                ui: {
-                  label: "Plain-English Summary",
-                  default_request: "Summarise {filename}.",
-                },
-              },
-            ],
-          },
-          is_valid: true,
-          validation_errors: [],
-        },
-      ],
-      ui_slots: [],
-    });
-    vi.spyOn(api, "listGrants").mockResolvedValue({
-      matter_id: "m-1",
-      grants: [
-        {
-          id: "g-1",
-          plugin: "demo.guided-skill",
-          skill: "summarise",
-          capability: "document.body.read",
-          scope_type: "matter",
-          scope_id: "m-1",
-          granted_at: "2026-01-01T00:00:00",
-        },
-        {
-          id: "g-2",
-          plugin: "demo.guided-skill",
-          skill: "summarise",
-          capability: "matter.artifact.write",
-          scope_type: "matter",
-          scope_id: "m-1",
-          granted_at: "2026-01-01T00:00:00",
-        },
-      ],
-    });
+    mockReadyDocumentSkill();
     vi.spyOn(api, "invokeCapability").mockResolvedValue({
       invocation_id: "inv-1",
       module_id: "demo.guided-skill",
@@ -655,6 +668,75 @@ describe("DocumentDetail", () => {
     expect(screen.getByTestId("document-output-links")).toHaveTextContent(
       "1 signed output cites this file",
     );
+  });
+
+  it("runs a ready document skill against a selected passage", async () => {
+    vi.spyOn(api, "listDocuments").mockResolvedValue([doc()]);
+    vi.spyOn(api, "getDocumentBody").mockResolvedValue(
+      body({
+        extracted_text: "The dismissal letter mentioned a single social-media post.",
+        char_count: 60,
+      }),
+    );
+    mockReadyDocumentSkill();
+    const invoke = vi.spyOn(api, "invokeCapability").mockResolvedValue({
+      invocation_id: "inv-1",
+      module_id: "demo.guided-skill",
+      capability_id: "summarise",
+      matter_id: "m-1",
+      result: { artifact_id: "art-1" },
+    });
+    vi.spyOn(api, "readArtifact").mockResolvedValue({
+      id: "art-1",
+      matter_id: "m-1",
+      module_id: "demo.guided-skill",
+      capability_id: "summarise",
+      invocation_id: "inv-1",
+      kind: "skill_response",
+      created_by_id: "u-1",
+      created_at: "2026-06-03T10:00:00",
+      size_bytes: 123,
+      payload: { output: "Summary" },
+    });
+
+    mount();
+    const content = await screen.findByTestId("document-content");
+    const textNode = await editorTextNode(content);
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "single social-media post",
+      anchorNode: textNode,
+      focusNode: textNode,
+    } as unknown as Selection);
+    fireEvent.mouseUp(content);
+    expect(await screen.findByTestId("document-selected-quote")).toHaveTextContent(
+      "single social-media post",
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Run skill on passage" }));
+
+    const expectedRequest = [
+      "Use this selected passage from claim-form.pdf:",
+      "",
+      '"single social-media post"',
+      "",
+      "Run Plain-English Summary.",
+    ].join("\n");
+    expect(screen.getAllByRole("textbox")[0]).toHaveValue(expectedRequest);
+    fireEvent.click(screen.getByTestId("generic-run-demo.guided-skill-summarise"));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        "khan",
+        expect.objectContaining({
+          module_id: "demo.guided-skill",
+          capability_id: "summarise",
+          args: expect.objectContaining({
+            input: expectedRequest,
+            document_id: "doc-1",
+          }),
+        }),
+      );
+    });
   });
 
   it("shows document review notes and lets the user add one", async () => {
@@ -775,8 +857,7 @@ describe("DocumentDetail", () => {
 
     mount();
     const content = await screen.findByTestId("document-content");
-    const textNode = content.querySelector(".legalise-document-editor")?.firstChild;
-    expect(textNode).toBeTruthy();
+    const textNode = await editorTextNode(content);
     vi.spyOn(window, "getSelection").mockReturnValue({
       toString: () => "single social-media post",
       anchorNode: textNode,

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -224,6 +224,9 @@ export function DocumentDetail({
     useState<"loading" | "ready" | "error">("loading");
   const [activeRunnerSkill, setActiveRunnerSkill] =
     useState<RunnableMatterSkill | null>(null);
+  const [runnerInitialInput, setRunnerInitialInput] = useState<string | undefined>(
+    undefined,
+  );
   const [documentArtifacts, setDocumentArtifacts] = useState<ArtifactRead[] | null>(null);
   const workbenchRef = useRef<HTMLDivElement | null>(null);
   const notesRef = useRef<HTMLElement | null>(null);
@@ -696,6 +699,24 @@ export function DocumentDetail({
       notesRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
     });
   };
+  const selectedPassageRequest = (skill: RunnableMatterSkill): string | undefined => {
+    const trimmed = selectedQuote.trim().replace(/\s+/g, " ");
+    if (!trimmed) return undefined;
+    return [
+      `Use this selected passage from ${doc?.filename ?? "the document"}:`,
+      "",
+      `"${trimmed}"`,
+      "",
+      `Run ${skill.title}.`,
+    ].join("\n");
+  };
+  const openDocumentSkill = (skill: RunnableMatterSkill, useSelection = false) => {
+    setRunnerInitialInput(useSelection ? selectedPassageRequest(skill) : undefined);
+    setActiveRunnerSkill(skill);
+    requestAnimationFrame(() => {
+      skillsRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
+    });
+  };
   const submitVersionUpload = async () => {
     if (!versionUploadFile) {
       setVersionUploadError("Choose a file to upload as the next version.");
@@ -760,12 +781,7 @@ export function DocumentDetail({
             title: `${primaryDocumentSkill.title} is ready for this file.`,
             body: "Run a governed skill with this document selected, then review and sign the output.",
             action: "Run with this file",
-            onClick: () => {
-              setActiveRunnerSkill(primaryDocumentSkill);
-              requestAnimationFrame(() => {
-                skillsRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
-              });
-            },
+            onClick: () => openDocumentSkill(primaryDocumentSkill),
           }
         : openComments.length > 0
           ? {
@@ -1320,10 +1336,7 @@ export function DocumentDetail({
                   <button
                     type="button"
                     onClick={() => {
-                      if (primaryDocumentSkill) setActiveRunnerSkill(primaryDocumentSkill);
-                      requestAnimationFrame(() => {
-                        skillsRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
-                      });
+                      if (primaryDocumentSkill) openDocumentSkill(primaryDocumentSkill);
                     }}
                     className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left text-sm hover:bg-paper-sunken"
                   >
@@ -1468,10 +1481,14 @@ export function DocumentDetail({
               {activeRunnerSkill ? (
                 <div className="mt-4">
                   <GenericSkillRunner
+                    key={`${activeRunnerSkill.moduleId}:${activeRunnerSkill.capabilityId}:${
+                      runnerInitialInput ?? "document"
+                    }`}
                     slug={slug}
                     skill={activeRunnerSkill}
                     documents={[doc]}
                     initialDocumentIds={[documentId]}
+                    initialInput={runnerInitialInput}
                     onRunComplete={(_response, artifacts) => {
                       const related = artifacts.filter((artifact) =>
                         artifactReferencesDocument(artifact, documentId),
@@ -1485,7 +1502,10 @@ export function DocumentDetail({
                         ];
                       });
                     }}
-                    onClose={() => setActiveRunnerSkill(null)}
+                    onClose={() => {
+                      setActiveRunnerSkill(null);
+                      setRunnerInitialInput(undefined);
+                    }}
                     compact
                   />
                 </div>
@@ -1511,12 +1531,7 @@ export function DocumentDetail({
                   {primaryDocumentSkill && (
                     <button
                       type="button"
-                      onClick={() => {
-                        setActiveRunnerSkill(primaryDocumentSkill);
-                        requestAnimationFrame(() => {
-                          skillsRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
-                        });
-                      }}
+                      onClick={() => openDocumentSkill(primaryDocumentSkill)}
                       className="w-full border border-ink bg-paper px-3 py-3 text-left hover:bg-paper-sunken"
                     >
                       <span className="flex items-start justify-between gap-3">
@@ -1552,15 +1567,7 @@ export function DocumentDetail({
                           <button
                             key={`${skill.moduleId}:${skill.capabilityId}`}
                             type="button"
-                            onClick={() => {
-                              setActiveRunnerSkill(skill);
-                              requestAnimationFrame(() => {
-                                skillsRef.current?.scrollIntoView?.({
-                                  block: "start",
-                                  behavior: "smooth",
-                                });
-                              });
-                            }}
+                            onClick={() => openDocumentSkill(skill)}
                             className="w-full border border-rule bg-paper px-3 py-2 text-left hover:border-ink"
                           >
                             <span className="block text-sm font-semibold text-ink">
@@ -1828,13 +1835,24 @@ export function DocumentDetail({
                           ? "This note will stay anchored to the current document text."
                           : "This passage can be quoted, but its exact text position was not found."}
                       </p>
-                      <button
-                        type="button"
-                        onClick={() => setCommentQuote(selectedQuote)}
-                        className="mt-3 border border-rule bg-paper px-3 py-2 text-xs font-medium text-ink hover:border-ink"
-                      >
-                        Quote this passage
-                      </button>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setCommentQuote(selectedQuote)}
+                          className="border border-rule bg-paper px-3 py-2 text-xs font-medium text-ink hover:border-ink"
+                        >
+                          Quote this passage
+                        </button>
+                        {primaryDocumentSkill && (
+                          <button
+                            type="button"
+                            onClick={() => openDocumentSkill(primaryDocumentSkill, true)}
+                            className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-black"
+                          >
+                            Run skill on passage
+                          </button>
+                        )}
+                      </div>
                     </div>
                   )}
                   <label className="grid gap-1 text-xs font-semibold uppercase tracking-track2 text-muted">


### PR DESCRIPTION
## Summary
- add selected-passage requests to the document workbench skill runner
- route all document skill launches through one generic helper
- keep the same canonical invokeCapability path, with the current document selected

## Validation
- npm run typecheck
- npx vitest run src/matter/DocumentDetail.test.tsx
- npm run build

## Scope
Frontend-only. No backend, no skill-specific branches, no schema changes.