### PR TITLE
documents: link workbench into chat

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -312,6 +312,10 @@ describe("DocumentDetail", () => {
     expect(open.getAttribute("href")).not.toContain("download=1");
     expect(download.getAttribute("href")).toContain("download=1");
     expect(screen.getByRole("button", { name: "Compare versions" })).toBeInTheDocument();
+    const ask = screen.getByTestId("document-ask-chat-link");
+    expect(ask).toHaveTextContent("Ask about this file");
+    expect(ask.getAttribute("href")).toContain("/matters/khan/assistant");
+    expect(ask.getAttribute("href")).toContain("document=doc-1");
     expect(screen.getAllByRole("link", { name: "View Record" }).length).toBeGreaterThan(0);
     expect(screen.queryByTestId("document-download-edited-docx")).toBeNull();
     expect(screen.queryByTestId("pdf-document-viewer")).toBeNull();

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -957,6 +957,15 @@ export function DocumentDetail({
               >
                 Compare versions
               </button>
+              <Link
+                to="/matters/$slug/$tab"
+                params={{ slug, tab: "assistant" }}
+                search={{ document: documentId }}
+                className="inline-flex items-center border border-rule px-3 py-2 text-ink hover:border-ink"
+                data-testid="document-ask-chat-link"
+              >
+                Ask about this file
+              </Link>
               <a
                 href={recordHref}
                 className="inline-flex items-center border border-rule px-3 py-2 text-ink hover:border-ink"

--- a/frontend/src/matter/MatterDetail.tsx
+++ b/frontend/src/matter/MatterDetail.tsx
@@ -63,6 +63,10 @@ export function MatterDetail({ slug }: { slug: string }) {
   const initialTab: TabKey =
     route.name === "detail" && route.tab && isTabKey(route.tab) ? route.tab : "assistant";
   const [tab, setTab] = useState<TabKey>(initialTab);
+  const initialChatDocumentId =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("document")
+      : null;
 
   // sync tab → drawer label
   useEffect(() => {
@@ -362,6 +366,7 @@ export function MatterDetail({ slug }: { slug: string }) {
               chronology={chron?.events ?? []}
               auditCount={audit?.length ?? 0}
               setTabAndHash={setTabAndHash}
+              initialDocumentId={initialChatDocumentId}
             />
           )}
           {tab === "documents" && (

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -37,6 +37,7 @@ function mountChat(overrides?: {
   docs?: MatterDocument[] | null;
   initialMessages?: AssistantMessage[];
   onDocumentChip?: (documentId: string) => void;
+  initialDocumentId?: string | null;
 }) {
   const setTabAndHash = overrides?.setTabAndHash ?? vi.fn();
   const docs = overrides?.docs ?? [];
@@ -54,6 +55,7 @@ function mountChat(overrides?: {
         showPostureInPulse={false}
         initialMessages={overrides?.initialMessages}
         onDocumentChip={overrides?.onDocumentChip}
+        initialDocumentId={overrides?.initialDocumentId}
       />
     ),
   });
@@ -141,6 +143,29 @@ describe("AssistantTab — in-chat skill picker", () => {
 
     fireEvent.click(screen.getByTestId("open-documents-link"));
     expect(setTabAndHash).toHaveBeenCalledWith("documents");
+  });
+
+  it("pre-attaches a document when opened from the document workbench", async () => {
+    mountChat({
+      initialDocumentId: "doc-1",
+      docs: [
+        {
+          id: "doc-1",
+          matter_id: "m-1",
+          filename: "witness-statement.docx",
+          mime_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          size_bytes: 1200,
+          sha256: "a".repeat(64),
+          tag: "draft",
+          from_disclosure: false,
+          uploaded_at: "2026-06-03T10:00:00",
+          uploaded_by_id: "u-1",
+        },
+      ],
+    });
+
+    expect(await screen.findByText("witness-statement.docx")).toBeInTheDocument();
+    expect(screen.getByTitle("Remove witness-statement.docx")).toBeInTheDocument();
   });
 
   it("mounts the generic runner for a runnable V2 skill instead of routing to a bespoke tab", async () => {

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -49,6 +49,7 @@ interface AssistantTabProps {
   // Optional route override for read-only/public shells. Normal matters
   // route source chips into the authenticated matter document reader.
   onDocumentChip?: (documentId: string) => void;
+  initialDocumentId?: string | null;
 }
 
 // Three concrete first-actions per matter type. Per JOY.md "Suggested
@@ -93,6 +94,7 @@ export function AssistantTab({
   showContextRail = true,
   onDisabledAction,
   onDocumentChip,
+  initialDocumentId,
   // back-compat — see AssistantTabProps; deliberately unused.
   auditCount: _auditCount,
   workflowsGrantedCount: _workflowsGrantedCount,
@@ -184,6 +186,16 @@ export function AssistantTab({
     for (const d of docs ?? []) map.set(d.id, d);
     return map;
   }, [docs]);
+
+  useEffect(() => {
+    if (!initialDocumentId || !docsById.has(initialDocumentId)) return;
+    setSelectedDocIds((prev) => {
+      if (prev.has(initialDocumentId)) return prev;
+      const next = new Set(prev);
+      next.add(initialDocumentId);
+      return next;
+    });
+  }, [initialDocumentId, docsById]);
 
   const recentDocs = useMemo(() => {
     if (!docs) return [];


### PR DESCRIPTION
## Summary
- add an Ask about this file command to the document workbench
- let Chat pre-attach a document from the ?document= query parameter
- keep the existing assistant selected-document payload path; no backend changes

## Validation
- frontend: npm run typecheck
- frontend: npx vitest run src/matter/tabs/AssistantTab.test.tsx src/matter/DocumentDetail.test.tsx
- frontend: npm run build