### PR TITLE
refactor: centralize upload and HTTP error helpers

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -27,10 +27,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import current_user
 from app.core.db import get_session
 from app.core.document_uploads import (
-    ALLOWED_UPLOAD_MIMES,
-    MAX_UPLOAD_BYTES,
-    MIME_TO_FORMAT,
-    sniff_format,
+    validate_upload_magic_bytes,
+    validate_upload_mime,
+    validate_upload_size,
 )
 from app.core.storage import (
     document_asset_key,
@@ -41,7 +40,14 @@ from app.core.storage import (
 )
 from app.core.text_extraction import extract as extract_text
 from app.core.model_gateway import gateway as model_gateway
-from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit, audit_failure, provider_error_http_exception
+from app.core.api import (
+    PROVIDER_HTTP_EXCEPTIONS,
+    audit,
+    audit_failure,
+    audit_storage_write_failure,
+    provider_error_http_exception,
+    storage_write_http_exception,
+)
 from app.core.config import settings
 from app.models import (
     AuditEntry,
@@ -571,28 +577,20 @@ async def post_document_asset(
             metadata={"sha256": digest, "document_id": str(doc.id)},
         )
     except StorageWriteError as exc:
-        await audit_failure(
+        await audit_storage_write_failure(
             session,
-            "storage.put_bytes.failed",
             actor_id=user.id,
             matter_id=matter.id,
-            module="storage",
             resource_type="document_asset",
             resource_id=str(asset_id),
-            payload={
-                "storage_key": key,
-                "backend": exc.backend,
-                "error_code": exc.error_code,
-            },
+            storage_key=key,
+            backend=exc.backend,
+            error_code=exc.error_code,
         )
-        raise HTTPException(
-            502,
-            detail={
-                "error": "storage_write_failed",
-                "message": "Failed to store document image.",
-                "storage_key": key,
-                "backend": exc.backend,
-            },
+        raise storage_write_http_exception(
+            message="Failed to store document image.",
+            storage_key=key,
+            backend=exc.backend,
         ) from exc
 
     await audit.log(
@@ -1775,39 +1773,10 @@ async def post_upload_document_version(
     """
     doc, matter = await _load_owned_document(document_id, session, user)
 
-    if file.content_type not in ALLOWED_UPLOAD_MIMES:
-        raise HTTPException(
-            415,
-            detail={
-                "error": "unsupported_mime",
-                "got": file.content_type,
-                "allowed": sorted(ALLOWED_UPLOAD_MIMES),
-            },
-        )
-
+    validate_upload_mime(file.content_type)
     contents = await file.read()
-    if len(contents) > MAX_UPLOAD_BYTES:
-        raise HTTPException(
-            413,
-            detail={
-                "error": "upload_too_large",
-                "max_bytes": MAX_UPLOAD_BYTES,
-                "got_bytes": len(contents),
-            },
-        )
-
-    declared_format = MIME_TO_FORMAT[file.content_type or ""]
-    inferred_format = sniff_format(contents[:1024])
-    if inferred_format is None or declared_format != inferred_format:
-        raise HTTPException(
-            415,
-            detail={
-                "error": "magic_byte_mismatch",
-                "declared_mime": file.content_type,
-                "declared_format": declared_format,
-                "inferred_format": inferred_format,
-            },
-        )
+    validate_upload_size(contents)
+    validate_upload_magic_bytes(file.content_type, contents)
 
     sha = hashlib.sha256(contents).hexdigest()
     filename = file.filename or doc.filename or "untitled"
@@ -1830,29 +1799,21 @@ async def post_upload_document_version(
             },
         )
     except StorageWriteError as exc:
-        await audit_failure(
+        await audit_storage_write_failure(
             session,
-            "storage.put_bytes.failed",
             actor_id=user.id,
             matter_id=matter.id,
-            module="storage",
             resource_type="document",
             resource_id=str(doc.id),
-            payload={
-                "storage_key": obj_key,
-                "backend": exc.backend,
-                "error_code": exc.error_code,
-                "version_upload": True,
-            },
+            storage_key=obj_key,
+            backend=exc.backend,
+            error_code=exc.error_code,
+            version_upload=True,
         )
-        raise HTTPException(
-            502,
-            detail={
-                "error": "storage_write_failed",
-                "message": "Failed to write document version to object storage.",
-                "storage_key": obj_key,
-                "backend": exc.backend,
-            },
+        raise storage_write_http_exception(
+            message="Failed to write document version to object storage.",
+            storage_key=obj_key,
+            backend=exc.backend,
         ) from exc
 
     next_version = (
@@ -2073,29 +2034,21 @@ async def post_restore_document_version(
                 },
             )
         except StorageWriteError as exc:
-            await audit_failure(
+            await audit_storage_write_failure(
                 session,
-                "storage.put_bytes.failed",
                 actor_id=user.id,
                 matter_id=matter.id,
-                module="storage",
                 resource_type="document_version",
                 resource_id=str(source.id),
-                payload={
-                    "storage_key": storage_uri,
-                    "backend": exc.backend,
-                    "error_code": exc.error_code,
-                    "restore": True,
-                },
+                storage_key=storage_uri,
+                backend=exc.backend,
+                error_code=exc.error_code,
+                restore=True,
             )
-            raise HTTPException(
-                502,
-                detail={
-                    "error": "storage_write_failed",
-                    "message": "Failed to store restored document version.",
-                    "storage_key": storage_uri,
-                    "backend": exc.backend,
-                },
+            raise storage_write_http_exception(
+                message="Failed to store restored document version.",
+                storage_key=storage_uri,
+                backend=exc.backend,
             ) from exc
 
     next_version = (

--- a/backend/app/api/invocations.py
+++ b/backend/app/api/invocations.py
@@ -39,7 +39,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.advice_boundary import AdviceBoundaryDenied
-from app.core.api import PROVIDER_HTTP_EXCEPTIONS, provider_error_http_exception
+from app.core.api import (
+    PROVIDER_HTTP_EXCEPTIONS,
+    http_error,
+    provider_error_http_exception,
+)
 from app.core.auth import current_user
 from app.core.capabilities import CapabilityDenied
 from app.core.db import get_session
@@ -99,9 +103,7 @@ async def _load_matter_or_404(
         )
     if matter is None or matter.status == STATUS_ARCHIVED:
         # Uniform 404 — never leak which matters exist for other users.
-        raise HTTPException(
-            status_code=404, detail=f"matter not found: {slug}"
-        )
+        raise HTTPException(status_code=404, detail=f"matter not found: {slug}")
     return matter
 
 
@@ -132,33 +134,19 @@ async def invoke_capability_endpoint(
         .order_by(InstalledModule.installed_at.desc())
     )
     if installed is None:
-        raise HTTPException(
-            status_code=404,
-            detail={
-                "error": "module_not_installed",
-                "module_id": body.module_id,
-            },
-        )
+        raise http_error(404, "module_not_installed", module_id=body.module_id)
     if not installed.enabled:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error": "module_disabled",
-                "module_id": body.module_id,
-            },
-        )
+        raise http_error(409, "module_disabled", module_id=body.module_id)
 
     # 2. Capability must be declared in the manifest.
     manifest = installed.manifest_snapshot or {}
     declaration = _find_capability_declaration(manifest, body.capability_id)
     if declaration is None:
-        raise HTTPException(
-            status_code=404,
-            detail={
-                "error": "capability_not_declared",
-                "module_id": body.module_id,
-                "capability_id": body.capability_id,
-            },
+        raise http_error(
+            404,
+            "capability_not_declared",
+            module_id=body.module_id,
+            capability_id=body.capability_id,
         )
 
     # 3. Decision #7 — scope must be matter (the matter URL only
@@ -166,33 +154,29 @@ async def invoke_capability_endpoint(
     #    get a dedicated future endpoint).
     declared_scope = declaration.get("scope", "workspace")
     if declared_scope != "matter":
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "error": "capability_scope_not_supported_here",
-                "capability_id": body.capability_id,
-                "capability_scope": declared_scope,
-                "message": (
-                    "POST /api/matters/{slug}/invocations only invokes "
-                    "matter-scope capabilities."
-                ),
-            },
+        raise http_error(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "capability_scope_not_supported_here",
+            capability_id=body.capability_id,
+            capability_scope=declared_scope,
+            message=(
+                "POST /api/matters/{slug}/invocations only invokes "
+                "matter-scope capabilities."
+            ),
         )
 
     # 4. Decision #7 — kind must be directly invokable.
     declared_kind = declaration.get("kind", "skill")
     if declared_kind not in _INVOKABLE_KINDS:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "error": "capability_kind_not_invokable",
-                "capability_id": body.capability_id,
-                "capability_kind": declared_kind,
-                "message": (
-                    f"capability kind {declared_kind!r} is dispatched "
-                    f"by the substrate, not via direct invocation"
-                ),
-            },
+        raise http_error(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "capability_kind_not_invokable",
+            capability_id=body.capability_id,
+            capability_kind=declared_kind,
+            message=(
+                f"capability kind {declared_kind!r} is dispatched "
+                f"by the substrate, not via direct invocation"
+            ),
         )
 
     # 5. Build invocation context + provider adapter.
@@ -237,34 +221,28 @@ async def invoke_capability_endpoint(
         # Defence-in-depth — the endpoint already filters scope=matter
         # above. A module that internally enforces scope and re-raises
         # this signals a manifest/runtime mismatch.
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "error": "capability_scope_not_supported_here",
-                "capability_id": exc.capability_id,
-                "capability_scope": exc.capability_scope,
-            },
+        raise http_error(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "capability_scope_not_supported_here",
+            capability_id=exc.capability_id,
+            capability_scope=exc.capability_scope,
         )
     except CapabilityDenied as exc:
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "error": "capability_denied",
-                "plugin": exc.plugin,
-                "skill": exc.skill,
-                "capability": exc.capability,
-                "matter_id": str(matter.id),
-                "scope": "matter",
-            },
+        raise http_error(
+            403,
+            "capability_denied",
+            plugin=exc.plugin,
+            skill=exc.skill,
+            capability=exc.capability,
+            matter_id=str(matter.id),
+            scope="matter",
         )
     except Phase1Blocked as exc:
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "error": "phase1_blocked",
-                "blocked_reason": exc.payload.blocked_reason.value,
-                "gate_state": exc.payload.gate_state,
-            },
+        raise http_error(
+            403,
+            "phase1_blocked",
+            blocked_reason=exc.payload.blocked_reason.value,
+            gate_state=exc.payload.gate_state,
         )
     except PROVIDER_HTTP_EXCEPTIONS as exc:
         raise provider_error_http_exception(
@@ -278,43 +256,38 @@ async def invoke_capability_endpoint(
         # The dispatcher disagreed with the endpoint's pre-check
         # (e.g. the module-author's invoke() rejects the capability
         # name even though it's in the manifest). 404 — same shape.
-        raise HTTPException(
-            status_code=404,
-            detail={
-                "error": "capability_not_declared",
-                "module_id": exc.module_id,
-                "capability_id": exc.capability_id,
-            },
+        raise http_error(
+            404,
+            "capability_not_declared",
+            module_id=exc.module_id,
+            capability_id=exc.capability_id,
         )
     except EntrypointResolutionError as exc:
         # The manifest is installed but its entrypoint can't be
         # imported — install-side data problem. 500.
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "entrypoint_resolution_failed",
-                "message": str(exc),
-            },
+        raise http_error(
+            500,
+            "entrypoint_resolution_failed",
+            message=str(exc),
         )
     except AdviceBoundaryDenied as exc:
         # Advice-boundary gate denial. Keep this typed so unrelated
         # PermissionError uses in future modules do not masquerade as
         # advice-boundary decisions.
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "error": "advice_boundary_denied",
-                "decision_id": str(exc.decision_id) if exc.decision_id else None,
-                "gate_state": exc.gate_state,
-                "message": str(exc),
-            },
+        raise http_error(
+            403,
+            "advice_boundary_denied",
+            decision_id=str(exc.decision_id) if exc.decision_id else None,
+            gate_state=exc.gate_state,
+            message=str(exc),
         )
     except ValueError as exc:
         # The capability raised on bad args (or unknown claim_type,
         # empty document_ids, etc.).
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={"error": "invalid_args", "message": str(exc)},
+        raise http_error(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "invalid_args",
+            message=str(exc),
         )
 
     await session.commit()

--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -18,10 +18,9 @@ from app.core.auth import current_user
 from app.core.db import get_session
 from app.core.limits import check_matter_create, check_document_upload
 from app.core.document_uploads import (
-    ALLOWED_UPLOAD_MIMES,
-    MAX_UPLOAD_BYTES,
-    MIME_TO_FORMAT,
-    sniff_format,
+    validate_upload_magic_bytes,
+    validate_upload_mime,
+    validate_upload_size,
 )
 from app.core.matter_fs import (
     append_history,
@@ -36,7 +35,13 @@ from app.core.storage import (
     StorageDeleteError,
 )
 from app.core.text_extraction import extract as extract_text
-from app.core.api import PROVIDER_HTTP_EXCEPTIONS, audit, provider_error_http_exception
+from app.core.api import (
+    PROVIDER_HTTP_EXCEPTIONS,
+    audit,
+    audit_storage_write_failure,
+    provider_error_http_exception,
+    storage_write_http_exception,
+)
 from app.models import (
     AuditEntry,
     Document,
@@ -290,44 +295,16 @@ async def upload_document(
     if tag is not None and tag not in TAG_VALUES:
         raise HTTPException(400, f"tag must be one of {sorted(TAG_VALUES)}")
 
-    if file.content_type not in ALLOWED_UPLOAD_MIMES:
-        raise HTTPException(
-            415,
-            detail={
-                "error": "unsupported_mime",
-                "got": file.content_type,
-                "allowed": sorted(ALLOWED_UPLOAD_MIMES),
-            },
-        )
-
+    validate_upload_mime(file.content_type)
     contents = await file.read()
-    if len(contents) > MAX_UPLOAD_BYTES:
-        raise HTTPException(
-            413,
-            detail={
-                "error": "upload_too_large",
-                "max_bytes": MAX_UPLOAD_BYTES,
-                "got_bytes": len(contents),
-            },
-        )
+    validate_upload_size(contents)
 
     # Evaluation limits: checked after the 413 size cap so oversized bodies
     # produce 413 (not 429). Counts are read from Postgres against committed
     # data; the document is not yet inserted at this point.
     await check_document_upload(user.id, matter.id, len(contents), session)
 
-    declared_format = MIME_TO_FORMAT[file.content_type or ""]
-    inferred_format = sniff_format(contents[:1024])
-    if inferred_format is None or declared_format != inferred_format:
-        raise HTTPException(
-            415,
-            detail={
-                "error": "magic_byte_mismatch",
-                "declared_mime": file.content_type,
-                "declared_format": declared_format,
-                "inferred_format": inferred_format,
-            },
-        )
+    validate_upload_magic_bytes(file.content_type, contents)
 
     sha = hashlib.sha256(contents).hexdigest()
 
@@ -372,29 +349,20 @@ async def upload_document(
         # flushed Document row so no orphan exists. Forensic provenance
         # for the failure goes via `audit_failure` on a separate
         # committed session — survives the rollback — R3 review fix.
-        from app.core.api import audit_failure
-        await audit_failure(
+        await audit_storage_write_failure(
             session,
-            "storage.put_bytes.failed",
             actor_id=user.id,
             matter_id=matter.id,
-            module="storage",
             resource_type="document",
             resource_id=str(doc.id),
-            payload={
-                "storage_key": obj_key,
-                "backend": exc.backend,
-                "error_code": exc.error_code,
-            },
+            storage_key=obj_key,
+            backend=exc.backend,
+            error_code=exc.error_code,
         )
-        raise HTTPException(
-            502,
-            detail={
-                "error": "storage_write_failed",
-                "message": "Failed to write document to object storage.",
-                "storage_key": obj_key,
-                "backend": exc.backend,
-            },
+        raise storage_write_http_exception(
+            message="Failed to write document to object storage.",
+            storage_key=obj_key,
+            backend=exc.backend,
         ) from exc
     doc.storage_uri = obj_key
 

--- a/backend/app/core/api.py
+++ b/backend/app/core/api.py
@@ -190,6 +190,70 @@ def provider_error_http_exception(
     )
 
 
+def http_error(
+    status_code: int,
+    error: str,
+    *,
+    message: str | None = None,
+    **detail: object,
+) -> HTTPException:
+    """Build a structured FastAPI HTTPException envelope.
+
+    Keeps repeated ``{"error": ..., "message": ...}`` shapes consistent
+    without hiding the status code at call sites.
+    """
+    payload: dict[str, object] = {"error": error}
+    if message is not None:
+        payload["message"] = message
+    payload.update({key: value for key, value in detail.items() if value is not None})
+    return HTTPException(status_code=status_code, detail=payload)
+
+
+def storage_write_http_exception(
+    *,
+    message: str,
+    storage_key: str,
+    backend: str,
+) -> HTTPException:
+    return http_error(
+        502,
+        "storage_write_failed",
+        message=message,
+        storage_key=storage_key,
+        backend=backend,
+    )
+
+
+async def audit_storage_write_failure(
+    request_session: AsyncSession,
+    *,
+    actor_id: uuid.UUID | None,
+    matter_id: uuid.UUID | None,
+    resource_type: str,
+    resource_id: str,
+    storage_key: str,
+    backend: str,
+    error_code: str,
+    **payload: object,
+) -> None:
+    """Record a storage write failure in the committed failure-audit path."""
+    await audit_failure(
+        request_session,
+        "storage.put_bytes.failed",
+        actor_id=actor_id,
+        matter_id=matter_id,
+        module="storage",
+        resource_type=resource_type,
+        resource_id=resource_id,
+        payload={
+            "storage_key": storage_key,
+            "backend": backend,
+            "error_code": error_code,
+            **payload,
+        },
+    )
+
+
 async def audit_failure(
     request_session: AsyncSession,
     action: str,
@@ -320,8 +384,11 @@ __all__ = [
     "get_matter",
     "audit",
     "audit_failure",
+    "audit_storage_write_failure",
+    "http_error",
     "PROVIDER_HTTP_EXCEPTIONS",
     "provider_error_http_exception",
+    "storage_write_http_exception",
     "model_gateway",
     "plugin_bridge",
     "storage",

--- a/backend/app/core/document_uploads.py
+++ b/backend/app/core/document_uploads.py
@@ -7,6 +7,8 @@ of route modules so the document engine does not drift by endpoint.
 
 from __future__ import annotations
 
+from fastapi import HTTPException
+
 MAX_UPLOAD_BYTES = 25 * 1024 * 1024  # 25 MB
 
 # Declared MIME -> canonical format key. The format key is what callers compare
@@ -39,3 +41,41 @@ def sniff_format(head: bytes) -> str | None:
     except UnicodeDecodeError:
         return None
 
+
+def validate_upload_mime(content_type: str | None) -> None:
+    if content_type not in ALLOWED_UPLOAD_MIMES:
+        raise HTTPException(
+            415,
+            detail={
+                "error": "unsupported_mime",
+                "got": content_type,
+                "allowed": sorted(ALLOWED_UPLOAD_MIMES),
+            },
+        )
+
+
+def validate_upload_size(contents: bytes) -> None:
+    if len(contents) > MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            413,
+            detail={
+                "error": "upload_too_large",
+                "max_bytes": MAX_UPLOAD_BYTES,
+                "got_bytes": len(contents),
+            },
+        )
+
+
+def validate_upload_magic_bytes(content_type: str | None, contents: bytes) -> None:
+    declared_format = MIME_TO_FORMAT[content_type or ""]
+    inferred_format = sniff_format(contents[:1024])
+    if inferred_format is None or declared_format != inferred_format:
+        raise HTTPException(
+            415,
+            detail={
+                "error": "magic_byte_mismatch",
+                "declared_mime": content_type,
+                "declared_format": declared_format,
+                "inferred_format": inferred_format,
+            },
+        )


### PR DESCRIPTION
## Summary
- move document upload MIME/size/magic-byte validation into the shared document_uploads policy module
- centralize storage write failure audit + 502 response handling
- add a small http_error helper and use it for repeated invocation error envelopes

## Stack
- stacked on #168 / codex/e4-provider-error-helper
- retarget to master after #168 lands

## Verification
- python3 -m py_compile on touched backend files
- git diff --check
- grep confirms raw storage.put_bytes.failed boilerplate is now only in the helper
- grep confirms upload API routes no longer import the upload constants directly