### PR TITLE
documents: add editor text colour

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.85.0",
+        "@tiptap/extension-color": "^3.25.0",
         "@tiptap/extension-highlight": "^3.25.0",
         "@tiptap/extension-link": "^3.25.0",
         "@tiptap/extension-placeholder": "^3.25.0",
@@ -20,6 +21,7 @@
         "@tiptap/extension-task-item": "^3.25.0",
         "@tiptap/extension-task-list": "^3.25.0",
         "@tiptap/extension-text-align": "^3.25.0",
+        "@tiptap/extension-text-style": "^3.25.0",
         "@tiptap/extension-typography": "^3.25.0",
         "@tiptap/extension-underline": "^3.25.0",
         "@tiptap/react": "^3.25.0",
@@ -2304,6 +2306,19 @@
         "@tiptap/pm": "3.25.0"
       }
     },
+    "node_modules/@tiptap/extension-color": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.25.0.tgz",
+      "integrity": "sha512-eBrxTDD9vKrrN5VPyvSRlwM9ApADSBqkCW8fA7Y3iedmIOAFb+iySv5LIh57tcnIL0e62LRyiXwTWpaxEfJFbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-text-style": "3.25.0"
+      }
+    },
     "node_modules/@tiptap/extension-document": {
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.25.0.tgz",
@@ -2630,6 +2645,19 @@
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.25.0.tgz",
       "integrity": "sha512-/VcaNtcljC4O7hOVTwwekgwef+hiAIwnx/xErYme9oHTeLjlGsN9ZKLRQxcW7kjT9A1SSD/hPGNvQSkQJ2jh3w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.25.0.tgz",
+      "integrity": "sha512-Oq0Gqa44tl2hEPhtriNyBlFBV2ZAk/1iYBqbUTW4qe0pkoe34yTZN7VQQ47RPZnGR7J3ddh8n67kM/9zoy4f8w==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.85.0",
+    "@tiptap/extension-color": "^3.25.0",
     "@tiptap/extension-highlight": "^3.25.0",
     "@tiptap/extension-link": "^3.25.0",
     "@tiptap/extension-placeholder": "^3.25.0",
@@ -30,6 +31,7 @@
     "@tiptap/extension-task-item": "^3.25.0",
     "@tiptap/extension-task-list": "^3.25.0",
     "@tiptap/extension-text-align": "^3.25.0",
+    "@tiptap/extension-text-style": "^3.25.0",
     "@tiptap/extension-typography": "^3.25.0",
     "@tiptap/extension-underline": "^3.25.0",
     "@tiptap/react": "^3.25.0",

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -675,6 +675,9 @@ describe("DocumentRichEditor surface", () => {
     expect(await screen.findByRole("button", { name: "Underline" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Link" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove link" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Ink text" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Red text" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove text colour" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Align left" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align centre" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align right" })).toBeInTheDocument();

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -12,10 +12,12 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
 import Highlight from "@tiptap/extension-highlight";
+import Color from "@tiptap/extension-color";
 import Link from "@tiptap/extension-link";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import TextAlign from "@tiptap/extension-text-align";
+import { TextStyle } from "@tiptap/extension-text-style";
 import { Table } from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
@@ -51,6 +53,13 @@ type DocumentStats = { words: number; chars: number; blocks: number };
 type DocumentCanvasMode = "page" | "wide";
 type OriginalImportState = "idle" | "loading" | "ready" | "error";
 type WorkingDiffPart = ReturnType<typeof buildVersionDiff>[number];
+const EDITOR_TEXT_COLORS = [
+  { label: "Ink text", value: "#181818" },
+  { label: "Red text", value: "#8C1D18" },
+  { label: "Amber text", value: "#8A5A00" },
+  { label: "Green text", value: "#236A44" },
+  { label: "Blue text", value: "#245B8A" },
+] as const;
 const SHARED_DRAFT_POLL_MS = 15_000;
 type DocumentLocalDraft = {
   documentId: string;
@@ -394,6 +403,36 @@ function ToolbarGroup({
   );
 }
 
+function ColorButton({
+  active,
+  color,
+  label,
+  onClick,
+}: {
+  active?: boolean;
+  color: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className={`inline-flex h-8 min-w-8 items-center justify-center border bg-paper px-2 ${
+        active ? "border-ink" : "border-rule hover:border-ink"
+      }`}
+    >
+      <span
+        className="block h-4 w-4 border border-rule"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}
+
 function ViewModeButton({
   active,
   children,
@@ -607,6 +646,8 @@ export function DocumentRichEditor({
         }),
         Typography,
         Highlight.configure({ multicolor: false }),
+        TextStyle,
+        Color,
         Link.configure({
           autolink: true,
           defaultProtocol: "https",
@@ -1235,6 +1276,24 @@ export function DocumentRichEditor({
                   }
                 >
                   Unlink
+                </ToolbarButton>
+              </ToolbarGroup>
+              <ToolbarGroup label="Colour">
+                {EDITOR_TEXT_COLORS.map((color) => (
+                  <ColorButton
+                    key={color.value}
+                    label={color.label}
+                    color={color.value}
+                    active={editor.isActive("textStyle", { color: color.value })}
+                    onClick={() => editor.chain().focus().setColor(color.value).run()}
+                  />
+                ))}
+                <ToolbarButton
+                  label="Remove text colour"
+                  disabled={!editor.isActive("textStyle")}
+                  onClick={() => editor.chain().focus().unsetColor().run()}
+                >
+                  Clear
                 </ToolbarButton>
               </ToolbarGroup>
               <ToolbarGroup label="Align">


### PR DESCRIPTION
## Summary
- add TipTip Color/TextStyle support to the document editor
- add accessible restrained text-colour swatches plus a remove-colour command
- keep colour presentational: plain-text fallback remains content-only

## Verification
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run typecheck
- npm run build