### PR TITLE
Install as a live scan; the Counsel Register

### DIFF
--- a/backend/app/api/module_routes/common.py
+++ b/backend/app/api/module_routes/common.py
@@ -153,6 +153,7 @@ class ValidateManifestResponse(BaseModel):
 
 class InstalledModuleOut(BaseModel):
     module_id: str
+    name: str | None = None
     version: str
     publisher: str
     visibility: str
@@ -161,6 +162,9 @@ class InstalledModuleOut(BaseModel):
     enabled: bool
     installed_at: str  # ISO-8601
     installed_by_user_id: str | None
+    # Manifest source_url captured at install (pinned-SHA provenance);
+    # "<inline>" for manifests installed without a source.
+    install_path: str | None = None
 
 
 class StartInstallRequest(BaseModel):

--- a/backend/app/api/module_routes/installed_listing.py
+++ b/backend/app/api/module_routes/installed_listing.py
@@ -51,6 +51,8 @@ async def list_installed_modules(
             sub.c.visibility,
             sub.c.signature_status,
             sub.c.permissions_snapshot,
+            sub.c.manifest_snapshot,
+            sub.c.install_path,
             sub.c.enabled,
             sub.c.installed_at,
             sub.c.installed_by_user_id,
@@ -62,6 +64,11 @@ async def list_installed_modules(
     return [
         InstalledModuleOut(
             module_id=r.module_id,
+            name=(
+                r.manifest_snapshot.get("name")
+                if isinstance(r.manifest_snapshot, dict)
+                else None
+            ),
             version=r.version,
             publisher=r.publisher,
             visibility=r.visibility,
@@ -76,6 +83,7 @@ async def list_installed_modules(
             installed_by_user_id=(
                 str(r.installed_by_user_id) if r.installed_by_user_id else None
             ),
+            install_path=r.install_path,
         )
         for r in rows
     ]

--- a/backend/tests/test_phase14_5_b_installed_modules.py
+++ b/backend/tests/test_phase14_5_b_installed_modules.py
@@ -223,9 +223,13 @@ async def test_response_shape_excludes_secrets_and_internals(client, db_session)
     rows = resp.json()
     matching = next((r for r in rows if r["module_id"] == module_id), None)
     assert matching is not None
-    # Documented fields present.
+    # Documented fields present. `name` (manifest display name) and
+    # `install_path` (the manifest's public source_url, pinned-SHA
+    # provenance for the register) were added for the Counsel Register —
+    # both come from the manifest the user already reviewed, not secrets.
     expected_keys = {
         "module_id",
+        "name",
         "version",
         "publisher",
         "visibility",
@@ -234,12 +238,12 @@ async def test_response_shape_excludes_secrets_and_internals(client, db_session)
         "enabled",
         "installed_at",
         "installed_by_user_id",
+        "install_path",
     }
     assert set(matching.keys()) == expected_keys
-    # Never leaks manifest / permissions / install_path.
+    # Never leaks the raw snapshots or signer internals.
     assert "manifest_snapshot" not in matching
     assert "permissions_snapshot" not in matching
-    assert "install_path" not in matching
     assert "signed_by" not in matching
 
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -290,3 +290,9 @@
     box-shadow: 0 0 0 1px rgba(24, 24, 24, 0.28);
   }
 }
+
+/* Ledger entries landing during the install scan. */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(2px); }
+  to   { opacity: 1; transform: none; }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -209,6 +209,7 @@ export const draftGithubModule = (url: string, overrides?: Record<string, unknow
 // badge and as one AND clause in GrantsPanel.runnablePairs.
 export interface InstalledModule {
   module_id: string;
+  name?: string | null;
   version: string;
   publisher: string;
   visibility: string;
@@ -217,6 +218,7 @@ export interface InstalledModule {
   enabled: boolean;
   installed_at: string;
   installed_by_user_id: string | null;
+  install_path?: string | null;
 }
 
 export const listInstalledModules = () =>

--- a/frontend/src/lib/route.ts
+++ b/frontend/src/lib/route.ts
@@ -41,6 +41,7 @@ export type Route =
   | { name: "appHome" }
   | { name: "moduleDetail"; moduleId: string }
   | { name: "moduleInstall"; ceremonyId: string }
+  | { name: "register" }
   | { name: "matterAudit"; slug: string }
   | { name: "matterArtifacts"; slug: string }
   | { name: "matterArtifactDetail"; slug: string; artifactId: string }
@@ -104,11 +105,12 @@ export function routeFromPath(pathname: string, search: string): Route {
   const adminUserMatch = path.match(/^\/admin\/users\/([^/]+)$/);
   if (adminUserMatch) return { name: "adminUserDetail", userId: adminUserMatch[1] };
 
-  const moduleInstallMatch = path.match(/^\/modules\/install\/([^/]+)$/);
+  const moduleInstallMatch = path.match(/^\/(?:skills|modules)\/install\/([^/]+)$/);
   if (moduleInstallMatch) {
     return { name: "moduleInstall", ceremonyId: moduleInstallMatch[1] };
   }
-  const moduleDetailMatch = path.match(/^\/modules\/([^/]+)$/);
+  if (path === "/register") return { name: "register" };
+  const moduleDetailMatch = path.match(/^\/(?:skills|modules)\/([^/]+)$/);
   if (moduleDetailMatch) {
     return { name: "moduleDetail", moduleId: moduleDetailMatch[1] };
   }

--- a/frontend/src/modules-v2/CounselRegister.tsx
+++ b/frontend/src/modules-v2/CounselRegister.tsx
@@ -1,0 +1,294 @@
+/**
+ * /register — the Counsel Register.
+ *
+ * Idea A from the standing reframe: render the workspace's installed
+ * skills as entries in a register of AI counsel. A pure renderer over
+ * the installed manifests — no second database, no new writes. Each
+ * certificate states what the record already holds: publisher
+ * (chambers), permission bands, advice ceiling, signature status,
+ * pinned source, date of admission.
+ *
+ * Design: Standing Order (the artist pass) — ink/paper/seal only,
+ * Didone monument + clerk's ledger, red spent like money. A revoked
+ * counsel is shown struck, with the same fidelity as the admitted.
+ */
+
+import { useEffect, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { listInstalledModules, type InstalledModule } from "../lib/api";
+import { useAuth } from "../auth/AuthProvider";
+
+const TIERS = [
+  "factual_extraction",
+  "legal_information",
+  "draft_advice",
+  "supervised_legal_advice",
+  "approved_final_advice",
+] as const;
+
+type Query =
+  | { status: "loading" }
+  | { status: "ready"; rows: InstalledModule[] }
+  | { status: "error"; message: string };
+
+function capList(row: InstalledModule, key: "reads" | "writes"): string[] {
+  const out = new Set<string>();
+  for (const raw of row.capabilities ?? []) {
+    if (!raw || typeof raw !== "object") continue;
+    const values = (raw as Record<string, unknown>)[key];
+    if (!Array.isArray(values)) continue;
+    for (const v of values) if (typeof v === "string") out.add(v);
+  }
+  return [...out].sort();
+}
+
+function adviceTier(row: InstalledModule): string {
+  let highest = 0;
+  for (const raw of row.capabilities ?? []) {
+    if (!raw || typeof raw !== "object") continue;
+    const t = (raw as Record<string, unknown>).advice_tier_max;
+    const idx = TIERS.indexOf(t as (typeof TIERS)[number]);
+    if (idx > highest) highest = idx;
+  }
+  return TIERS[highest];
+}
+
+function displayName(row: InstalledModule): string {
+  if (row.name) return row.name;
+  const tail = row.module_id.split(".").pop() ?? row.module_id;
+  return tail
+    .split(/[-_]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function sourceRef(row: InstalledModule): { label: string; href: string } | null {
+  const p = row.install_path;
+  if (!p || !p.startsWith("http")) return null;
+  const m = p.match(/github\.com\/([^/]+\/[^/]+)(?:\/tree\/([^/]+))?/);
+  if (!m) return { label: p.replace(/^https?:\/\//, ""), href: p };
+  return {
+    label: `${m[1]}${m[2] ? ` @ ${m[2].slice(0, 8)}` : ""}`,
+    href: p,
+  };
+}
+
+export function CounselRegister() {
+  const auth = useAuth();
+  const [q, setQ] = useState<Query>({ status: "loading" });
+
+  useEffect(() => {
+    if (!auth.user) return;
+    let cancelled = false;
+    listInstalledModules()
+      .then((rows) => {
+        if (!cancelled) setQ({ status: "ready", rows });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setQ({ status: "error", message: String(err) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.user]);
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-14 text-ink">
+      <div className="flex items-baseline justify-between border-b border-ink pb-2">
+        <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
+          The register of AI counsel · series 1
+        </p>
+        <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
+          Legalise
+        </p>
+      </div>
+
+      <h1 className="mt-8 font-redaction35 text-[64px] leading-none tracking-tight2 sm:text-[88px]">
+        Standing
+      </h1>
+      <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-muted">
+        over capability
+      </p>
+
+      <p className="mt-8 max-w-xl text-sm leading-relaxed text-prose">
+        The register does not say what counsel can do. It says what counsel
+        has been admitted to do under supervision — which matters it may
+        read, what it may write, the ceiling on its advice, and who vouched
+        for it. Admission is the trust ceremony; every entry below is
+        derived from the signed record, nothing else.
+      </p>
+
+      {q.status === "loading" && (
+        <p className="mt-12 text-sm text-muted">Opening the register…</p>
+      )}
+      {q.status === "error" && (
+        <p className="mt-12 text-sm text-seal">
+          Could not open the register: {q.message}
+        </p>
+      )}
+
+      {q.status === "ready" && q.rows.length === 0 && (
+        <div className="mt-12 border border-rule bg-paper p-6">
+          <p className="text-sm text-prose">
+            No counsel hold standing in this workspace yet.
+          </p>
+          <Link
+            to="/skills/lawve"
+            className="mt-3 inline-flex items-center rounded-md bg-ink px-4 py-2 text-sm text-paper hover:opacity-90"
+          >
+            Instruct your first counsel
+          </Link>
+        </div>
+      )}
+
+      {q.status === "ready" && q.rows.length > 0 && (
+        <div className="mt-12 grid gap-6 sm:grid-cols-2" data-testid="register-grid">
+          {q.rows.map((row, i) => (
+            <Certificate key={row.module_id} row={row} index={i} />
+          ))}
+        </div>
+      )}
+
+      <p className="mt-14 border-t border-rule pt-3 text-[10px] uppercase tracking-[0.2em] text-muted">
+        Refusals and revocations are recorded with the same fidelity as
+        admissions — the record testifies against itself when it must.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function Certificate({ row, index }: { row: InstalledModule; index: number }) {
+  const reads = capList(row, "reads");
+  const writes = capList(row, "writes");
+  const tier = adviceTier(row);
+  const tierIdx = TIERS.indexOf(tier as (typeof TIERS)[number]);
+  const src = sourceRef(row);
+  const verified = row.signature_status === "structure_verified";
+  const revoked = !row.enabled;
+  const admitted = new Date(row.installed_at);
+
+  return (
+    <article
+      className={
+        "relative border bg-paper p-5 " +
+        (revoked ? "border-seal/40" : "border-ink/70")
+      }
+      data-testid={`certificate-${row.module_id}`}
+    >
+      <div className="flex items-baseline justify-between">
+        <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
+          Counsel {String(index + 1).padStart(2, "0")}
+        </p>
+        <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
+          {row.visibility?.replaceAll("_", " ")}
+        </p>
+      </div>
+
+      <h2
+        className={
+          "mt-3 text-[22px] leading-tight tracking-tight2 " +
+          (revoked ? "text-seal line-through decoration-1" : "text-ink")
+        }
+      >
+        {displayName(row)}
+      </h2>
+      <p className="mt-1 text-xs text-muted">
+        {row.publisher} (chambers) · v{row.version}
+      </p>
+
+      {/* Practice bands — what the counsel may read and write. */}
+      <div className="mt-4 space-y-2">
+        <Band label="Reads" values={reads} />
+        <Band label="Writes" values={writes} />
+      </div>
+
+      <div className="mt-4 flex items-center justify-between border-t border-rule pt-3">
+        <span
+          aria-label={`advice ceiling: ${tier.replaceAll("_", " ")}`}
+          className="tracking-[0.25em] text-ink text-sm"
+        >
+          {TIERS.map((_t, i) => (i <= tierIdx ? "●" : "○")).join("")}
+        </span>
+        <span className="text-[10px] uppercase tracking-[0.18em] text-muted">
+          {tier.replaceAll("_", " ")}
+        </span>
+      </div>
+
+      <dl className="mt-3 space-y-1 text-[11px] text-muted">
+        <div className="flex justify-between gap-3">
+          <dt className="uppercase tracking-[0.18em]">Signature</dt>
+          <dd className={verified ? "text-ink" : ""}>
+            {(row.signature_status ?? "unknown").replaceAll("_", " ")}
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="uppercase tracking-[0.18em]">Admitted</dt>
+          <dd>
+            {admitted.toLocaleDateString("en-GB", {
+              day: "2-digit",
+              month: "short",
+              year: "numeric",
+            })}
+          </dd>
+        </div>
+        {src && (
+          <div className="flex justify-between gap-3">
+            <dt className="uppercase tracking-[0.18em]">Source</dt>
+            <dd className="truncate">
+              <a
+                href={src.href}
+                target="_blank"
+                rel="noreferrer"
+                className="tech-token hover:underline"
+              >
+                {src.label}
+              </a>
+            </dd>
+          </div>
+        )}
+        {revoked && (
+          <div className="flex justify-between gap-3 text-seal">
+            <dt className="uppercase tracking-[0.18em]">Standing</dt>
+            <dd>revoked</dd>
+          </div>
+        )}
+      </dl>
+
+      {/* The seal — only counsel with a verified signature carry it. */}
+      {verified && !revoked && (
+        <span
+          aria-label="verified standing"
+          className="absolute -right-2 -top-2 flex h-12 w-12 rotate-12 items-center justify-center rounded-full border-2 border-seal text-[8px] uppercase tracking-[0.15em] text-seal"
+        >
+          Signed
+        </span>
+      )}
+    </article>
+  );
+}
+
+function Band({ label, values }: { label: string; values: string[] }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-12 shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
+        {label}
+      </span>
+      {values.length === 0 ? (
+        <span className="text-[11px] text-muted">—</span>
+      ) : (
+        <span className="flex min-w-0 flex-1 flex-wrap gap-1" title={values.join(", ")}>
+          {values.map((v) => (
+            <span
+              key={v}
+              className="h-2.5 bg-ink"
+              style={{ width: `${Math.min(96, 18 + v.length * 4)}px` }}
+              title={v}
+            />
+          ))}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/modules-v2/InstallCeremony.test.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.test.tsx
@@ -1,14 +1,16 @@
 /**
- * Phase 14 B — InstallCeremony regression tests.
+ * InstallCeremony — admission-scan regression tests.
  *
  * Coverage focus:
- *   - Stepper reflects substrate state
- *   - Advance buttons call the substrate with the right action string
- *   - 409 invalid-transition surfaces a structured banner including
- *     the module.ceremony.rejected audit-row reference + deep-link
- *     (Phase 14 E target)
- *   - Reject path bounces to /skills
- *   - Terminal-failure states block further advances
+ *   - The scan auto-advances the verification states on load (one
+ *     "trust" advance per state, each its own audited transition) and
+ *     halts at the decision boundary
+ *   - Ledger rows render the real verification results
+ *   - Approve & enable drives granted → enabled (trust then grant)
+ *   - Refuse strikes the entry in seal red and bounces to /skills
+ *   - Terminal failures stop the scan and hide the decision
+ *   - Revisiting an enabled ceremony renders the record without
+ *     re-advancing
  *
  * Reviewer-narrow: no polling, no telemetry assertions, no audit
  * row inspection (substrate-side tests already cover those).
@@ -29,6 +31,14 @@ import { InstallCeremony } from "./InstallCeremony";
 import * as api from "../lib/api";
 import type { CeremonyResponse } from "../lib/api";
 
+const FULL_PATH_ORDER = [
+  "inspected",
+  "signature_checked",
+  "publisher_checked",
+  "permissions_reviewed",
+  "gates_reviewed",
+] as const;
+
 function makeCeremony(overrides: Partial<CeremonyResponse> = {}): CeremonyResponse {
   return {
     ceremony_id: "cer-1",
@@ -44,14 +54,42 @@ function makeCeremony(overrides: Partial<CeremonyResponse> = {}): CeremonyRespon
       signature_status: "structure_verified",
       visibility: "first_party",
       version: "0.2.1",
-      capabilities: [{ id: "cap-1" }],
-      audit_events: [{ action: "module.enabled" }],
-      gates: [],
-      advice_tier_max: "tier_2",
+      capabilities: [
+        {
+          id: "review",
+          kind: "skill",
+          reads: ["document.body.read"],
+          writes: ["matter.artifact.write"],
+          model_access: "required",
+        },
+      ],
+      audit_events: ["module.enabled"],
+      gates: ["privilege_posture"],
+      advice_tier_max: "draft_advice",
+      data_movement_summary: { local_only: true },
     },
     history: [],
     ...overrides,
   };
+}
+
+/** advanceCeremony stub that walks the full path one state per call. */
+function walkingAdvance() {
+  let i = 0;
+  return vi
+    .spyOn(api, "advanceCeremony")
+    .mockImplementation(async (_id, action) => {
+      if (action === "reject") {
+        return makeCeremony({ state: "rejected_by_user", is_terminal: true });
+      }
+      if (action === "grant") {
+        return makeCeremony({ state: "enabled", is_terminal: true });
+      }
+      const state = FULL_PATH_ORDER[Math.min(i, FULL_PATH_ORDER.length - 1)];
+      i += 1;
+      if (i > FULL_PATH_ORDER.length) return makeCeremony({ state: "granted" });
+      return makeCeremony({ state });
+    });
 }
 
 function mountAt(initialPath: string) {
@@ -69,7 +107,12 @@ function mountAt(initialPath: string) {
     path: "/skills",
     component: () => <div data-testid="modules-stub" />,
   });
-  const tree = root.addChildren([ceremonyRoute, modulesStub]);
+  const registerStub = createRoute({
+    getParentRoute: () => root,
+    path: "/register",
+    component: () => <div data-testid="register-stub" />,
+  });
+  const tree = root.addChildren([ceremonyRoute, modulesStub, registerStub]);
   const router = createRouter({
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: [initialPath] }),
@@ -84,139 +127,150 @@ afterEach(() => {
   cleanup();
 });
 
-describe("InstallCeremony — stepper", () => {
-  it("highlights the current substrate state", async () => {
-    vi.spyOn(api, "getCeremony").mockResolvedValue(
-      makeCeremony({ state: "permissions_reviewed" }),
-    );
-    mountAt("/skills/install/cer-1");
-    await waitFor(() => {
-      expect(screen.getByText("Permissions reviewed")).toBeInTheDocument();
-    });
-    // Permission card always visible (substrate publishes it from
-    // discovered onward). Phase 18-B: the module name now also heads the
-    // page, so it appears both in the headline and the permission card.
-    expect(screen.getAllByText("Contract Review").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("0.2.1")).toBeInTheDocument();
-  });
-});
-
-describe("InstallCeremony — advance actions", () => {
-  it("continues review before the granted boundary", async () => {
+describe("InstallCeremony — the scan", () => {
+  it("auto-advances the verification states and halts at the decision", async () => {
     vi.spyOn(api, "getCeremony").mockResolvedValue(makeCeremony());
-    const advance = vi
-      .spyOn(api, "advanceCeremony")
-      .mockResolvedValue(makeCeremony({ state: "inspected" }));
+    const advance = walkingAdvance();
 
     mountAt("/skills/install/cer-1");
-    await waitFor(() => {
-      expect(screen.getByText("Step through review")).toBeInTheDocument();
-    });
 
-    expect(screen.queryByText("Enable skill")).toBeNull();
-
-    fireEvent.click(screen.getByText("Step through review"));
-    await waitFor(() => {
-      expect(advance).toHaveBeenCalledWith("cer-1", "trust");
-    });
-  });
-
-  it("renders the enable action only at the granted boundary", async () => {
-    vi.spyOn(api, "getCeremony").mockResolvedValue(
-      makeCeremony({ state: "granted" }),
+    // The scan walks discovered → … → gates_reviewed with one audited
+    // "trust" advance per state, then presents the single decision.
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("ceremony-decision")).toBeInTheDocument();
+      },
+      { timeout: 6000 },
     );
-    const advance = vi
-      .spyOn(api, "advanceCeremony")
-      .mockResolvedValue(makeCeremony({ state: "enabled", is_terminal: true }));
+    expect(advance).toHaveBeenCalledTimes(FULL_PATH_ORDER.length);
+    for (const call of advance.mock.calls) {
+      expect(call).toEqual(["cer-1", "trust"]);
+    }
 
-    mountAt("/skills/install/cer-1");
-    await waitFor(() => {
-      expect(screen.getByText("Enable skill")).toBeInTheDocument();
-    });
+    // The ledger shows the real verification results.
+    expect(screen.getByTestId("scan-row-signature_checked")).toHaveTextContent(
+      "structure verified",
+    );
+    expect(screen.getByTestId("scan-row-publisher_checked")).toHaveTextContent(
+      "legalise · verified",
+    );
+    expect(screen.getByTestId("scan-row-gates_reviewed")).toHaveTextContent(
+      "privilege_posture",
+    );
 
+    // One decision: approve or refuse. No stepper, no step buttons.
+    expect(screen.getByTestId("ceremony-approve-all")).toBeInTheDocument();
+    expect(screen.getByTestId("ceremony-refuse")).toBeInTheDocument();
     expect(screen.queryByText("Step through review")).toBeNull();
+  }, 10000);
 
-    fireEvent.click(screen.getByText("Enable skill"));
-    await waitFor(() => {
-      expect(advance).toHaveBeenCalledWith("cer-1", "grant");
-    });
-  });
-
-  it("reject bounces to /skills after the terminal state renders", async () => {
-    vi.spyOn(api, "getCeremony").mockResolvedValue(makeCeremony());
-    vi.spyOn(api, "advanceCeremony").mockResolvedValue(
+  it("approve drives granted then enabled and shows the enrolment", async () => {
+    // Start at the decision boundary so the test skips the scan stagger.
+    vi.spyOn(api, "getCeremony").mockResolvedValue(
       makeCeremony({
-        state: "rejected_by_user",
-        is_terminal: true,
+        state: "gates_reviewed",
+        history: [
+          { state: "discovered" },
+          { state: "inspected" },
+          { state: "signature_checked" },
+          { state: "publisher_checked" },
+          { state: "permissions_reviewed" },
+          { state: "gates_reviewed" },
+        ],
       }),
     );
+    const advance = vi
+      .spyOn(api, "advanceCeremony")
+      .mockResolvedValueOnce(makeCeremony({ state: "granted" }))
+      .mockResolvedValueOnce(
+        makeCeremony({ state: "enabled", is_terminal: true }),
+      );
 
     mountAt("/skills/install/cer-1");
     await waitFor(() => {
-      expect(screen.getByText("Reject")).toBeInTheDocument();
+      expect(screen.getByTestId("ceremony-approve-all")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText("Reject"));
 
+    fireEvent.click(screen.getByTestId("ceremony-approve-all"));
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("ceremony-enrolled")).toBeInTheDocument();
+      },
+      { timeout: 4000 },
+    );
+    expect(advance).toHaveBeenNthCalledWith(1, "cer-1", "trust");
+    expect(advance).toHaveBeenNthCalledWith(2, "cer-1", "grant");
+    // The enrolment points at the register.
+    expect(screen.getByRole("link", { name: /view the register/i })).toBeInTheDocument();
+  }, 10000);
+
+  it("refuse strikes the entry and bounces to /skills", async () => {
+    vi.spyOn(api, "getCeremony").mockResolvedValue(
+      makeCeremony({
+        state: "gates_reviewed",
+        history: [{ state: "discovered" }],
+      }),
+    );
+    vi.spyOn(api, "advanceCeremony").mockResolvedValue(
+      makeCeremony({ state: "rejected_by_user", is_terminal: true }),
+    );
+
+    mountAt("/skills/install/cer-1");
+    await waitFor(() => {
+      expect(screen.getByTestId("ceremony-refuse")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId("ceremony-refuse"));
+
+    // The refusal lands as a struck ledger entry before the bounce.
+    await waitFor(() => {
+      expect(screen.getByTestId("scan-row-refused")).toBeInTheDocument();
+    });
     await waitFor(
       () => {
         expect(screen.getByTestId("modules-stub")).toBeInTheDocument();
       },
-      { timeout: 1500 },
+      { timeout: 2500 },
     );
-  });
-});
+  }, 10000);
 
-describe("InstallCeremony — 409 invalid-transition", () => {
-  it("renders a structured banner naming the substrate audit row", async () => {
+  it("revisiting an enabled ceremony renders the record without advancing", async () => {
     vi.spyOn(api, "getCeremony").mockResolvedValue(
-      makeCeremony({ state: "granted" }),
+      makeCeremony({
+        state: "enabled",
+        is_terminal: true,
+        history: [
+          { state: "discovered" },
+          { state: "inspected" },
+          { state: "signature_checked" },
+          { state: "publisher_checked" },
+          { state: "permissions_reviewed" },
+          { state: "gates_reviewed" },
+          { state: "granted" },
+          { state: "enabled" },
+        ],
+      }),
     );
-    vi.spyOn(api, "advanceCeremony").mockRejectedValueOnce(
-      new api.InvalidCeremonyTransitionError(
-        "cannot grant before permissions_reviewed",
-        "cer-1",
-        "grant",
-      ),
-    );
+    const advance = vi.spyOn(api, "advanceCeremony");
 
     mountAt("/skills/install/cer-1");
     await waitFor(() => {
-      expect(screen.getByText("Enable skill")).toBeInTheDocument();
+      expect(screen.getByTestId("ceremony-enrolled")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText("Enable skill"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText(/invalid ceremony transition/i),
-      ).toBeInTheDocument();
-    });
-    // The banner references the substrate's audit row by name.
-    expect(screen.getByText(/module\.ceremony\.rejected/)).toBeInTheDocument();
-    // Phase 14.5 C — the deep-link is back. Action-filter only per
-    // the Phase 14.5 plan P1 redline (no ?ceremony= param).
-    const link = screen.getByRole("link", { name: /audit log/i });
-    expect(link.getAttribute("href")).toBe(
-      "/admin/audit?action=module.ceremony.rejected",
-    );
-    // The link MUST NOT carry a ceremony_id — that param doesn't
-    // exist on the backend.
-    expect(link.getAttribute("href")).not.toMatch(/ceremony=/);
+    expect(advance).not.toHaveBeenCalled();
+    expect(screen.getByTestId("scan-row-signature_checked")).toBeInTheDocument();
   });
 });
 
 describe("InstallCeremony — terminal failures", () => {
-  it("hides advance buttons and shows the failure banner", async () => {
+  it("stops the scan and hides the decision", async () => {
     vi.spyOn(api, "getCeremony").mockResolvedValue(
       makeCeremony({ state: "publisher_blocked", is_terminal: true }),
     );
     mountAt("/skills/install/cer-1");
     await waitFor(() => {
-      expect(
-        screen.getByText(/ceremony terminated/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/admission terminated/i)).toBeInTheDocument();
     });
-    expect(screen.queryByText("Step through review")).toBeNull();
-    expect(screen.queryByText("Enable skill")).toBeNull();
-    expect(screen.queryByText("Reject")).toBeNull();
+    expect(screen.queryByTestId("ceremony-approve-all")).toBeNull();
+    expect(screen.queryByTestId("ceremony-refuse")).toBeNull();
   });
 });

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -1,58 +1,37 @@
 /**
- * /modules/install/{ceremony_id}.
+ * /skills/install/{ceremony_id} — admission to the register.
  *
- * Trust-ceremony stepper. Reads ceremony state via GET /api/modules/install/{id}
- * and lets an admin advance via POST .../advance with action=trust|grant|reject.
+ * The trust ceremony, rendered as a live scan instead of a stepper.
+ * The substrate's verification states (inspect → signature → publisher
+ * → permissions → gates) advance automatically on load, each landing
+ * as a ledger entry with its real result — every transition is still
+ * an individual audit row; the compression is in the clicking, not the
+ * record. The scan halts at the decision boundary: one human choice,
+ * Approve & enable (granted → enabled) or Refuse (entry struck).
  *
- * State machine (substrate, see app/core/trust_ceremony.py:CeremonyState):
+ * State machine (substrate, app/core/trust_ceremony.py):
  *   discovered → inspected → signature_checked → publisher_checked
- *     → permissions_reviewed → gates_reviewed → granted → enabled
- *   Terminal: enabled / rejected_by_user / signature_failed /
- *             publisher_blocked / permission_denied /
- *             sandbox_profile_missing
+ *     → permissions_reviewed → gates_reviewed → [decision] → granted
+ *     → enabled.
+ *   Fast path (verified publisher): discovered → publisher_checked
+ *     → permissions_reviewed → [decision] → granted → enabled.
+ *   Terminal failures: rejected_by_user / signature_failed /
+ *     publisher_blocked / permission_denied / sandbox_profile_missing.
  *
- * Action policy (mirrors substrate):
- *   - "trust"  — non-terminal, non-granted: advance one review step
- *   - "grant"  — only rendered at the granted-ready boundary; persists
- *                InstalledModule and emits module.enabled
- *   - "reject" — any non-terminal: emits module.denied + returns to /modules
- *
- * 409 invalid-transition path:
- *   substrate emits module.ceremony.rejected via audit_failure; this
- *   UI surfaces a structured banner naming that audit row + deep-
- *   links to /admin/audit?action=module.ceremony.rejected (workspace
- *   audit surface). Action-only — no ceremony_id query param
- *   (the backend only filters by invocation_id + action).
- *
- * Reviewer-narrow: no install retry, no manifest editor here (Update
- * is on the detail page), no telemetry beyond the substrate audit rows.
+ * Design: Standing Order (docs in the artist pass) — ink/paper/seal,
+ * ledger rows with hairline rules, red spent only where something
+ * happened (a refusal, a failure, the final seal).
  */
 
-import { useCallback, useEffect, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
 import {
   advanceCeremony,
   getCeremony,
   InvalidCeremonyTransitionError,
-  type CeremonyAction,
+  type CeremonyPermissionCard,
   type CeremonyResponse,
 } from "../lib/api";
-import { DescItem as DT, PageHeader } from "../ui/primitives";
-
-const ORDERED_STATES: ReadonlyArray<{
-  key: string;
-  label: string;
-  blurb: string;
-}> = [
-  { key: "discovered", label: "Discovered", blurb: "Skill manifest located in the registry." },
-  { key: "inspected", label: "Inspected", blurb: "Manifest shape + structural validation passed." },
-  { key: "signature_checked", label: "Signature checked", blurb: "Signature structure checked (or fast-path declared) — structural, not cryptographic." },
-  { key: "publisher_checked", label: "Publisher checked", blurb: "Publisher identity confirmed against policy." },
-  { key: "permissions_reviewed", label: "Permissions reviewed", blurb: "Permission sets + data movement acknowledged." },
-  { key: "gates_reviewed", label: "Gates reviewed", blurb: "Privilege + advice-tier gates acknowledged." },
-  { key: "granted", label: "Granted", blurb: "All permissions approved; ready to enable." },
-  { key: "enabled", label: "Enabled", blurb: "Skill added and available." },
-];
 
 const TERMINAL_FAILURE_STATES: ReadonlySet<string> = new Set([
   "rejected_by_user",
@@ -62,208 +41,426 @@ const TERMINAL_FAILURE_STATES: ReadonlySet<string> = new Set([
   "sandbox_profile_missing",
 ]);
 
-type CeremonyQuery =
-  | { status: "loading" }
-  | { status: "ready"; ceremony: CeremonyResponse }
-  | { status: "error"; message: string };
+// Verification states the scan walks through automatically. The order
+// matters for rendering; fast-path ceremonies simply never visit some.
+const SCAN_STATES = [
+  "discovered",
+  "inspected",
+  "signature_checked",
+  "publisher_checked",
+  "permissions_reviewed",
+  "gates_reviewed",
+] as const;
 
-type AdvanceState =
-  | { kind: "idle" }
-  | { kind: "running"; action: CeremonyAction }
-  | {
-      kind: "invalid_transition";
-      message: string;
-      requestedAction: CeremonyAction;
-      ceremonyId: string;
+const TIERS = [
+  "factual_extraction",
+  "legal_information",
+  "draft_advice",
+  "supervised_legal_advice",
+  "approved_final_advice",
+] as const;
+
+function decisionState(fastPath: boolean): string {
+  return fastPath ? "permissions_reviewed" : "gates_reviewed";
+}
+
+function capStrings(card: CeremonyPermissionCard, key: "reads" | "writes"): string[] {
+  const out = new Set<string>();
+  for (const raw of card.capabilities ?? []) {
+    if (!raw || typeof raw !== "object") continue;
+    const values = (raw as Record<string, unknown>)[key];
+    if (!Array.isArray(values)) continue;
+    for (const v of values) if (typeof v === "string") out.add(v);
+  }
+  return [...out].sort();
+}
+
+function gateStrings(card: CeremonyPermissionCard): string[] {
+  return Array.isArray(card.gates)
+    ? card.gates.filter((g): g is string => typeof g === "string")
+    : [];
+}
+
+function needsModel(card: CeremonyPermissionCard): boolean {
+  return (card.capabilities ?? []).some(
+    (raw) =>
+      raw &&
+      typeof raw === "object" &&
+      (raw as Record<string, unknown>).model_access === "required",
+  );
+}
+
+function localOnly(card: CeremonyPermissionCard): boolean | null {
+  const dm = card.data_movement_summary;
+  if (!dm || typeof dm !== "object") return null;
+  const v = (dm as Record<string, unknown>).local_only;
+  return typeof v === "boolean" ? v : null;
+}
+
+// One ledger entry per scan state, with the real verification result.
+function entryFor(
+  state: string,
+  card: CeremonyPermissionCard,
+): { label: string; value: string; bad?: boolean } | null {
+  switch (state) {
+    case "discovered":
+      return {
+        label: "Manifest located",
+        value: `${card.module_id}${card.version ? ` · v${card.version}` : ""}`,
+      };
+    case "inspected":
+      return {
+        label: "Manifest inspected",
+        value: `${(card.capabilities ?? []).length} permission set(s) declared`,
+      };
+    case "signature_checked": {
+      const status = card.signature_status ?? "unknown";
+      return {
+        label: "Signature",
+        value: status.replaceAll("_", " "),
+        bad: status === "failed" || status === "invalid",
+      };
     }
-  | { kind: "error"; message: string };
+    case "publisher_checked":
+      return {
+        label: "Publisher",
+        value: `${card.publisher || "unknown"} · ${
+          card.publisher_verified ? "verified" : "community — unverified"
+        }`,
+      };
+    case "permissions_reviewed": {
+      const reads = capStrings(card, "reads");
+      const writes = capStrings(card, "writes");
+      return {
+        label: "Permissions",
+        value:
+          [
+            reads.length ? `reads ${reads.length}` : null,
+            writes.length ? `writes ${writes.length}` : null,
+            needsModel(card) ? "model required" : null,
+          ]
+            .filter(Boolean)
+            .join(" · ") || "none declared",
+      };
+    }
+    case "gates_reviewed": {
+      const gates = gateStrings(card);
+      return {
+        label: "Gates",
+        value: gates.length ? gates.join(" · ") : "none",
+      };
+    }
+    case "granted":
+      return { label: "Standing granted", value: "permissions approved" };
+    case "enabled":
+      return { label: "Enrolled", value: "added to this workspace" };
+    default:
+      return null;
+  }
+}
+
+type Phase =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "scanning" }
+  | { kind: "decision" }
+  | { kind: "enrolling" }
+  | { kind: "enrolled" }
+  | { kind: "refused" }
+  | { kind: "failed"; state: string };
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
   const nav = useNavigate();
-  const [q, setQ] = useState<CeremonyQuery>({ status: "loading" });
-  const [adv, setAdv] = useState<AdvanceState>({ kind: "idle" });
+  const [ceremony, setCeremony] = useState<CeremonyResponse | null>(null);
+  const [reached, setReached] = useState<string[]>([]);
+  const [phase, setPhase] = useState<Phase>({ kind: "loading" });
+  const [banner, setBanner] = useState<string | null>(null);
+  const scanStarted = useRef(false);
 
-  const refresh = useCallback(async () => {
-    try {
-      const ceremony = await getCeremony(ceremonyId);
-      setQ({ status: "ready", ceremony });
-    } catch (err) {
-      setQ({ status: "error", message: String(err) });
-    }
-  }, [ceremonyId]);
+  const phaseFor = useCallback((c: CeremonyResponse): Phase => {
+    if (c.state === "enabled") return { kind: "enrolled" };
+    if (c.state === "rejected_by_user") return { kind: "refused" };
+    if (TERMINAL_FAILURE_STATES.has(c.state)) return { kind: "failed", state: c.state };
+    if (c.state === decisionState(c.fast_path) || c.state === "granted")
+      return { kind: "decision" };
+    return { kind: "scanning" };
+  }, []);
 
+  // Load + auto-scan. Each advance is its own audited transition; the
+  // stagger exists so the operator can watch the workings land.
   useEffect(() => {
-    void refresh();
-  }, [refresh]);
+    if (scanStarted.current) return; // StrictMode double-mount guard
+    scanStarted.current = true;
+    let cancelled = false;
 
-  const onApproveAll = async () => {
-    setAdv({ kind: "running", action: "trust" });
-    try {
-      // Walk the review states in one user decision. Every step is still
-      // recorded individually in the audit log — the compression is in
-      // the clicking, not the record.
-      let current = q.status === "ready" ? q.ceremony : null;
-      for (let i = 0; i < 12 && current && !current.is_terminal; i++) {
-        const action: CeremonyAction =
-          current.state === "granted" ? "grant" : "trust";
-        current = await advanceCeremony(ceremonyId, action);
-        setQ({ status: "ready", ceremony: current });
-        if (current.state === "enabled") break;
-      }
-      setAdv({ kind: "idle" });
-    } catch (err) {
-      if (err instanceof InvalidCeremonyTransitionError) {
-        setAdv({
-          kind: "invalid_transition",
-          message: err.message,
-          requestedAction: err.requestedAction,
-          ceremonyId: err.ceremonyId,
-        });
-        void refresh();
+    void (async () => {
+      let c: CeremonyResponse;
+      try {
+        c = await getCeremony(ceremonyId);
+      } catch (err) {
+        if (!cancelled) setPhase({ kind: "error", message: String(err) });
         return;
       }
-      setAdv({ kind: "error", message: String(err) });
+      if (cancelled) return;
+      setCeremony(c);
+
+      // States already passed (revisit / reload) render immediately.
+      const seen = new Set<string>();
+      for (const h of c.history) {
+        const s = (h as Record<string, unknown>).state;
+        if (typeof s === "string") seen.add(s);
+      }
+      seen.add(c.state);
+      setReached(SCAN_STATES.filter((s) => seen.has(s)));
+
+      const initial = phaseFor(c);
+      setPhase(initial);
+      if (initial.kind !== "scanning") return;
+
+      // Walk the verification states. Stop at the decision boundary.
+      try {
+        const stopAt = decisionState(c.fast_path);
+        let safety = 8;
+        while (!cancelled && c.state !== stopAt && safety-- > 0) {
+          await sleep(450);
+          if (cancelled) return;
+          c = await advanceCeremony(ceremonyId, "trust");
+          if (cancelled) return;
+          setCeremony(c);
+          setReached((prev) =>
+            prev.includes(c.state) ? prev : [...prev, c.state],
+          );
+          if (c.is_terminal || TERMINAL_FAILURE_STATES.has(c.state)) {
+            setPhase(phaseFor(c));
+            return;
+          }
+        }
+        if (!cancelled) {
+          await sleep(350);
+          setPhase({ kind: "decision" });
+        }
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof InvalidCeremonyTransitionError) {
+          setBanner(err.message);
+          try {
+            const fresh = await getCeremony(ceremonyId);
+            setCeremony(fresh);
+            setPhase(phaseFor(fresh));
+          } catch {
+            setPhase({ kind: "error", message: err.message });
+          }
+          return;
+        }
+        setPhase({ kind: "error", message: String(err) });
+      }
+    })();
+
+    return () => {
+      // StrictMode mounts effects twice: the first run is cancelled here,
+      // so release the guard and let the surviving mount run the scan.
+      cancelled = true;
+      scanStarted.current = false;
+    };
+  }, [ceremonyId, phaseFor]);
+
+  const onApprove = async () => {
+    if (!ceremony) return;
+    setPhase({ kind: "enrolling" });
+    try {
+      let c = ceremony;
+      // granted (module.grant.created) then grant → enabled
+      // (module.enabled). Two audited transitions, one decision.
+      if (c.state !== "granted") {
+        c = await advanceCeremony(ceremonyId, "trust");
+        setCeremony(c);
+        setReached((prev) => [...prev, "granted"]);
+        await sleep(450);
+      }
+      c = await advanceCeremony(ceremonyId, "grant");
+      setCeremony(c);
+      setReached((prev) => [...prev, "enabled"]);
+      setPhase({ kind: "enrolled" });
+    } catch (err) {
+      if (err instanceof InvalidCeremonyTransitionError) {
+        setBanner(err.message);
+        const fresh = await getCeremony(ceremonyId).catch(() => null);
+        if (fresh) {
+          setCeremony(fresh);
+          setPhase(phaseFor(fresh));
+          return;
+        }
+      }
+      setPhase({ kind: "error", message: String(err) });
     }
   };
 
-  const onAdvance = async (action: CeremonyAction) => {
-    setAdv({ kind: "running", action });
+  const onRefuse = async () => {
     try {
-      const next = await advanceCeremony(ceremonyId, action);
-      setAdv({ kind: "idle" });
-      if (action === "reject") {
-        // Reject is terminal; bounce to catalog after a beat so the
-        // user sees the terminal-state row before the route change.
-        setQ({ status: "ready", ceremony: next });
-        window.setTimeout(() => {
-          void nav({ to: "/skills" });
-        }, 700);
-        return;
-      }
-      setQ({ status: "ready", ceremony: next });
+      const c = await advanceCeremony(ceremonyId, "reject");
+      setCeremony(c);
+      setPhase({ kind: "refused" });
+      window.setTimeout(() => {
+        void nav({ to: "/skills" });
+      }, 1400);
     } catch (err) {
-      if (err instanceof InvalidCeremonyTransitionError) {
-        setAdv({
-          kind: "invalid_transition",
-          message: err.message,
-          requestedAction: err.requestedAction,
-          ceremonyId: err.ceremonyId,
-        });
-        // Refresh to get authoritative state — substrate may have moved
-        // it via the audit_failure side-channel.
-        void refresh();
-        return;
-      }
-      setAdv({ kind: "error", message: String(err) });
+      setPhase({ kind: "error", message: String(err) });
     }
   };
 
-  if (q.status === "loading") {
+  if (phase.kind === "loading") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12 text-sm text-muted">
-        Loading ceremony…
+      <div className="mx-auto max-w-2xl px-6 py-14 text-sm text-muted">
+        Opening the record…
       </div>
     );
   }
-  if (q.status === "error") {
+  if (phase.kind === "error" || !ceremony) {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="mx-auto max-w-2xl px-6 py-14">
         <h1 className="text-xl font-bold tracking-tight2">Ceremony not found</h1>
-        <p className="mt-3 text-sm text-muted">{q.message}</p>
+        <p className="mt-3 text-sm text-muted">
+          {phase.kind === "error" ? phase.message : "No ceremony loaded."}
+        </p>
       </div>
     );
   }
 
-  const c = q.ceremony;
-  const isTerminal = c.is_terminal;
-  const isFailure = TERMINAL_FAILURE_STATES.has(c.state);
-  const canEnable = c.state === "granted";
+  const card = ceremony.permission_card;
+  const scanning = phase.kind === "scanning";
+  const refused = phase.kind === "refused";
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
-      <PageHeader
-        eyebrow="Add review"
-        title={c.permission_card.module_name ?? c.module_id}
-        subId={`ceremony ${c.ceremony_id}`}
-        description="Verify the publisher, review the permissions this skill is asking for, then enable it. Each step is recorded in the audit log."
-      />
+    <div className="mx-auto max-w-2xl px-6 py-14 text-ink">
+      <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
+        The register of AI counsel — admission
+      </p>
+      <h1 className="mt-3 text-[32px] leading-tight tracking-tight2">
+        {card.module_name || ceremony.module_id}
+      </h1>
+      <p className="mt-1 text-xs text-muted">
+        {card.publisher || "unknown publisher"}
+        {card.version ? ` · v${card.version}` : ""} ·{" "}
+        <span className="tech-token">{ceremony.ceremony_id.slice(0, 8)}</span>
+      </p>
 
-      <Stepper currentState={c.state} />
+      {/* The scan ledger */}
+      <div className="mt-10 border-t border-rule" data-testid="ceremony-scan">
+        {reached.map((state, i) => {
+          const e = entryFor(state, card);
+          if (!e) return null;
+          return (
+            <div
+              key={state}
+              data-testid={`scan-row-${state}`}
+              className="flex items-baseline gap-4 border-b border-rule/60 py-2.5 animate-[fadeIn_0.4s_ease-out]"
+            >
+              <span className="tech-token w-10 shrink-0 text-[11px] text-muted">
+                {String(i + 1).padStart(4, "0")}
+              </span>
+              <span className="w-40 shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
+                {e.label}
+              </span>
+              <span
+                className={
+                  "flex-1 text-sm " + (e.bad ? "text-seal" : "text-ink")
+                }
+              >
+                {e.value}
+              </span>
+              <span
+                aria-hidden="true"
+                className={
+                  "shrink-0 text-xs " + (e.bad ? "text-seal" : "text-ink")
+                }
+              >
+                {e.bad ? "✕" : "✓"}
+              </span>
+            </div>
+          );
+        })}
+        {scanning && (
+          <div className="flex items-baseline gap-4 py-2.5">
+            <span className="tech-token w-10 shrink-0 text-[11px] text-muted">
+              {String(reached.length + 1).padStart(4, "0")}
+            </span>
+            <span className="text-sm text-muted">verifying…</span>
+          </div>
+        )}
+        {refused && (
+          <div
+            className="flex items-baseline gap-4 border-b border-seal/50 py-2.5"
+            data-testid="scan-row-refused"
+          >
+            <span className="tech-token w-10 shrink-0 text-[11px] text-seal">
+              {String(reached.length + 1).padStart(4, "0")}
+            </span>
+            <span className="w-40 shrink-0 text-[10px] uppercase tracking-[0.18em] text-seal">
+              Refused
+            </span>
+            <span className="flex-1 text-sm text-seal line-through">
+              admission declined — entry struck
+            </span>
+            <span aria-hidden="true" className="shrink-0 text-xs text-seal">
+              ✕
+            </span>
+          </div>
+        )}
+      </div>
 
-      <PermissionCard card={c.permission_card} />
-
-      {/* Banners */}
-      {adv.kind === "invalid_transition" && (
-        <InvalidTransitionBanner state={adv} />
-      )}
-      {adv.kind === "error" && (
-        <div className="mt-6 rounded-md border border-seal/40 bg-seal/5 px-4 py-3 text-sm text-seal">
-          {adv.message}
+      {banner && (
+        <div className="mt-6 border border-seal/40 bg-seal/5 px-4 py-3 text-sm text-seal">
+          {banner}
         </div>
       )}
-      {isFailure && (
-        <div className="mt-6 rounded-md border border-seal/40 bg-seal/5 px-4 py-3">
+
+      {/* The decision */}
+      {(phase.kind === "decision" || phase.kind === "enrolling") && (
+        <Decision
+          card={card}
+          enrolling={phase.kind === "enrolling"}
+          onApprove={() => void onApprove()}
+          onRefuse={() => void onRefuse()}
+        />
+      )}
+
+      {phase.kind === "enrolled" && (
+        <div className="mt-10 border border-rule bg-paper p-5" data-testid="ceremony-enrolled">
+          <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
+            Admitted to the register
+          </p>
+          <p className="mt-2 text-sm leading-relaxed text-prose">
+            {card.module_name || ceremony.module_id} holds standing in this
+            workspace. It runs only on matters where it is enabled, and every
+            run leaves a signed, auditable record.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Link
+              to="/register"
+              className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-sm text-paper hover:opacity-90"
+            >
+              View the register
+            </Link>
+            <Link
+              to="/skills"
+              className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-sm hover:border-ink"
+            >
+              Back to the library
+            </Link>
+          </div>
+        </div>
+      )}
+
+      {phase.kind === "failed" && (
+        <div className="mt-10 border border-seal/40 bg-seal/5 p-5">
           <p className="text-sm font-medium text-seal">
-            Ceremony terminated: {c.state}
+            Admission terminated: {phase.state.replaceAll("_", " ")}
           </p>
           <p className="mt-1 text-sm text-muted">
-            No further steps. Return to the catalog to start a new
-            ceremony if needed.
-          </p>
-        </div>
-      )}
-
-      {/* Controls */}
-      {!isTerminal && (
-        <div className="mt-8 flex flex-wrap items-center gap-3">
-          <button
-            type="button"
-            onClick={() => void onApproveAll()}
-            disabled={adv.kind === "running"}
-            data-testid="ceremony-approve-all"
-            className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-paper hover:opacity-90 disabled:opacity-50"
-          >
-            {adv.kind === "running" ? "Approving…" : "Approve & enable"}
-          </button>
-          {!canEnable && (
-            <button
-              type="button"
-              onClick={() => onAdvance("trust")}
-              disabled={adv.kind === "running"}
-              className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-ink hover:border-ink disabled:opacity-50"
-            >
-              Step through review
-            </button>
-          )}
-          {canEnable && (
-            <button
-              type="button"
-              onClick={() => onAdvance("grant")}
-              disabled={adv.kind === "running"}
-              className="inline-flex items-center rounded-md border border-rule px-4 py-2 text-ink hover:border-ink disabled:opacity-50"
-            >
-              Enable skill
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => onAdvance("reject")}
-            disabled={adv.kind === "running"}
-            className="inline-flex items-center rounded-md border border-line px-4 py-2 text-muted hover:text-ink disabled:opacity-50"
-          >
-            {adv.kind === "running" && adv.action === "reject"
-              ? "Rejecting…"
-              : "Reject"}
-          </button>
-        </div>
-      )}
-
-      {c.state === "enabled" && (
-        <div className="mt-8 rounded-md border border-line p-4">
-          <p className="text-sm font-medium">Skill enabled</p>
-          <p className="mt-1 text-sm text-muted">
-            This skill is now added and can be enabled on your
-            matters. The trust ceremony was recorded in the audit log.
+            The refusal is recorded with the same fidelity as an approval.
+            Return to the library to start again.
           </p>
         </div>
       )}
@@ -273,251 +470,100 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
 
 // ---------------------------------------------------------------------------
 
-function Stepper({ currentState }: { currentState: string }) {
-  const currentIdx = ORDERED_STATES.findIndex((s) => s.key === currentState);
-  const isFailure = TERMINAL_FAILURE_STATES.has(currentState);
-
-  return (
-    <ol className="mt-8 space-y-3">
-      {ORDERED_STATES.map((step, i) => {
-        const done = !isFailure && i < currentIdx;
-        const active = !isFailure && i === currentIdx;
-        return (
-          <li key={step.key} className="flex items-start gap-3">
-            <span
-              aria-hidden="true"
-              className={
-                "mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full border text-xs " +
-                (done
-                  ? "border-ink bg-ink text-paper"
-                  : active
-                    ? "border-ink text-ink"
-                    : "border-line text-muted")
-              }
-            >
-              {done ? "✓" : i + 1}
-            </span>
-            <div className="text-sm">
-              <p className={active ? "font-medium" : "text-muted"}>
-                {step.label}
-              </p>
-              <p className="text-xs text-muted">{step.blurb}</p>
-            </div>
-          </li>
-        );
-      })}
-    </ol>
-  );
-}
-
-function PermissionCard({
+function Decision({
   card,
+  enrolling,
+  onApprove,
+  onRefuse,
 }: {
-  card: CeremonyResponse["permission_card"];
+  card: CeremonyPermissionCard;
+  enrolling: boolean;
+  onApprove: () => void;
+  onRefuse: () => void;
 }) {
-  const caps = Array.isArray(card.capabilities) ? card.capabilities : [];
-  const events = Array.isArray(card.audit_events) ? card.audit_events : [];
-
-  // Blueprint §4A.5 step 5: signature/manifest disclosure is collapsed
-  // by default. The trust ceremony stays a multi-step page (the
-  // backend ceremony chain forces it), but the visible review now
-  // matches the Vercel install-pattern anatomy step-for-step:
-  //   1. skill icon + name        (Skill row, top of card)
-  //   2. install-to header        (page eyebrow + title above)
-  //   3. scope picker             (Workspace scope section below)
-  //   4. permissions checklist    (CapabilityChecklist below)
-  //   5. signature/manifest       (SignatureDisclosure, collapsed)
-  //   6. footer cancel/install    (advance buttons in the parent page)
-  return (
-    <section className="mt-10 rounded-md border border-line p-4">
-      <h2 className="text-sm uppercase tracking-widest text-muted">
-        Review permissions
-      </h2>
-      <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-        <DT label="Skill">
-          {card.module_name ?? card.module_id}
-        </DT>
-        <DT label="Version">{card.version ?? "—"}</DT>
-        <DT label="Publisher">
-          {card.publisher ?? "—"}
-          {card.publisher_verified ? " (verified)" : ""}
-        </DT>
-        <DT label="Visibility">{card.visibility ?? "—"}</DT>
-        <DT label="Advice tier max">{card.advice_tier_max ?? "—"}</DT>
-        <DT label="Audit events">{events.length}</DT>
-      </dl>
-
-      <WorkspaceScopePicker />
-      <CapabilityChecklist capabilities={caps} />
-      <SignatureDisclosure card={card} />
-    </section>
+  const reads = capStrings(card, "reads");
+  const writes = capStrings(card, "writes");
+  const local = localOnly(card);
+  const tierIdx = Math.max(
+    0,
+    TIERS.indexOf((card.advice_tier_max ?? "factual_extraction") as (typeof TIERS)[number]),
   );
-}
 
-// §4A.5 step 3 — scope picker. The current substrate trusts a skill
-// workspace-wide (no per-matter narrowing at install time; matter
-// enablement is the separate ceremony in PR 4). This input states the
-// honest semantics so the user isn't misled, and is wired as a
-// read-only acknowledgement until matter-scoped trust lands.
-function WorkspaceScopePicker() {
   return (
-    <div className="mt-4 border-t border-rule pt-4">
-      <p className="text-xs uppercase tracking-widest text-muted">
-        Workspace scope
+    <section className="mt-10" data-testid="ceremony-decision">
+      <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
+        Grant of standing
       </p>
-      <label className="mt-2 flex items-start gap-2 text-sm">
-        <input
-          type="radio"
-          checked
-          readOnly
-          aria-label="All matters in this workspace"
-          className="mt-1"
-        />
-        <span>
-          <span className="text-ink">All matters in this workspace</span>
-          <span className="mt-0.5 block text-xs text-muted">
-            Per-matter enablement is a separate step inside each matter.
-            Trusting a skill here does not run it anywhere on its own.
+      <div className="mt-3 space-y-2 text-sm leading-relaxed text-prose">
+        {reads.length > 0 && (
+          <p>
+            Reads{" "}
+            {reads.map((r, i) => (
+              <span key={r}>
+                <span className="tech-token text-xs">{r}</span>
+                {i < reads.length - 1 ? ", " : ""}
+              </span>
+            ))}
+            .
+          </p>
+        )}
+        {writes.length > 0 && (
+          <p>
+            Writes{" "}
+            {writes.map((w, i) => (
+              <span key={w}>
+                <span className="tech-token text-xs">{w}</span>
+                {i < writes.length - 1 ? ", " : ""}
+              </span>
+            ))}
+            .
+          </p>
+        )}
+        {needsModel(card) && (
+          <p>
+            Calls the model through the workspace gateway, under each
+            matter's privilege posture — a paused matter blocks the call.
+          </p>
+        )}
+        {local === true && <p>Nothing leaves the workspace.</p>}
+        {local === false && (
+          <p className="text-seal">Sends data outside the workspace.</p>
+        )}
+        <p className="flex items-center gap-2">
+          <span>Advice ceiling:</span>
+          <span aria-hidden="true" className="tracking-[0.2em] text-ink">
+            {TIERS.map((_t, i) => (i <= tierIdx ? "●" : "○")).join("")}
           </span>
-        </span>
-      </label>
-    </div>
-  );
-}
-
-// §4A.5 step 4 — permissions list with checkmarks. Each capability is
-// rendered as a tickable row so the operator can read off what the
-// runtime will enforce, not just count them.
-function CapabilityChecklist({ capabilities }: { capabilities: unknown[] }) {
-  if (capabilities.length === 0) {
-    return (
-      <div className="mt-4 border-t border-rule pt-4">
-        <p className="text-xs uppercase tracking-widest text-muted">
-          Permissions requested
+          <span className="text-xs text-muted">
+            {(card.advice_tier_max ?? "factual_extraction").replaceAll("_", " ")}
+          </span>
         </p>
-        <p className="mt-2 text-sm text-muted">
-          This skill declares no permissions.
+        <p className="text-xs text-muted">
+          Workspace-wide trust; running it is enabled per matter. Every run
+          is recorded and its output requires review and sign-off.
         </p>
       </div>
-    );
-  }
-  return (
-    <div className="mt-4 border-t border-rule pt-4">
-      <p className="text-xs uppercase tracking-widest text-muted">
-        Permissions requested
-      </p>
-      <ul className="mt-2 space-y-1.5 text-sm">
-        {capabilities.map((raw, i) => {
-          const c =
-            raw && typeof raw === "object"
-              ? (raw as Record<string, unknown>)
-              : {};
-          const id = typeof c.id === "string" ? c.id : `capability-${i + 1}`;
-          const kind = typeof c.kind === "string" ? c.kind : null;
-          const reads = Array.isArray(c.reads)
-            ? c.reads.filter((v): v is string => typeof v === "string")
-            : [];
-          const writes = Array.isArray(c.writes)
-            ? c.writes.filter((v): v is string => typeof v === "string")
-            : [];
-          return (
-            <li key={id} className="flex items-start gap-2">
-              <span aria-hidden="true" className="mt-0.5 text-ink">
-                ✓
-              </span>
-              <span>
-                <span className="tech-token text-xs text-ink">{id}</span>
-                {kind && (
-                  <span className="ml-2 text-xs text-muted">({kind})</span>
-                )}
-                {(reads.length > 0 || writes.length > 0) && (
-                  <span className="mt-0.5 block text-xs text-muted">
-                    {reads.length > 0 && `reads ${reads.join(", ")}`}
-                    {reads.length > 0 && writes.length > 0 && " · "}
-                    {writes.length > 0 && `writes ${writes.join(", ")}`}
-                  </span>
-                )}
-              </span>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
-}
 
-// §4A.5 step 5 — signature & manifest disclosure, collapsed by default.
-// Surfaces signer/version/visibility/permission-count without making
-// the operator hunt for them in the audit trail.
-function SignatureDisclosure({
-  card,
-}: {
-  card: CeremonyResponse["permission_card"];
-}) {
-  const [open, setOpen] = useState(false);
-  const caps = Array.isArray(card.capabilities) ? card.capabilities : [];
-  return (
-    <div className="mt-4 border-t border-rule pt-4">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        data-testid="ceremony-signature-disclosure"
-        className="flex w-full items-center justify-between text-left"
-      >
-        <span className="text-xs uppercase tracking-widest text-muted">
-          Signature &amp; manifest
-        </span>
-        <span aria-hidden="true" className="text-xs text-muted">
-          {open ? "Hide" : "Show"}
-        </span>
-      </button>
-      {open && (
-        <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-          <DT label="Module id">{card.module_id}</DT>
-          <DT label="Signature">{card.signature_status ?? "—"}</DT>
-          <DT label="Publisher">
-            {card.publisher ?? "—"}
-            {card.publisher_verified ? " (verified)" : ""}
-          </DT>
-          <DT label="Permission sets">{caps.length}</DT>
-        </dl>
-      )}
-    </div>
-  );
-}
-
-function InvalidTransitionBanner({
-  state,
-}: {
-  state: Extract<AdvanceState, { kind: "invalid_transition" }>;
-}) {
-  // Workspace audit surface exists, banner gets its deep-link back.
-  // Action-only — no ?ceremony= query param (the backend only
-  // filters by invocation_id + action).
-  const auditHref =
-    "/admin/audit?action=module.ceremony.rejected";
-  return (
-    <div className="mt-6 rounded-md border border-seal/40 bg-seal/5 px-4 py-3">
-      <p className="text-sm font-medium text-seal">
-        Invalid ceremony transition
-      </p>
-      <p className="mt-1 text-sm text-muted">
-        Action <span className="tech-token">{state.requestedAction}</span> is
-        not valid from the current state. {state.message}
-      </p>
-      <p className="mt-2 text-sm text-muted">
-        The runtime wrote a{" "}
-        <span className="tech-token">module.ceremony.rejected</span> audit
-        row for this attempt.{" "}
-        <a
-          href={auditHref}
-          className="underline underline-offset-4 hover:text-ink"
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={onApprove}
+          disabled={enrolling}
+          data-testid="ceremony-approve-all"
+          className="inline-flex items-center rounded-md bg-ink px-5 py-2.5 text-sm text-paper hover:opacity-90 disabled:opacity-50"
         >
-          View audit log
-        </a>
-        .
-      </p>
-    </div>
+          {enrolling ? "Recording…" : "Approve & enable"}
+        </button>
+        <button
+          type="button"
+          onClick={onRefuse}
+          disabled={enrolling}
+          data-testid="ceremony-refuse"
+          className="inline-flex items-center px-3 py-2.5 text-sm text-muted hover:text-seal disabled:opacity-50"
+        >
+          Refuse admission
+        </button>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -215,6 +215,12 @@ export function ModulesCatalog() {
                 >
                   Create skill
                 </Link>
+                <Link
+                  to="/register"
+                  className="inline-flex items-center px-2 py-2 text-sm text-muted hover:text-ink"
+                >
+                  View the register →
+                </Link>
               </>
             ) : (
               <a

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -29,6 +29,7 @@ import { CreateModule } from "../modules-v2/CreateModule";
 import { LawveImport } from "../modules-v2/LawveImport";
 import { DemoLoop } from "../demo/DemoLoop";
 import { InstallCeremony } from "../modules-v2/InstallCeremony";
+import { CounselRegister } from "../modules-v2/CounselRegister";
 import { ArtifactsList } from "../matter/ArtifactsList";
 import { ArtifactDetail } from "../matter/ArtifactDetail";
 import { SignOff } from "../matter/SignOff";
@@ -365,6 +366,12 @@ const legacyModuleDetailRedirect = createRoute({
   component: () => null,
 });
 
+const counselRegisterRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: "/register",
+  component: CounselRegister,
+});
+
 const moduleInstallRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: "/skills/install/$ceremonyId",
@@ -546,7 +553,8 @@ const routeTree = rootRoute.addChildren([
     demoLoopRoute,
     moduleDetailRoute,
     legacyModuleDetailRedirect,
-    moduleInstallRoute,
+    counselRegisterRoute,
+  moduleInstallRoute,
     legacyModuleInstallRedirect,
     matterAuditRoute,
     matterArtifactsRoute,

--- a/frontend/src/ui/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar.tsx
@@ -135,7 +135,15 @@ export function Sidebar({
         (route.name === "modules" ||
           route.name === "moduleDetail" ||
           route.name === "moduleInstall" ||
+          route.name === "lawveImport" ||
           route.name === "createModule"),
+    },
+    {
+      key: "register",
+      label: "Register",
+      href: "/register",
+      icon: <NavIcon name="audit" />,
+      active: !onMatterArea && route.name === "register",
     },
   ];
 


### PR DESCRIPTION
## What

Two builds from the standing reframe, in the Standing Order design language (the artist pass: ink/paper/seal, ledger + certificate, red spent like money).

### The ceremony is no longer a five-step behemoth
On load, the verification states advance **automatically**, each landing as a ledger entry with its real result — manifest located/inspected, signature, publisher, permissions, gates — staggered so you watch the workings. **Every transition is still its own audit row**; the compression is in the clicking, not the record. The scan halts at one human decision: **Approve & enable** (granted → enabled, two audited transitions) or **Refuse** (entry struck in seal red, recorded like everything else).

Also fixes the legacy-chrome layout bug: `/skills/install/:id` and `/skills/:id` were never matched by the route shim, so those pages rendered outside the app shell.

### /register — the Counsel Register (Idea A)
Installed skills rendered as a register of AI counsel: practicing certificates with publisher-as-chambers, permission bands, advice-ceiling dots, signature status, pinned source (`owner/repo @ sha`), date of admission. A **pure renderer over the installed manifests** — no second database. Revoked counsel are struck with the same fidelity as the admitted. Sidebar entry + link from /skills; the enrolment screen points at it.

Backend: installed listing now exposes manifest `name` + `install_path` (pinned-SHA provenance) for the certificates.

### Verified live
GitHub import of `b1rdmania/pre-motion` → scan (6 entries with real values) → Approve & enable → certificate on /register showing `b1rdmania/pre-motion @ df11fcdb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Register page to view and manage installed AI counsel with their capabilities, verification status, and permissions.
  * Added navigation links to the Register from the module catalog header and sidebar.
  * Installed modules now display additional metadata including name and installation source information.

* **Style**
  * Added fade-in animation effect for UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->