### PR TITLE
documents: surface review note navigator

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -4,7 +4,7 @@
 // body-missing state is honest, and deep metadata sits behind Details.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -794,6 +794,18 @@ describe("DocumentDetail", () => {
     expect(await screen.findByTestId("document-comments")).toHaveTextContent(
       "Check the context before relying on this.",
     );
+    expect(await screen.findByTestId("document-note-navigator")).toHaveTextContent(
+      "1 open note on this file.",
+    );
+    expect(screen.getByTestId("document-note-navigator")).toHaveTextContent(
+      "Check the context before relying on this.",
+    );
+    fireEvent.click(
+      within(screen.getByTestId("document-note-navigator")).getByRole("button", {
+        name: /Note 1/i,
+      }),
+    );
+    expect(screen.getByTestId("document-content")).toBeInTheDocument();
     expect(screen.getByTestId("document-comments")).toHaveTextContent("Open");
     expect(screen.getByTestId("document-comments")).toHaveTextContent("Anchored");
     expect(screen.getByTestId("document-comments")).toHaveTextContent("Resolved");
@@ -940,9 +952,12 @@ describe("DocumentDetail", () => {
         created_at: "2026-06-03T10:00:00",
         resolved_at: "2026-06-03T10:10:00",
         resolved_by_id: "u-1",
-      });
+    });
     mount();
