### PR TITLE
documents: preserve rich editor nodes in docx export

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -13,7 +13,8 @@ from typing import Any, Literal
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
 from fastapi.responses import StreamingResponse
 from docx import Document as DocxDocument
-from docx.enum.text import WD_COLOR_INDEX
+from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_COLOR_INDEX
+from docx.shared import RGBColor
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -514,6 +515,30 @@ def _append_document_comments_docx(
             meta.add_run(comment.resolved_at.isoformat())
 
 
+def _rgb_from_hex(value: str | None) -> RGBColor | None:
+    if not value:
+        return None
+    cleaned = value.strip().lstrip("#")
+    if len(cleaned) != 6:
+        return None
+    try:
+        return RGBColor(
+            int(cleaned[0:2], 16),
+            int(cleaned[2:4], 16),
+            int(cleaned[4:6], 16),
+        )
+    except ValueError:
+        return None
+
+
+def _paragraph_alignment(value: str | None):
+    return {
+        "left": WD_ALIGN_PARAGRAPH.LEFT,
+        "center": WD_ALIGN_PARAGRAPH.CENTER,
+        "right": WD_ALIGN_PARAGRAPH.RIGHT,
+    }.get(value or "")
+
+
 def _add_tiptap_inline_content(paragraph, nodes: list[dict[str, Any]] | None) -> None:
     for node in nodes or []:
         node_type = node.get("type")
@@ -529,8 +554,19 @@ def _add_tiptap_inline_content(paragraph, nodes: list[dict[str, Any]] | None) ->
             run.underline = "underline" in mark_types
             if "highlight" in mark_types:
                 run.font.highlight_color = WD_COLOR_INDEX.YELLOW
+            for mark in node.get("marks") or []:
+                if not isinstance(mark, dict) or mark.get("type") != "textStyle":
+                    continue
+                color = _rgb_from_hex((mark.get("attrs") or {}).get("color"))
+                if color is not None:
+                    run.font.color.rgb = color
         elif node_type == "hardBreak":
             paragraph.add_run().add_break()
+        elif node_type == "image":
+            attrs = node.get("attrs") or {}
+            label = attrs.get("alt") or attrs.get("src") or "image"
+            run = paragraph.add_run(f"[image: {label}]")
+            run.italic = True
         elif isinstance(node.get("content"), list):
             _add_tiptap_inline_content(paragraph, node.get("content"))
 
@@ -545,6 +581,9 @@ def _add_tiptap_paragraph(
         paragraph = document.add_heading(level=max(1, min(level, 4)))
     else:
         paragraph = document.add_paragraph(style=style)
+    alignment = _paragraph_alignment((node.get("attrs") or {}).get("textAlign"))
+    if alignment is not None:
+        paragraph.alignment = alignment
     _add_tiptap_inline_content(paragraph, node.get("content"))
 
 
@@ -576,6 +615,26 @@ def _add_tiptap_list(document: DocxDocument, node: dict[str, Any], style: str) -
             _add_tiptap_list_item(document, child, style)
 
 
+def _add_tiptap_task_item(document: DocxDocument, item: dict[str, Any]) -> None:
+    checked = bool((item.get("attrs") or {}).get("checked"))
+    prefix = "[x] " if checked else "[ ] "
+    children = item.get("content") or []
+    paragraph_children: list[dict[str, Any]] | None = None
+    for child in children:
+        if isinstance(child, dict) and child.get("type") == "paragraph":
+            paragraph_children = child.get("content")
+            break
+    paragraph = document.add_paragraph()
+    paragraph.add_run(prefix)
+    _add_tiptap_inline_content(paragraph, paragraph_children)
+
+
+def _add_tiptap_task_list(document: DocxDocument, node: dict[str, Any]) -> None:
+    for child in node.get("content") or []:
+        if isinstance(child, dict) and child.get("type") == "taskItem":
+            _add_tiptap_task_item(document, child)
+
+
 def _tiptap_cell_text(cell: dict[str, Any]) -> str:
     text = _plain_text_from_tiptap_node(cell).strip()
     return re.sub(r"\n{2,}", "\n", text)
@@ -587,11 +646,18 @@ def _plain_text_from_tiptap_node(node: dict[str, Any]) -> str:
         return str(node.get("text") or "")
     if node_type == "hardBreak":
         return "\n"
+    if node_type == "image":
+        attrs = node.get("attrs") or {}
+        label = attrs.get("alt") or attrs.get("src") or "image"
+        return f"[image: {label}]\n"
     children = "".join(
         _plain_text_from_tiptap_node(child)
         for child in node.get("content") or []
         if isinstance(child, dict)
     )
+    if node_type == "taskItem":
+        prefix = "[x] " if (node.get("attrs") or {}).get("checked") else "[ ] "
+        return f"{prefix}{children.strip()}\n"
     if node_type in {"paragraph", "heading", "listItem"}:
         return f"{children}\n"
     if node_type == "tableRow":
@@ -661,6 +727,11 @@ def _render_tiptap_docx(
             _add_tiptap_list(document, node, "List Bullet")
         elif node_type == "orderedList":
             _add_tiptap_list(document, node, "List Number")
+        elif node_type == "taskList":
+            _add_tiptap_task_list(document, node)
+        elif node_type == "image":
+            paragraph = document.add_paragraph()
+            _add_tiptap_inline_content(paragraph, [node])
         elif node_type == "table":
             _add_tiptap_table(document, node)
     _append_document_comments_docx(document, comments or [])

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -17,6 +17,8 @@ import zipfile
 
 import pytest
 from docx import Document as DocxDocument
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.shared import RGBColor
 
 
 EMAIL_A = "acl-sweep-a@example.com"
@@ -621,7 +623,10 @@ async def test_get_manual_document_version_docx_preserves_rich_editor_marks(clie
     save = await client.post(
         f"/api/documents/{doc_id}/versions/manual",
         json={
-            "resolved_text": "Important term\n\nListed point",
+            "resolved_text": (
+                "Important term\n\nListed point\n\nRight aligned red\n\n"
+                "[ ] Review source\n[x] Check deadline\n\n[image: timeline diagram]"
+            ),
             "resolved_json": {
                 "type": "doc",
                 "content": [
@@ -655,6 +660,54 @@ async def test_get_manual_document_version_docx_preserves_rich_editor_marks(clie
                                 ],
                             }
                         ],
+                    },
+                    {
+                        "type": "paragraph",
+                        "attrs": {"textAlign": "right"},
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Right aligned red",
+                                "marks": [
+                                    {
+                                        "type": "textStyle",
+                                        "attrs": {"color": "#8C1D18"},
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "type": "taskList",
+                        "content": [
+                            {
+                                "type": "taskItem",
+                                "attrs": {"checked": False},
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [{"type": "text", "text": "Review source"}],
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "taskItem",
+                                "attrs": {"checked": True},
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [{"type": "text", "text": "Check deadline"}],
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "type": "image",
+                        "attrs": {
+                            "src": "https://example.com/timeline.png",
+                            "alt": "timeline diagram",
+                        },
                     },
                     {
                         "type": "table",
@@ -728,6 +781,12 @@ async def test_get_manual_document_version_docx_preserves_rich_editor_marks(clie
     bullet = next(p for p in docx.paragraphs if p.text == "Listed point")
     assert bullet.style.name.startswith("List Bullet")
     assert bullet.runs[0].font.highlight_color is not None
+    aligned = next(p for p in docx.paragraphs if p.text == "Right aligned red")
+    assert aligned.alignment == WD_ALIGN_PARAGRAPH.RIGHT
+    assert aligned.runs[0].font.color.rgb == RGBColor(0x8C, 0x1D, 0x18)
+    assert next(p for p in docx.paragraphs if p.text == "[ ] Review source")
+    assert next(p for p in docx.paragraphs if p.text == "[x] Check deadline")
+    assert next(p for p in docx.paragraphs if p.text == "[image: timeline diagram]")
     assert docx.tables[0].cell(0, 0).text == "Issue"
     assert docx.tables[0].cell(0, 1).text == "Risk"
     assert docx.tables[0].cell(1, 0).text == "Indemnity"


### PR DESCRIPTION
## Summary
- preserve TipTap text colour and paragraph alignment in document version DOCX export
- export checklist nodes as [ ] / [x] document lines
- represent image nodes as explicit italic placeholders in generated DOCX until governed media upload is added
- extend the existing rich editor DOCX route test to cover the new nodes

## Verification
- python py_compile backend/app/api/documents.py backend/tests/test_route_acl_sweep.py
- backend route test deferred to CI because local shell has no project pytest/uv on PATH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for colored text and text alignment in exported documents.
  * Implemented task list rendering with checkbox states in exports.
  * Enhanced image support in document exports and plain-text extraction.

* **Tests**
  * Expanded test coverage for rich document formatting including colors, alignment, task lists, and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->