### PR TITLE
documents: surface workbench status in list

### DIFF
--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -43,6 +43,7 @@ from app.models import (
     AuditEntry,
     Document,
     DocumentComment,
+    DocumentEdit,
     Job,
     Matter,
     User,
@@ -57,6 +58,8 @@ from app.models import (
     JOB_KIND_EXPORT,
     JOB_STATUS_SUCCEEDED,
 )
+from app.models.document_comment import COMMENT_STATUS_OPEN
+from app.models.document_edit import EDIT_STATUS_PENDING
 from app.models.document_body import DocumentBody, BODY_KIND_EXTRACTED
 from app.models.document_version import DocumentVersion, VERSION_KIND_UPLOAD
 
@@ -136,6 +139,10 @@ class DocumentRead(BaseModel):
     uploaded_at: datetime
     uploaded_by_id: uuid.UUID
     comment_count: int = 0
+    open_comment_count: int = 0
+    version_count: int = 0
+    edit_count: int = 0
+    pending_edit_count: int = 0
 
     model_config = {"from_attributes": True}
 
@@ -487,18 +494,70 @@ async def list_documents(
     )
     if matter is None:
         raise HTTPException(404, f"matter not found: {slug}")
+    comment_counts = (
+        select(
+            DocumentComment.document_id.label("document_id"),
+            func.count(DocumentComment.id).label("comment_count"),
+            func.count(DocumentComment.id)
+            .filter(DocumentComment.status == COMMENT_STATUS_OPEN)
+            .label("open_comment_count"),
+        )
+        .group_by(DocumentComment.document_id)
+        .subquery()
+    )
+    version_counts = (
+        select(
+            DocumentVersion.document_id.label("document_id"),
+            func.count(DocumentVersion.id).label("version_count"),
+        )
+        .group_by(DocumentVersion.document_id)
+        .subquery()
+    )
+    edit_counts = (
+        select(
+            DocumentVersion.document_id.label("document_id"),
+            func.count(DocumentEdit.id).label("edit_count"),
+            func.count(DocumentEdit.id)
+            .filter(DocumentEdit.status == EDIT_STATUS_PENDING)
+            .label("pending_edit_count"),
+        )
+        .join(DocumentEdit, DocumentEdit.document_version_id == DocumentVersion.id)
+        .group_by(DocumentVersion.document_id)
+        .subquery()
+    )
     rows = await session.execute(
-        select(Document, func.count(DocumentComment.id).label("comment_count"))
-        .outerjoin(DocumentComment, DocumentComment.document_id == Document.id)
+        select(
+            Document,
+            comment_counts.c.comment_count,
+            comment_counts.c.open_comment_count,
+            version_counts.c.version_count,
+            edit_counts.c.edit_count,
+            edit_counts.c.pending_edit_count,
+        )
+        .outerjoin(comment_counts, comment_counts.c.document_id == Document.id)
+        .outerjoin(version_counts, version_counts.c.document_id == Document.id)
+        .outerjoin(edit_counts, edit_counts.c.document_id == Document.id)
         .where(Document.matter_id == matter.id)
-        .group_by(Document.id)
         .order_by(Document.uploaded_at.desc())
     )
     return [
         DocumentRead.model_validate(doc).model_copy(
-            update={"comment_count": int(comment_count or 0)}
+            update={
+                "comment_count": int(comment_count or 0),
+                "open_comment_count": int(open_comment_count or 0),
+                "version_count": int(version_count or 0),
+                "edit_count": int(edit_count or 0),
+                "pending_edit_count": int(pending_edit_count or 0),
+            }
         )
-        for doc, comment_count in rows.all()
+        for (
+            doc,
+            comment_count,
+            open_comment_count,
+            version_count,
+            edit_count,
+            pending_edit_count,
+        ) in rows.all()
     ]
 
 

--- a/backend/tests/test_documents_routes.py
+++ b/backend/tests/test_documents_routes.py
@@ -45,6 +45,12 @@ async def test_list_documents_returns_three_seeded_docs(client) -> None:
         "witness-statement-khan.docx",
         "synthetic-mutual-nda.docx",
     }
