### PR TITLE
documents: add editor checklist support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
         "@tiptap/extension-table-cell": "^3.25.0",
         "@tiptap/extension-table-header": "^3.25.0",
         "@tiptap/extension-table-row": "^3.25.0",
+        "@tiptap/extension-task-item": "^3.25.0",
+        "@tiptap/extension-task-list": "^3.25.0",
         "@tiptap/extension-text-align": "^3.25.0",
         "@tiptap/extension-typography": "^3.25.0",
         "@tiptap/extension-underline": "^3.25.0",
@@ -2583,6 +2585,32 @@
       },
       "peerDependencies": {
         "@tiptap/extension-table": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-item": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-3.25.0.tgz",
+      "integrity": "sha512-SLneMmcXltJUjuyxbthr3glCXygkBvU4OsMXWNIVvh3/oE/PDp06i6sbFLUmeBl+LJGgWBNTj2DBM2BGY7PUSg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-list": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-3.25.0.tgz",
+      "integrity": "sha512-9cP0G7MjmFkoqkmPNRre0CklkMreNfYdm63NQJ/ZB7L+27qXuqar0MmFL38EGU+FtbMqNu9DNWvooEL5Q3UL/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.25.0"
       }
     },
     "node_modules/@tiptap/extension-text": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,8 @@
     "@tiptap/extension-table-cell": "^3.25.0",
     "@tiptap/extension-table-header": "^3.25.0",
     "@tiptap/extension-table-row": "^3.25.0",
+    "@tiptap/extension-task-item": "^3.25.0",
+    "@tiptap/extension-task-list": "^3.25.0",
     "@tiptap/extension-text-align": "^3.25.0",
     "@tiptap/extension-typography": "^3.25.0",
     "@tiptap/extension-underline": "^3.25.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -145,6 +145,36 @@
     padding: 0 0.08em;
   }
 
+  .legalise-document-editor ul[data-type="taskList"] {
+    list-style: none;
+    margin: 0 0 1.25rem;
+    padding: 0;
+  }
+
+  .legalise-document-editor ul[data-type="taskList"] li {
+    align-items: flex-start;
+    display: flex;
+    gap: 0.65rem;
+    margin: 0.25rem 0;
+  }
+
+  .legalise-document-editor ul[data-type="taskList"] li > label {
+    flex: 0 0 auto;
+    line-height: 1.8;
+    user-select: none;
+  }
+
+  .legalise-document-editor ul[data-type="taskList"] li > div {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .legalise-document-editor ul[data-type="taskList"] input[type="checkbox"] {
+    accent-color: #181818;
+    height: 1rem;
+    width: 1rem;
+  }
+
   .legalise-document-editor table {
     border-collapse: collapse;
     margin: 0 0 1.25rem;

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -124,6 +124,35 @@ describe("DocumentRichEditor text conversion", () => {
     ).toBe("Issues\n\nLimitation\nDisclosure");
   });
 
+  it("keeps checklist items readable in the plain-text fallback", () => {
+    expect(
+      editorJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "taskList",
+            content: [
+              {
+                type: "taskItem",
+                attrs: { checked: false },
+                content: [
+                  { type: "paragraph", content: [{ type: "text", text: "Review source" }] },
+                ],
+              },
+              {
+                type: "taskItem",
+                attrs: { checked: true },
+                content: [
+                  { type: "paragraph", content: [{ type: "text", text: "Check deadline" }] },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe("[ ] Review source\n[x] Check deadline");
+  });
+
   it("keeps table cells legible in the plain-text fallback", () => {
     expect(
       editorJsonToPlainText({

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -13,6 +13,8 @@ import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
 import Highlight from "@tiptap/extension-highlight";
 import Link from "@tiptap/extension-link";
+import TaskItem from "@tiptap/extension-task-item";
+import TaskList from "@tiptap/extension-task-list";
 import TextAlign from "@tiptap/extension-text-align";
 import { Table } from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
@@ -238,6 +240,9 @@ function plainTextFromNode(node: TiptapNode): string {
   if (node.type === "hardBreak") return "\n";
   const children = node.content?.map(plainTextFromNode).join("") ?? "";
   if (node.type === "paragraph" || node.type === "heading") return `${children}\n\n`;
+  if (node.type === "taskItem") {
+    return `${node.attrs?.checked ? "[x]" : "[ ]"} ${children.trimEnd()}\n`;
+  }
   if (node.type === "listItem") return `${children.trimEnd()}\n`;
   if (node.type === "tableCell" || node.type === "tableHeader") return children.trim();
   if (node.type === "tableRow") {
@@ -612,6 +617,10 @@ export function DocumentRichEditor({
         }),
         TextAlign.configure({
           types: ["heading", "paragraph"],
+        }),
+        TaskList,
+        TaskItem.configure({
+          nested: true,
         }),
         findExtension,
         reviewNoteExtension,
@@ -1265,6 +1274,13 @@ export function DocumentRichEditor({
                   onClick={() => editor.chain().focus().toggleOrderedList().run()}
                 >
                   1.
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Checklist"
+                  active={editor.isActive("taskList")}
+                  onClick={() => editor.chain().focus().toggleTaskList().run()}
+                >
+                  ☑
                 </ToolbarButton>
               </ToolbarGroup>
               <ToolbarGroup label="Table">


### PR DESCRIPTION
## Summary
- add TipTap task-list/task-item extensions to the document editor
- expose a Checklist toolbar action in the existing Lists group
- style task lists inside the document canvas and preserve checklist state in plain-text fallback as [ ] / [x]

## Verification
- npm run typecheck
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run build