### PR TITLE
refactor: centralize provider HTTP errors

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -40,9 +40,8 @@ from app.core.storage import (
     uploaded_key,
 )
 from app.core.text_extraction import extract as extract_text
-from app.core.model_gateway import PrivilegePaused, gateway as model_gateway
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
-from app.core.api import audit, audit_failure
+from app.core.model_gateway import gateway as model_gateway
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit, audit_failure, provider_error_http_exception
 from app.core.config import settings
 from app.models import (
     AuditEntry,
@@ -450,23 +449,8 @@ async def post_edit_instruction(
         raise HTTPException(404, str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={"error": "provider_key_missing", "provider": exc.provider, "message": str(exc)},
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
 
     await session.commit()
     return EditInstructionResponse(
@@ -2900,27 +2884,8 @@ async def post_anonymise_document(
         raise HTTPException(404, str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={
-                "error": "provider_key_missing",
-                "provider": exc.provider,
-                "message": str(exc),
-            },
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
     except RuntimeError as exc:
         # Presidio not installed in this environment. 503 communicates
         # "service is real but disabled" more honestly than 500.

--- a/backend/app/api/invocations.py
+++ b/backend/app/api/invocations.py
@@ -39,11 +39,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.advice_boundary import AdviceBoundaryDenied
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, provider_error_http_exception
 from app.core.auth import current_user
 from app.core.capabilities import CapabilityDenied
 from app.core.db import get_session
 from app.core.grants_lifecycle import CapabilityScopeUnsupported
-from app.core.model_gateway import ProviderKeyMissing, ProviderUpstreamError
 from app.core.phase1_runtime.exceptions import Phase1Blocked
 from app.core.posture_gate import PostureBlocked
 from app.core.runtime import (
@@ -266,28 +266,14 @@ async def invoke_capability_endpoint(
                 "gate_state": exc.payload.gate_state,
             },
         )
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "error": "provider_key_missing",
-                "provider": getattr(exc, "provider", None),
-                "message": (
-                    "User has not configured an API key for the "
-                    "selected provider."
-                ),
-            },
-        )
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            status_code=502,
-            detail={
-                "error": "provider_upstream_error",
-                "provider": getattr(exc, "provider", None),
-                "code": getattr(exc, "code", None),
-                "upstream_status": getattr(exc, "upstream_status", None),
-            },
-        )
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(
+            exc,
+            missing_key_message=(
+                "User has not configured an API key for the selected provider."
+            ),
+            upstream_shape="generic",
+        ) from exc
     except CapabilityNotDeclared as exc:
         # The dispatcher disagreed with the endpoint's pre-check
         # (e.g. the module-author's invoke() rejects the capability

--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -28,7 +28,6 @@ from app.core.matter_fs import (
     materialise_matter,
     record_document,
 )
-from app.core.model_gateway import PrivilegePaused
 from app.core.storage import (
     get_storage_backend,
     uploaded_key,
@@ -37,8 +36,7 @@ from app.core.storage import (
     StorageDeleteError,
 )
 from app.core.text_extraction import extract as extract_text
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
-from app.core.api import audit
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit, provider_error_http_exception
 from app.models import (
     AuditEntry,
     Document,
@@ -704,23 +702,8 @@ async def invoke_plugin(
         raise HTTPException(404, str(exc)) from exc
     except SkillDisabled as exc:
         raise HTTPException(403, str(exc)) from exc
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={"error": "provider_key_missing", "provider": exc.provider, "message": str(exc)},
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
 

--- a/backend/app/core/api.py
+++ b/backend/app/core/api.py
@@ -32,7 +32,9 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from typing import Literal
 
+from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import (
     AsyncConnection,
@@ -42,7 +44,8 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from app.adapters import plugin_bridge as _plugin_bridge_module
-from app.core.model_gateway import gateway as _gateway
+from app.core.model_gateway import PrivilegePaused, gateway as _gateway
+from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
 from app.models import AuditEntry, Matter
 
 
@@ -130,6 +133,61 @@ class _AuditAPI:
 
 
 audit = _AuditAPI()
+
+
+PROVIDER_HTTP_EXCEPTIONS = (
+    PrivilegePaused,
+    ProviderKeyMissing,
+    ProviderUpstreamError,
+)
+
+
+def provider_error_http_exception(
+    exc: PrivilegePaused | ProviderKeyMissing | ProviderUpstreamError,
+    *,
+    missing_key_message: str | None = None,
+    upstream_shape: Literal["module", "generic"] = "module",
+) -> HTTPException:
+    """Translate model-provider exceptions into the canonical HTTP envelopes.
+
+    Most module routers expose upstream failures as ``{"error": exc.code,
+    "message": str(exc)}``. The generic invocation endpoint historically uses
+    ``{"error": "provider_upstream_error", "code": exc.code}``. Keep both
+    shapes explicit so callers can centralise translation without changing
+    their public wire contract.
+    """
+    if isinstance(exc, PrivilegePaused):
+        return HTTPException(409, str(exc))
+    if isinstance(exc, ProviderKeyMissing):
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "error": "provider_key_missing",
+                "provider": getattr(exc, "provider", None),
+                "message": missing_key_message or str(exc),
+            },
+        )
+
+    if upstream_shape == "generic":
+        return HTTPException(
+            status_code=502,
+            detail={
+                "error": "provider_upstream_error",
+                "provider": getattr(exc, "provider", None),
+                "code": getattr(exc, "code", None),
+                "upstream_status": getattr(exc, "upstream_status", None),
+            },
+        )
+
+    return HTTPException(
+        status_code=502,
+        detail={
+            "error": exc.code,
+            "provider": exc.provider,
+            "upstream_status": exc.upstream_status,
+            "message": str(exc),
+        },
+    )
 
 
 async def audit_failure(
@@ -262,6 +320,8 @@ __all__ = [
     "get_matter",
     "audit",
     "audit_failure",
+    "PROVIDER_HTTP_EXCEPTIONS",
+    "provider_error_http_exception",
     "model_gateway",
     "plugin_bridge",
     "storage",

--- a/backend/app/modules/assistant/router.py
+++ b/backend/app/modules/assistant/router.py
@@ -11,11 +11,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_user
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, provider_error_http_exception
 from app.core.db import get_session
 from app.core.limits import check_assistant_message
 from app.core.matter_access import resolve_owned_open_matter
-from app.core.model_gateway import PrivilegePaused
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
 from app.models import Matter, User
 from app.models.assistant import AssistantMessage as AssistantMessageRow
 
@@ -89,27 +88,8 @@ async def post_message(
             actor_id=user.id,
             request=request,
         )
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={
-                "error": "provider_key_missing",
-                "provider": exc.provider,
-                "message": str(exc),
-            },
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
 
     return AssistantPostResponse(
         user=_to_schema(user_row),

--- a/backend/app/modules/case_law/router.py
+++ b/backend/app/modules/case_law/router.py
@@ -25,9 +25,7 @@ from app.adapters.plugin_bridge import SkillDisabled
 from app.core.auth import current_user
 from app.core.db import get_session
 from app.core.matter_access import resolve_owned_open_matter
-from app.core.model_gateway import PrivilegePaused
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
-from app.core.api import audit
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit, provider_error_http_exception
 from app.models import Matter, MatterCitation, User
 
 from .schemas import (
@@ -71,27 +69,8 @@ async def case_law_search(
         raise HTTPException(404, str(exc)) from exc
     except SkillDisabled as exc:
         raise HTTPException(403, str(exc)) from exc
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={
-                "error": "provider_key_missing",
-                "provider": exc.provider,
-                "message": str(exc),
-            },
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
 

--- a/backend/app/modules/letters/router.py
+++ b/backend/app/modules/letters/router.py
@@ -29,9 +29,8 @@ from app.core.db import get_session
 from app.core.limits import check_generated_artefact
 from app.core.matter_access import resolve_owned_open_matter
 from app.core.model_gateway import PrivilegePaused, gateway as model_gateway
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
 from app.core.storage import StorageWriteError
-from app.core.api import audit
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit, provider_error_http_exception
 from app.models import Matter, User
 
 from .catalog import catalogue_for_matter_type, resolve
@@ -103,23 +102,8 @@ async def draft_letter(
         raise HTTPException(404, str(exc)) from exc
     except SkillDisabled as exc:
         raise HTTPException(403, str(exc)) from exc
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={"error": "provider_key_missing", "provider": exc.provider, "message": str(exc)},
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
 

--- a/backend/app/modules/pre_motion/router.py
+++ b/backend/app/modules/pre_motion/router.py
@@ -19,7 +19,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api import audit as audit_api
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit as audit_api, provider_error_http_exception
 from app.core.auth import current_user
 from app.core.config import settings
 from app.core.db import get_session
@@ -30,7 +30,11 @@ from app.core.model_gateway import (
     PrivilegePosture,
     gateway as model_gateway,
 )
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError, get_user_provider_key
+from app.core.user_keys import (
+    ProviderKeyMissing,
+    ProviderUpstreamError,
+    get_user_provider_key,
+)
 from app.core.storage import StorageWriteError
 from app.models import STATUS_ARCHIVED, Matter, User
 
@@ -68,23 +72,8 @@ async def run_pre_motion_endpoint(
             actor_id=user.id,
             inputs=body,
         )
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={"error": "provider_key_missing", "provider": exc.provider, "message": str(exc)},
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
 
 
 @router.post("/{slug}/pre-motion/run-stream")

--- a/backend/app/modules/tabular_review/router.py
+++ b/backend/app/modules/tabular_review/router.py
@@ -19,12 +19,11 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.api import audit as audit_api
+from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit as audit_api, provider_error_http_exception
 from app.core.auth import current_user
 from app.core.db import get_session
 from app.core.matter_access import resolve_owned_open_matter
-from app.core.model_gateway import PrivilegePaused, gateway as model_gateway
-from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
+from app.core.model_gateway import gateway as model_gateway
 from app.core.storage import StorageWriteError
 from app.models import Document, Matter, User
 from app.models.tabular_review import TabularReview, TabularReviewRow
@@ -339,27 +338,8 @@ async def run_review_endpoint(
         raise HTTPException(409, str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
-    except PrivilegePaused as exc:
-        raise HTTPException(409, str(exc)) from exc
-    except ProviderKeyMissing as exc:
-        raise HTTPException(
-            422,
-            detail={
-                "error": "provider_key_missing",
-                "provider": exc.provider,
-                "message": str(exc),
-            },
-        ) from exc
-    except ProviderUpstreamError as exc:
-        raise HTTPException(
-            502,
-            detail={
-                "error": exc.code,
-                "provider": exc.provider,
-                "upstream_status": exc.upstream_status,
-                "message": str(exc),
-            },
-        ) from exc
+    except PROVIDER_HTTP_EXCEPTIONS as exc:
+        raise provider_error_http_exception(exc) from exc
 
     await session.commit()
     return report


### PR DESCRIPTION
## Summary
- add a shared provider_error_http_exception helper for HTTP routes
- replace duplicated PrivilegePaused / ProviderKeyMissing / ProviderUpstreamError translation in module and API routers
- preserve the generic invocation endpoint's existing upstream error envelope

## Verification
- python3 -m py_compile on touched backend files
- git diff --check
- grep confirmed remaining direct provider catches are runner/SSE/DOCX-specific, not duplicated HTTP route translations

## Notes
- local import smoke could not run with system Python because this checkout has no FastAPI environment installed
- no frontend or schema changes