### PR TITLE
documents: add editor image support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-router": "^1.85.0",
         "@tiptap/extension-color": "^3.25.0",
         "@tiptap/extension-highlight": "^3.25.0",
+        "@tiptap/extension-image": "^3.25.0",
         "@tiptap/extension-link": "^3.25.0",
         "@tiptap/extension-placeholder": "^3.25.0",
         "@tiptap/extension-table": "^3.25.0",
@@ -2425,6 +2426,19 @@
       "peerDependencies": {
         "@tiptap/core": "3.25.0",
         "@tiptap/pm": "3.25.0"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.25.0.tgz",
+      "integrity": "sha512-LO1W36UovZzs7CqqHo1Fo3/nQDz9UJaV26D+YolqnbMBC2UDxozBPuxxvwkfl7965E3Q/gM8HjdDVM2DcH0VoQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.25.0"
       }
     },
     "node_modules/@tiptap/extension-italic": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-router": "^1.85.0",
     "@tiptap/extension-color": "^3.25.0",
     "@tiptap/extension-highlight": "^3.25.0",
+    "@tiptap/extension-image": "^3.25.0",
     "@tiptap/extension-link": "^3.25.0",
     "@tiptap/extension-placeholder": "^3.25.0",
     "@tiptap/extension-table": "^3.25.0",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -175,6 +175,14 @@
     width: 1rem;
   }
 
+  .legalise-document-editor img {
+    border: 1px solid #D9D9D6;
+    display: block;
+    height: auto;
+    margin: 1rem auto 1.25rem;
+    max-width: 100%;
+  }
+
   .legalise-document-editor table {
     border-collapse: collapse;
     margin: 0 0 1.25rem;

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -153,6 +153,23 @@ describe("DocumentRichEditor text conversion", () => {
     ).toBe("[ ] Review source\n[x] Check deadline");
   });
 
+  it("keeps image placeholders readable in the plain-text fallback", () => {
+    expect(
+      editorJsonToPlainText({
+        type: "doc",
+        content: [
+          {
+            type: "image",
+            attrs: {
+              src: "https://example.com/diagram.png",
+              alt: "timeline diagram",
+            },
+          },
+        ],
+      }),
+    ).toBe("[image: timeline diagram]");
+  });
+
   it("keeps table cells legible in the plain-text fallback", () => {
     expect(
       editorJsonToPlainText({
@@ -681,6 +698,7 @@ describe("DocumentRichEditor surface", () => {
     expect(screen.getByRole("button", { name: "Align left" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align centre" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align right" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Insert image" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Insert table" })).toBeInTheDocument();
     expect(screen.getByTestId("document-editor-stats")).toHaveTextContent("words");
     expect(screen.getByRole("button", { name: "Copy text" })).toBeInTheDocument();

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -13,6 +13,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
 import Highlight from "@tiptap/extension-highlight";
 import Color from "@tiptap/extension-color";
+import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
@@ -247,6 +248,7 @@ export function textToEditorHtml(
 function plainTextFromNode(node: TiptapNode): string {
   if (node.type === "text") return node.text ?? "";
   if (node.type === "hardBreak") return "\n";
+  if (node.type === "image") return node.attrs?.alt ? `[image: ${node.attrs.alt}]\n\n` : "[image]\n\n";
   const children = node.content?.map(plainTextFromNode).join("") ?? "";
   if (node.type === "paragraph" || node.type === "heading") return `${children}\n\n`;
   if (node.type === "taskItem") {
@@ -648,6 +650,10 @@ export function DocumentRichEditor({
         Highlight.configure({ multicolor: false }),
         TextStyle,
         Color,
+        Image.configure({
+          allowBase64: false,
+          inline: false,
+        }),
         Link.configure({
           autolink: true,
           defaultProtocol: "https",
@@ -1080,6 +1086,16 @@ export function DocumentRichEditor({
     editor.chain().focus().extendMarkRange("link").setLink({ href: trimmed }).run();
   }
 
+  function insertEditorImage() {
+    if (!editor) return;
+    const src = window.prompt("Paste image URL");
+    if (src === null) return;
+    const trimmed = src.trim();
+    if (!trimmed) return;
+    const alt = window.prompt("Image description", "")?.trim() ?? "";
+    editor.chain().focus().setImage({ src: trimmed, alt }).run();
+  }
+
   function downloadWorkingText() {
     const blob = new Blob([plainText], { type: "text/plain;charset=utf-8" });
     const url = window.URL.createObjectURL(blob);
@@ -1340,6 +1356,14 @@ export function DocumentRichEditor({
                   onClick={() => editor.chain().focus().toggleTaskList().run()}
                 >
                   ☑
+                </ToolbarButton>
+              </ToolbarGroup>
+              <ToolbarGroup label="Media">
+                <ToolbarButton
+                  label="Insert image"
+                  onClick={insertEditorImage}
+                >
+                  Img
                 </ToolbarButton>
               </ToolbarGroup>
               <ToolbarGroup label="Table">


### PR DESCRIPTION
## Summary
- add TipTap Image support to the document editor
- expose an Insert image command in the existing editor toolbar
- style embedded images inside the document canvas and preserve image alt text in plain-text fallback

## Verification
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run typecheck
- npm run build