### PR TITLE
documents: upload governed editor images

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -6,7 +6,9 @@ import io
 import hashlib
 import re
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from urllib.parse import unquote, urlparse
 
 from typing import Any, Literal
 
@@ -14,7 +16,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Respon
 from fastapi.responses import StreamingResponse
 from docx import Document as DocxDocument
 from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_COLOR_INDEX
-from docx.shared import RGBColor
+from docx.shared import Inches, RGBColor
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,6 +30,7 @@ from app.core.document_uploads import (
     sniff_format,
 )
 from app.core.storage import (
+    document_asset_key,
     get_storage_backend,
     StorageReadError,
     StorageWriteError,
@@ -78,6 +81,36 @@ from app.modules.anonymisation.schemas import (
 )
 
 router = APIRouter()
+
+IMAGE_ASSET_MIMES = {
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+}
+MAX_DOCUMENT_ASSET_BYTES = 5 * 1024 * 1024
+DOCUMENT_ASSET_URL_RE = re.compile(
+    r"^/api/documents/"
+    r"(?P<document_id>[0-9a-fA-F-]{36})/assets/"
+    r"(?P<asset_id>[0-9a-fA-F-]{36})/"
+    r"(?P<filename>[^?#]+)$"
+)
+
+
+@dataclass(frozen=True)
+class DocumentAssetContext:
+    user_id: uuid.UUID
+    matter_id: uuid.UUID
+    document_id: uuid.UUID
+
+
+class DocumentAssetUploadRead(BaseModel):
+    id: uuid.UUID
+    filename: str
+    mime_type: str
+    size_bytes: int
+    sha256: str
+    url: str
 
 
 class DocumentBodyRead(BaseModel):
@@ -462,12 +495,190 @@ def _safe_filename(title: str | None, file_uuid: str) -> str:
     return f"generated-{file_uuid[:8]}.docx"
 
 
+def _safe_asset_filename(filename: str | None, fallback: str) -> str:
+    if filename:
+        cleaned = _FILENAME_SAFE_RE.sub("-", filename).strip("-._")
+        cleaned = cleaned[:100].rstrip("-._")
+        if cleaned:
+            return cleaned
+    return fallback
+
+
 def _docx_export_filename(filename: str, version_number: int) -> str:
     stem = filename.rsplit(".", 1)[0] if "." in filename else filename
     cleaned = _FILENAME_SAFE_RE.sub("-", stem).strip("-._")[:80].rstrip("-._")
     if not cleaned:
         cleaned = "document"
     return f"{cleaned}-v{version_number}.docx"
+
+
+async def _owned_live_document(
+    session: AsyncSession,
+    document_id: uuid.UUID,
+    user: User,
+) -> tuple[Document, Matter]:
+    row = await session.execute(
+        select(Document, Matter)
+        .join(Matter, Matter.id == Document.matter_id)
+        .where(Document.id == document_id)
+    )
+    pair = row.first()
+    if pair is None:
+        raise HTTPException(404, "document not found")
+    doc, matter = pair
+    if matter.created_by_id != user.id or matter.status == STATUS_ARCHIVED:
+        raise HTTPException(404, "document not found")
+    return doc, matter
+
+
+@router.post("/{document_id}/assets", response_model=DocumentAssetUploadRead)
+async def post_document_asset(
+    document_id: uuid.UUID,
+    file: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> DocumentAssetUploadRead:
+    """Upload an embedded editor image for a document.
+
+    Assets live under the matter storage prefix and are retrieved through
+    the backend, so auth and matter cleanup stay inside the existing
+    document boundary. Reads are not audited because every render would
+    otherwise create noisy rows; the upload itself is recorded.
+    """
+    doc, matter = await _owned_live_document(session, document_id, user)
+    mime_type = file.content_type or "application/octet-stream"
+    if mime_type not in IMAGE_ASSET_MIMES:
+        raise HTTPException(415, "unsupported image type")
+    data = await file.read()
+    if not data:
+        raise HTTPException(400, "empty image")
+    if len(data) > MAX_DOCUMENT_ASSET_BYTES:
+        raise HTTPException(413, "image too large")
+
+    asset_id = uuid.uuid4()
+    extension = {
+        "image/gif": "gif",
+        "image/jpeg": "jpg",
+        "image/png": "png",
+        "image/webp": "webp",
+    }[mime_type]
+    filename = _safe_asset_filename(file.filename, f"{asset_id}.{extension}")
+    if "." not in filename:
+        filename = f"{filename}.{extension}"
+    digest = hashlib.sha256(data).hexdigest()
+    key = document_asset_key(user.id, matter.id, doc.id, asset_id, filename)
+    try:
+        get_storage_backend().put_bytes(
+            key,
+            data,
+            content_type=mime_type,
+            metadata={"sha256": digest, "document_id": str(doc.id)},
+        )
+    except StorageWriteError as exc:
+        await audit_failure(
+            session,
+            "storage.put_bytes.failed",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="storage",
+            resource_type="document_asset",
+            resource_id=str(asset_id),
+            payload={
+                "storage_key": key,
+                "backend": exc.backend,
+                "error_code": exc.error_code,
+            },
+        )
+        raise HTTPException(
+            502,
+            detail={
+                "error": "storage_write_failed",
+                "message": "Failed to store document image.",
+                "storage_key": key,
+                "backend": exc.backend,
+            },
+        ) from exc
+
+    await audit.log(
+        session,
+        "document.asset.uploaded",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module="document_editor",
+        resource_type="document_asset",
+        resource_id=str(asset_id),
+        payload={
+            "document_id": str(doc.id),
+            "filename": filename,
+            "mime_type": mime_type,
+            "size_bytes": len(data),
+            "sha256": digest,
+        },
+    )
+    await session.commit()
+    return DocumentAssetUploadRead(
+        id=asset_id,
+        filename=filename,
+        mime_type=mime_type,
+        size_bytes=len(data),
+        sha256=digest,
+        url=f"/api/documents/{doc.id}/assets/{asset_id}/{filename}",
+    )
+
+
+@router.get("/{document_id}/assets/{asset_id}/{filename}")
+async def get_document_asset(
+    document_id: uuid.UUID,
+    asset_id: uuid.UUID,
+    filename: str,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> StreamingResponse:
+    doc, matter = await _owned_live_document(session, document_id, user)
+    safe_filename = _safe_asset_filename(filename, f"{asset_id}")
+    key = document_asset_key(user.id, matter.id, doc.id, asset_id, safe_filename)
+    try:
+        data = get_storage_backend().get_bytes(key)
+    except KeyError:
+        raise HTTPException(404, "document asset not found")
+    except StorageReadError as exc:
+        await audit_failure(
+            session,
+            "storage.get_bytes.failed",
+            actor_id=user.id,
+            matter_id=matter.id,
+            module="storage",
+            resource_type="document_asset",
+            resource_id=str(asset_id),
+            payload={
+                "storage_key": key,
+                "backend": exc.backend,
+                "error_code": exc.error_code,
+            },
+        )
+        raise HTTPException(
+            502,
+            detail={
+                "error": "storage_read_failed",
+                "message": "Failed to read document image.",
+                "storage_key": key,
+                "backend": exc.backend,
+            },
+        ) from exc
+
+    suffix = safe_filename.rsplit(".", 1)[-1].lower() if "." in safe_filename else ""
+    mime_type = {
+        "gif": "image/gif",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+        "webp": "image/webp",
+    }.get(suffix, "application/octet-stream")
+    return StreamingResponse(
+        iter([data]),
+        media_type=mime_type,
+        headers={"Content-Length": str(len(data))},
+    )
 
 
 def _render_resolved_text_docx(
@@ -539,7 +750,57 @@ def _paragraph_alignment(value: str | None):
     }.get(value or "")
 
 
-def _add_tiptap_inline_content(paragraph, nodes: list[dict[str, Any]] | None) -> None:
+def _document_asset_key_from_src(
+    src: str | None,
+    context: DocumentAssetContext | None,
+) -> str | None:
+    if not src or context is None:
+        return None
+    parsed = urlparse(src)
+    path = parsed.path if parsed.scheme or parsed.netloc else src
+    match = DOCUMENT_ASSET_URL_RE.match(path)
+    if match is None:
+        return None
+    try:
+        document_id = uuid.UUID(match.group("document_id"))
+        asset_id = uuid.UUID(match.group("asset_id"))
+    except ValueError:
+        return None
+    if document_id != context.document_id:
+        return None
+    filename = _safe_asset_filename(unquote(match.group("filename")), f"{asset_id}")
+    return document_asset_key(
+        context.user_id,
+        context.matter_id,
+        context.document_id,
+        asset_id,
+        filename,
+    )
+
+
+def _add_tiptap_image(paragraph, attrs: dict[str, Any], context: DocumentAssetContext | None) -> bool:
+    key = _document_asset_key_from_src(
+        attrs.get("src") if isinstance(attrs.get("src"), str) else None,
+        context,
+    )
+    if key is None:
+        return False
+    try:
+        data = get_storage_backend().get_bytes(key)
+    except (KeyError, StorageReadError):
+        return False
+    try:
+        paragraph.add_run().add_picture(io.BytesIO(data), width=Inches(5.8))
+    except Exception:
+        return False
+    return True
+
+
+def _add_tiptap_inline_content(
+    paragraph,
+    nodes: list[dict[str, Any]] | None,
+    asset_context: DocumentAssetContext | None = None,
+) -> None:
     for node in nodes or []:
         node_type = node.get("type")
         if node_type == "text":
@@ -564,17 +825,19 @@ def _add_tiptap_inline_content(paragraph, nodes: list[dict[str, Any]] | None) ->
             paragraph.add_run().add_break()
         elif node_type == "image":
             attrs = node.get("attrs") or {}
-            label = attrs.get("alt") or attrs.get("src") or "image"
-            run = paragraph.add_run(f"[image: {label}]")
-            run.italic = True
+            if not _add_tiptap_image(paragraph, attrs, asset_context):
+                label = attrs.get("alt") or attrs.get("src") or "image"
+                run = paragraph.add_run(f"[image: {label}]")
+                run.italic = True
         elif isinstance(node.get("content"), list):
-            _add_tiptap_inline_content(paragraph, node.get("content"))
+            _add_tiptap_inline_content(paragraph, node.get("content"), asset_context)
 
 
 def _add_tiptap_paragraph(
     document: DocxDocument,
     node: dict[str, Any],
     style: str | None = None,
+    asset_context: DocumentAssetContext | None = None,
 ) -> None:
     if node.get("type") == "heading":
         level = int((node.get("attrs") or {}).get("level") or 1)
@@ -584,10 +847,15 @@ def _add_tiptap_paragraph(
     alignment = _paragraph_alignment((node.get("attrs") or {}).get("textAlign"))
     if alignment is not None:
         paragraph.alignment = alignment
-    _add_tiptap_inline_content(paragraph, node.get("content"))
+    _add_tiptap_inline_content(paragraph, node.get("content"), asset_context)
 
 
-def _add_tiptap_list_item(document: DocxDocument, item: dict[str, Any], style: str) -> None:
+def _add_tiptap_list_item(
+    document: DocxDocument,
+    item: dict[str, Any],
+    style: str,
+    asset_context: DocumentAssetContext | None = None,
+) -> None:
     children = item.get("content") or []
     wrote_paragraph = False
     for child in children:
@@ -599,23 +867,33 @@ def _add_tiptap_list_item(document: DocxDocument, item: dict[str, Any], style: s
                 document,
                 child,
                 style=style if not wrote_paragraph else None,
+                asset_context=asset_context,
             )
             wrote_paragraph = True
         elif child_type == "bulletList":
-            _add_tiptap_list(document, child, "List Bullet")
+            _add_tiptap_list(document, child, "List Bullet", asset_context)
         elif child_type == "orderedList":
-            _add_tiptap_list(document, child, "List Number")
+            _add_tiptap_list(document, child, "List Number", asset_context)
     if not wrote_paragraph:
         document.add_paragraph(style=style)
 
 
-def _add_tiptap_list(document: DocxDocument, node: dict[str, Any], style: str) -> None:
+def _add_tiptap_list(
+    document: DocxDocument,
+    node: dict[str, Any],
+    style: str,
+    asset_context: DocumentAssetContext | None = None,
+) -> None:
     for child in node.get("content") or []:
         if isinstance(child, dict) and child.get("type") == "listItem":
-            _add_tiptap_list_item(document, child, style)
+            _add_tiptap_list_item(document, child, style, asset_context)
 
 
-def _add_tiptap_task_item(document: DocxDocument, item: dict[str, Any]) -> None:
+def _add_tiptap_task_item(
+    document: DocxDocument,
+    item: dict[str, Any],
+    asset_context: DocumentAssetContext | None = None,
+) -> None:
     checked = bool((item.get("attrs") or {}).get("checked"))
     prefix = "[x] " if checked else "[ ] "
     children = item.get("content") or []
@@ -626,13 +904,17 @@ def _add_tiptap_task_item(document: DocxDocument, item: dict[str, Any]) -> None:
             break
     paragraph = document.add_paragraph()
     paragraph.add_run(prefix)
-    _add_tiptap_inline_content(paragraph, paragraph_children)
+    _add_tiptap_inline_content(paragraph, paragraph_children, asset_context)
 
 
-def _add_tiptap_task_list(document: DocxDocument, node: dict[str, Any]) -> None:
+def _add_tiptap_task_list(
+    document: DocxDocument,
+    node: dict[str, Any],
+    asset_context: DocumentAssetContext | None = None,
+) -> None:
     for child in node.get("content") or []:
         if isinstance(child, dict) and child.get("type") == "taskItem":
-            _add_tiptap_task_item(document, child)
+            _add_tiptap_task_item(document, child, asset_context)
 
 
 def _tiptap_cell_text(cell: dict[str, Any]) -> str:
@@ -711,6 +993,7 @@ def _render_tiptap_docx(
     body_json: dict[str, Any],
     fallback_text: str,
     comments: list[DocumentComment] | None = None,
+    asset_context: DocumentAssetContext | None = None,
 ) -> bytes:
     if body_json.get("type") != "doc" or not isinstance(body_json.get("content"), list):
         return _render_resolved_text_docx(title, fallback_text, comments or [])
@@ -722,16 +1005,16 @@ def _render_tiptap_docx(
             continue
         node_type = node.get("type")
         if node_type in {"paragraph", "heading"}:
-            _add_tiptap_paragraph(document, node)
+            _add_tiptap_paragraph(document, node, asset_context=asset_context)
         elif node_type == "bulletList":
-            _add_tiptap_list(document, node, "List Bullet")
+            _add_tiptap_list(document, node, "List Bullet", asset_context)
         elif node_type == "orderedList":
-            _add_tiptap_list(document, node, "List Number")
+            _add_tiptap_list(document, node, "List Number", asset_context)
         elif node_type == "taskList":
-            _add_tiptap_task_list(document, node)
+            _add_tiptap_task_list(document, node, asset_context)
         elif node_type == "image":
             paragraph = document.add_paragraph()
-            _add_tiptap_inline_content(paragraph, [node])
+            _add_tiptap_inline_content(paragraph, [node], asset_context)
         elif node_type == "table":
             _add_tiptap_table(document, node)
     _append_document_comments_docx(document, comments or [])
@@ -1698,6 +1981,7 @@ async def get_document_version_docx(
             version.resolved_json,
             version.resolved_text,
             comments,
+            DocumentAssetContext(user.id, matter.id, doc.id),
         )
         if version.resolved_json
         else _render_resolved_text_docx(doc.filename, version.resolved_text, comments)

--- a/backend/app/core/storage.py
+++ b/backend/app/core/storage.py
@@ -114,6 +114,27 @@ def generated_key(
     return f"users/{user_id}/matters/{matter_id}/generated/{document_id}/{safe}"
 
 
+def document_asset_key(
+    user_id: uuid.UUID,
+    matter_id: uuid.UUID,
+    document_id: uuid.UUID,
+    asset_id: uuid.UUID,
+    filename: str,
+) -> str:
+    """Canonical object-storage key for document editor embedded assets.
+
+    Key: ``users/{user_id}/matters/{matter_id}/documents/{document_id}/assets/{asset_id}/{safe_filename}``
+
+    It deliberately lives under the matter prefix so destructive matter
+    deletion sweeps assets with the rest of the matter storage.
+    """
+    safe = _sanitise_filename(filename)
+    return (
+        f"users/{user_id}/matters/{matter_id}/documents/"
+        f"{document_id}/assets/{asset_id}/{safe}"
+    )
+
+
 def artifact_key(
     user_id: uuid.UUID,
     matter_id: uuid.UUID,
@@ -536,5 +557,6 @@ __all__ = [
     "_reset_backend",
     "uploaded_key",
     "generated_key",
+    "document_asset_key",
     "matter_prefix",
 ]

--- a/backend/tests/test_route_acl_sweep.py
+++ b/backend/tests/test_route_acl_sweep.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import base64
 import uuid
 import zipfile
 
@@ -27,6 +28,9 @@ EMAIL_B = "acl-sweep-b@example.com"
 PASSWORD_B = "acl-sweep-b-password-2026"
 
 _PDF_MAGIC = b"%PDF-1.4 1 0 obj<</Type /Catalog>>stream\nHello\nendstream\nendobj"
+_ONE_PIXEL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
 
 
 async def _signup_and_login(client, email: str, password: str) -> None:
@@ -104,6 +108,62 @@ async def test_get_document_versions_cross_user_returns_404(client) -> None:
 
     await _signup_and_login(client, EMAIL_B, PASSWORD_B)
     resp = await client.get(f"/api/documents/{doc_id}/versions")
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_document_asset_owner_can_upload_and_read_image(client) -> None:
+    """Owner can upload an embedded editor image and read it through the proxy."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload_text(client, "Document body.")
+
+    png = b"\x89PNG\r\n\x1a\nlegalise-image"
+    uploaded = await client.post(
+        f"/api/documents/{doc_id}/assets",
+        files={"file": ("diagram.png", io.BytesIO(png), "image/png")},
+    )
+    assert uploaded.status_code == 200, uploaded.text
+    payload = uploaded.json()
+    assert payload["filename"] == "diagram.png"
+    assert payload["mime_type"] == "image/png"
+    assert payload["size_bytes"] == len(png)
+    assert payload["sha256"] == hashlib.sha256(png).hexdigest()
+    assert payload["url"].startswith(f"/api/documents/{doc_id}/assets/")
+
+    read_back = await client.get(payload["url"])
+    assert read_back.status_code == 200, read_back.text
+    assert read_back.headers["content-type"].startswith("image/png")
+    assert read_back.content == png
+
+
+@pytest.mark.asyncio
+async def test_document_asset_rejects_unsupported_mime(client) -> None:
+    """Image assets are intentionally image-only."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload_text(client, "Document body.")
+
+    resp = await client.post(
+        f"/api/documents/{doc_id}/assets",
+        files={"file": ("payload.svg", io.BytesIO(b"<svg />"), "image/svg+xml")},
+    )
+    assert resp.status_code == 415, resp.text
+
+
+@pytest.mark.asyncio
+async def test_document_asset_cross_user_returns_404(client) -> None:
+    """User B cannot read User A's embedded editor images by document UUID."""
+    await _signup_and_login(client, EMAIL_A, PASSWORD_A)
+    _, doc_id = await _create_matter_and_upload_text(client, "Document body.")
+    uploaded = await client.post(
+        f"/api/documents/{doc_id}/assets",
+        files={"file": ("diagram.png", io.BytesIO(b"png-bytes"), "image/png")},
+    )
+    assert uploaded.status_code == 200, uploaded.text
+    url = uploaded.json()["url"]
+    await client.post("/auth/logout")
+
+    await _signup_and_login(client, EMAIL_B, PASSWORD_B)
+    resp = await client.get(url)
     assert resp.status_code == 404, resp.text
 
 
@@ -619,13 +679,20 @@ async def test_get_manual_document_version_docx_preserves_rich_editor_marks(clie
     """Rich editor saves keep basic formatting when exported as .docx."""
     await _signup_and_login(client, EMAIL_A, PASSWORD_A)
     _, doc_id = await _create_matter_and_upload(client)
+    image_upload = await client.post(
+        f"/api/documents/{doc_id}/assets",
+        files={"file": ("governed.png", io.BytesIO(_ONE_PIXEL_PNG), "image/png")},
+    )
+    assert image_upload.status_code == 200, image_upload.text
+    governed_image_url = image_upload.json()["url"]
 
     save = await client.post(
         f"/api/documents/{doc_id}/versions/manual",
         json={
             "resolved_text": (
                 "Important term\n\nListed point\n\nRight aligned red\n\n"
-                "[ ] Review source\n[x] Check deadline\n\n[image: timeline diagram]"
+                "[ ] Review source\n[x] Check deadline\n\n"
+                "[image: timeline diagram]\n\n[image: governed diagram]"
             ),
             "resolved_json": {
                 "type": "doc",
@@ -710,6 +777,13 @@ async def test_get_manual_document_version_docx_preserves_rich_editor_marks(clie
                         },
                     },
                     {
+                        "type": "image",
+                        "attrs": {
+                            "src": governed_image_url,
+                            "alt": "governed diagram",
+                        },
+                    },
+                    {
                         "type": "table",
                         "content": [
                             {
@@ -787,6 +861,8 @@ async def test_get_manual_document_version_docx_preserves_rich_editor_marks(clie
     assert next(p for p in docx.paragraphs if p.text == "[ ] Review source")
     assert next(p for p in docx.paragraphs if p.text == "[x] Check deadline")
     assert next(p for p in docx.paragraphs if p.text == "[image: timeline diagram]")
+    assert not any(p.text == "[image: governed diagram]" for p in docx.paragraphs)
+    assert len(docx.inline_shapes) == 1
     assert docx.tables[0].cell(0, 0).text == "Issue"
     assert docx.tables[0].cell(0, 1).text == "Risk"
     assert docx.tables[0].cell(1, 0).text == "Indemnity"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1785,6 +1785,15 @@ export interface DocumentWorkingDraftRead {
   client_id: string | null;
 }
 
+export interface DocumentAssetUploadRead {
+  id: string;
+  filename: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string;
+  url: string;
+}
+
 export class ConflictError extends Error {
   status = 409;
   detail: unknown;
@@ -1946,6 +1955,39 @@ export const uploadDocumentVersion = async (
     );
   }
   return resolutionJsonOrThrow<DocumentVersionRead>(res);
+};
+
+export const uploadDocumentAsset = async (
+  documentId: string,
+  file: File,
+): Promise<DocumentAssetUploadRead> => {
+  const fd = new FormData();
+  fd.append("file", file);
+  const res = await apiFetch(`${API}/documents/${documentId}/assets`, {
+    method: "POST",
+    body: fd,
+  });
+  if (res.status === 413 || res.status === 415) {
+    if (res.status === 415) {
+      throw new UploadError(
+        "unsupported_mime",
+        415,
+        "That image type is not supported. Upload PNG, JPEG, WebP, or GIF.",
+      );
+    }
+    throw new UploadError(
+      "upload_too_large",
+      413,
+      `Image is too large (${formatMb(file.size)}). The limit is ${formatMb(
+        5 * 1024 * 1024,
+      )} per image.`,
+    );
+  }
+  const uploaded = await resolutionJsonOrThrow<DocumentAssetUploadRead>(res);
+  return {
+    ...uploaded,
+    url: uploaded.url.startsWith("/api/") ? `${BACKEND_ROOT}${uploaded.url}` : uploaded.url,
+  };
 };
 
 export const restoreDocumentVersion = (

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -698,7 +698,12 @@ describe("DocumentRichEditor surface", () => {
     expect(screen.getByRole("button", { name: "Align left" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align centre" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align right" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Insert image" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upload image" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Insert image URL" })).toBeInTheDocument();
+    expect(screen.getByTestId("document-image-upload-input")).toHaveAttribute(
+      "accept",
+      "image/png,image/jpeg,image/webp,image/gif",
+    );
     expect(screen.getByRole("button", { name: "Insert table" })).toBeInTheDocument();
     expect(screen.getByTestId("document-editor-stats")).toHaveTextContent("words");
     expect(screen.getByRole("button", { name: "Copy text" })).toBeInTheDocument();
@@ -712,6 +717,69 @@ describe("DocumentRichEditor surface", () => {
     });
     expect(screen.getByTestId("document-editor-copy-status")).toHaveTextContent(
       "Copied working text",
+    );
+  });
+
+  it("uploads an image asset before inserting it into the editor", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/documents/doc-1/draft") && !init?.method) {
+        return Promise.resolve(
+          jsonResponse({
+            document_id: "doc-1",
+            updated_by_id: null,
+            updated_at: null,
+            plain_text: "Existing text.",
+            editor_json: null,
+            base_version_id: "version-1",
+            version_counter: 0,
+            client_id: null,
+          }),
+        );
+      }
+      if (url.endsWith("/documents/doc-1/assets") && init?.method === "POST") {
+        expect(init.body).toBeInstanceOf(FormData);
+        return Promise.resolve(
+          jsonResponse({
+            id: "asset-1",
+            filename: "diagram.png",
+            mime_type: "image/png",
+            size_bytes: 7,
+            sha256: "abc",
+            url: "/api/documents/doc-1/assets/asset-1/diagram.png",
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({ detail: "not found" }, 404));
+    });
+
+    render(
+      <DocumentRichEditor
+        documentId="doc-1"
+        filename="draft.docx"
+        initialText="Existing text."
+        latestVersionNumber={2}
+        latestVersionId="version-1"
+        sourceLabel="extracted · 14 chars"
+        onSaved={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByTestId("document-editor-canvas")).toHaveTextContent(
+      "Existing text.",
+    );
+    const file = new File(["diagram"], "diagram.png", { type: "image/png" });
+    fireEvent.change(screen.getByTestId("document-image-upload-input"), {
+      target: { files: [file] },
+    });
+
+    expect(await screen.findByAltText("diagram.png")).toHaveAttribute(
+      "src",
+      "/api/documents/doc-1/assets/asset-1/diagram.png",
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/documents/doc-1/assets",
+      expect.objectContaining({ method: "POST" }),
     );
   });
 

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -3,6 +3,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { EditorContent, useEditor, type Editor } from "@tiptap/react";
@@ -33,6 +34,7 @@ import {
   fetchDocumentOriginalBlob,
   getDocumentWorkingDraft,
   saveDocumentWorkingDraft,
+  uploadDocumentAsset,
   type DocumentVersionRead,
   type DocumentWorkingDraftRead,
 } from "../../lib/api";
@@ -523,6 +525,7 @@ export function DocumentRichEditor({
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [downloadingDocx, setDownloadingDocx] = useState(false);
+  const [uploadingImage, setUploadingImage] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedMessage, setSavedMessage] = useState<string | null>(null);
   const [copiedMessage, setCopiedMessage] = useState<string | null>(null);
@@ -538,6 +541,7 @@ export function DocumentRichEditor({
   const [draftBaselineText, setDraftBaselineText] = useState(initialText);
   const [canvasMode, setCanvasMode] = useState<DocumentCanvasMode>("page");
   const findInputRef = useRef<HTMLInputElement | null>(null);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
   const draftSaveTimerRef = useRef<number | null>(null);
   const dirtyRef = useRef(false);
   const draftBaseVersionIdRef = useRef<string | null>(latestVersionId ?? null);
@@ -1086,7 +1090,7 @@ export function DocumentRichEditor({
     editor.chain().focus().extendMarkRange("link").setLink({ href: trimmed }).run();
   }
 
-  function insertEditorImage() {
+  function insertEditorImageUrl() {
     if (!editor) return;
     const src = window.prompt("Paste image URL");
     if (src === null) return;
@@ -1094,6 +1098,27 @@ export function DocumentRichEditor({
     if (!trimmed) return;
     const alt = window.prompt("Image description", "")?.trim() ?? "";
     editor.chain().focus().setImage({ src: trimmed, alt }).run();
+  }
+
+  async function handleEditorImageUpload(event: ChangeEvent<HTMLInputElement>) {
+    if (!editor) return;
+    const file = event.target.files?.[0] ?? null;
+    event.target.value = "";
+    if (!file) return;
+    setUploadingImage(true);
+    setError(null);
+    try {
+      const uploaded = await uploadDocumentAsset(documentId, file);
+      editor.chain().focus().setImage({
+        src: uploaded.url,
+        alt: uploaded.filename,
+      }).run();
+      setSavedMessage("Image inserted into the working copy.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not upload image.");
+    } finally {
+      setUploadingImage(false);
+    }
   }
 
   function downloadWorkingText() {
@@ -1359,9 +1384,24 @@ export function DocumentRichEditor({
                 </ToolbarButton>
               </ToolbarGroup>
               <ToolbarGroup label="Media">
+                <input
+                  ref={imageInputRef}
+                  data-testid="document-image-upload-input"
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp,image/gif"
+                  className="hidden"
+                  onChange={(event) => void handleEditorImageUpload(event)}
+                />
                 <ToolbarButton
-                  label="Insert image"
-                  onClick={insertEditorImage}
+                  label={uploadingImage ? "Uploading image" : "Upload image"}
+                  disabled={uploadingImage}
+                  onClick={() => imageInputRef.current?.click()}
+                >
+                  Up
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Insert image URL"
+                  onClick={insertEditorImageUrl}
                 >
                   Img
                 </ToolbarButton>


### PR DESCRIPTION
## Summary
- add owner-scoped document image asset upload/read endpoints backed by matter storage
- insert uploaded images into the TipTap document editor instead of relying only on remote URLs
- cover owner read, unsupported image type, cross-user 404, and editor upload wiring

## Local checks
- python3 -m py_compile backend/app/core/storage.py backend/app/api/documents.py backend/tests/test_route_acl_sweep.py
- npm run typecheck
- npx vitest run src/modules/document_edit/DocumentRichEditor.test.tsx
- npm run build

## Notes
No schema change. Image asset uploads are audited as document.asset.uploaded; image reads are intentionally not audited to avoid noisy rows on every render.