+    for doc in body:
+        assert "comment_count" in doc
+        assert "open_comment_count" in doc
+        assert "version_count" in doc
+        assert "edit_count" in doc
+        assert "pending_edit_count" in doc
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -35,6 +35,10 @@ export interface MatterDocument {
   uploaded_at: string;
   uploaded_by_id: string;
   comment_count?: number;
+  open_comment_count?: number;
+  version_count?: number;
+  edit_count?: number;
+  pending_edit_count?: number;
 }
 
 export interface MatterCreate {

--- a/frontend/src/matter/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.test.tsx
@@ -37,6 +37,10 @@ describe("DocumentsTab — document ingress", () => {
       uploaded_at: "2026-06-03T10:00:00",
       uploaded_by_id: "u-1",
       comment_count: 2,
+      open_comment_count: 1,
+      version_count: 3,
+      edit_count: 4,
+      pending_edit_count: 2,
     },
     {
       id: "doc-2",
@@ -50,6 +54,10 @@ describe("DocumentsTab — document ingress", () => {
       uploaded_at: "2026-06-03T11:00:00",
       uploaded_by_id: "u-1",
       comment_count: 0,
+      open_comment_count: 0,
+      version_count: 1,
+      edit_count: 0,
+      pending_edit_count: 0,
     },
   ];
 
@@ -62,12 +70,16 @@ describe("DocumentsTab — document ingress", () => {
       />,
     );
 
-    expect(screen.getAllByText("Notes").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("2 notes")).toBeInTheDocument();
+    expect(screen.getAllByText("Open notes").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("1 note")).toBeInTheDocument();
+    expect(screen.getByText("3 saved versions")).toBeInTheDocument();
+    expect(screen.getByText("2 pending changes")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Documents in this project" })).toBeInTheDocument();
     expect(screen.getByText("Open workbench")).toBeInTheDocument();
     expect(screen.getAllByText("Files")[0]).toBeInTheDocument();
     expect(screen.getAllByText("1K")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Versions")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Changes")[0]).toBeInTheDocument();
   });
 
   it("searches and filters the document library without opening files", async () => {

--- a/frontend/src/matter/tabs/DocumentsTab.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.tsx
@@ -37,6 +37,10 @@ function formatDate(iso: string): string {
   return `${d.getUTCDate()} ${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
 }
 
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralLabel}`;
+}
+
 type IngressStatus =
   | { kind: "idle" }
   | { kind: "uploading"; done: number; total: number; current: string }
@@ -116,7 +120,12 @@ export function DocumentsTab({
     "bg-paper border border-rule px-3 py-2 text-[16px] focus:border-ink focus:outline-none transition-colors min-h-[40px] font-sans text-ink";
   const totalBytes = docs?.reduce((total, d) => total + d.size_bytes, 0) ?? 0;
   const disclosureCount = docs?.filter((d) => d.from_disclosure).length ?? 0;
-  const noteCount = docs?.reduce((total, d) => total + (d.comment_count ?? 0), 0) ?? 0;
+  const openNoteCount =
+    docs?.reduce((total, d) => total + (d.open_comment_count ?? 0), 0) ?? 0;
+  const versionCount =
+    docs?.reduce((total, d) => total + (d.version_count ?? 0), 0) ?? 0;
+  const pendingEditCount =
+    docs?.reduce((total, d) => total + (d.pending_edit_count ?? 0), 0) ?? 0;
   const filteredDocs =
     docs?.filter((d) => {
       const query = documentQuery.trim().toLowerCase();
@@ -240,7 +249,7 @@ export function DocumentsTab({
                 with the matter record.
               </p>
             </div>
-            <dl className="grid grid-cols-3 gap-2 text-center text-xs">
+            <dl className="grid grid-cols-2 gap-2 text-center text-xs sm:grid-cols-5">
               <div className="border border-rule bg-paper-sunken p-2">
                 <dt className="font-mono uppercase tracking-track2 text-muted">Files</dt>
                 <dd className="mt-1 text-sm font-semibold text-ink">{docs.length}</dd>
@@ -250,8 +259,16 @@ export function DocumentsTab({
                 <dd className="mt-1 text-sm font-semibold text-ink">{formatBytes(totalBytes)}</dd>
               </div>
               <div className="border border-rule bg-paper-sunken p-2">
-                <dt className="font-mono uppercase tracking-track2 text-muted">Notes</dt>
-                <dd className="mt-1 text-sm font-semibold text-ink">{noteCount}</dd>
+                <dt className="font-mono uppercase tracking-track2 text-muted">Open notes</dt>
+                <dd className="mt-1 text-sm font-semibold text-ink">{openNoteCount}</dd>
+              </div>
+              <div className="border border-rule bg-paper-sunken p-2">
+                <dt className="font-mono uppercase tracking-track2 text-muted">Versions</dt>
+                <dd className="mt-1 text-sm font-semibold text-ink">{versionCount}</dd>
+              </div>
+              <div className="border border-rule bg-paper-sunken p-2">
+                <dt className="font-mono uppercase tracking-track2 text-muted">Changes</dt>
+                <dd className="mt-1 text-sm font-semibold text-ink">{pendingEditCount}</dd>
               </div>
             </dl>
           </div>
@@ -306,6 +323,14 @@ export function DocumentsTab({
           >
             {filteredDocs?.map((d) => {
               const typeLabel = deriveType(d);
+              const openNotes = d.open_comment_count ?? 0;
+              const versions = d.version_count ?? 0;
+              const pendingEdits = d.pending_edit_count ?? 0;
+              const workStatus = [
+                openNotes > 0 ? plural(openNotes, "open note") : null,
+                versions > 0 ? plural(versions, "saved version") : null,
+                pendingEdits > 0 ? plural(pendingEdits, "pending change") : null,
+              ].filter(Boolean);
               return (
                 <Link
                   key={d.id}
@@ -342,11 +367,11 @@ export function DocumentsTab({
                     </div>
                     <div>
                       <dt className="font-mono text-[10px] uppercase tracking-track2 text-muted">
-                        Notes
+                        Open notes
                       </dt>
                       <dd className="mt-1 text-ink">
-                        {d.comment_count
-                          ? `${d.comment_count} note${d.comment_count === 1 ? "" : "s"}`
+                        {openNotes
+                          ? plural(openNotes, "note")
                           : "None"}
                       </dd>
                     </div>
@@ -357,6 +382,22 @@ export function DocumentsTab({
                       <dd className="mt-1 text-ink">{formatDate(d.uploaded_at)}</dd>
                     </div>
                   </dl>
+                  <div className="mt-4 flex flex-wrap gap-2" aria-label={`Workbench status for ${d.filename}`}>
+                    {workStatus.length > 0 ? (
+                      workStatus.map((item) => (
+                        <span
+                          key={item}
+                          className="border border-rule bg-paper-sunken px-2 py-1 text-xs font-medium text-ink"
+                        >
+                          {item}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="border border-rule bg-paper-sunken px-2 py-1 text-xs text-muted">
+                        Ready to review
+                      </span>
+                    )}
+                  </div>
                   <div className="mt-5 flex items-center justify-between border-t border-rule pt-3">
                     <span className="text-xs leading-5 text-muted">
                       Reader, notes, versions, skills, and Record links open together.


### PR DESCRIPTION
## Summary
- add document list counts for open notes, saved versions, edit rows, and pending changes
- show those counts as workbench status on the Documents cards
- keep the existing document detail workbench as the target surface, with no new route or audit source

## Validation
- frontend: npm run typecheck
- frontend: npx vitest run src/matter/tabs/DocumentsTab.test.tsx
- frontend: npm run build
- backend: python -m py_compile backend/app/api/matters.py backend/tests/test_documents_routes.py

Local backend pytest is not on PATH in this shell; CI remains the backend gate.