### PR TITLE
Stock the skill shelf: installed skills visible everywhere, catalogue inline, one-click ceremony

### DIFF
--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -25,6 +25,7 @@ import {
   manifestText,
   runnableMatterSkills,
   shortCapabilityList,
+  withInstalledEntries,
 } from "./skillRunnerModel";
 
 interface Props {
@@ -117,6 +118,11 @@ export function MatterSkillsTab({ slug }: Props) {
   // it on this matter. Grants are per (module_id, capability)
   // tuple, so any presence implies the skill has been enabled at least
   // partially.)
+  const allModules = useMemo(
+    () => withInstalledEntries(modules, installed),
+    [modules, installed],
+  );
+
   const grantedModuleIds = useMemo(() => {
     const set = new Set<string>();
     for (const g of grants ?? []) set.add(g.plugin);
@@ -125,16 +131,16 @@ export function MatterSkillsTab({ slug }: Props) {
 
   const enabledModules = useMemo(
     () =>
-      modules.filter((m) => {
+      allModules.filter((m) => {
         const inst = installed.get(m.module_id);
         return inst?.enabled === true && grantedModuleIds.has(m.module_id);
       }),
-    [modules, installed, grantedModuleIds],
+    [allModules, installed, grantedModuleIds],
   );
 
   const runnableSkills = useMemo(
-    () => runnableMatterSkills({ modules, installed, grants }),
-    [modules, installed, grants],
+    () => runnableMatterSkills({ modules: allModules, installed, grants }),
+    [allModules, installed, grants],
   );
 
   const runnableModuleIds = useMemo(
@@ -149,11 +155,11 @@ export function MatterSkillsTab({ slug }: Props) {
 
   const availableModules = useMemo(
     () =>
-      modules.filter((m) => {
+      allModules.filter((m) => {
         const inst = installed.get(m.module_id);
         return inst?.enabled === true && !grantedModuleIds.has(m.module_id);
       }),
-    [modules, installed, grantedModuleIds],
+    [allModules, installed, grantedModuleIds],
   );
 
   return (
@@ -201,8 +207,7 @@ export function MatterSkillsTab({ slug }: Props) {
           ))}
           {runnableSkills.length === 0 && enabledModules.length === 0 && (
             <p className="text-sm text-muted">
-              No skills are enabled in this matter yet. Pick one from
-              Available to enable below.
+              No skills are enabled on this matter yet.
             </p>
           )}
         </div>
@@ -216,7 +221,7 @@ export function MatterSkillsTab({ slug }: Props) {
         />
         {availableModules.length === 0 ? (
           <p className="mt-3 text-sm text-muted" data-testid="available-empty">
-            Everything trusted in the workspace is already enabled here.{" "}
+            Nothing waiting. Add skills from the library.{" "}
             <Link
               to="/skills"
               className="underline underline-offset-4 hover:text-ink"

--- a/frontend/src/matter/skillRunnerModel.ts
+++ b/frontend/src/matter/skillRunnerModel.ts
@@ -137,6 +137,44 @@ function capabilityHasRequiredGrantRows(
   return required.every((need) => granted.has(need));
 }
 
+
+function titleFromModuleId(moduleId: string): string {
+  const tail = moduleId.includes(".") ? moduleId.split(".").pop() ?? moduleId : moduleId;
+  return tail
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Installed modules that have no filesystem-catalogue entry (imported
+ * Lawve skills live only in installed_modules) get a synthetic entry
+ * built from the install-time permissions snapshot, so every surface
+ * that lists skills sees one truthful set.
+ */
+export function withInstalledEntries(
+  modules: V2ManifestEntry[],
+  installed: Map<string, InstalledModule>,
+): V2ManifestEntry[] {
+  const catalogued = new Set(modules.map((entry) => entry.module_id));
+  const synthesized: V2ManifestEntry[] = [];
+  for (const inst of installed.values()) {
+    if (catalogued.has(inst.module_id)) continue;
+    synthesized.push({
+      module_id: inst.module_id,
+      source_kind: "installed",
+      manifest: {
+        name: titleFromModuleId(inst.module_id),
+        capabilities: inst.capabilities ?? [],
+      },
+      is_valid: true,
+      validation_errors: [],
+    });
+  }
+  return synthesized.length === 0 ? modules : [...modules, ...synthesized];
+}
+
 export function runnableMatterSkills({
   modules,
   installed,

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -27,6 +27,7 @@ import { InlineAgentStatus, MessageBubble, type InlineAgentStep } from "../Messa
 import { GenericSkillRunner } from "../GenericSkillRunner";
 import {
   runnableMatterSkills,
+  withInstalledEntries,
   type RunnableMatterSkill,
 } from "../skillRunnerModel";
 import type { TabKey } from "./types";
@@ -179,7 +180,7 @@ export function AssistantTab({
   const runnableModuleSkills = useMemo(
     () =>
       runnableMatterSkills({
-        modules: moduleEntries,
+        modules: withInstalledEntries(moduleEntries, installedModules),
         installed: installedModules,
         grants: grantRows,
       }),
@@ -651,16 +652,18 @@ export function AssistantTab({
                       )}
                     </div>
                   )}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSkillsOpen(false);
-                      openAddSkill();
-                    }}
-                    className="mt-3 text-xs text-muted underline underline-offset-4 hover:text-ink"
-                  >
-                    Add skill →
-                  </button>
+                  {runnableSkillCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSkillsOpen(false);
+                        openAddSkill();
+                      }}
+                      className="mt-3 text-xs text-muted underline underline-offset-4 hover:text-ink"
+                    >
+                      Add skill →
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={() => {

--- a/frontend/src/modules-v2/InstallCeremony.test.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.test.tsx
@@ -110,12 +110,12 @@ describe("InstallCeremony — advance actions", () => {
 
     mountAt("/skills/install/cer-1");
     await waitFor(() => {
-      expect(screen.getByText("Continue review")).toBeInTheDocument();
+      expect(screen.getByText("Step through review")).toBeInTheDocument();
     });
 
     expect(screen.queryByText("Enable skill")).toBeNull();
 
-    fireEvent.click(screen.getByText("Continue review"));
+    fireEvent.click(screen.getByText("Step through review"));
     await waitFor(() => {
       expect(advance).toHaveBeenCalledWith("cer-1", "trust");
     });
@@ -134,7 +134,7 @@ describe("InstallCeremony — advance actions", () => {
       expect(screen.getByText("Enable skill")).toBeInTheDocument();
     });
 
-    expect(screen.queryByText("Continue review")).toBeNull();
+    expect(screen.queryByText("Step through review")).toBeNull();
 
     fireEvent.click(screen.getByText("Enable skill"));
     await waitFor(() => {
@@ -215,7 +215,7 @@ describe("InstallCeremony — terminal failures", () => {
         screen.getByText(/ceremony terminated/i),
       ).toBeInTheDocument();
     });
-    expect(screen.queryByText("Continue review")).toBeNull();
+    expect(screen.queryByText("Step through review")).toBeNull();
     expect(screen.queryByText("Enable skill")).toBeNull();
     expect(screen.queryByText("Reject")).toBeNull();
   });

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -96,6 +96,36 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
     void refresh();
   }, [refresh]);
 
+  const onApproveAll = async () => {
+    setAdv({ kind: "running", action: "trust" });
+    try {
+      // Walk the review states in one user decision. Every step is still
+      // recorded individually in the audit log — the compression is in
+      // the clicking, not the record.
+      let current = q.status === "ready" ? q.ceremony : null;
+      for (let i = 0; i < 12 && current && !current.is_terminal; i++) {
+        const action: CeremonyAction =
+          current.state === "granted" ? "grant" : "trust";
+        current = await advanceCeremony(ceremonyId, action);
+        setQ({ status: "ready", ceremony: current });
+        if (current.state === "enabled") break;
+      }
+      setAdv({ kind: "idle" });
+    } catch (err) {
+      if (err instanceof InvalidCeremonyTransitionError) {
+        setAdv({
+          kind: "invalid_transition",
+          message: err.message,
+          requestedAction: err.requestedAction,
+          ceremonyId: err.ceremonyId,
+        });
+        void refresh();
+        return;
+      }
+      setAdv({ kind: "error", message: String(err) });
+    }
+  };
+
   const onAdvance = async (action: CeremonyAction) => {
     setAdv({ kind: "running", action });
     try {
@@ -186,16 +216,23 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
       {/* Controls */}
       {!isTerminal && (
         <div className="mt-8 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void onApproveAll()}
+            disabled={adv.kind === "running"}
+            data-testid="ceremony-approve-all"
+            className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-paper hover:opacity-90 disabled:opacity-50"
+          >
+            {adv.kind === "running" ? "Approving…" : "Approve & enable"}
+          </button>
           {!canEnable && (
             <button
               type="button"
               onClick={() => onAdvance("trust")}
               disabled={adv.kind === "running"}
-              className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-paper hover:opacity-90 disabled:opacity-50"
+              className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-ink hover:border-ink disabled:opacity-50"
             >
-              {adv.kind === "running" && adv.action === "trust"
-                ? "Advancing…"
-                : "Continue review"}
+              Step through review
             </button>
           )}
           {canEnable && (
@@ -203,11 +240,9 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
               type="button"
               onClick={() => onAdvance("grant")}
               disabled={adv.kind === "running"}
-              className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-paper hover:opacity-90 disabled:opacity-50"
+              className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-ink hover:border-ink disabled:opacity-50"
             >
-              {adv.kind === "running" && adv.action === "grant"
-                ? "Enabling…"
-                : "Enable skill"}
+              Enable skill
             </button>
           )}
           <button

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -65,6 +65,21 @@ export function LawveImport() {
   }, []);
 
   const skills = q.status === "ready" ? q.skills : [];
+
+  // Deep-link preselect: /skills/lawve?skill=<slug> (the stocked
+  // library on /skills links straight to a skill's review pane).
+  useEffect(() => {
+    if (q.status !== "ready" || selected || selecting) return;
+    const slug =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search).get("skill")
+        : null;
+    if (slug && q.skills.some((s) => s.slug === slug)) {
+      void openSkill(slug);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q.status]);
+
   const licenses = useMemo(
     () => [...new Set(skills.map((s) => s.license).filter((l): l is string => !!l))].sort(),
     [skills],

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -25,6 +25,7 @@ import {
   type V2ManifestEntry,
 } from "../lib/api";
 import { PageHeader } from "../ui/primitives";
+import { listLawveSkills, type LawveSkillRow } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
 
 type ModuleState = "available" | "installed" | "disabled";
@@ -108,6 +109,23 @@ export function ModulesCatalog() {
   const [modules, setModules] = useState<V2ManifestEntry[] | null>(null);
   const [installed, setInstalled] = useState<Map<string, InstalledModule>>(new Map());
   const [skills, setSkills] = useState<PublicModuleSkill[] | null>(null);
+  const [lawve, setLawve] = useState<LawveSkillRow[] | null>(null);
+
+  useEffect(() => {
+    if (!authed) return;
+    let cancelled = false;
+    listLawveSkills()
+      .then((res) => {
+        if (!cancelled) setLawve(res?.skills ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setLawve([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authed]);
   const [skillsRepo, setSkillsRepo] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showSkills, setShowSkills] = useState(false);
@@ -198,7 +216,7 @@ export function ModulesCatalog() {
         title="Skills"
         description={
           authed
-            ? "Add legal skills to the workspace, then enable them inside the matter where they should run."
+            ? "A skill is a piece of legal work — review an NDA, screen a dismissal, draft a letter. Add one from the catalogue, enable it on a matter, run it from Chat. Every run leaves a signed, auditable record."
             : "Legal skills are small pieces of legal work: review an NDA, test a claim, draft a letter, check authorities. Browse the library, then open the demo to see one run against a matter."
         }
         actions={
@@ -393,6 +411,54 @@ export function ModulesCatalog() {
           </ul>
         )}
       </section>
+      )}
+
+      {/* The stocked shelf: the open Lawve catalogue, reviewable and
+          addable in two clicks. */}
+      {authed && (
+        <section className="mt-10" data-testid="lawve-catalogue">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <h2 className="text-xs uppercase tracking-widest text-muted">
+              Catalogue{lawve ? ` (${lawve.length})` : ""}
+            </h2>
+            <Link
+              to="/skills/lawve"
+              className="text-sm text-muted underline underline-offset-4 hover:text-ink"
+            >
+              Open full importer →
+            </Link>
+          </div>
+          {lawve == null ? (
+            <p className="mt-3 text-sm text-muted">Loading catalogue…</p>
+          ) : lawve.length === 0 ? (
+            <p className="mt-3 text-sm text-muted">
+              Catalogue unavailable right now.
+            </p>
+          ) : (
+            <ul className="mt-3 divide-y divide-rule rounded-card border border-rule/60 bg-paper shadow-panel">
+              {lawve.map((s) => (
+                <li key={s.slug} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-ink">{s.name}</p>
+                    <p className="mt-0.5 max-w-2xl truncate text-[13px] text-muted">
+                      {s.description}
+                    </p>
+                    <p className="mt-0.5 text-[11px] text-muted">
+                      {s.author_name ?? "unknown"}
+                      {s.license ? ` · ${s.license}` : ""}
+                    </p>
+                  </div>
+                  <a
+                    href={`/skills/lawve?skill=${encodeURIComponent(s.slug)}`}
+                    className="shrink-0 rounded-item border border-rule px-3 py-1.5 text-xs text-ink hover:border-ink"
+                  >
+                    Review & add →
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
       )}
 
       {/* Secondary: open skill library (browse only, not an add path) */}


### PR DESCRIPTION
Answers 'I'm not sure the skill library actually works' with a verified walk and the fixes it surfaced.

## Verified end-to-end (screenshots in session)
Lawve browse (42 live skills) → convert to draft → trust ceremony → install → enable on Khan → **run → OUTPUT WRITTEN** with invocation id, cited source, Review & sign. The pipe works.

## What was broken
1. **Installed skills were invisible.** `runnableMatterSkills` iterated the filesystem catalogue only — Lawve imports live in `installed_modules`, so a fully-installed, fully-granted skill appeared in *neither* the matter Skills lists *nor* the chat popover, with contradictory empty-states ('No skills enabled… pick from Available' over 'Everything is already enabled'). Fixed with `withInstalledEntries()` — synthetic catalogue entries from the install-time permissions snapshot, one truthful set for both surfaces.
2. **The ceremony was a blind click-grind** — same button seven times. Now: **Approve & enable** chains the review states in one decision; every state is still individually recorded in the audit log. Step-through remains.
3. **The shelf was empty.** /skills now renders the full Lawve catalogue inline with Review & add → deep links (`?skill=` preselect). Teach header explains skill → run → record in one line.
4. Chat popover duplicate 'Add skill' affordances deduped.

277 tests green, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Approve & Enable" button to expedite skill installation by advancing through multiple review steps in one action
  * Integrated new Lawve skill catalogue for browsing and adding skills
  * Added deep-linking support to navigate directly to specific skills

* **Improvements**
  * Updated button labels for clarity in the skill installation workflow
  * Enhanced empty state messaging across skills sections
  * Improved visibility and handling of installed modules in skill tabs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->