### PR TITLE
documents: add PDF page index

### DIFF
--- a/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.test.tsx
@@ -9,7 +9,7 @@ import * as api from "../../lib/api";
 vi.mock("docx-preview", () => ({
   renderAsync: vi.fn(async (_blob: Blob, container: HTMLElement) => {
     container.innerHTML =
-      "<article>Rendered Word body with dismissal facts and a limitation point.</article>";
+      "<h1>Witness statement</h1><h2>Dismissal facts</h2><article>Rendered Word body with dismissal facts and a limitation point.</article>";
   }),
 }));
 
@@ -41,6 +41,12 @@ describe("DocxOriginalPreview", () => {
     });
     expect(screen.getByText(/Rendered Word body/)).toBeInTheDocument();
     expect(api.fetchDocumentOriginalBlob).toHaveBeenCalledWith("doc-1");
+    expect(screen.getByTestId("document-docx-outline")).toHaveTextContent(
+      "Witness statement",
+    );
+    expect(screen.getByTestId("document-docx-outline")).toHaveTextContent(
+      "Dismissal facts",
+    );
     expect(screen.getByRole("button", { name: "Paper" })).toHaveClass("bg-ink");
     await userEvent.click(screen.getByRole("button", { name: "Wide" }));
     expect(screen.getByRole("button", { name: "Wide" })).toHaveClass("bg-ink");
@@ -66,15 +72,15 @@ describe("DocxOriginalPreview", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("1 match · 1 / 1")).toBeInTheDocument();
+      expect(screen.getByText("2 matches · 1 / 2")).toBeInTheDocument();
     });
     expect(screen.getAllByText(/dismissal facts/).length).toBeGreaterThan(0);
     const activeHit = document.querySelector(".legalise-docx-search-hit-active");
-    expect(activeHit).toHaveTextContent("dismissal facts");
+    expect(activeHit?.textContent?.toLowerCase()).toContain("dismissal facts");
 
-    await userEvent.click(screen.getByRole("button", { name: "Quote in note" }));
+    await userEvent.click(screen.getAllByRole("button", { name: "Quote in note" })[0]);
     expect(onQuoteSelected).toHaveBeenCalledWith(
-      expect.stringContaining("dismissal facts"),
+      expect.stringMatching(/dismissal facts/i),
     );
 
     await userEvent.clear(screen.getByPlaceholderText("Search text in this Word file"));

--- a/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
+++ b/frontend/src/modules/document_preview/DocxOriginalPreview.tsx
@@ -13,6 +13,12 @@ type DocxSearchHit = {
   preview: string;
 };
 
