### PR TITLE
documents: add editor text alignment

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@tiptap/extension-table-cell": "^3.25.0",
         "@tiptap/extension-table-header": "^3.25.0",
         "@tiptap/extension-table-row": "^3.25.0",
+        "@tiptap/extension-text-align": "^3.25.0",
         "@tiptap/extension-typography": "^3.25.0",
         "@tiptap/extension-underline": "^3.25.0",
         "@tiptap/react": "^3.25.0",
@@ -2588,6 +2589,19 @@
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.25.0.tgz",
       "integrity": "sha512-qXAYiIIOX7F6wVftN7FeHTAg9lDLzgqrscrT4BJxTL3Vk38EP1R3w1sDDfSCTQ53ui8SzoaKe0iyzkTa6V/1LQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-align": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.25.0.tgz",
+      "integrity": "sha512-/VcaNtcljC4O7hOVTwwekgwef+hiAIwnx/xErYme9oHTeLjlGsN9ZKLRQxcW7kjT9A1SSD/hPGNvQSkQJ2jh3w==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@tiptap/extension-table-cell": "^3.25.0",
     "@tiptap/extension-table-header": "^3.25.0",
     "@tiptap/extension-table-row": "^3.25.0",
+    "@tiptap/extension-text-align": "^3.25.0",
     "@tiptap/extension-typography": "^3.25.0",
     "@tiptap/extension-underline": "^3.25.0",
     "@tiptap/react": "^3.25.0",

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -646,6 +646,9 @@ describe("DocumentRichEditor surface", () => {
     expect(await screen.findByRole("button", { name: "Underline" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Link" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove link" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Align left" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Align centre" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Align right" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Insert table" })).toBeInTheDocument();
     expect(screen.getByTestId("document-editor-stats")).toHaveTextContent("words");
     expect(screen.getByRole("button", { name: "Copy text" })).toBeInTheDocument();

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -13,6 +13,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
 import Highlight from "@tiptap/extension-highlight";
 import Link from "@tiptap/extension-link";
+import TextAlign from "@tiptap/extension-text-align";
 import { Table } from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
@@ -608,6 +609,9 @@ export function DocumentRichEditor({
           HTMLAttributes: {
             class: "text-ink underline underline-offset-4",
           },
+        }),
+        TextAlign.configure({
+          types: ["heading", "paragraph"],
         }),
         findExtension,
         reviewNoteExtension,
@@ -1222,6 +1226,29 @@ export function DocumentRichEditor({
                   }
                 >
                   Unlink
+                </ToolbarButton>
+              </ToolbarGroup>
+              <ToolbarGroup label="Align">
+                <ToolbarButton
+                  label="Align left"
+                  active={editor.isActive({ textAlign: "left" })}
+                  onClick={() => editor.chain().focus().setTextAlign("left").run()}
+                >
+                  L
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Align centre"
+                  active={editor.isActive({ textAlign: "center" })}
+                  onClick={() => editor.chain().focus().setTextAlign("center").run()}
+                >
+                  C
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Align right"
+                  active={editor.isActive({ textAlign: "right" })}
+                  onClick={() => editor.chain().focus().setTextAlign("right").run()}
+                >
+                  R
                 </ToolbarButton>
               </ToolbarGroup>
               <ToolbarGroup label="Lists">


### PR DESCRIPTION
## Summary
- add TipTap's official TextAlign extension
- expose left / centre / right alignment controls for paragraphs and headings
- pin the controls in the editor surface test

## Local checks
- npm run typecheck
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run build
