### PR TITLE
Lavern pass: calmer shell, minimal chat, lifted cards

### DIFF
--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -282,7 +282,7 @@ function DemoWorkflowsTab({
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {workflows.map((w) => (
-          <section key={w.title} className="rounded-card border border-rule bg-paper p-5 hover:border-ink transition-colors">
+          <section key={w.title} className="rounded-card border border-rule/60 bg-paper p-5 shadow-panel hover:border-ink transition-colors">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <div className="text-lg font-semibold tracking-tight2 text-ink">{w.title}</div>

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -94,7 +94,6 @@ export function ArtifactsList({ slug }: { slug: string }) {
         eyebrow="Matter"
         title="Signed outputs"
         subId={slug}
-        description="Drafts and signed material produced on this matter. Open an output to review sources, sign it, or trace how it was made."
       />
 
       {q.status === "loading" && (

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -130,7 +130,7 @@ export function GenericSkillRunner({
 
   return (
     <section
-      className={compact ? "rounded-card border border-rule bg-paper p-3" : "rounded-card border border-rule bg-paper p-4"}
+      className={compact ? "rounded-card border border-rule/60 bg-paper shadow-panel p-3" : "rounded-card border border-rule/60 bg-paper shadow-panel p-4"}
       data-testid={`generic-runner-${skill.moduleId}-${skill.capabilityId}`}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">

--- a/frontend/src/matter/GrantsPanel.tsx
+++ b/frontend/src/matter/GrantsPanel.tsx
@@ -589,11 +589,6 @@ export function GrantsPanel({
           <h3 className="text-xs uppercase tracking-widest text-muted">
             Available skills
           </h3>
-          <p className="mt-2 text-xs text-muted">
-            These skills are added, enabled, and fully permitted on this
-            matter. Readiness shows the provider-key boundary before a run
-            starts.
-          </p>
           <ul className="mt-3 space-y-3">
             {runnablePairs.map((p) => (
               <li

--- a/frontend/src/matter/MatterDetail.tsx
+++ b/frontend/src/matter/MatterDetail.tsx
@@ -169,7 +169,7 @@ export function MatterDetail({ slug }: { slug: string }) {
   return (
     <div className="flex-1 min-w-0">
         <div className="flex">
-        <main className="flex-1 min-w-0 px-4 sm:px-6 lg:px-10 py-10">
+        <main className="flex-1 min-w-0 px-4 sm:px-6 lg:px-12 py-12">
           {error && matter && <ErrorCallout message={error} compact />}
           {matter && (
             <PostureBanner

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -29,7 +29,7 @@ export function MatterList() {
   }, []);
 
   return (
-    <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-12">
+    <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-14">
       <div className="mb-10 flex flex-wrap items-end justify-between gap-6">
         <div>
           <h1 className="text-3xl sm:text-4xl font-bold tracking-tight2 text-ink leading-[1.1] mb-1">

--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -159,18 +159,9 @@ export function MatterSkillsTab({ slug }: Props) {
   return (
     <section>
       <header className="mb-6">
-        <p className="text-xs uppercase tracking-widest text-muted">
-          Matter skills
-        </p>
-        <h2 className="mt-1 text-lg font-semibold tracking-tight2 text-ink">
-          What you can run on this matter
+        <h2 className="text-xl font-semibold tracking-tight2 text-ink">
+          Skills
         </h2>
-        <p className="mt-2 max-w-2xl text-sm text-prose">
-          Each skill below names what it reads, what it writes, and when
-          it last ran here. Enabling a skill on this matter is a
-          matter-scoped decision — workspace trust is inherited, not
-          re-asked.
-        </p>
       </header>
 
       {error && (
@@ -314,7 +305,7 @@ function EnabledModuleRow({
 
   return (
     <article
-      className="rounded-card border border-rule bg-paper p-4"
+      className="rounded-card border border-rule/60 bg-paper shadow-panel p-4"
       data-testid={`enabled-module-${entry.module_id}`}
     >
       <div className="flex flex-wrap items-baseline justify-between gap-3">
@@ -370,7 +361,7 @@ function AvailableModuleRow({
 
   return (
     <article
-      className="rounded-card border border-rule bg-paper p-4"
+      className="rounded-card border border-rule/60 bg-paper shadow-panel p-4"
       data-testid={`available-module-${entry.module_id}`}
     >
       <div className="flex flex-wrap items-baseline justify-between gap-3">
@@ -491,7 +482,7 @@ function EnableSkillModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-full max-w-[480px] rounded-card border border-rule bg-paper p-5 shadow-xl">
+      <div className="w-full max-w-[480px] rounded-card border border-rule/60 bg-paper shadow-panel p-5 shadow-xl">
         <p className="text-[11px] uppercase tracking-widest text-muted">
           Enable skill
         </p>

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -13,11 +13,12 @@ import type {
 // - Citations: small bordered chips BELOW the assistant paragraph (not inline).
 // - Suggestions: compact outline buttons below the assistant paragraph.
 
-const MODEL_LABEL = "Claude Sonnet 4.6";
 
-function modelLabel(message: AssistantMessage): string {
+function modelLabel(message: AssistantMessage): string | null {
+  // The model is a settings choice, not per-message chrome; only the
+  // honesty case (no model at all) earns a token in the meta line.
   if (message.model_used === "deterministic-summary") return "extract, no model";
-  return MODEL_LABEL;
+  return null;
 }
 
 interface Props {
@@ -107,7 +108,7 @@ function AssistantMessageView({
         }
       >
         <div className={`tech-token ${metaSizing} text-muted`}>
-          Assistant{compact ? "" : ` · ${modelLabel(message)}`}
+          Assistant{!compact && modelLabel(message) ? ` · ${modelLabel(message)}` : ""}
           {!compact && sourceCount > 0
             ? ` · ${sourceCount} source${sourceCount === 1 ? "" : "s"}`
             : ""}

--- a/frontend/src/matter/PostureBanner.tsx
+++ b/frontend/src/matter/PostureBanner.tsx
@@ -227,7 +227,7 @@ function BannerShell({
   return (
     <div
       data-testid="posture-banner"
-      className={`mb-6 rounded-md border px-4 py-3 ${toneClasses}`}
+      className={`mb-6 rounded-card border px-4 py-3 ${toneClasses}`}
     >
       <div className="flex items-start gap-3">
         <span

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -253,11 +253,6 @@ export function ReconstructionView({ slug }: { slug: string }) {
           <p className="text-xs uppercase tracking-widest text-muted">Matter record</p>
           <h1 className="mt-2 text-2xl font-bold tracking-tight2">What happened here</h1>
           <p className="mt-1 text-xs tech-token text-muted">{slug}</p>
-          <p className="mt-3 max-w-2xl text-sm text-muted">
-            Skills run, documents referenced, outputs written, sign-offs,
-            reviews, and blocked attempts. Raw audit sources are still here,
-            but they sit behind Advanced details.
-          </p>
         </div>
         <div className="flex flex-wrap gap-2">
           <a

--- a/frontend/src/matter/tabs/ApprovalsTab.tsx
+++ b/frontend/src/matter/tabs/ApprovalsTab.tsx
@@ -59,8 +59,6 @@ export function ApprovalsTab({ slug }: { slug: string }) {
   return (
     <div className="max-w-3xl">
       <p className="text-sm text-muted">
-        A produced output enters human review here; a reviewer records a
-        decision and the audit trail reconstructs the chain.{" "}
         <span className="text-ink">
           "Approved in Legalise" records that a human reviewed an output —
           it is not legal advice certification or SRA approval.

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -190,7 +190,6 @@ describe("AssistantTab — in-chat skill picker", () => {
     });
 
     const context = await screen.findByTestId("chat-attached-document-context");
-    expect(context).toHaveTextContent(/Asking about/i);
     expect(context).toHaveTextContent("witness-statement.docx");
     expect(screen.getByTitle("Remove witness-statement.docx")).toBeInTheDocument();
   });

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -419,15 +419,12 @@ export function AssistantTab({
 
         {attachedDocs.length > 0 && (
           <section
-            className="mb-4 rounded-card border border-rule bg-paper-sunken px-4 py-3"
+            className="mb-4 border-t border-rule py-2"
             data-testid="chat-attached-document-context"
           >
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0">
-                <p className="text-[11px] uppercase tracking-widest text-muted">
-                  Asking about
-                </p>
-                <div className="mt-1 flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2">
                   {attachedDocs.map((doc) => (
                     <span
                       key={doc.id}
@@ -552,7 +549,7 @@ export function AssistantTab({
           </div>
           ) : null
         ) : (
-          <div className="mt-3 sticky bottom-0 bg-paper pt-3">
+          <div className="sticky bottom-0 bg-paper pt-2">
           {/* Context attachments as chips ABOVE the composer */}
           {attachedDocs.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-2">
@@ -562,11 +559,10 @@ export function AssistantTab({
                   type="button"
                   onClick={() => removeDoc(d.id)}
                   title={`Remove ${d.filename}`}
-                  className="inline-flex items-center gap-1.5 rounded-item border border-rule bg-paper px-2 py-1 tech-token text-[11px] text-ink hover:border-ink transition-colors"
+                  className="inline-flex items-center gap-1.5 text-xs text-muted hover:text-ink transition-colors"
                 >
-                  <span className="text-muted">Document</span>
-                  <span className="max-w-[180px] truncate">{d.filename}</span>
-                  <span className="text-muted ml-1" aria-hidden>x</span>
+                  <span className="max-w-[200px] truncate">{d.filename}</span>
+                  <span aria-hidden>×</span>
                 </button>
               ))}
             </div>
@@ -607,10 +603,9 @@ export function AssistantTab({
                 <div
                   role="menu"
                   aria-label="Skills enabled in this matter"
-                  className="absolute bottom-full left-0 mb-2 rounded-card border border-rule bg-paper p-3 w-[300px] z-10"
+                  className="absolute bottom-full left-0 mb-2 rounded-item border border-rule bg-paper p-2 w-[300px] z-10"
                   data-testid="chat-skills-popover"
                 >
-                  <div className="eyebrow mb-2">Run a skill</div>
                   {runnableSkillCount === 0 ? (
                     <p className="text-xs text-muted">
                       Nothing runnable here right now.{" "}
@@ -635,7 +630,7 @@ export function AssistantTab({
                                 type="button"
                                 role="menuitem"
                                 onClick={() => onPickRunnerSkill(skill)}
-                                className="flex w-full items-start justify-between gap-2 rounded-item border border-rule px-2 py-1.5 text-left text-xs hover:border-ink"
+                                className="flex w-full items-start justify-between gap-2 rounded-item px-2 py-1.5 text-left text-xs hover:bg-panel-hover"
                                 data-testid={`chat-runner-skill-${skill.moduleId}-${skill.capabilityId}`}
                               >
                                 <span className="block">
@@ -679,8 +674,7 @@ export function AssistantTab({
                 </div>
               )}
               {attachOpen && recentDocs.length > 0 && (
-                <div className="absolute bottom-full left-0 mb-2 rounded-card border border-rule bg-paper p-3 w-[280px] z-10">
-                  <div className="eyebrow mb-2">Attach documents</div>
+                <div className="absolute bottom-full left-0 mb-2 rounded-item border border-rule bg-paper p-2 w-[280px] z-10">
                   <ul className="space-y-2">
                     {recentDocs.map((d) => {
                       const checked = selectedDocIds.has(d.id);
@@ -715,7 +709,7 @@ export function AssistantTab({
               <button
                 onClick={onSend}
                 disabled={pending || !input.trim()}
-                className={`${primaryBtn} min-h-[38px] px-4 py-1.5 text-[14px]`}
+                className={`${primaryBtn} min-h-[44px] px-4 py-1.5 text-[14px]`}
               >
                 {pending ? "Sending…" : "Send"}
               </button>

--- a/frontend/src/matter/tabs/ChronologyTab.tsx
+++ b/frontend/src/matter/tabs/ChronologyTab.tsx
@@ -24,7 +24,7 @@ export function ChronologyTab({
       {chron.events.length === 0 && (
         <EmptyState
           title="No events yet"
-          body="Upload dated documents on the Documents tab. Chronology events are extracted from each document body and appear here with their source. Live extraction lands in v0.2."
+          body="Upload dated documents on the Documents tab. Chronology events are extracted from each document body and appear here with their source."
         />
       )}
 

--- a/frontend/src/matter/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.test.tsx
@@ -70,29 +70,23 @@ describe("DocumentsTab — document ingress", () => {
       />,
     );
 
-    expect(screen.getAllByText("Open notes").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("1 note")).toBeInTheDocument();
+    // P26 minimal list: statuses appear only when non-zero; chrome is gone.
+    expect(screen.getByText("1 open note")).toBeInTheDocument();
     expect(screen.getByText("3 saved versions")).toBeInTheDocument();
     expect(screen.getByText("2 pending changes")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Documents in this project" })).toBeInTheDocument();
-    expect(screen.getByText("Open workbench")).toBeInTheDocument();
-    expect(screen.getAllByText("Files")[0]).toBeInTheDocument();
-    expect(screen.getAllByText("1K")[0]).toBeInTheDocument();
-    expect(screen.getAllByText("Versions")[0]).toBeInTheDocument();
-    expect(screen.getAllByText("Changes")[0]).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Documents" })).toBeInTheDocument();
+    expect(screen.queryByText("Open workbench")).toBeNull();
+    expect(screen.queryByText("Ready to review")).toBeNull();
   });
 
   it("searches and filters the document library without opening files", async () => {
     render(<DocumentsTab slug="khan" docs={sampleDocs} onUpload={vi.fn()} />);
 
-    expect(screen.getByText("Showing 2 of 2 documents.")).toBeInTheDocument();
-
-    await userEvent.type(screen.getByPlaceholderText("Filename, tag, hash, source"), "dismissal");
+    await userEvent.type(screen.getByPlaceholderText("Search files"), "dismissal");
     expect(screen.queryByText("witness.docx")).not.toBeInTheDocument();
     expect(screen.getByText("dismissal-letter.pdf")).toBeInTheDocument();
-    expect(screen.getByText("Showing 1 of 2 documents.")).toBeInTheDocument();
 
-    await userEvent.clear(screen.getByPlaceholderText("Filename, tag, hash, source"));
+    await userEvent.clear(screen.getByPlaceholderText("Search files"));
     await userEvent.click(screen.getByRole("button", { name: "With notes" }));
     expect(screen.getByText("witness.docx")).toBeInTheDocument();
     expect(screen.queryByText("dismissal-letter.pdf")).not.toBeInTheDocument();

--- a/frontend/src/matter/tabs/DocumentsTab.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.tsx
@@ -119,11 +119,8 @@ export function DocumentsTab({
   const inputCls =
     "bg-paper border border-rule px-3 py-2 text-[16px] focus:border-ink focus:outline-none transition-colors min-h-[40px] font-sans text-ink";
   const totalBytes = docs?.reduce((total, d) => total + d.size_bytes, 0) ?? 0;
-  const disclosureCount = docs?.filter((d) => d.from_disclosure).length ?? 0;
   const openNoteCount =
     docs?.reduce((total, d) => total + (d.open_comment_count ?? 0), 0) ?? 0;
-  const versionCount =
-    docs?.reduce((total, d) => total + (d.version_count ?? 0), 0) ?? 0;
   const pendingEditCount =
     docs?.reduce((total, d) => total + (d.pending_edit_count ?? 0), 0) ?? 0;
   const filteredDocs =
@@ -153,9 +150,6 @@ export function DocumentsTab({
       <details className="mb-8 rounded-card border border-rule bg-paper" open={!docs || docs.length === 0}>
         <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-ink">
           Add documents
-          <span className="ml-2 font-normal text-muted">
-            PDFs, Word files, or text; each upload is hashed and recorded.
-          </span>
         </summary>
         <div className="grid gap-px border-t border-rule bg-rule md:grid-cols-[1.4fr_1fr]">
           <label
@@ -174,9 +168,6 @@ export function DocumentsTab({
             </span>
             <span className="mt-4 text-base font-medium text-ink">
               Drop files here, or click to browse
-            </span>
-            <span className="mt-1 text-sm text-muted">
-              Extraction and audit trail are automatic.
             </span>
             <input
               type="file"
@@ -239,58 +230,28 @@ export function DocumentsTab({
       )}
       {docs && docs.length > 0 && (
         <div>
-          <div className="mb-4 grid gap-3 rounded-card border border-rule bg-paper p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-            <div>
-              <h2 className="text-xl font-semibold tracking-tight2 text-ink">
-                Documents in this project
-              </h2>
-              <p className="mt-1 text-sm leading-6 text-muted">
-                Open a file to read, edit, compare versions, and keep review notes
-                with the matter record.
-              </p>
-            </div>
-            <dl className="grid grid-cols-2 gap-2 text-center text-xs sm:grid-cols-5">
-              <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                <dt className="tech-token uppercase tracking-track2 text-muted">Files</dt>
-                <dd className="mt-1 text-sm font-semibold text-ink">{docs.length}</dd>
-              </div>
-              <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                <dt className="tech-token uppercase tracking-track2 text-muted">Size</dt>
-                <dd className="mt-1 text-sm font-semibold text-ink">{formatBytes(totalBytes)}</dd>
-              </div>
-              <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                <dt className="tech-token uppercase tracking-track2 text-muted">Open notes</dt>
-                <dd className="mt-1 text-sm font-semibold text-ink">{openNoteCount}</dd>
-              </div>
-              <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                <dt className="tech-token uppercase tracking-track2 text-muted">Versions</dt>
-                <dd className="mt-1 text-sm font-semibold text-ink">{versionCount}</dd>
-              </div>
-              <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                <dt className="tech-token uppercase tracking-track2 text-muted">Changes</dt>
-                <dd className="mt-1 text-sm font-semibold text-ink">{pendingEditCount}</dd>
-              </div>
-            </dl>
-          </div>
-          {disclosureCount > 0 && (
-            <p className="mb-3 border-l-2 border-rule bg-paper px-3 py-2 text-sm text-muted">
-              {disclosureCount} disclosure document{disclosureCount === 1 ? "" : "s"} marked
-              as CPR 31 material.
+          <div className="mb-4 flex flex-wrap items-baseline justify-between gap-3">
+            <h2 className="text-xl font-semibold tracking-tight2 text-ink">
+              Documents
+            </h2>
+            <p className="text-[13px] text-muted">
+              {docs.length} file{docs.length === 1 ? "" : "s"} · {formatBytes(totalBytes)}
+              {openNoteCount > 0 ? ` · ${openNoteCount} open note${openNoteCount === 1 ? "" : "s"}` : ""}
+              {pendingEditCount > 0 ? ` · ${pendingEditCount} pending change${pendingEditCount === 1 ? "" : "s"}` : ""}
             </p>
-          )}
+          </div>
           <div
-            className="mb-4 grid gap-3 rounded-card border border-rule bg-paper px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto]"
+            className="mb-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]"
             data-testid="document-library-controls"
           >
-            <label className="text-xs font-semibold uppercase tracking-track2 text-muted">
-              Search documents
-              <input
+            <label className="sr-only" htmlFor="document-search">Search documents</label>
+            <input
+                id="document-search"
                 value={documentQuery}
                 onChange={(event) => setDocumentQuery(event.target.value)}
-                placeholder="Filename, tag, hash, source"
-                className="mt-1 min-h-[40px] w-full rounded-item border border-rule bg-paper-sunken px-3 font-sans text-sm font-normal normal-case tracking-normal text-ink outline-none focus:border-ink"
+                placeholder="Search files"
+                className="min-h-[40px] w-full rounded-item border border-rule bg-paper px-3 font-sans text-sm text-ink outline-none focus:border-ink"
               />
-            </label>
             <div className="flex flex-wrap items-end gap-2">
               {[
                 ["all", "All"],
@@ -313,9 +274,6 @@ export function DocumentsTab({
                 </button>
               ))}
             </div>
-            <p className="text-xs text-muted md:col-span-2">
-              Showing {filteredDocs?.length ?? 0} of {docs.length} document{docs.length === 1 ? "" : "s"}.
-            </p>
           </div>
           <div
             className="grid gap-3 md:grid-cols-2"
@@ -336,7 +294,7 @@ export function DocumentsTab({
                   key={d.id}
                   to="/matters/$slug/documents/$documentId"
                   params={{ slug, documentId: d.id }}
-                  className="group rounded-card border border-rule bg-paper p-4 transition-colors hover:border-ink hover:bg-wash"
+                  className="group rounded-card border border-rule/60 bg-paper p-5 shadow-panel transition-colors hover:border-ink"
                   title={`SHA-256 ${d.sha256}`}
                 >
                   <div className="flex items-start justify-between gap-4">
@@ -344,67 +302,26 @@ export function DocumentsTab({
                       <p className="truncate text-base font-semibold text-ink">
                         {d.filename}
                       </p>
-                      <p className="mt-1 truncate tech-token text-[11px] text-muted">
-                        {d.sha256.slice(0, 8)}
+                      <p className="mt-1 truncate text-[13px] text-muted">
+                        {d.from_disclosure ? "CPR 31 disclosure" : "Upload"} · {formatBytes(d.size_bytes)} · {formatDate(d.uploaded_at)}
                       </p>
                     </div>
                     <Badge>{typeLabel}</Badge>
                   </div>
-                  <dl className="mt-5 grid grid-cols-2 gap-3 text-sm">
-                    <div>
-                      <dt className="tech-token text-[10px] uppercase tracking-track2 text-muted">
-                        Source
-                      </dt>
-                      <dd className="mt-1 text-ink">
-                        {d.from_disclosure ? "CPR 31 disclosure" : "Upload"}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="tech-token text-[10px] uppercase tracking-track2 text-muted">
-                        Size
-                      </dt>
-                      <dd className="mt-1 text-ink">{formatBytes(d.size_bytes)}</dd>
-                    </div>
-                    <div>
-                      <dt className="tech-token text-[10px] uppercase tracking-track2 text-muted">
-                        Open notes
-                      </dt>
-                      <dd className="mt-1 text-ink">
-                        {openNotes
-                          ? plural(openNotes, "note")
-                          : "None"}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="tech-token text-[10px] uppercase tracking-track2 text-muted">
-                        Updated
-                      </dt>
-                      <dd className="mt-1 text-ink">{formatDate(d.uploaded_at)}</dd>
-                    </div>
-                  </dl>
-                  <div className="mt-4 flex flex-wrap gap-2" aria-label={`Workbench status for ${d.filename}`}>
-                    {workStatus.length > 0 ? (
-                      workStatus.map((item) => (
+                  {workStatus.length > 0 && (
+                    <div className="mt-3 flex flex-wrap gap-2" aria-label={`Workbench status for ${d.filename}`}>
+                      {workStatus.map((item) => (
                         <span
                           key={item}
-                          className="rounded-item border border-rule bg-paper-sunken px-2 py-1 text-xs font-medium text-ink"
+                          className="rounded-item bg-paper-sunken px-2 py-1 text-xs font-medium text-ink"
                         >
                           {item}
                         </span>
-                      ))
-                    ) : (
-                      <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1 text-xs text-muted">
-                        Ready to review
-                      </span>
-                    )}
-                  </div>
-                  <div className="mt-5 flex items-center justify-between border-t border-rule pt-3">
-                    <span className="text-xs leading-5 text-muted">
-                      Reader, notes, versions, skills, and Record links open together.
-                    </span>
-                    <span className="shrink-0 rounded-item border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper group-hover:bg-black">
-                      Open workbench
-                    </span>
+                      ))}
+                    </div>
+                  )}
+                  <div className="mt-3 text-right text-xs text-muted group-hover:text-ink">
+                    Open →
                   </div>
                 </Link>
               );

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -192,7 +192,7 @@ export function ModulesCatalog() {
   }, [modules, tab, tabCounts.installed, tabCounts.available]);
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-12 text-ink">
+    <div className="mx-auto max-w-5xl px-6 py-14 text-ink">
       <PageHeader
         eyebrow={authed ? "Workspace" : "Skill library"}
         title="Skills"

--- a/frontend/src/ui/SidebarView.tsx
+++ b/frontend/src/ui/SidebarView.tsx
@@ -126,26 +126,25 @@ export function SidebarView({
         {/* New CTA — top of rail */}
         {(newHref || onNew) && (
           newHref ? (
-            <a href={newHref} className="mx-3 mt-3 mb-1 flex items-center justify-center gap-2 min-h-[40px] rounded-item bg-ink text-paper font-redaction20 text-[11px] font-bold uppercase tracking-track1 hover:bg-black transition-colors">
+            <a href={newHref} className="mx-3 mt-4 mb-2 flex items-center justify-center gap-2 min-h-[40px] rounded-item bg-ink text-paper text-[13px] font-medium hover:bg-black transition-colors">
               <PlusIcon /> New matter
             </a>
           ) : (
-            <button type="button" onClick={onNew} className="mx-3 mt-3 mb-1 flex items-center justify-center gap-2 min-h-[40px] rounded-item bg-ink text-paper font-redaction20 text-[11px] font-bold uppercase tracking-track1 hover:bg-black transition-colors">
+            <button type="button" onClick={onNew} className="mx-3 mt-4 mb-2 flex items-center justify-center gap-2 min-h-[40px] rounded-item bg-ink text-paper text-[13px] font-medium hover:bg-black transition-colors">
               <PlusIcon /> New matter
             </button>
           )
         )}
 
         <nav className="flex-1 overflow-y-auto py-2" aria-label="Workspace sections">
-          <SectionLabel>Workspace</SectionLabel>
+          <div className="pt-3" aria-hidden="true" />
           {globalItems.map((it) => (
             <NavLink key={it.key} item={it} />
           ))}
 
           {matterItems && matterItems.length > 0 && (
             <>
-              <div className="px-3 pt-5 pb-1.5">
-                <div className="text-[10px] font-semibold uppercase tracking-widest text-muted mb-1.5">Matter</div>
+              <div className="px-3 pt-7 pb-2">
                 <div className="flex items-center gap-2 flex-wrap">
                   <span className="text-sm font-semibold text-ink leading-snug break-words">{matterTitle}</span>
                   {matterPosture && (

--- a/frontend/src/ui/TopBar.tsx
+++ b/frontend/src/ui/TopBar.tsx
@@ -83,7 +83,7 @@ export function TopBar({
                 <a
                   href="/matters"
                   className={
-                    "transition-colors " + (isList ? "text-ink font-semibold" : "text-ink hover:text-seal")
+                    "transition-colors " + (isList ? "text-ink font-semibold" : "text-ink hover:opacity-70")
                   }
                 >
                   Matters
@@ -91,7 +91,7 @@ export function TopBar({
                 <a
                   href="/skills"
                   className={
-                    "transition-colors " + (isModules ? "text-ink font-semibold" : "text-ink hover:text-seal")
+                    "transition-colors " + (isModules ? "text-ink font-semibold" : "text-ink hover:opacity-70")
                   }
                 >
                   Skills
@@ -99,7 +99,7 @@ export function TopBar({
                 <a
                   href="/settings/profile"
                   className={
-                    "transition-colors " + (route.name === "settings" ? "text-ink font-semibold" : "text-ink hover:text-seal")
+                    "transition-colors " + (route.name === "settings" ? "text-ink font-semibold" : "text-ink hover:opacity-70")
                   }
                 >
                   Settings
@@ -110,7 +110,7 @@ export function TopBar({
                     data-testid="admin-nav-anchor"
                     className={
                       "transition-colors " +
-                      (isAdmin ? "text-ink font-semibold" : "text-ink hover:text-seal")
+                      (isAdmin ? "text-ink font-semibold" : "text-ink hover:opacity-70")
                     }
                   >
                     Admin
@@ -124,7 +124,7 @@ export function TopBar({
                   href={DEMO_HREF_UNAUTHED}
                   className={
                     "transition-colors " +
-                    (isDemo ? "text-ink font-semibold" : "text-ink hover:text-seal")
+                    (isDemo ? "text-ink font-semibold" : "text-ink hover:opacity-70")
                   }
                 >
                   Demo
@@ -133,7 +133,7 @@ export function TopBar({
                   href="/skills"
                   className={
                     "transition-colors " +
-                    (isModules ? "text-ink font-semibold" : "text-ink hover:text-seal")
+                    (isModules ? "text-ink font-semibold" : "text-ink hover:opacity-70")
                   }
                 >
                   Skills
@@ -142,7 +142,7 @@ export function TopBar({
                   href="https://github.com/b1rdmania/legalise"
                   target="_blank"
                   rel="noreferrer"
-                  className="text-ink hover:text-seal transition-colors"
+                  className="text-ink hover:opacity-70 transition-colors"
                 >
                   GitHub
                 </a>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -36,9 +36,9 @@ export default {
         // See docs/DESIGN.md P21. Used by the matter workspace only;
         // Landing/auth keep paper #FFFFFF.
         canvas: '#E8E8E8',
-        panel: '#F5F5F5',
-        'panel-hover': '#EBEBEB',
-        'panel-sel': '#E2E2E2',
+        panel: '#FAFAFA',
+        'panel-hover': '#F3F3F3',
+        'panel-sel': '#E6E6E6',
         'panel-2': '#F7F7F7',
       },
       maxWidth: {


### PR DESCRIPTION
The overnight design pass. One rule applied everywhere: **the page does the work; nothing narrates it.** Lavern is the bar — one message per surface, generous air, soft lift instead of border boxes.

- **Tokens**: panel #F5F5F5 → #FAFAFA (the inset-panel float finally reads); page mains breathe.
- **Shell**: sidebar section eyebrows gone, sentence-case New matter, no oxblood in nav hover.
- **Chat**: model name out of the meta line (only the keyless honesty token survives), quiet attachment treatment, clean popovers.
- **Files**: stat-card board, banners, hashes, metadata grids and CTA footers all cut — name + one meta line + Open →, on shadow-lifted cards.
- **Pages**: explainer sentences cut across Approvals/Artifacts/Chronology/Reconstruction/Skills/Grants; legal caveats kept.

Verified in browser (chat, files, document page screenshots in session). 277 tests green, build green. Builds on #177's P25 strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)