### PR TITLE
documents: run skills from selected passage

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -889,10 +889,9 @@ describe("DocumentDetail", () => {
     } as unknown as Selection);
 
     fireEvent.mouseUp(content);
-    expect(await screen.findByTestId("document-editor-selected-passage")).toHaveTextContent(
-      "single social-media post",
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Add review note" }));
+    const selectedPassage = await screen.findByTestId("document-editor-selected-passage");
+    expect(selectedPassage).toHaveTextContent("single social-media post");
+    fireEvent.click(within(selectedPassage).getByRole("button", { name: "Add review note" }));
     fireEvent.change(
       screen.getByPlaceholderText("What should be checked before relying on this document?"),
       {

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1265,6 +1265,11 @@ export function DocumentDetail({
                       selectedQuote={selectedQuote || undefined}
                       selectedQuoteAnchored={Boolean(selectedAnchor)}
                       onCreateNoteFromSelection={startNoteFromCurrentSelection}
+                      onRunSkillFromSelection={
+                        primaryDocumentSkill
+                          ? () => openDocumentSkill(primaryDocumentSkill, true)
+                          : undefined
+                      }
                       onSaved={(version) => {
                         setSelectedVersionId(version.id);
                         getDocumentVersions(documentId)

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -729,6 +729,7 @@ describe("DocumentRichEditor surface", () => {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
     const onCreateNoteFromSelection = vi.fn();
+    const onRunSkillFromSelection = vi.fn();
     render(
       <DocumentRichEditor
         documentId="doc-1"
@@ -738,6 +739,7 @@ describe("DocumentRichEditor surface", () => {
         selectedQuote="single social-media post"
         selectedQuoteAnchored
         onCreateNoteFromSelection={onCreateNoteFromSelection}
+        onRunSkillFromSelection={onRunSkillFromSelection}
         onSaved={() => undefined}
       />,
     );
@@ -752,6 +754,8 @@ describe("DocumentRichEditor surface", () => {
     expect(ribbon).toHaveTextContent("single social-media post");
     fireEvent.click(within(ribbon).getByRole("button", { name: "Find in document" }));
     expect(screen.getByLabelText("Find")).toHaveValue("single social-media post");
+    fireEvent.click(within(ribbon).getByRole("button", { name: "Run skill" }));
+    expect(onRunSkillFromSelection).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole("button", { name: "Copy passage" }));
     await waitFor(() => {
       expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -451,6 +451,7 @@ export function DocumentRichEditor({
   selectedQuote,
   selectedQuoteAnchored,
   onCreateNoteFromSelection,
+  onRunSkillFromSelection,
   onSaved,
   onDirtyChange,
 }: {
@@ -467,6 +468,7 @@ export function DocumentRichEditor({
   selectedQuote?: string;
   selectedQuoteAnchored?: boolean;
   onCreateNoteFromSelection?: () => void;
+  onRunSkillFromSelection?: () => void;
   onSaved: (version: DocumentVersionRead) => void;
   onDirtyChange?: (dirty: boolean) => void;
 }) {
@@ -1305,6 +1307,15 @@ export function DocumentRichEditor({
                 Add review note
               </button>
             )}
+            {onRunSkillFromSelection && (
+              <button
+                type="button"
+                onClick={onRunSkillFromSelection}
+                className="border border-ink bg-paper px-3 py-2 text-xs font-semibold text-ink hover:bg-paper-sunken"
+              >
+                Run skill
+              </button>
+            )}
           </div>
         </div>
       )}
@@ -1694,6 +1705,15 @@ export function DocumentRichEditor({
                       className="bg-ink px-2 py-1 text-xs font-semibold text-paper hover:bg-black"
                     >
                       Add note
+                    </button>
+                  )}
+                  {onRunSkillFromSelection && (
+                    <button
+                      type="button"
+                      onClick={onRunSkillFromSelection}
+                      className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
+                    >
+                      Run skill
                     </button>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- add a Run skill action to the selected-passage ribbon and editor selection menu
- connect the document editor to the existing document-scoped GenericSkillRunner via DocumentDetail
- keep the route/backend unchanged: selected passage uses the same project skill runner and artifact flow

## Local checks
- npm run typecheck
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx src/matter/DocumentDetail.test.tsx
- npm run build