-    await screen.findByText("Resolve after checking the source.");
+    await screen.findByTestId("document-comments");
+    expect(screen.getByTestId("document-comments")).toHaveTextContent(
+      "Resolve after checking the source.",
+    );
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     fireEvent.change(screen.getByLabelText("Edit note"), {
       target: { value: "Edited after checking the source." },

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -89,6 +89,12 @@ function formatBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(1)} MB`;
 }
 
+function compactText(value: string | null | undefined, max = 96): string {
+  const compact = (value ?? "").trim().replace(/\s+/g, " ");
+  if (compact.length <= max) return compact;
+  return `${compact.slice(0, max - 3).trimEnd()}...`;
+}
+
 type DocQuery =
   | { status: "loading" }
   | { status: "ready"; doc: MatterDocument }
@@ -666,7 +672,7 @@ export function DocumentDetail({
     setCompareVersionId(EXTRACTED_VERSION_ID);
     setWorkbenchView("editor");
     requestAnimationFrame(() => {
-      workbenchRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+      workbenchRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" });
     });
   };
   const startQuotedNote = (quote: string) => {
@@ -1040,43 +1046,111 @@ export function DocumentDetail({
             )}
 
             {workbenchView === "editor" && (
-            <div data-testid="document-content">
-              {bodyMissing && !selectedResolvedVersion ? (
-                <div className="p-6">
-                  <EmptyState
-                    title="No extracted text"
-                    body="No extracted body is available for this document (extraction may have failed or not run). The original file is still available."
-                  />
+              <div className="space-y-3">
+                {openComments.length > 0 && (
+                  <section
+                    className="border border-rule bg-paper p-3"
+                    data-testid="document-note-navigator"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                          Review notes
+                        </p>
+                        <p className="mt-1 text-sm font-semibold text-ink">
+                          {openComments.length} open note
+                          {openComments.length === 1 ? "" : "s"} on this file.
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          notesRef.current?.scrollIntoView?.({
+                            block: "start",
+                            behavior: "smooth",
+                          })
+                        }
+                        className="border border-rule px-3 py-2 text-xs font-semibold text-muted hover:border-ink hover:text-ink"
+                      >
+                        Manage notes
+                      </button>
+                    </div>
+                    <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                      {openComments.slice(0, 4).map((comment, index) => (
+                        <button
+                          key={comment.id}
+                          type="button"
+                          onClick={() => {
+                            if (comment.quote_text) jumpToCommentQuote(comment.quote_text);
+                            else {
+                              notesRef.current?.scrollIntoView?.({
+                                block: "start",
+                                behavior: "smooth",
+                              });
+                            }
+                          }}
+                          className="border border-rule bg-paper-sunken px-3 py-2 text-left text-sm hover:border-ink"
+                        >
+                          <span className="text-[10px] font-semibold uppercase tracking-track2 text-muted">
+                            Note {index + 1}
+                          </span>
+                          <span className="mt-1 block font-medium text-ink">
+                            {compactText(comment.body, 72)}
+                          </span>
+                          {comment.quote_text && (
+                            <span className="mt-1 block text-xs text-muted">
+                              Quote: {compactText(comment.quote_text, 72)}
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                    {openComments.length > 4 && (
+                      <p className="mt-2 text-xs text-muted">
+                        {openComments.length - 4} more open note
+                        {openComments.length - 4 === 1 ? "" : "s"} in the review rail.
+                      </p>
+                    )}
+                  </section>
+                )}
+                <div data-testid="document-content">
+                  {bodyMissing && !selectedResolvedVersion ? (
+                    <div className="p-6">
+                      <EmptyState
+                        title="No extracted text"
+                        body="No extracted body is available for this document (extraction may have failed or not run). The original file is still available."
+                      />
+                    </div>
+                  ) : !body && !selectedResolvedVersion ? (
+                    <div className="border border-rule bg-paper p-6">
+                      <LoadingLine label="loading document text" />
+                    </div>
+                  ) : (
+                    <DocumentRichEditor
+                      documentId={documentId}
+                      filename={doc.filename}
+                      initialText={editorText}
+                      initialJson={editorJson}
+                      latestVersionNumber={latestVersion?.version_number}
+                      latestVersionId={latestVersion?.id ?? null}
+                      originalMimeType={doc.mime_type}
+                      sourceLabel={editorSourceLabel}
+                      sourceHighlight={currentReaderQuote}
+                      noteHighlights={anchoredOpenNotes}
+                      selectedQuote={selectedQuote || undefined}
+                      selectedQuoteAnchored={Boolean(selectedAnchor)}
+                      onCreateNoteFromSelection={startNoteFromCurrentSelection}
+                      onSaved={(version) => {
+                        setSelectedVersionId(version.id);
+                        getDocumentVersions(documentId)
+                          .then(setVersions)
+                          .catch(() => undefined);
+                      }}
+                      onDirtyChange={setEditorDirty}
+                    />
+                  )}
                 </div>
-              ) : !body && !selectedResolvedVersion ? (
-                <div className="border border-rule bg-paper p-6">
-                  <LoadingLine label="loading document text" />
-                </div>
-              ) : (
-                <DocumentRichEditor
-                  documentId={documentId}
-                  filename={doc.filename}
-                  initialText={editorText}
-                  initialJson={editorJson}
-                  latestVersionNumber={latestVersion?.version_number}
-                  latestVersionId={latestVersion?.id ?? null}
-                  originalMimeType={doc.mime_type}
-                  sourceLabel={editorSourceLabel}
-                  sourceHighlight={currentReaderQuote}
-                  noteHighlights={anchoredOpenNotes}
-                  selectedQuote={selectedQuote || undefined}
-                  selectedQuoteAnchored={Boolean(selectedAnchor)}
-                  onCreateNoteFromSelection={startNoteFromCurrentSelection}
-                  onSaved={(version) => {
-                    setSelectedVersionId(version.id);
-                    getDocumentVersions(documentId)
-                      .then(setVersions)
-                      .catch(() => undefined);
-                  }}
-                  onDirtyChange={setEditorDirty}
-                />
-              )}
-            </div>
+              </div>
             )}
 
             {workbenchView === "original" && (


### PR DESCRIPTION
## Summary
- add a compact open-note navigator above the document editor
- let anchored note cards jump back into the document text
- keep the full editable notes rail intact below the document workbench
- harden one scrollIntoView call for jsdom/browser compatibility

## Validation
- npm run typecheck
- npx vitest run src/matter/DocumentDetail.test.tsx
- npm run build

## Scope
Frontend-only. No backend, no document schema changes.