+type WordOutlineItem = {
+  id: string;
+  label: string;
+  level: number;
+};
+
 function previewAround(text: string, index: number, length: number): string {
   const start = Math.max(0, index - 80);
   const end = Math.min(text.length, index + length + 120);
@@ -89,6 +95,7 @@ export function DocxOriginalPreview({
   const [query, setQuery] = useState(sourceHighlight?.trim() ?? "");
   const [viewMode, setViewMode] = useState<"paper" | "wide">("paper");
   const [activeHitIndex, setActiveHitIndex] = useState(0);
+  const [outline, setOutline] = useState<WordOutlineItem[]>([]);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const searchTerm = query.trim();
@@ -154,6 +161,7 @@ export function DocxOriginalPreview({
     const container = containerRef.current;
     if (!container) return;
     container.innerHTML = "";
+    setOutline([]);
     setState({ status: "loading" });
     setRenderedText("");
 
@@ -178,7 +186,23 @@ export function DocxOriginalPreview({
           useBase64URL: true,
         });
         if (!cancelled) {
-          setRenderedText(containerRef.current?.textContent ?? "");
+          const rendered = containerRef.current;
+          setRenderedText(rendered?.textContent ?? "");
+          const headings = Array.from(
+            rendered?.querySelectorAll("h1,h2,h3") ?? [],
+          ).slice(0, 16);
+          setOutline(
+            headings
+              .map((heading, index) => {
+                const level = Number(heading.tagName.slice(1));
+                const label = heading.textContent?.trim().replace(/\s+/g, " ") ?? "";
+                if (!label) return null;
+                const id = `docx-outline-${index}`;
+                heading.id = id;
+                return { id, label, level };
+              })
+              .filter((item): item is WordOutlineItem => Boolean(item)),
+          );
           setState({ status: "ready" });
         }
       })
@@ -308,17 +332,54 @@ export function DocxOriginalPreview({
           <p className="mt-3 text-xs text-muted">No matches in the rendered Word text.</p>
         )}
       </div>
-      <div
-        className="max-h-[780px] overflow-auto bg-paper-sunken px-4 py-5"
-        data-testid="document-docx-reader-canvas"
-      >
+      <div className="grid max-h-[780px] grid-cols-1 overflow-hidden bg-paper-sunken lg:grid-cols-[260px_minmax(0,1fr)]">
+        <aside
+          className="max-h-[220px] overflow-auto border-b border-rule bg-paper px-3 py-3 lg:max-h-none lg:border-b-0 lg:border-r"
+          data-testid="document-docx-outline"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+              Outline
+            </p>
+            <span className="text-xs text-muted">{outline.length}</span>
+          </div>
+          {outline.length === 0 ? (
+            <p className="mt-3 text-xs leading-5 text-muted">
+              No headings found in the rendered Word file.
+            </p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {outline.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() =>
+                    document.getElementById(item.id)?.scrollIntoView?.({
+                      block: "start",
+                      behavior: "smooth",
+                    })
+                  }
+                  className="w-full border border-rule bg-paper-sunken px-3 py-2 text-left text-xs hover:border-ink"
+                  style={{ paddingLeft: `${0.75 + (item.level - 1) * 0.5}rem` }}
+                >
+                  <span className="block font-semibold text-ink">{item.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </aside>
         <div
-          ref={containerRef}
-          aria-label={`Original Word preview for ${filename}`}
-          className={`legalise-docx-preview ${
-            viewMode === "wide" ? "legalise-docx-preview-wide" : ""
-          }`}
-        />
+          className="overflow-auto px-4 py-5"
+          data-testid="document-docx-reader-canvas"
+        >
+          <div
+            ref={containerRef}
+            aria-label={`Original Word preview for ${filename}`}
+            className={`legalise-docx-preview ${
+              viewMode === "wide" ? "legalise-docx-preview-wide" : ""
+            }`}
+          />
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/modules/document_preview/PdfDocumentViewer.test.tsx
+++ b/frontend/src/modules/document_preview/PdfDocumentViewer.test.tsx
@@ -66,10 +66,16 @@ describe("PdfDocumentViewer", () => {
     expect(screen.getByText("PDF reader")).toBeInTheDocument();
     expect(screen.getByText(/dismissal-letter.pdf/)).toBeInTheDocument();
     expect(screen.getByTestId("mock-pdf-page")).toHaveTextContent("Page 1");
+    expect(screen.getByTestId("pdf-page-index")).toHaveTextContent("Pages");
 
     await waitFor(() => {
       expect(screen.getByText("1 page · 1 / 1")).toBeInTheDocument();
     });
+    expect(screen.getByTestId("pdf-page-index")).toHaveTextContent(
+      "The dismissal letter mentioned a single social-media post",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Page 2/i }));
+    expect(screen.getByTestId("mock-pdf-page")).toHaveTextContent("Page 2");
 
     await userEvent.clear(screen.getByPlaceholderText("Search text in this PDF"));
     await userEvent.type(screen.getByPlaceholderText("Search text in this PDF"), "dismissal");

--- a/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
+++ b/frontend/src/modules/document_preview/PdfDocumentViewer.tsx
@@ -32,6 +32,13 @@ function previewAround(text: string, index: number, length: number): string {
   return text.slice(start, end).replace(/\s+/g, " ").trim();
 }
 
+function pagePreview(text: string): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  if (!compact) return "No selectable text indexed on this page.";
+  if (compact.length <= 110) return compact;
+  return `${compact.slice(0, 107).trimEnd()}...`;
+}
+
 export function PdfDocumentViewer({
   fileUrl,
   filename,
@@ -274,26 +281,62 @@ export function PdfDocumentViewer({
         </div>
       )}
 
-      <div className="flex max-h-[760px] justify-center overflow-auto bg-neutral-100 px-4 py-6">
-        <Document
-          file={file}
-          loading={<p className="text-sm text-muted">Loading PDF...</p>}
-          error={<p className="text-sm text-red-700">Could not render this PDF.</p>}
-          onLoadError={(err) => setError(err.message)}
-          onLoadSuccess={(pdf) => {
-            setError(null);
-            setNumPages(pdf.numPages);
-            setPageNumber(1);
-            void extractText(pdf);
-          }}
+      <div className="grid max-h-[760px] grid-cols-1 overflow-hidden bg-neutral-100 lg:grid-cols-[260px_minmax(0,1fr)]">
+        <aside
+          className="max-h-[220px] overflow-auto border-b border-rule bg-paper px-3 py-3 lg:max-h-none lg:border-b-0 lg:border-r"
+          data-testid="pdf-page-index"
         >
-          <Page
-            pageNumber={pageNumber}
-            scale={scale}
-            renderAnnotationLayer
-            renderTextLayer
-          />
-        </Document>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+              Pages
+            </p>
+            <span className="text-xs text-muted">{numPages || "?"}</span>
+          </div>
+          {numPages === 0 ? (
+            <p className="mt-3 text-xs text-muted">Loading page index...</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {Array.from({ length: numPages }, (_, index) => index + 1).map((page) => (
+                <button
+                  key={page}
+                  type="button"
+                  onClick={() => setPageNumber(page)}
+                  className={`w-full border px-3 py-2 text-left text-xs leading-5 ${
+                    page === pageNumber
+                      ? "border-ink bg-paper text-ink"
+                      : "border-rule bg-paper-sunken text-muted hover:border-ink hover:text-ink"
+                  }`}
+                >
+                  <span className="block font-semibold">Page {page}</span>
+                  <span className="mt-1 block max-h-10 overflow-hidden">
+                    {pagePreview(pageTexts[page - 1] ?? "")}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </aside>
+        <div className="flex overflow-auto px-4 py-6 lg:justify-center">
+          <Document
+            file={file}
+            loading={<p className="text-sm text-muted">Loading PDF...</p>}
+            error={<p className="text-sm text-red-700">Could not render this PDF.</p>}
+            onLoadError={(err) => setError(err.message)}
+            onLoadSuccess={(pdf) => {
+              setError(null);
+              setNumPages(pdf.numPages);
+              setPageNumber(1);
+              void extractText(pdf);
+            }}
+          >
+            <Page
+              pageNumber={pageNumber}
+              scale={scale}
+              renderAnnotationLayer
+              renderTextLayer
+            />
+          </Document>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a page index rail to the PDF original viewer
- show extracted text previews per page
- let users jump directly to a page from the index

## Validation
- npm run typecheck
- npx vitest run src/modules/document_preview/PdfDocumentViewer.test.tsx

## Scope
Frontend-only. Uses the existing react-pdf text extraction; no backend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added outline panel to Word document previews, displaying document headings with clickable navigation to jump to sections.
  * Added pages sidebar to PDF previews, showing page previews for quick document navigation.

* **Tests**
  * Updated document preview tests to verify new outline and page navigation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->