### PR TITLE
chore: retire contract-review stream route

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Open-source infrastructure for solicitor-owned AI preparation in
 England & Wales.
 
-Open a matter. Add documents. Run governed actions. Review outputs with
+Open a matter. Add documents. Run skills. Review outputs with
 cited sources visible. **Sign the output as a record of professional
 judgement.** Export the matter record.
 
@@ -39,20 +39,24 @@ The full thesis lives in [`docs/MANIFESTO.md`](./docs/MANIFESTO.md). The claim b
 ## What is in the repo
 
 Legalise currently ships a worked evaluation workspace around the
-Khan v Acme sample matter. The matter surface compresses to four tabs:
+Khan v Acme sample matter. The matter surface now follows the golden
+loop directly:
 
-- **Matter desk:** parties, posture, retention clock, readiness.
+- **Chat:** the project front door. Ask about the matter or run a
+  ready skill against the selected documents.
 - **Documents:** drag/drop ingress, extracted bodies, version history,
   CPR 31.22 disclosure flag, original-file retrieval through an
   owner-only backend proxy.
-- **Actions:** governed actions an installed module can run on this
-  matter — readiness shown up-front (`Ready` / `Keyless demo model` /
+- **Skills:** governed legal skills enabled for this matter — readiness
+  shown up-front (`Ready` / `Keyless demo model` /
   `Requires Anthropic key` / `Requires OpenAI key`).
-- **Activity Trail:** the matter's record of what happened — module
+- **Record:** the matter's proof layer — module
   invoked, model called, output written, sign-off recorded, supervisor
   decision (when used), gate denials.
+- **Signed outputs** and **Working pack:** the signed material and
+  exportable matter record.
 
-Available actions produce **outputs** (artifacts) the user reviews,
+Skills produce **outputs** (artifacts) the user reviews,
 signs, and exports:
 
 - **Professional Sign-Off:** the author reads an AI-prepared output and
@@ -72,13 +76,13 @@ signs, and exports:
 
 Supporting substrate:
 
-- **Capability gates:** manifests declare what a module needs; the
+- **Permission gates:** manifests declare what a skill needs; the
   workspace grants it on a matter; runtime checks it.
-- **Privilege posture + advice-boundary gate** before every model call.
+- **Privilege control + advice-boundary gate** before every model call.
 - **Matter-scoped model gateway** across Anthropic, OpenAI, and Ollama.
 - **BYO keys:** users store their own provider keys encrypted at rest;
   Legalise itself does not provide model access.
-- **Audit trail:** model calls, module actions, denials, mutations,
+- **Record / audit trail:** model calls, skill actions, denials, mutations,
   provider failures, and storage failures leave rows.
 
 A second module path imports prompt-only skills from the
@@ -196,13 +200,13 @@ Evaluation release. Honest about what's in and what isn't.
 
 **Shipped:**
 
-- Compressed four-tab matter surface (Matter desk / Documents / Actions
-  / Activity Trail) with the Activity Trail as the explanatory spine.
+- Matter surface ordered around the golden loop: Chat / Documents /
+  Skills / Record / Signed outputs / Working pack.
 - Documents are first-class: routed detail page, body/versions/
   anonymisation/edit surfaces, original-file retrieval through an
   owner-only backend proxy with an `document.original.accessed` audit
   row on successful access.
-- Governed actions on a matter, with readiness shown up-front from a
+- Governed skills on a matter, with readiness shown up-front from a
   single backend `Matter.required_provider` field — no model-family
   guessing in the UI.
 - Two module runtimes:
@@ -213,7 +217,7 @@ Evaluation release. Honest about what's in and what isn't.
     instructions, server-built document anchors, optional model claim
     enrichment with `quote_found_in_source`.
 - **Professional Sign-Off:** author sign-off as the matter's main
-  decision point. Append-only history. Hash pinning. Activity Trail
+  decision point. Append-only history. Hash pinning. Record
   promotes sign-off as a foreground event.
 - **Source anchors v1** across the prompt runtime and Contract Review.
 - **Export Gating v1.1:** sign-off status + integrity flag + source

--- a/backend/app/modules/contract_review/router.py
+++ b/backend/app/modules/contract_review/router.py
@@ -1,267 +1,41 @@
-"""Contract Review router — `POST /api/matters/{slug}/contract-review/*`.
+"""Contract Review document export route.
 
-Three endpoints:
-    POST /run         — non-streaming, returns ContractReviewResult.
-    POST /run-stream  — SSE, mirrors Pre-Motion's stream shape.
-    POST /docx        — round-trip a ContractReviewResult to a Word doc.
-
-v0.1 does not persist runs. The frontend POSTs the envelope back to /docx
-for export. The audit log is the canonical record of every call.
+Contract-review execution is durable-job backed via
+``POST /api/matters/{slug}/contract-review/jobs`` in ``app.api.jobs``.
+This router remains mounted only for the legacy-compatible DOCX export
+surface, which round-trips a ``ContractReviewResult`` envelope to a
+generated Word document until a generic artifact export path replaces it.
 """
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
-import json
-from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import StreamingResponse
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_user
-from app.core.config import settings
 from app.core.db import get_session
 from app.core.matter_access import resolve_owned_open_matter
 from app.core.limits import check_generated_artefact
 from app.core.model_gateway import (
     PrivilegePaused,
-    PrivilegePosture,
     gateway as model_gateway,
 )
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError, get_user_provider_key
 from app.core.storage import StorageWriteError
 from app.core.api import audit
-from app.models import STATUS_ARCHIVED, Matter, User
+from app.models import Matter, User
 
 from .export import render_contract_review_markdown
-from .pipeline import run_contract_review
-from .schemas import ContractReviewInputs, ContractReviewResult
+from .schemas import ContractReviewResult
 
 
 router = APIRouter()
 
 
-_SSE_SENTINEL: dict[str, Any] = {"__done__": True}
-
-
-def _sse_format(event: str, data: dict[str, Any]) -> bytes:
-    return f"event: {event}\ndata: {json.dumps(data, default=str)}\n\n".encode("utf-8")
-
-
 async def _resolve_matter(session: AsyncSession, slug: str, user_id) -> Matter:
     matter = await resolve_owned_open_matter(session, slug, user_id)
     return matter
-
-
-# ----- POST /run (non-streaming) ------------------------------------------
-
-
-@router.post("/{slug}/contract-review/run", response_model=ContractReviewResult)
-async def run_endpoint(
-    slug: str,
-    inputs: ContractReviewInputs,
-    session: AsyncSession = Depends(get_session),
-    user: User = Depends(current_user),
-) -> ContractReviewResult:
-    matter = await _resolve_matter(session, slug, user.id)
-    try:
-        return await run_contract_review(
-            session=session,
-            gateway=model_gateway,
-            matter=matter,
-            actor_id=user.id,
-            inputs=inputs,
-        )
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={
-                "error": "provider_key_missing",
-                "provider": exc.provider,
-                "message": str(exc),
-            },
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
-    except ValueError as exc:
-        # Bad document_id / no body / matter / etc.
-        raise HTTPException(422, str(exc)) from exc
-
-
-# ----- POST /run-stream (SSE) ---------------------------------------------
-
-
-@router.post("/{slug}/contract-review/run-stream")
-async def run_stream_endpoint(
-    slug: str,
-    inputs: ContractReviewInputs,
-    request: Request,
-    user: User = Depends(current_user),
-) -> StreamingResponse:
-    """SSE variant. Mirrors Pre-Motion's pattern: posture + provider-key
-    preflight before opening the stream, then a background task that owns
-    its own session and emits stage.start / stage.end / result / error
-    frames. Audit rows always land even on client disconnect."""
-    factory = request.app.state.session_factory
-
-    async with factory() as preflight_session:
-        row = (
-            await preflight_session.execute(
-                select(
-                    Matter.id, Matter.privilege_posture, Matter.default_model_id
-                ).where(
-                    Matter.slug == slug,
-                    Matter.created_by_id == user.id,
-                    Matter.status != STATUS_ARCHIVED,
-                )
-            )
-        ).first()
-        if row is None:
-            # Missing, cross-user, or archived — 404 per repo convention.
-            raise HTTPException(404, f"matter not found: {slug}")
-        _, posture_value, default_model_id = row
-        if PrivilegePosture(posture_value) is PrivilegePosture.C_PAUSED:
-            raise HTTPException(
-                409,
-                "Matter privilege posture is C_paused — Contract review blocked. "
-                "Change posture to A_cleared or B_mixed to run.",
-            )
-        # Codex R2: defer to the gateway's own routing rather than
-        # demanding a key for `claude-*` outright — Ollama on a B_mixed
-        # matter should run keylessly.
-        selected_provider = model_gateway.select_provider_name(
-            default_model_id, PrivilegePosture(posture_value)
-        )
-        if model_gateway.is_keyed_provider(selected_provider):
-            user_key = await get_user_provider_key(
-                preflight_session, user.id, selected_provider
-            )
-            fallback_allowed = (
-                settings.environment in {"development", "dev", "local"}
-                and settings.allow_server_key_fallback
-            )
-            if user_key is None and not fallback_allowed:
-                raise HTTPException(
-                    422,
-                    detail={
-                        "error": "provider_key_missing",
-                        "provider": selected_provider,
-                        "message": (
-                            f"Add a {selected_provider} API key in Settings → API Keys to run Contract review."
-                        ),
-                    },
-                )
-
-    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
-
-    async def on_event(name: str, payload: dict[str, Any]) -> None:
-        await queue.put({"event": name, "data": payload})
-
-    async def run_bg() -> None:
-        try:
-            async with factory() as bg_session:
-                # Re-resolve on the background session. Archived between
-                # preflight and pipeline start = treat as vanished.
-                matter = await bg_session.scalar(
-                    select(Matter).where(
-                        Matter.slug == slug,
-                        Matter.created_by_id == user.id,
-                        Matter.status != STATUS_ARCHIVED,
-                    )
-                )
-                if matter is None:
-                    await queue.put(
-                        {"event": "error", "data": {"message": f"matter vanished: {slug}"}}
-                    )
-                    return
-                try:
-                    result = await run_contract_review(
-                        session=bg_session,
-                        gateway=model_gateway,
-                        matter=matter,
-                        actor_id=user.id,
-                        inputs=inputs,
-                        on_event=on_event,
-                    )
-                except PrivilegePaused as exc:
-                    await queue.put(
-                        {"event": "error", "data": {"message": str(exc), "code": 409}}
-                    )
-                    return
-                except ProviderKeyMissing as exc:
-                    await queue.put(
-                        {
-                            "event": "error",
-                            "data": {
-                                "message": str(exc),
-                                "code": 422,
-                                "error": "provider_key_missing",
-                                "provider": exc.provider,
-                            },
-                        }
-                    )
-                    return
-                except ProviderUpstreamError as exc:
-                    await queue.put(
-                        {
-                            "event": "error",
-                            "data": {
-                                "message": str(exc),
-                                "code": 502,
-                                "error": exc.code,
-                                "provider": exc.provider,
-                                "upstream_status": exc.upstream_status,
-                            },
-                        }
-                    )
-                    return
-                except ValueError as exc:
-                    await queue.put(
-                        {"event": "error", "data": {"message": str(exc), "code": 422}}
-                    )
-                    return
-                except Exception as exc:  # noqa: BLE001
-                    await queue.put({"event": "error", "data": {"message": str(exc)}})
-                    return
-                await queue.put({"event": "result", "data": result.model_dump()})
-        finally:
-            await queue.put(_SSE_SENTINEL)
-
-    task = asyncio.create_task(run_bg())
-
-    async def event_stream():
-        try:
-            while True:
-                item = await queue.get()
-                if item is _SSE_SENTINEL or item.get("__done__"):
-                    break
-                yield _sse_format(item["event"], item["data"])
-        finally:
-            if not task.done():
-                pass
-
-    return StreamingResponse(
-        event_stream(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-            "Connection": "keep-alive",
-        },
-    )
 
 
 # ----- POST /docx ----------------------------------------------------------
@@ -276,9 +50,8 @@ async def export_docx(
 ) -> dict:
     """Render a ContractReviewResult to .docx via `generate_docx`.
 
-    Body is the run envelope — runs are not persisted in v0.1, so the
-    frontend POSTs back what it received from `/run` or the `result` SSE
-    frame. Writes `module.contract_review.docx.exported`.
+    Body is the run envelope returned by the durable job result payload.
+    Writes `module.contract_review.docx.exported`.
     """
     matter = await _resolve_matter(session, slug, user.id)
     if result.matter_slug != slug:
@@ -287,8 +60,6 @@ async def export_docx(
             f"run envelope matter_slug={result.matter_slug} does not match url slug={slug}",
         )
 
-    # TODO(durable-job-runs): once /run + /run-stream move to durable jobs,
-    # add check_generated_artefact to the job-completion path in jobs.py.
     await check_generated_artefact(user.id, session)
 
     body_markdown = render_contract_review_markdown(matter, result)

--- a/backend/tests/test_smoke_evals.py
+++ b/backend/tests/test_smoke_evals.py
@@ -40,7 +40,8 @@ from app.models import AuditEntry
 from app.models.document_edit import DocumentEdit
 from app.modules.contract_review import agents as cr_agents
 from app.modules.contract_review.agents import AgentCall, ParserAgent, RedlinerAgent
-from app.modules.contract_review.schemas import ParsedContract
+from app.modules.contract_review.pipeline import run_contract_review
+from app.modules.contract_review.schemas import ContractReviewInputs, ParsedContract
 from app.modules.document_edit.resolver import apply_anchor_substitution
 
 
@@ -571,41 +572,22 @@ def _agent_call(stage: str, parsed: dict[str, Any]) -> AgentCall:
     )
 
 
-class TestContractReviewOrchestratorE2E:
-    """`POST /api/matters/{slug}/contract-review/run` against canned agents."""
+class TestContractReviewOrchestrator:
+    """Contract Review pipeline against canned agents.
 
-    def _build_client(self, matter: _MatterStub) -> tuple[Any, _RoutingSession, _UserStub]:
-        from fastapi.testclient import TestClient
-
-        from app.core.auth import current_user
-        from app.core.db import get_session
-        from app.main import app
-
-        session = _RoutingSession(matter)
-        user = _UserStub()
-
-        async def _override_session():
-            yield session
-
-        async def _override_user():
-            return user
-
-        app.dependency_overrides[current_user] = _override_user
-        app.dependency_overrides[get_session] = _override_session
-        return TestClient(app), session, user
-
-    def _clear_overrides(self) -> None:
-        from app.main import app
-
-        app.dependency_overrides.clear()
+    The HTTP run/stream endpoints were retired after the UI moved to
+    durable jobs. The job worker calls this same pipeline, so the smoke
+    keeps the regulated-adjacent orchestration proof without preserving
+    a deleted route as the test subject.
+    """
 
     @pytest.mark.asyncio
-    async def test_run_endpoint_returns_envelope_against_khan_nda(self) -> None:
+    async def test_pipeline_returns_envelope_against_khan_nda(self) -> None:
         matter = _MatterStub()
         matter.slug = "khan-v-acme"
         matter.privilege_posture = "B_mixed"
-
-        client, session, _user = self._build_client(matter)
+        session = _RoutingSession(matter)
+        user = _UserStub()
 
         async def _parser_run(self_inner, **_kw):
             return _agent_call("parser", _canned_parsed_envelope())
@@ -619,28 +601,27 @@ class TestContractReviewOrchestratorE2E:
         async def _summariser_run(self_inner, **_kw):
             return _agent_call("summariser", _canned_summary_envelope())
 
-        try:
-            with patch.object(cr_agents.ParserAgent, "run", _parser_run), patch.object(
-                cr_agents.AnalystAgent, "run", _analyst_run
-            ), patch.object(
-                cr_agents.RedlinerAgent, "run", _redliner_run
-            ), patch.object(
-                cr_agents.SummariserAgent, "run", _summariser_run
-            ):
-                resp = client.post(
-                    "/api/matters/khan-v-acme/contract-review/run",
-                    json={
-                        "document_id": str(session.document.id),
-                        "posture": "balanced",
-                        "contract_type": "nda",
-                        "counterparty_name": "Acme Ltd",
-                    },
-                )
-        finally:
-            self._clear_overrides()
+        with patch.object(cr_agents.ParserAgent, "run", _parser_run), patch.object(
+            cr_agents.AnalystAgent, "run", _analyst_run
+        ), patch.object(
+            cr_agents.RedlinerAgent, "run", _redliner_run
+        ), patch.object(
+            cr_agents.SummariserAgent, "run", _summariser_run
+        ):
+            result = await run_contract_review(
+                session=session,
+                gateway=_FakeGateway({}),
+                matter=matter,
+                actor_id=user.id,
+                inputs=ContractReviewInputs(
+                    document_id=str(session.document.id),
+                    posture="balanced",
+                    contract_type="nda",
+                    counterparty_name="Acme Ltd",
+                ),
+            )
 
-        assert resp.status_code == 200, resp.text
-        body = resp.json()
+        body = result.model_dump()
         assert body["matter_slug"] == "khan-v-acme"
         assert body["document_id"] == str(session.document.id)
         assert len(body["parsed"]["clauses"]) >= 1
@@ -653,27 +634,27 @@ class TestContractReviewOrchestratorE2E:
         )
 
     @pytest.mark.asyncio
-    async def test_run_endpoint_returns_409_on_c_paused(self) -> None:
+    async def test_pipeline_blocks_c_paused(self) -> None:
         matter = _MatterStub()
         matter.slug = "khan-v-acme"
         matter.privilege_posture = "C_paused"
+        session = _RoutingSession(matter)
+        user = _UserStub()
 
-        client, _session, _user = self._build_client(matter)
-        try:
-            resp = client.post(
-                "/api/matters/khan-v-acme/contract-review/run",
-                json={
-                    "document_id": str(uuid.uuid4()),
-                    "posture": "balanced",
-                    "contract_type": "nda",
-                },
+        with pytest.raises(PrivilegePaused) as info:
+            await run_contract_review(
+                session=session,
+                gateway=_FakeGateway({}),
+                matter=matter,
+                actor_id=user.id,
+                inputs=ContractReviewInputs(
+                    document_id=str(uuid.uuid4()),
+                    posture="balanced",
+                    contract_type="nda",
+                ),
             )
-        finally:
-            self._clear_overrides()
 
-        assert resp.status_code == 409
-        detail = resp.json().get("detail", "")
-        assert "C_paused" in detail or "paused" in detail.lower()
+        assert "C_paused" in str(info.value) or "paused" in str(info.value).lower()
 
 
 # ---------------------------------------------------------------------------

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,133 +1,111 @@
 # Demo runbook — Khan v Acme walkthrough
 
 This is the evaluator-facing walkthrough. It assumes you have followed
-[`README.md` → Try it](../README.md#try-it) and are signed in as a
-superuser. If `legalise doctor` is green and `khan.demo_present` is
-`ok`, you are in the right place.
+[`README.md` → Try it](../README.md#try-it), signed in, and run
+`legalise doctor` successfully. If `khan.demo_present` is `ok`, the Khan
+v Acme matter is ready.
 
-The walkthrough drives the same end-to-end path that the Phase 15
-Playwright `first-run` spec drives in CI. The audit-row coverage split
-is recorded in [`docs/spec/AUDIT_COVERAGE_MATRIX.md`](./spec/AUDIT_COVERAGE_MATRIX.md):
-rows marked **e2e-covered** are asserted by name by the Phase 15 spec;
-rows marked **pytest-covered** are substrate-tested but not asserted
-by name in the e2e run — they still land on the matter timeline
-because the same substrate emits them. Nothing here is invented.
+The goal is to prove the Legalise loop without explaining every internal
+row name:
+
+> open a project → inspect documents → enable/run a skill → review output
+> → sign → read the Record → export the working pack.
 
 ## What this proves
 
 By the end of the walkthrough you will have:
 
-- Installed a real module through the trust ceremony state machine.
-- Granted that module a capability on a real matter.
-- Run the module deterministically (via the keyless `stub-echo`
-  model — no provider key required).
-- Read back the matter Audit tab and seen the substrate rows the run
-  emitted.
+- opened a real matter folder;
+- inspected the documents the skill can use;
+- installed and enabled a governed skill;
+- run the skill through the durable job path;
+- reviewed and signed the output;
+- read the matter Record; and
+- exported the working pack.
 
 That sequence is the smallest end-to-end demonstration of
-[supervised autonomy](./SUPERVISED_AUTONOMY.md): a capability declared
-in a manifest, granted on install, enforced at runtime, and recorded
-in an audit trail you can reconstruct.
+[supervised autonomy](./SUPERVISED_AUTONOMY.md): a skill declares what it
+needs, the matter grants it, runtime checks enforce it, output is signed,
+and the record preserves what happened.
 
-## 1 — Install Contract Review via the trust ceremony
+## 1 — Open the Khan matter
 
-1. Navigate to <http://localhost:3000/modules>.
-2. Find **Contract Review** (`examples.contract-review`) in the
-   catalog and click **Install**.
-3. Walk through each step of the trust ceremony until the module shows
-   as **Enabled**. Each advance is a real state-machine transition;
-   nothing here is a UI fast-path.
+1. Navigate to <http://localhost:3000/matters>.
+2. Open **Khan v Acme Trading Ltd**.
+3. Confirm the left rail shows the matter section and the main surface
+   lands on **Chat**.
 
-Audit rows the install emits (workspace scope — visible to a superuser
-in the admin reconstruction view at <http://localhost:3000/admin/audit>):
+## 2 — Inspect documents
 
-| Action | Coverage | Where it comes from |
-| --- | --- | --- |
-| `module.enabled` | e2e-covered | Ceremony completion, terminal state |
+1. Open **Documents**.
+2. Open a seeded document.
+3. Confirm the extracted text is readable and the metadata is secondary.
+4. Use the back link to return to the matter.
 
-## 2 — Grant Contract Review on the Khan v Acme matter
+## 3 — Install a skill at the workspace
 
-1. Navigate to <http://localhost:3000/matters/khan-v-acme-trading-2026>.
-2. In the Grants panel, grant the Contract Review **`review`**
-   capability on the matter.
+1. Navigate to <http://localhost:3000/skills>.
+2. Pick a reference skill such as **Contract Review** or **Pre-Motion**.
+3. Walk the install ceremony.
 
-Audit row this emits (matter scope — visible on the matter's own
-Audit tab):
+Installation is workspace-level trust. It does **not** make the skill
+runnable in every matter.
 
-| Action | Coverage | Where it comes from |
-| --- | --- | --- |
-| `module.grant.created` | e2e-covered | The grant write |
+## 4 — Enable the skill on Khan
 
-The grant is matter-scoped per the doctrine in
-[`README.md`](../README.md#trust-mechanics):
-*manifest requests capabilities, workspace grants capabilities,
-runtime enforces capabilities.*
+1. Return to the Khan matter.
+2. Open **Skills**.
+3. Enable the installed skill for this matter.
+4. Confirm the card reads as ready in this project.
 
-## 3 — Run Contract Review
+Matter-level enablement is where the skill receives permission to read
+documents and write outputs for this matter.
 
-1. From the Khan v Acme matter page, click the **Run** button for the
-   review capability.
-2. Watch the result panel render. The default model is `stub-echo` for
-   the demo so the output is deterministic — no provider key needed.
-3. The result panel renders the invocation id alongside a **See audit
-   trail for this invocation** link that jumps straight to the
-   filtered timeline. (If you want to inspect the URL manually,
-   the displayed id is selectable.)
+## 5 — Run the skill
 
-Audit rows this emits (matter scope):
+1. Open **Chat**.
+2. Use the Skills picker, or open **Skills** and run from the skill card.
+3. For Contract Review, the frontend creates a durable job and polls the
+   job result. It no longer uses the retired contract-review stream route.
+4. Wait for the typed output to render.
 
-| Action | Coverage | Where it comes from |
-| --- | --- | --- |
-| `module.capability.invoked` | e2e-covered | Run is dispatched |
-| `model.call` | e2e-covered | Gateway dispatched the call to `stub-echo` |
-| `model.invoked` | pytest-covered | `audit_cost` helper emits per model call; reconstruction source |
-| `advice_boundary.decision.completed` | pytest-covered | Substrate gate decision for matters at posture `B_mixed` / `C_paused`; reconstruction source |
-| `module.capability.completed` | e2e-covered | Result returned to the UI |
+The demo may use the keyless `stub-echo` provider where configured. Real
+provider-backed runs require the user to add their own model key.
 
-`model.invoked` and `advice_boundary.decision.completed` are not
-asserted by name in the Phase 15 e2e run — pytest covers them
-directly — but they land on the matter timeline because the same
-substrate emits them. Khan v Acme defaults to `B_mixed` so the
-advice-boundary row is the expected shape.
+## 6 — Review and sign
 
-## 4 — Read the Audit tab
+1. Open the produced output.
+2. Review its source references and any quote-location cautions.
+3. Use **Review & sign**.
+4. Choose `signed`, `signed_with_observations`, or `rejected`.
 
-1. Use the **See audit trail for this invocation** link from step 3,
-   or navigate to
-   <http://localhost:3000/matters/khan-v-acme-trading-2026/audit>
-   and paste the invocation id into the `invocation_id` filter.
-2. You should see the matter-scope rows from step 3, plus an
-   `audit.reconstruction.viewed` row that the substrate emits when
-   the timeline is read.
+The signature records professional ownership of the output and pins the
+signed payload by hash. It is not a claim that Legalise certifies the
+legal position.
 
-The reconstruction view pulls from three substrate sources — the
-`audit_entries` table, `state_machine_transitions`, and
-`advice_boundary_decisions` — and reconstructs the timeline across all
-three. This is what the regulator-facing record looks like.
+## 7 — Read the Record
 
-## 5 — Pre-Motion (same loop, second module)
+1. Open **Record** for the matter.
+2. Confirm it shows the story of the run: skill run, model call, output,
+   sign-off, and any gates or denials.
+3. Use advanced details only if you need raw row filters.
 
-Pre-Motion (`examples.pre-motion`) is the second reference module and
-exercises the same install → grant → run → audit loop:
+The Record is the proof layer. The raw audit rows remain inspectable, but
+they are not the primary user surface.
 
-1. <http://localhost:3000/modules> → Pre-Motion → Install → walk
-   through the ceremony.
-2. Khan v Acme → grant the Pre-Motion `draft_motion` capability.
-3. Run it from the matter page.
-4. The matter Audit tab shows a fresh run with the same five rows
-   the Contract Review run produced:
-   `module.capability.invoked` (e2e-covered), `model.call`
-   (e2e-covered), `model.invoked` (pytest-covered),
-   `advice_boundary.decision.completed` (pytest-covered, posture
-   `B_mixed`), `module.capability.completed` (e2e-covered).
+## 8 — Export the working pack
 
-Two modules, two grants, two invocations. Same substrate, same
-contract, same receipts.
+1. Open **Working pack**.
+2. Start an export and wait for the job to complete.
+3. Download the pack.
+
+The pack contains the matter metadata, documents, outputs, sign-off
+records, reviews, reconstruction data, and README/manifest copy that
+states the honesty boundaries.
 
 ## If something looks wrong
 
-- Doctor first: `docker compose -f infra/docker-compose.yml exec
-  backend python -m app.tools.doctor`.
+- Doctor first: `docker compose -f infra/docker-compose.yml exec backend python -m app.tools.doctor`.
 - Common setup errors and their fixes:
   [`docs/TROUBLESHOOTING.md`](./TROUBLESHOOTING.md).
 - Audit row names and emission sites:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,13 +10,13 @@ evaluation copy. The hosted site is not for live client matters.
 
 Shipped surfaces:
 
-- **Matter-first workspace**, four-tab compression: Matter desk, Documents,
-  Actions, Activity Trail.
+- **Matter-first workspace** ordered around the golden loop: Chat, Documents,
+  Skills, Record, Signed outputs, Working pack.
 - **Documents** as first-class records: ingress, extraction, versions,
   optional anonymisation (Presidio detection + deterministic token map +
   detokenise round-trip), original-file retrieval through an owner-only
   backend proxy, `document.original.accessed` audit row on access.
-- **Capability runtime.** Manifests declare what a module needs; the
+- **Permission runtime.** Manifests declare what a skill needs; the
   workspace grants it on a matter; the runtime checks at every privileged
   boundary. Denied attempts emit structured 403 + canonical `*.blocked`
   audit row via the `audit_failure` helper.

--- a/docs/SUPERVISED_AUTONOMY.md
+++ b/docs/SUPERVISED_AUTONOMY.md
@@ -36,7 +36,8 @@ V1 ships an evaluation workspace around the Khan v Acme sample matter.
 The shipped surface includes:
 
 - **Matter-first workspace** with the four-tab loop
-  (`Matter desk` / `Documents` / `Actions` / `Activity Trail`).
+  (`Chat` / `Documents` / `Skills` / `Record`) plus signed outputs and
+  the working-pack export.
 - **Documents** as first-class records: ingress, extraction, versions,
   optional anonymisation, original-file retrieval through an
   owner-only backend proxy, and a `document.original.accessed` audit
@@ -62,7 +63,7 @@ The shipped surface includes:
   and records `signed` / `signed_with_observations` / `rejected`.
   Append-only history. The exact output payload (including its
   anchors) is pinned by a hash; the signature attaches to the hash.
-  The Activity Trail promotes sign-off as a foreground decision event.
+  The Record promotes sign-off as a foreground decision event.
 - **Supervisor Review** remains available as an optional separate
   review path. It does not compete with the author sign-off path; it
   is the firm-mode "second pair of eyes" surface.
@@ -171,7 +172,7 @@ The V1 flow:
 2. Documents are present (seeded) or added through the Documents tab.
 3. Disclosure-tainted entries are flagged; the chronology gate
    requires acknowledgement before detail renders.
-4. From the Actions tab, run a governed action against matter material
+4. From Chat or the Skills tab, run a governed skill against matter material
    under declared, granted capabilities.
 5. The action emits an output that carries its **source anchors** —
    the documents it used, and (where the model returned a quote) a
@@ -179,7 +180,7 @@ The V1 flow:
 6. The author reads the output with cited sources visible, then signs:
    `signed`, `signed_with_observations` (free-text reasoning), or
    `rejected`. The exact output payload is pinned by hash. The
-   sign-off event lands in the Activity Trail as a foreground
+   sign-off event lands in the Record as a foreground
    decision row.
 7. Export the matter; the bundle preserves documents, audit,
    reconstruction, outputs, sign-off status, and integrity flags.
@@ -194,7 +195,7 @@ default loop.
 
 Use:
 
-> Open a matter. Add documents. Run governed actions. Review outputs
+> Open a matter. Add documents. Run skills. Review outputs
 > with cited sources visible. Sign the output as a record of
 > professional judgement. Export the matter record.
 

--- a/docs/handovers/CUTLIST_VERIFIED_2026-06-04.md
+++ b/docs/handovers/CUTLIST_VERIFIED_2026-06-04.md
@@ -71,26 +71,25 @@ traffic, not the loop. Retire only after the confidence window (tracked follow-u
 ## Bumper 2 — Collapse first-party modules (THE headline cut, now small)
 
 ### 2.1 `contract_review` — the only real violation (HIGH risk, staged)
-`ContractReviewTab` calls `runContractReviewStream` (`lib/api.ts:2623` →
-`POST /…/contract-review/run-stream`) and `exportContractReviewDocx`
-(`lib/api.ts:2698` → `/contract-review/docx`) directly, bypassing
-manifest→invocation→artifact. **The generic jobs path already exists and is
-proven** (`api/jobs.py:227` `POST /…/contract-review/jobs`; `worker.py:165`
-`_run_contract_review`; `router.py:290` carries the matching TODO).
+`ContractReviewTab` formerly called a bespoke SSE route. Stage 1 shipped in
+PR #165: the frontend now creates a durable contract-review job, polls
+`GET /api/matters/{slug}/jobs/{job_id}`, and renders from `result_payload`.
+The empty frontend API shim was deleted.
 
-- Migrate `frontend/src/modules/contract_review/ContractReviewTab.tsx` from the
-  streamer to the **jobs API**; move export to the artifact/generic handler.
-- Then delete `/run`, `/run-stream`, `/docx` from
-  `backend/app/modules/contract_review/router.py`, and remove
-  `main.py:58 include_router(contract_review_router)`.
-- Delete `frontend/src/modules/contract_review/api.ts` (empty shim).
+Stage 2 is backend cleanup:
+
+- Delete `/run` and `/run-stream` from
+  `backend/app/modules/contract_review/router.py`.
+- Keep `/docx` until a generic artifact/export path explicitly replaces it.
+  DOCX export still round-trips the job result envelope and must keep working.
+- Keep `main.py`'s `contract_review_router` include while `/docx` lives there.
 - **KEEP** `{schemas,pipeline,prompts,agents,export}.py` (shared by the worker)
   and `{ResultPanel,StageStrip}.tsx` (presentation-only).
 - Gate: `pytest backend/tests -k "contract_review or jobs or worker"` +
   `vitest run frontend/src/modules/contract_review` + a manual golden-loop walk
   on Khan v Acme (open → select contract-review skill → run via job → typed
-  output → sign-off → record → export); confirm an audit row + artifact land and
-  no `/run-stream` request fires.
+  output → sign-off → record → export); confirm DOCX export still works and no
+  `/run-stream` request fires.
 
 ### 2.2–2.5 `pre_motion` / `letters` / `case_law` / `tabular_review` — KEEP
 All legitimate, no edges to sever, low risk. Do **not** lump `pre_motion` in
@@ -105,8 +104,8 @@ separate, deliberate initiative — not this cleanup.
 - **Split `frontend/src/lib/api.ts` (2,785 lines)** per-domain — *after* 2.1
   removes `runContractReviewStream`/`exportContractReviewDocx`, so the split
   lands on the post-cut surface.
-- **Provider/SSE dedupe** — `pre-motion/run-stream` and `contract-review/run-stream`
-  share near-duplicate SSE plumbing; fold the remaining helper after 2.1.
+- **Provider/SSE dedupe** — only the remaining Pre-Motion stream should be
+  considered after 2.1; contract-review no longer owns SSE.
 - Gate: full `vitest run` + `tsc --noEmit` + `pytest backend/tests` + prod build.
 
 ---

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -4,7 +4,7 @@
  * Hits `GET /api/matters/{slug}/artifacts/{id}` (returns ArtifactSummary
  * fields + parsed `payload`). Kind-aware rendering via ArtifactPreview.
  *
- * Deep-link to the Activity Trail: this page links to
+ * Deep-link to the Record: this page links to
  * `/matters/{slug}/audit?invocation_id=<id>`. The query-param contract
  * is preserved for signed/exported output chains.
  *

--- a/frontend/src/matter/InvocationRunner.tsx
+++ b/frontend/src/matter/InvocationRunner.tsx
@@ -19,7 +19,7 @@
  *
  * Per Reviewer-narrow brief, this component handles invocation +
  * result rendering only. No reconstruction inline, no admin, no
- * settings, no async. The "View in Activity Trail" link from the result
+ * settings, no async. The "View in Record" link from the result
  * panel points at /matters/{slug}/audit?invocation_id=…, preserving the
  * reconstruction deep-link for the output chain.
  */

--- a/frontend/src/matter/MatterDetail.tsx
+++ b/frontend/src/matter/MatterDetail.tsx
@@ -407,7 +407,7 @@ export function MatterDetail({ slug }: { slug: string }) {
           )}
           {tab === "audit" && <AuditTab audit={audit} matter={matter} />}
           {tab === "approvals" && <ApprovalsTab slug={matter.slug} />}
-          {/* Action surfaces reached from Actions; sidebar highlights Actions. */}
+          {/* Skill surfaces reached from Skills; sidebar highlights Skills. */}
           {tab === "premotion" && (
             <PreMotionTab
               matter={matter}

--- a/frontend/src/matter/tabs/WorkflowsTab.tsx
+++ b/frontend/src/matter/tabs/WorkflowsTab.tsx
@@ -1,7 +1,7 @@
-// WorkflowsTab - historical filename for the matter Actions page.
+// WorkflowsTab - historical filename for the matter Skills page.
 // Built-in legal actions (Pre-Motion / Letters / Contract Review /
 // Tabular Review / Case Law) render as cards linking to their surfaces;
-// the sidebar highlights Actions when one is open.
+// the sidebar highlights Skills when one is open.
 //
 // State (grant + availability + last_run_at) is fetched from the
 // backend per matter; no static placeholders.

--- a/frontend/src/matter/tabs/types.ts
+++ b/frontend/src/matter/tabs/types.ts
@@ -23,8 +23,8 @@ export type TabKey =
   | "workflows"
   | "audit"
   | "approvals"
-  // Built-in action surfaces (reached via Actions; sidebar highlights
-  // Actions when one is open)
+  // Built-in skill surfaces (reached via Skills; sidebar highlights
+  // Skills when one is open)
   | "premotion"
   | "letters"
   | "contract-review"
@@ -104,7 +104,7 @@ export function isTabKey(v: string): v is TabKey {
 }
 
 // Which sidebar item should highlight as active given the current tab.
-// Workflow surfaces (premotion / letters / etc.) highlight Workflows.
+// Workflow surfaces (premotion / letters / etc.) highlight Skills.
 export function sidebarActiveFor(tab: TabKey): TabKey {
   if (tab === "premotion" || tab === "letters" || tab === "contract-review" || tab === "reviews" || tab === "research") {
     return "workflows";

--- a/infra/deploy/cloudflare.md
+++ b/infra/deploy/cloudflare.md
@@ -275,19 +275,17 @@ during it.
 Run against the seeded Khan matter:
 
 ```bash
-# 1. Kick off a Contract Review SSE stream. Capture the first stage frame,
-# then disconnect immediately (curl --max-time 5 hangs up after 5s).
-curl --max-time 5 -N -s \
-  -H "Accept: text/event-stream" \
+# 1. Kick off a Contract Review durable job.
+curl -s \
+  -H "Content-Type: application/json" \
   -X POST \
-  https://api.legalise.dev/api/matters/khan-v-acme-trading-2026/contract-review/run-stream \
-  | head -20
+  https://api.legalise.dev/api/matters/khan-v-acme-trading-2026/contract-review/jobs \
+  -d '{"document_id":"<document-id>","posture":"balanced","contract_type":"nda"}'
 
-# 2. Wait ~30s for the background task to either finish or wedge.
+# 2. Poll GET /api/matters/{slug}/jobs/{job_id} until terminal.
 sleep 30
 
-# 3. Tail the backend logs for the matter slug. Expect to see a terminal
-# audit row (action ending in `run.completed` or `run.failed`) AND no
+# 3. Tail the backend logs for the matter slug. Expect to see no
 # 'asyncio Task was destroyed but it is pending' warnings.
 fly logs --app legalise-backend | grep -E "khan-v-acme-trading-2026|asyncio|Task was destroyed" | tail -40
 
@@ -298,25 +296,24 @@ curl -s https://api.legalise.dev/api/matters/khan-v-acme-trading-2026/audit \
 ```
 
 **Green state — all four must hold:**
-- The background task reached a terminal audit row (`...run.completed` or
-  `...run.failed`). A missing terminal row means the task was cancelled
-  with the client disconnect — a v0.1 launch blocker.
+- The job reaches a terminal state via `GET /api/matters/{slug}/jobs/{job_id}`.
 - No `asyncio Task was destroyed but it is pending` warning in logs.
 - No `SQLAlchemy DBAPIError` or `connection already closed` in logs
-  (the DB session must close cleanly even though the response stream
-  was severed).
-- Re-running the smoke from step 1 succeeds with a fresh SSE stream.
+  (the worker DB session must close cleanly).
+- Re-running the smoke from step 1 creates a fresh job.
 
 **If any of the above fail, do not promote to launch.** This is the
 signal that `arq` + Redis (the locked v0.2 direction) needs to land before
 v0.1 ships, not after. Surface to Andy.
 
 **Manual click-through after the curls pass:**
-- Visit `https://legalise.dev/`. Hero + four SurfaceCards render, TopBar shows `lhr1` green, `OPEN DEMO MATTER →` is enabled (assumes a seeded matter exists from step 3).
-- Click the demo CTA. Matter detail loads, audit log non-empty.
-- Click `RUN PREMORTEM →`. SSE stages tick through (4 stage strips, terminal-green "running" → platinum "done"). Final result card renders with verdict.
-- Click `EXPORT PDF →`. PDF downloads. Open it — verdict + summary + stages table + failure scenarios all rendered.
-- Open the Letters section. Catalogue lists 6 ET letter types (Khan is ET). Click `lba`, then `DRAFT LETTER →`. Draft renders.
+- Visit `https://legalise.dev/`.
+- Open the demo matter.
+- Confirm Chat, Documents, Skills, Record, Signed outputs, and Working pack
+  are reachable.
+- Run a ready skill. The output should render, offer Review & sign, and link to
+  the Record for the invocation.
+- Start a Working pack export and confirm the job reaches a terminal state.
 
 If any of the curl steps red, **do not proceed** — debug before the click-through wastes Anthropic tokens.
 


### PR DESCRIPTION
## What

Completes the backend stage after #165 moved the frontend onto durable jobs.

- Deletes the bespoke Contract Review `/run` and `/run-stream` routes.
- Keeps `/contract-review/docx` intact so DOCX export still works from the job result envelope.
- Rewrites the old `/run` smoke eval to exercise `run_contract_review(...)` directly, which is the same pipeline the worker calls for durable jobs.
- Updates current-truth docs and deploy smoke copy away from the old Matter desk / Actions / Activity Trail / Workflows model and away from Contract Review SSE.
- Tidies a few stale UI comments from Actions / Activity Trail to Skills / Record.

## Guardrails

- No deletion of `/docx`.
- `contract_review_router` stays mounted because `/docx` still lives there.
- Pre-Motion SSE remains untouched.
- No `lib/api.ts` changes in this PR.

## Validation

- `rg -n "contract-review/(run|run-stream)|run_endpoint|run_stream_endpoint|_sse_format" backend frontend docs infra -S` → only Pre-Motion `_sse_format` remains.
- Current-doc stale vocabulary sweep clean for: Matter desk / Activity Trail / Workflows / Workspace audit / Dashboard / `#/modules` / old localhost modules routes.
- `python3 -m py_compile backend/app/modules/contract_review/router.py backend/tests/test_smoke_evals.py`
- `git diff --check`
- `npm run typecheck`

Not run locally: backend pytest. This shell has no `pytest`, `uv`, or `poetry`; CI should run the targeted smoke eval and full backend suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Terminology updates across guides: "Activity Trail" → "Record," "Actions" → "Skills," and "Capability gates" → "Permission gates."

* **Refactor**
  * Contract Review now executes via durable job API endpoints instead of direct HTTP routes.

* **Tests**
  * Updated test suite to reflect API architecture changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->