### PR TITLE
feat(contract-review): jobs-first migration — frontend (stage 1)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2587,54 +2587,20 @@ export interface ContractReviewResult {
   contract_type: ContractKind;
 }
 
-export type ContractReviewStreamEvent =
-  | { event: "stage.start"; data: { stage: string } }
-  | {
-      event: "stage.end";
-      data: {
-        stage: string;
-        duration_ms: number;
-        token_count: number;
-        status: "ok" | "error" | "skipped";
-        error?: string;
-      };
-    }
-  | { event: "result"; data: ContractReviewResult }
-  | {
-      event: "error";
-      data: {
-        message: string;
-        code?: number;
-        error?: string;
-        provider?: string;
-      };
-    };
-
-export class StreamPreflightError extends Error {
-  status: number;
-  body: unknown;
-  constructor(status: number, body: unknown, message: string) {
-    super(message);
-    this.status = status;
-    this.body = body;
-  }
-}
-
-export async function* runContractReviewStream(
+// Contract Review runs on the durable jobs path (POST .../contract-review/jobs);
+// the frontend polls `getJob` for stage/progress + the final result_payload.
+// (The bespoke /run-stream SSE path is retired — 2026-06-04.) Provider-key /
+// upstream preflight failures surface synchronously here, same as before.
+export async function createContractReviewJob(
   slug: string,
   inputs: ContractReviewInputs,
-  signal?: AbortSignal,
-): AsyncIterableIterator<ContractReviewStreamEvent> {
-  const resp = await apiFetch(
-    `${API}/matters/${slug}/contract-review/run-stream`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(inputs),
-      signal,
-    },
-  );
-  if (!resp.ok || !resp.body) {
+): Promise<JobRead> {
+  const resp = await apiFetch(`${API}/matters/${slug}/contract-review/jobs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(inputs),
+  });
+  if (!resp.ok) {
     const text = await resp.text();
     let parsed: unknown = text;
     try {
@@ -2661,31 +2627,9 @@ export async function* runContractReviewStream(
     } else if (typeof parsed === "string" && parsed) {
       message = parsed;
     }
-    throw new StreamPreflightError(resp.status, parsed, message);
+    throw new Error(message);
   }
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder("utf-8");
-  let buffer = "";
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) return;
-    buffer += decoder.decode(value, { stream: true });
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) >= 0) {
-      const frame = buffer.slice(0, sep);
-      buffer = buffer.slice(sep + 2);
-      let event = "message";
-      const dataLines: string[] = [];
-      for (const line of frame.split("\n")) {
-        if (line.startsWith("event:")) event = line.slice(6).trim();
-        else if (line.startsWith("data:"))
-          dataLines.push(line.slice(5).trim());
-      }
-      if (dataLines.length === 0) continue;
-      const data = JSON.parse(dataLines.join("\n"));
-      yield { event, data } as ContractReviewStreamEvent;
-    }
-  }
+  return (await resp.json()) as JobRead;
 }
 
 export interface DocxExportResult {

--- a/frontend/src/modules/contract_review/ContractReviewTab.tsx
+++ b/frontend/src/modules/contract_review/ContractReviewTab.tsx
@@ -1,29 +1,28 @@
 // ContractReviewTab - host component for the four-stage redliner UI.
 //
-// Takes `matter` and `docs` from the parent (App.tsx) - module cannot
-// modify lib/api.ts (owned by other workstreams). Filter to documents
-// that are plausibly contracts (filename hint + tag) but show all docs
-// with a "pick a doc with extracted body" note so a user with weird
-// filenames isn't locked out.
+// Runs on the durable jobs path (createContractReviewJob -> poll getJob);
+// the bespoke /run-stream SSE path is retired (2026-06-04). Takes `matter`
+// and `docs` from the parent. Filter to documents that are plausibly
+// contracts (filename hint + tag) but show all docs with a "pick a doc with
+// extracted body" note so a user with weird filenames isn't locked out.
 
-import { useMemo, useState } from "react";
-
-import type { Matter, MatterDocument } from "../../lib/api";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  createContractReviewJob,
   exportContractReviewDocx,
+  getJob,
   ProviderKeyMissingError,
-  runContractReviewStream,
-  StreamPreflightError,
   ProviderUpstreamError,
   providerUpstreamMessage,
-  tryParseProviderUpstream,
   type ContractKind,
   type ContractReviewResult,
+  type JobRead,
+  type Matter,
+  type MatterDocument,
   type Posture,
-  type StageState,
   type StageStatus,
-} from "./api";
+} from "../../lib/api";
 import { ResultPanel } from "./ResultPanel";
 import { StageStrip } from "./StageStrip";
 import { ErrorCallout, ProviderKeyMissingBanner } from "../../ui/primitives";
@@ -62,6 +61,24 @@ const INITIAL_STAGES: StageStatus[] = [
   { name: "redliner", status: "pending", sub_agent_count: 1, duration_ms: 0, token_count: 0, errors: [] },
   { name: "summariser", status: "pending", sub_agent_count: 1, duration_ms: 0, token_count: 0, errors: [] },
 ];
+
+// The job reports one current stage name as it runs; mark earlier stages done
+// and the current one running so the StageStrip still animates under polling.
+const STAGE_ORDER = ["parser", "analyst", "redliner", "summariser"];
+const TERMINAL_JOB = new Set(["succeeded", "failed", "cancelled"]);
+const POLL_INTERVAL_MS = 1500;
+
+function stagesUpTo(current: string | null): Record<string, Partial<StageStatus>> {
+  if (!current) return {};
+  const idx = STAGE_ORDER.indexOf(current);
+  if (idx < 0) return {};
+  const out: Record<string, Partial<StageStatus>> = {};
+  STAGE_ORDER.forEach((name, i) => {
+    if (i < idx) out[name] = { status: "done" };
+    else if (i === idx) out[name] = { status: "running" };
+  });
+  return out;
+}
 
 function guessContractKind(filename: string): ContractKind {
   const f = filename.toLowerCase();
@@ -117,6 +134,14 @@ export function ContractReviewTab({ matter, docs, previewResult, onRunOverride }
   const [exportError, setExportError] = useState<string | null>(null);
   const [exportLink, setExportLink] = useState<string | null>(null);
 
+  // Stop polling state-updates if the tab unmounts mid-run.
+  const aliveRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
   const onPickDoc = (id: string) => {
     setDocumentId(id);
     const doc = orderedDocs.find((d) => d.id === id);
@@ -140,68 +165,41 @@ export function ContractReviewTab({ matter, docs, previewResult, onRunOverride }
     setExportLink(null);
     setExportError(null);
     try {
-      const iter = runContractReviewStream(matter.slug, {
+      const job = await createContractReviewJob(matter.slug, {
         document_id: documentId,
         posture,
         contract_type: contractType,
         counterparty_name: counterparty || null,
         deal_value: dealValue || null,
       });
-      for await (const evt of iter) {
-        if (evt.event === "stage.start") {
-          const name = evt.data.stage;
-          setLiveStages((prev) => ({
-            ...prev,
-            [name]: { ...(prev[name] || {}), status: "running" },
-          }));
-        } else if (evt.event === "stage.end") {
-          const { stage, status, duration_ms, token_count, error: stageErr } =
-            evt.data;
-          const mapped: StageState =
-            status === "ok"
-              ? "done"
-              : status === "skipped"
-              ? "skipped"
-              : "error";
-          setLiveStages((prev) => ({
-            ...prev,
-            [stage]: {
-              status: mapped,
-              duration_ms,
-              token_count,
-              errors: stageErr ? [stageErr] : [],
-            },
-          }));
-          if (status === "error" && stageErr) {
-            setError(`${stage}: ${stageErr}`);
-          }
-        } else if (evt.event === "result") {
-          setResult(evt.data);
-          // Clear live overrides - the canonical stages array now drives UI.
-          setLiveStages({});
-        } else if (evt.event === "error") {
-          const upstream = tryParseProviderUpstream(evt.data);
-          if (upstream) {
-            setError(providerUpstreamMessage(upstream));
-          } else {
-            setError(evt.data.message || "Contract review failed.");
-          }
-        }
+      // Poll the durable job to completion, animating the StageStrip from the
+      // job's current stage as it advances.
+      let current: JobRead = job;
+      while (!TERMINAL_JOB.has(current.status)) {
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+        if (!aliveRef.current) return;
+        current = await getJob(matter.slug, job.id);
+        setLiveStages(stagesUpTo(current.stage));
+      }
+      if (!aliveRef.current) return;
+      if (current.status === "succeeded" && current.result_payload) {
+        setResult(current.result_payload as unknown as ContractReviewResult);
+        // The canonical stages array on the result now drives the StageStrip.
+        setLiveStages({});
+      } else {
+        setError(current.error_message || "Contract review failed.");
       }
     } catch (e: unknown) {
       if (e instanceof ProviderKeyMissingError) {
         setKeyMissingProvider(e.provider);
       } else if (e instanceof ProviderUpstreamError) {
         setError(providerUpstreamMessage(e));
-      } else if (e instanceof StreamPreflightError) {
-        // 422 (provider_key_missing) and 409 (privilege-paused) land here.
-        setError(e.message);
       } else {
         const msg = e instanceof Error ? e.message : String(e);
         setError(`Contract review failed. ${msg}`);
       }
     } finally {
-      setRunning(false);
+      if (aliveRef.current) setRunning(false);
     }
   };
 

--- a/frontend/src/modules/contract_review/ResultPanel.tsx
+++ b/frontend/src/modules/contract_review/ResultPanel.tsx
@@ -10,7 +10,7 @@ import type {
   Redline,
   RiskSeverity,
   UkIssueCategory,
-} from "./api";
+} from "../../lib/api";
 
 interface Props {
   result: ContractReviewResult;

--- a/frontend/src/modules/contract_review/StageStrip.tsx
+++ b/frontend/src/modules/contract_review/StageStrip.tsx
@@ -2,7 +2,7 @@
 // Pill state maps to StageState; visuals mirror the Pre-Motion strip's
 // Paper Ink Workspace tokens (bg-paper / border-rule / text-ink).
 
-import type { StageState, StageStatus } from "./api";
+import type { StageState, StageStatus } from "../../lib/api";
 
 interface Props {
   stages: StageStatus[];

--- a/frontend/src/modules/contract_review/api.ts
+++ b/frontend/src/modules/contract_review/api.ts
@@ -1,2 +1,0 @@
-// Re-export shim. Consolidated into `src/lib/api.ts`.
-export * from "../../lib/api";


### PR DESCRIPTION
Stage 1 of the contract-review jobs-first migration (#162 §2.1, hot-path owned solo).

## What this does
Moves `ContractReviewTab` off the bespoke `/contract-review/run-stream` SSE onto the **existing durable jobs path**:
- `createContractReviewJob` → poll `getJob` (StageStrip animated from `job.stage`/`progress`) → render `ResultPanel` from `job.result_payload`.
- `/docx` export **unchanged** (no DOCX regression — the guard from the read pass).
- Removed `runContractReviewStream` + `StreamPreflightError` + `ContractReviewStreamEvent` from `lib/api.ts`; deleted the `modules/contract_review/api.ts` re-export shim; repointed `ResultPanel`/`StageStrip` imports to `lib/api`.

The bespoke `/run` **UI path is now gone** — the acceptance-rule win. No `if (skill === …)`; the tab runs through the generic jobs runner.

## Verification
- `tsc --noEmit` clean
- Full frontend `vitest`: **274 passed**

## Staged next (separate, deliberate)
- Backend: delete `/run` + `/run-stream` from `modules/contract_review/router.py` (the routes are now UI-unused), keep `/docx`.
- Tests: rewrite `test_smoke_evals.py`'s `/run` E2E to drive the pipeline (`run_contract_review`) directly + assert via the `/jobs` create path — not a find-replace; deferred so the regulated-adjacent test rewrite gets proper care + reviewer eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
