### PR TITLE
Deflake the parallel-load vitest trio

### DIFF
--- a/frontend/src/matter/DocumentDetail.test.tsx
+++ b/frontend/src/matter/DocumentDetail.test.tsx
@@ -1267,8 +1267,17 @@ describe("DocumentDetail", () => {
       expect(screen.getByTestId("from-chat-note")).toHaveTextContent(
         /cited passage is highlighted/i,
       );
-    });
-    expect(container.querySelector("mark")).not.toBeNull();
+    }, { timeout: 5000 });
+    // The <mark> is painted by Tiptap/ProseMirror, whose editor view
+    // mounts in an effect AFTER the React commit that renders the
+    // from-chat note — under parallel CI load the highlight can land a
+    // tick later than the note. Wait for it explicitly.
+    await waitFor(
+      () => {
+        expect(container.querySelector("mark")).not.toBeNull();
+      },
+      { timeout: 5000 },
+    );
   });
 
   it("warns when a source quote was not located in the extracted source body", async () => {

--- a/frontend/src/matter/GrantsPanel.test.tsx
+++ b/frontend/src/matter/GrantsPanel.test.tsx
@@ -124,10 +124,15 @@ describe("GrantsPanel — create", () => {
     });
 
     render(<GrantsPanel slug="khan" />);
-    await waitFor(() => {
-      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
-    });
-    fireEvent.change(screen.getByLabelText(/Skill/i), {
+    // Generous timeouts: this test failed under parallel CI load (1s
+    // default), never alone.
+    await waitFor(
+      () => {
+        expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.change(await screen.findByLabelText(/Skill/i, {}, { timeout: 5000 }), {
       target: { value: "contract-review" },
     });
     fireEvent.change(screen.getByLabelText(/Permission/i), {
@@ -135,20 +140,33 @@ describe("GrantsPanel — create", () => {
     });
     fireEvent.click(screen.getByText("Enable"));
 
-    await waitFor(() => {
-      expect(create).toHaveBeenCalledWith("khan", {
-        module_id: "contract-review",
-        capability_id: "review",
-      });
-    });
+    await waitFor(
+      () => {
+        expect(create).toHaveBeenCalledWith("khan", {
+          module_id: "contract-review",
+          capability_id: "review",
+        });
+      },
+      { timeout: 5000 },
+    );
     // After the create resolves the list refreshes via the second
-    // listGrants spy return.
-    expect(listGrants).toHaveBeenCalledTimes(2);
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Enabled\. This skill may now use that permission/i),
-      ).toBeInTheDocument();
-    });
+    // listGrants spy return. The refresh fires in a microtask AFTER
+    // createGrant's promise resolves, so a synchronous count assertion
+    // here races it under load — wait for it.
+    await waitFor(
+      () => {
+        expect(listGrants).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 5000 },
+    );
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Enabled\. This skill may now use that permission/i),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
   });
 
   it("offers installed inline modules that are not in the v2 registry catalog", async () => {
@@ -226,10 +244,15 @@ describe("GrantsPanel — create", () => {
     );
 
     render(<GrantsPanel slug="khan" />);
-    await waitFor(() => {
-      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
-    });
-    fireEvent.change(screen.getByLabelText(/Skill/i), {
+    // Generous timeouts: this test failed under parallel CI load (1s
+    // default), never alone.
+    await waitFor(
+      () => {
+        expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.change(await screen.findByLabelText(/Skill/i, {}, { timeout: 5000 }), {
       target: { value: "contract-review" },
     });
     fireEvent.change(screen.getByLabelText(/Permission/i), {
@@ -258,10 +281,15 @@ describe("GrantsPanel — create", () => {
     );
 
     render(<GrantsPanel slug="khan" />);
-    await waitFor(() => {
-      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
-    });
-    fireEvent.change(screen.getByLabelText(/Skill/i), {
+    // Generous timeouts: this test failed under parallel CI load (1s
+    // default), never alone.
+    await waitFor(
+      () => {
+        expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.change(await screen.findByLabelText(/Skill/i, {}, { timeout: 5000 }), {
       target: { value: "contract-review" },
     });
     fireEvent.change(screen.getByLabelText(/Permission/i), {
@@ -291,10 +319,15 @@ describe("GrantsPanel — create", () => {
     });
 
     render(<GrantsPanel slug="khan" />);
-    await waitFor(() => {
-      expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
-    });
-    fireEvent.change(screen.getByLabelText(/Skill/i), {
+    // Generous timeouts: this test failed under parallel CI load (1s
+    // default), never alone.
+    await waitFor(
+      () => {
+        expect(screen.getByText(/Enable a permission/i)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    fireEvent.change(await screen.findByLabelText(/Skill/i, {}, { timeout: 5000 }), {
       target: { value: "contract-review" },
     });
     fireEvent.change(screen.getByLabelText(/Permission/i), {

--- a/frontend/src/matter/ReconstructionView.test.tsx
+++ b/frontend/src/matter/ReconstructionView.test.tsx
@@ -296,18 +296,26 @@ describe("ReconstructionView — source chips", () => {
 
     mountAt("/matters/khan/audit");
     // Initial render fires getReconstruction with no include filter
-    // (all three sources).
-    await waitFor(() => {
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
+    // (all three sources). Generous timeouts: the full production
+    // router + AuthProvider mount can exceed vitest's 1s default under
+    // parallel CI load (this test failed repeatedly in CI, never alone).
+    await waitFor(
+      () => {
+        expect(spy).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5000 },
+    );
     expect(spy.mock.calls[0]?.[1]?.include).toBeUndefined();
 
     // Toggle "advice_boundary" off.
-    fireEvent.click(screen.getByTestId("source-chip-advice_boundary"));
+    fireEvent.click(await screen.findByTestId("source-chip-advice_boundary", {}, { timeout: 5000 }));
 
-    await waitFor(() => {
-      expect(spy).toHaveBeenCalledTimes(2);
-    });
+    await waitFor(
+      () => {
+        expect(spy).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 5000 },
+    );
     const lastCall = spy.mock.calls[1]?.[1];
     expect(lastCall?.include).toEqual(["audit", "state_machine"]);
   });


### PR DESCRIPTION
ReconstructionView's source-toggle test failed twice consecutively on master CI while passing alone: full production-router mount under parallel worker load blows vitest's 1s default waitFor. 5s timeouts + findBy in the three known victims. Test-only; trio run 3x green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)