### PR TITLE
documents: add editor link support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.85.0",
         "@tiptap/extension-highlight": "^3.25.0",
+        "@tiptap/extension-link": "^3.25.0",
         "@tiptap/extension-placeholder": "^3.25.0",
         "@tiptap/extension-table": "^3.25.0",
         "@tiptap/extension-table-cell": "^3.25.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.85.0",
     "@tiptap/extension-highlight": "^3.25.0",
+    "@tiptap/extension-link": "^3.25.0",
     "@tiptap/extension-placeholder": "^3.25.0",
     "@tiptap/extension-table": "^3.25.0",
     "@tiptap/extension-table-cell": "^3.25.0",

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -644,6 +644,8 @@ describe("DocumentRichEditor surface", () => {
     expect(screen.getByTestId("document-editor")).toHaveTextContent("Document editor");
     expect(screen.getByTestId("document-editor-canvas")).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Underline" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Link" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove link" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Insert table" })).toBeInTheDocument();
     expect(screen.getByTestId("document-editor-stats")).toHaveTextContent("words");
     expect(screen.getByRole("button", { name: "Copy text" })).toBeInTheDocument();

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -12,6 +12,7 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
 import Highlight from "@tiptap/extension-highlight";
+import Link from "@tiptap/extension-link";
 import { Table } from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
@@ -600,6 +601,14 @@ export function DocumentRichEditor({
         }),
         Typography,
         Highlight.configure({ multicolor: false }),
+        Link.configure({
+          autolink: true,
+          defaultProtocol: "https",
+          openOnClick: false,
+          HTMLAttributes: {
+            class: "text-ink underline underline-offset-4",
+          },
+        }),
         findExtension,
         reviewNoteExtension,
         Table.configure({ resizable: true }),
@@ -1002,6 +1011,21 @@ export function DocumentRichEditor({
     editor.chain().focus().toggleHighlight().run();
   }
 
+  function setEditorLink() {
+    if (!editor) return;
+    const currentHref = typeof editor.getAttributes("link").href === "string"
+      ? editor.getAttributes("link").href
+      : "";
+    const nextHref = window.prompt("Paste link URL. Leave blank to remove the link.", currentHref);
+    if (nextHref === null) return;
+    const trimmed = nextHref.trim();
+    if (!trimmed) {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+    editor.chain().focus().extendMarkRange("link").setLink({ href: trimmed }).run();
+  }
+
   function downloadWorkingText() {
     const blob = new Blob([plainText], { type: "text/plain;charset=utf-8" });
     const url = window.URL.createObjectURL(blob);
@@ -1182,6 +1206,22 @@ export function DocumentRichEditor({
                   onClick={() => editor.chain().focus().toggleHighlight().run()}
                 >
                   H
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Link"
+                  active={editor.isActive("link")}
+                  onClick={setEditorLink}
+                >
+                  Link
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Remove link"
+                  disabled={!editor.isActive("link")}
+                  onClick={() =>
+                    editor.chain().focus().extendMarkRange("link").unsetLink().run()
+                  }
+                >
+                  Unlink
                 </ToolbarButton>
               </ToolbarGroup>
               <ToolbarGroup label="Lists">
@@ -1697,6 +1737,13 @@ export function DocumentRichEditor({
                     className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
                   >
                     Highlight
+                  </button>
+                  <button
+                    type="button"
+                    onClick={setEditorLink}
+                    className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
+                  >
+                    Link
                   </button>
                   {onCreateNoteFromSelection && (
                     <button


### PR DESCRIPTION
## Summary
- add TipTap's official Link extension to the document editor
- expose Link / Remove link controls in the editor toolbar
- add Link to the selection menu so selected passages can be linked in place

## Local checks
- npm run typecheck
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run build
