### PR TITLE
P27: the register idiom everywhere; useRoute render-storm fix; WebKit pass

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1586,3 +1586,28 @@ Deliberate divergences from the artist pass: the 64–88px monument is reserved 
 P26 deliberate divergences (2026-06-11 audit reconciliation): the demo and the matter chat shell carry the ruled-eyebrow idiom hand-rolled (`demo-masthead`), not the PageHeader primitive — their P22 chat-shell contract has no header block to convert; recorded, not drift. The AuditTab blocked-row strike (`line-through decoration-1` on seal refusal rows) is ratified — it is the artwork's struck-entry move on an already-seal row. Navigation-shaped bg-ink buttons ("View the register", "Working pack", "Open Activity", "Create account") keep ink hover: they go somewhere, they don't commit anything. `primaryBtn` is the single source of commit styling (hover:bg-seal); do not fork inline copies.
 
 P25 reconciliation (2026-06-11, hardening): the editor's More overflow now reads Save & download DOCX / Copy text / Download text / N words / Print / PDF / Reset — word count and print joined deliberately with the tracked-changes build (word count lives in the overflow, NOT the command bar, preserving the strip). The command bar gains exactly one conditional control: "Redlines (N)", rendered only when proposed edits exist. Inline tracked changes (struck deletions in seal, underlined insertions, per-change accept/refuse) are the document surface's first-class review idiom; the suggested-edits rail remains the fallback for unanchorable edits.
+
+---
+
+## P27 — The register idiom, everywhere (page-body anatomy)
+
+Source: our own `/register` page (CounselRegister.tsx) — ratified by Andy 2026-06-11 with screenshot: "I really like these headers and this type layout"; sub-pages (explicitly /skills) judged weak because P25/P26 stripped chrome and added mastheads but left page BODIES as generic card grids. P27 re-anatomies the bodies: content renders as certificates and ledger entries, placed like a clerk filled them in.
+
+What we lift (from CounselRegister.tsx, exact):
+- Monument masthead: ruled eyebrow row (`border-b border-ink pb-2`, both sides `text-[10px] uppercase tracking-[0.3em]`, left muted / right ink), then `font-redaction35 leading-none tracking-tight2` headline, then a whispered subline (`mt-2 text-[11px] uppercase tracking-[0.3em] text-muted`), then a REAL serif prose paragraph (`mt-8 max-w-xl text-sm leading-relaxed text-prose`) that states what the page IS — not a one-line description.
+- Certificate card: `border border-ink/70 bg-paper p-5` (seal/40 border only for revoked/refused). Anatomy top-to-bottom: index eyebrow row (`COUNSEL 01` left / category right, both `text-[10px] uppercase tracking-[0.25em] text-muted`), title `text-[22px] leading-tight tracking-tight2`, sub-line `mt-1 text-xs text-muted`, ink bands (`h-2.5 bg-ink`, width from content length, gap-1), divider `border-t border-rule pt-3`, dot scale (`tracking-[0.25em]`) with right small-caps label, then label/value ledger rows: `dl space-y-1 text-[11px] text-muted`, each row `flex justify-between gap-3`, dt `uppercase tracking-[0.18em]`, value right-aligned.
+- Ledger row (for list pages; same anatomy as the admission scan): index `tech-token w-10 text-[11px] text-muted` (0001…), label `w-40 text-[10px] uppercase tracking-[0.18em] text-muted`, value `flex-1 text-sm text-ink`, right-aligned mark/figure, rows divided `border-b border-rule/60 py-2.5`.
+- Closing colophon line: `border-t border-rule pt-3 text-[10px] uppercase tracking-[0.2em] text-muted` — one institutional sentence, only where it earns its place.
+
+Exact values (copy, do not approximate):
+| Property | Value | Notes |
+|---|---|---|
+| PageHeader display tier (P27 revision) | `font-redaction35 text-[52px] sm:text-[64px] leading-none tracking-tight2` | up from 40/52; /register keeps its 64/88 monument |
+| PageHeader gains `whisper` prop | rendered `mt-2 text-[11px] uppercase tracking-[0.3em] text-muted` under the title | section homes only |
+| Section-home description | becomes the serif prose paragraph (`max-w-xl text-sm leading-relaxed text-prose`) | write copy that states what the page IS in the register's voice |
+| Card → certificate | `border border-ink/70 bg-paper p-5`, index eyebrow row, 22px title, ledger dl rows | replaces rounded-card/shadow-panel card bodies on section pages |
+| List → ledger | scan-row anatomy above | tables may stay tables but adopt the ledger header + row rhythm |
+| Eyebrow tracking | masthead row `tracking-[0.3em]`; card-level eyebrows `tracking-[0.25em]`; dl labels `tracking-[0.18em]` | three tiers, never mixed |
+
+Where it lands: ModulesCatalog (workspace skills + Lawve catalogue + requested-skills as certificates/ledger), MatterList (ledger rhythm + certificate-grade row typography), Settings, AdminUsersList, AdminAuditView, LawveImport, ModuleDetail, Help, AppHome, CreateModule. NOT touched: matter chat shell (P22), document editor (P25), InstallCeremony + CounselRegister (already the reference).
+Deliberate divergences: none yet — filled by the post-build audit.

--- a/frontend/.webkit-pass.mjs
+++ b/frontend/.webkit-pass.mjs
@@ -1,0 +1,101 @@
+// Safari/WebKit pass — drives the key surfaces in Playwright WebKit and
+// reports console errors, render basics, and editor behaviour.
+// Run AFTER the P27 fleet lands (vite hot-reloads under their edits).
+import { webkit } from "playwright-core";
+import { mkdirSync } from "node:fs";
+
+const OUT = "/tmp/legalise-webkit";
+mkdirSync(OUT, { recursive: true });
+const BASE = "http://localhost:3000";
+const findings = [];
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await webkit.launch({ headless: true });
+const ctx = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+const page = await ctx.newPage();
+const errors = [];
+page.on("console", (m) => { if (m.type() === "error") errors.push(m.text().slice(0, 200)); });
+page.on("pageerror", (e) => errors.push("PAGEERROR: " + String(e).slice(0, 200)));
+
+// Sign in
+await page.goto(`${BASE}/auth/signin`);
+await page.fill('input[type="email"]', "scan-demo@example.com");
+await page.fill('input[type="password"]', "scan-demo-pass-2026");
+await page.click('button:has-text("Sign in")');
+await page.waitForURL("**/matters", { timeout: 20000 });
+findings.push("signin: OK");
+
+const SURFACES = [
+  ["landing", "/", "h1"],
+  ["matters", "/matters", "h1"],
+  ["skills", "/skills", "h1"],
+  ["register", "/register", "h1"],
+  ["lawve", "/skills/lawve", "h1"],
+  ["settings", "/settings/profile", "h1"],
+  ["help", "/help", "h1"],
+  ["demo", "/demo", "h1"],
+  ["demo-audit", "/demo/audit", "main"],
+  ["matter-chat", "/matters/khan-v-acme-trading-2026/assistant", "main"],
+];
+
+for (const [name, path, sel] of SURFACES) {
+  errors.length = 0;
+  try {
+    await page.goto(`${BASE}${path}`, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector(sel, { timeout: 15000 });
+    await sleep(1200);
+    await page.screenshot({ path: `${OUT}/${name}.png` });
+    findings.push(`${name}: rendered${errors.length ? " · CONSOLE ERRORS: " + errors.join(" | ") : ""}`);
+  } catch (e) {
+    findings.push(`${name}: FAILED — ${String(e).slice(0, 160)}`);
+  }
+}
+
+// Editor behaviour: open a document, type, check decorations CSS applies,
+// exercise find (Cmd+F is Meta on webkit/mac).
+errors.length = 0;
+try {
+  const docs = await page.evaluate(async () => {
+    const r = await fetch("/api/matters/khan-v-acme-trading-2026/documents", { credentials: "include" });
+    return (await r.json()).map((d) => d.id);
+  });
+  await page.goto(`${BASE}/matters/khan-v-acme-trading-2026/documents/${docs[1] ?? docs[0]}`);
+  await page.waitForSelector(".ProseMirror", { timeout: 20000 });
+  await sleep(1000);
+  // Type into the editor
+  await page.click(".ProseMirror");
+  await page.keyboard.type(" WebKit typing check.", { delay: 20 });
+  await sleep(800);
+  const typed = await page.evaluate(() => document.querySelector(".ProseMirror")?.textContent?.includes("WebKit typing check"));
+  findings.push(`editor-typing: ${typed ? "OK" : "FAILED"}`);
+  // Tracked-changes CSS computed check (synthetic, outside PM)
+  const css = await page.evaluate(() => {
+    const wrap = document.createElement("div");
+    wrap.className = "legalise-document-editor";
+    wrap.innerHTML = '<span class="legalise-track-delete">x</span><span class="legalise-track-insert">y</span>';
+    document.body.appendChild(wrap);
+    const d = getComputedStyle(wrap.querySelector(".legalise-track-delete"));
+    const i = getComputedStyle(wrap.querySelector(".legalise-track-insert"));
+    const out = { del: d.textDecorationLine + "/" + d.color, ins: i.textDecorationLine + "/" + i.color };
+    wrap.remove();
+    return out;
+  });
+  findings.push(`track-css: del=${css.del} ins=${css.ins}`);
+  // Find panel via keyboard
+  await page.keyboard.press("Meta+f");
+  await sleep(500);
+  const findOpen = await page.evaluate(() => !!document.querySelector('input[placeholder*="ind"], [data-testid*="find"]'));
+  findings.push(`find-shortcut: ${findOpen ? "OK" : "not visible (check binding on webkit)"}`);
+  // Reset the draft so the typing check leaves no residue
+  const more = await page.$('[data-testid="document-editor-more"] summary');
+  if (more) { await more.click(); await sleep(300); }
+  const reset = await page.$('button:has-text("Reset")');
+  if (reset) { await reset.click(); await sleep(600); findings.push("draft-reset: OK"); }
+  await page.screenshot({ path: `${OUT}/editor.png` });
+  if (errors.length) findings.push("editor console errors: " + errors.join(" | "));
+} catch (e) {
+  findings.push("editor: FAILED — " + String(e).slice(0, 200));
+}
+
+await browser.close();
+console.log(findings.join("\n"));

--- a/frontend/src/admin/AdminAuditView.tsx
+++ b/frontend/src/admin/AdminAuditView.tsx
@@ -30,6 +30,7 @@ import {
 import { useAuth } from "../auth/AuthProvider";
 import { adminAuditRoute } from "../router";
 import { PageHeader } from "../ui/primitives";
+import { SectionRule } from "../ui/certificate";
 
 type FetchState =
   | { status: "loading" }
@@ -51,11 +52,11 @@ const WORKSPACE_BOUND_SOURCES: ReadonlySet<ReconstructionSource> = new Set([
 function sourceTone(source: ReconstructionSource): string {
   switch (source) {
     case "audit":
-      return "bg-ink/10 text-ink";
+      return "text-muted";
     case "state_machine":
-      return "bg-amber-500/15 text-amber-700";
+      return "text-amber-700";
     case "advice_boundary":
-      return "bg-seal/10 text-seal";
+      return "text-seal";
   }
 }
 
@@ -134,18 +135,24 @@ export function AdminAuditView() {
       <PageHeader
         display
         eyebrow="Workspace records"
-        eyebrowRight={
+        eyebrowRight="Legalise"
+        title="Workspace audit"
+        whisper="The workspace record"
+        description="What the workspace did when no matter was before it — admission ceremonies, settings key operations, role changes, and the viewing of this very page. Entries bound to a matter live with the matter; nothing renders here that the audit chain does not hold."
+      />
+
+      <SectionRule
+        label="The record"
+        right={
           fetchState.status === "ready"
             ? `${fetchState.entries.length} loaded`
             : undefined
         }
-        title="Workspace audit"
-        description="Workspace-scoped audit rows — events that are not bound to a specific matter (install ceremonies, settings key operations, admin role changes, this very view, etc.). Matter rows are reachable via the per-matter reconstruction page."
       />
 
       {(invocationFilter || actionFilter) && (
         <div className="mt-5 flex flex-wrap items-center gap-2">
-          <span className="text-xs uppercase tracking-widest text-muted">
+          <span className="text-[10px] uppercase tracking-[0.18em] text-muted">
             Filtered by
           </span>
           {invocationFilter && (
@@ -174,7 +181,7 @@ export function AdminAuditView() {
       )}
 
       <div className="mt-4 flex flex-wrap items-center gap-2">
-        <span className="text-xs uppercase tracking-widest text-muted">
+        <span className="text-[10px] uppercase tracking-[0.18em] text-muted">
           Sources
         </span>
         {ALL_RECONSTRUCTION_SOURCES.map((s) => {
@@ -227,12 +234,11 @@ export function AdminAuditView() {
       )}
       {fetchState.status === "ready" && (
         <>
-          <p className="mt-6 text-xs text-muted">
-            {fetchState.entries.length} loaded
-            {fetchState.totalEstimate > fetchState.entries.length
-              ? ` · ~${fetchState.totalEstimate} in window`
-              : ""}
-          </p>
+          {fetchState.totalEstimate > fetchState.entries.length && (
+            <p className="mt-6 text-xs text-muted">
+              ~{fetchState.totalEstimate} in window
+            </p>
+          )}
 
           {fetchState.entries.length === 0 ? (
             <p
@@ -244,7 +250,7 @@ export function AdminAuditView() {
                 : "No workspace audit rows yet."}
             </p>
           ) : (
-            <ol className="mt-4 space-y-3">
+            <ol className="mt-4">
               {fetchState.entries.map((e) => (
                 <TimelineRow key={`${e.source}::${e.source_row_id}`} entry={e} />
               ))}
@@ -319,30 +325,30 @@ function TimelineRow({ entry }: { entry: TimelineEntry }) {
   const tone = sourceTone(entry.source);
   return (
     <li
-      className="rounded-md border border-line p-3"
+      className="border-b border-rule/60"
       data-testid={`admin-timeline-row-${entry.source_row_id}`}
     >
       <button
         type="button"
-        className="flex w-full items-start justify-between gap-3 text-left"
+        className="flex w-full items-baseline justify-between gap-3 py-2.5 text-left"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
       >
         <div className="flex flex-1 flex-wrap items-baseline gap-3">
           <span
-            className={`shrink-0 rounded-full px-2 py-0.5 text-xs ${tone}`}
+            className={`w-28 shrink-0 text-[10px] uppercase tracking-[0.18em] ${tone}`}
             data-testid="row-source-pill"
           >
             {SOURCE_LABEL[entry.source]}
           </span>
-          <code className="tech-token text-sm">{entry.action}</code>
+          <code className="tech-token text-sm text-ink">{entry.action}</code>
         </div>
-        <span className="shrink-0 text-xs tech-token text-muted">
+        <span className="shrink-0 tech-token text-[11px] text-muted">
           {entry.occurred_at.replace("T", " ").slice(0, 19)}
         </span>
       </button>
       {expanded && (
-        <div className="mt-3 space-y-2">
+        <div className="mb-3 space-y-2">
           <Block label="payload" data={entry.payload} />
           <Block label="refs" data={entry.refs} />
         </div>
@@ -355,15 +361,19 @@ function Block({ label, data }: { label: string; data: Record<string, unknown> }
   if (!data || Object.keys(data).length === 0) {
     return (
       <div>
-        <p className="text-xs uppercase tracking-widest text-muted">{label}</p>
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
+          {label}
+        </p>
         <p className="mt-1 text-xs text-muted">empty</p>
       </div>
     );
   }
   return (
     <div>
-      <p className="text-xs uppercase tracking-widest text-muted">{label}</p>
-      <pre className="mt-1 max-h-[40vh] overflow-auto rounded-md border border-line bg-paper px-2 py-1 text-xs">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
+        {label}
+      </p>
+      <pre className="mt-1 max-h-[40vh] overflow-auto border border-rule bg-paper px-2 py-1 text-xs">
         {JSON.stringify(data, null, 2)}
       </pre>
     </div>

--- a/frontend/src/admin/AdminUserDetail.tsx
+++ b/frontend/src/admin/AdminUserDetail.tsx
@@ -26,7 +26,8 @@ import {
   type UserRole,
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
-import { DescItem as DT, PageHeader } from "../ui/primitives";
+import { PageHeader } from "../ui/primitives";
+import { CertCard, CertEyebrow, LedgerRow, SectionRule } from "../ui/certificate";
 
 type Query =
   | { status: "loading" }
@@ -173,21 +174,35 @@ export function AdminUserDetail({ userId }: { userId: string }) {
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
       <PageHeader eyebrow="Workspace administration" eyebrowRight={user.role} title={user.email} subId={user.id} />
 
-      <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-        <DT label="Name">{user.name || "—"}</DT>
-        <DT label="Role">
-          <code className="tech-token text-xs">{user.role}</code>
-        </DT>
-        <DT label="Superuser">{user.is_superuser ? "yes" : "no"}</DT>
-        <DT label="Active">{user.is_active ? "yes" : "no"}</DT>
-        <DT label="Verified">{user.is_verified ? "yes" : "no"}</DT>
-        <DT label="Created">{user.created_at ?? "—"}</DT>
-      </dl>
+      <CertCard testid="practitioner-card">
+        <CertEyebrow
+          left="Practitioner"
+          right={user.is_superuser ? "Superuser" : undefined}
+          rightTone="ink"
+        />
+        <h2 className="mt-3 text-[22px] leading-tight tracking-tight2 text-ink">
+          {user.email}
+        </h2>
+        {user.name && <p className="mt-1 text-xs text-muted">{user.name}</p>}
+        <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
+          <LedgerRow label="Role">
+            <code className="tech-token">{user.role}</code>
+          </LedgerRow>
+          <LedgerRow label="Superuser">
+            {user.is_superuser ? "yes" : "no"}
+          </LedgerRow>
+          <LedgerRow label="Active">{user.is_active ? "yes" : "no"}</LedgerRow>
+          <LedgerRow label="Verified">
+            {user.is_verified ? "yes" : "no"}
+          </LedgerRow>
+          <LedgerRow label="Created">
+            <span className="tech-token">{user.created_at ?? "—"}</span>
+          </LedgerRow>
+        </dl>
+      </CertCard>
 
       <section className="mt-10">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Firm role controls
-        </h2>
+        <SectionRule label="Firm role controls" />
         <p className="mt-2 text-xs text-muted">
           These are deployment controls for firms that enforce role
           gates. By default the gates are dormant — hosted evaluation
@@ -198,8 +213,10 @@ export function AdminUserDetail({ userId }: { userId: string }) {
           and writes no audit row.
         </p>
         <form onSubmit={onSubmit} className="mt-4 flex flex-wrap items-end gap-3">
-          <label className="flex flex-col text-xs text-muted">
-            <span className="mb-1">Role</span>
+          <label className="flex flex-col text-muted">
+            <span className="mb-1 text-[10px] uppercase tracking-[0.18em]">
+              Role
+            </span>
             <select
               data-testid="role-select"
               value={draftRole}

--- a/frontend/src/admin/AdminUsersList.test.tsx
+++ b/frontend/src/admin/AdminUsersList.test.tsx
@@ -102,7 +102,7 @@ describe("AdminUsersList — admin", () => {
     });
   });
 
-  it("renders the user table with substrate columns + Open link", async () => {
+  it("renders the user ledger with role + Open link", async () => {
     vi.spyOn(api, "listAdminUsers").mockResolvedValue([
       makeUser({ id: "u-row", email: "row@example.com", role: "solicitor" }),
     ]);
@@ -111,13 +111,10 @@ describe("AdminUsersList — admin", () => {
     await waitFor(() => {
       expect(screen.getByText("row@example.com")).toBeInTheDocument();
     });
-    // Role appears in the table cell. Filter dropdown also has a
-    // "solicitor" option; match the row cell specifically by its
-    // monospace styling — only role cells use tech-token on this page.
-    const rowCell = Array.from(document.querySelectorAll("td.tech-token")).find(
-      (el) => el.textContent === "solicitor",
-    );
-    expect(rowCell).toBeTruthy();
+    // Role appears in the row's ledger label. Filter dropdown also has
+    // a "solicitor" option; scope to the row testid to disambiguate.
+    const row = screen.getByTestId("user-row-u-row");
+    expect(row.textContent).toContain("solicitor");
     const link = screen.getByRole("link", { name: /open/i });
     expect(link.getAttribute("href")).toBe("/admin/users/u-row");
   });

--- a/frontend/src/admin/AdminUsersList.tsx
+++ b/frontend/src/admin/AdminUsersList.tsx
@@ -26,6 +26,7 @@ import {
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
 import { PageHeader } from "../ui/primitives";
+import { LedgerLine, SectionRule } from "../ui/certificate";
 
 type Query =
   | { status: "loading" }
@@ -93,12 +94,15 @@ export function AdminUsersList() {
             : undefined
         }
         title="Users"
-        description="Every user in this workspace. Role changes happen on the per-user page; bulk operations are not exposed by the substrate."
+        whisper="The roll of practitioners"
+        description="Every practitioner admitted to this workspace, entered in the order the roll holds them. The roll records; it does not act. A role is changed on the practitioner's own page, and the substrate exposes no bulk operations."
       />
 
       <div className="mt-6 flex flex-wrap items-end gap-4">
-        <label className="flex flex-col text-xs text-muted">
-          <span className="mb-1">Role</span>
+        <label className="flex flex-col text-muted">
+          <span className="mb-1 text-[10px] uppercase tracking-[0.18em]">
+            Role
+          </span>
           <select
             data-testid="role-filter"
             value={roleFilter}
@@ -113,8 +117,10 @@ export function AdminUsersList() {
             ))}
           </select>
         </label>
-        <label className="flex flex-col text-xs text-muted">
-          <span className="mb-1">Superuser</span>
+        <label className="flex flex-col text-muted">
+          <span className="mb-1 text-[10px] uppercase tracking-[0.18em]">
+            Superuser
+          </span>
           <select
             data-testid="superuser-filter"
             value={superFilter}
@@ -145,54 +151,47 @@ export function AdminUsersList() {
         </p>
       )}
       {q.status === "ready" && q.users.length > 0 && (
-        <div className="mt-8 overflow-x-auto rounded-md border border-line">
-          <table className="min-w-full text-sm">
-            <thead className="text-[10px] uppercase tracking-[0.18em] text-muted">
-              <tr className="border-b border-ink">
-                <th className="px-3 py-2 text-left">Email</th>
-                <th className="px-3 py-2 text-left">Role</th>
-                <th className="px-3 py-2 text-left">Superuser</th>
-                <th className="px-3 py-2 text-left">Verified</th>
-                <th className="px-3 py-2 text-left">Active</th>
-                <th className="px-3 py-2 text-left">Created</th>
-                <th className="px-3 py-2 text-right"> </th>
-              </tr>
-            </thead>
-            <tbody>
-              {q.users.map((u) => (
-                <tr
+        <section className="mt-8">
+          <SectionRule label="The roll" right={String(q.users.length)} />
+          <div className="mt-1">
+            {q.users.map((u, i) => {
+              const flags = [
+                u.is_superuser ? "superuser" : null,
+                u.is_verified ? null : "unverified",
+                u.is_active ? null : "inactive",
+              ].filter(Boolean);
+              return (
+                <LedgerLine
                   key={u.id}
-                  className="border-t border-line"
-                  data-testid={`user-row-${u.id}`}
+                  index={i + 1}
+                  label={u.role.replaceAll("_", " ")}
+                  testid={`user-row-${u.id}`}
+                  right={
+                    <span className="flex items-baseline gap-3">
+                      <span className="tech-token text-[11px] text-muted">
+                        {u.created_at ? u.created_at.slice(0, 10) : "—"}
+                      </span>
+                      <Link
+                        to="/admin/users/$userId"
+                        params={{ userId: u.id }}
+                        className="text-sm text-muted hover:text-seal"
+                      >
+                        Open →
+                      </Link>
+                    </span>
+                  }
                 >
-                  <td className="px-3 py-2 text-sm">{u.email}</td>
-                  <td className="px-3 py-2 tech-token text-xs">{u.role}</td>
-                  <td className="px-3 py-2 text-xs">
-                    {u.is_superuser ? "yes" : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-xs text-muted">
-                    {u.is_verified ? "yes" : "no"}
-                  </td>
-                  <td className="px-3 py-2 text-xs text-muted">
-                    {u.is_active ? "yes" : "no"}
-                  </td>
-                  <td className="px-3 py-2 text-xs text-muted">
-                    {u.created_at ? u.created_at.slice(0, 10) : "—"}
-                  </td>
-                  <td className="px-3 py-2 text-right">
-                    <Link
-                      to="/admin/users/$userId"
-                      params={{ userId: u.id }}
-                      className="text-xs underline underline-offset-4 hover:text-seal"
-                    >
-                      Open
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                  <span className="text-ink">{u.email}</span>
+                  {flags.length > 0 && (
+                    <span className="ml-2 text-[11px] text-muted">
+                      {flags.join(" · ")}
+                    </span>
+                  )}
+                </LedgerLine>
+              );
+            })}
+          </div>
+        </section>
       )}
     </div>
   );

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -20,6 +20,7 @@ import {
   inputCls,
   primaryBtn,
 } from "../ui/primitives";
+import { SectionRule } from "../ui/certificate";
 
 export type SettingsTab = "profile" | "keys" | "preferences";
 
@@ -54,6 +55,8 @@ export function Settings({ tab }: { tab: SettingsTab }) {
         eyebrow="Your account"
         eyebrowRight="Legalise"
         title="Settings"
+        whisper="Your account at the registry"
+        description="The account holds your profile, your provider keys, and your defaults. Your name appears in audit rows; key changes are themselves recorded."
       />
       <div className="flex flex-col lg:flex-row gap-10">
         <aside className="lg:w-64 shrink-0 lg:border-r lg:border-rule lg:pr-6">
@@ -63,9 +66,9 @@ export function Settings({ tab }: { tab: SettingsTab }) {
                 key={item.key}
                 href={`/settings/${item.key}`}
                 className={
-                  "py-2 lg:py-2 px-3 lg:px-4 text-sm transition-colors lg:border-l-2 -mb-px lg:-ml-px " +
+                  "py-2 lg:py-2 px-3 lg:px-4 text-[10px] uppercase tracking-[0.18em] transition-colors lg:border-l-2 -mb-px lg:-ml-px " +
                   (tab === item.key
-                    ? "text-ink font-semibold lg:border-ink lg:bg-wash"
+                    ? "text-ink lg:border-ink lg:bg-wash"
                     : "text-muted hover:text-ink lg:border-transparent")
                 }
               >
@@ -186,7 +189,12 @@ function SettingsProfile({
 
   return (
     <div className="flex flex-col gap-8">
-      <p className="prose-p mb-0">Visible in audit rows. Email and verification status read-only.</p>
+      <div>
+        <SectionRule label="Profile" />
+        <p className="prose-p mb-0 mt-3">
+          Visible in audit rows. Email and verification status read-only.
+        </p>
+      </div>
 
       {error && <ErrorCallout message={error} />}
 
@@ -263,21 +271,23 @@ function SettingsProfile({
       </div>
 
       {/* Usage Plan */}
-      <div>
-        <div className="eyebrow mb-4 mt-12">Usage Plan</div>
-        <div className="text-sm font-semibold text-ink capitalize">{planLabel}</div>
+      <div className="mt-12">
+        <SectionRule label="Usage Plan" />
+        <div className="mt-4 text-sm font-semibold text-ink capitalize">{planLabel}</div>
       </div>
 
       {/* Actions */}
-      <div>
-        <div className="eyebrow mb-4 mt-12">Actions</div>
-        <SignOutButton />
+      <div className="mt-12">
+        <SectionRule label="Actions" />
+        <div className="mt-4">
+          <SignOutButton />
+        </div>
       </div>
 
       {/* Danger zone */}
-      <div>
-        <div className="eyebrow mb-4 mt-12 text-seal">Danger zone</div>
-        <p className="text-sm text-muted mb-4">
+      <div className="mt-12">
+        <SectionRule label="Danger zone" />
+        <p className="mt-4 text-sm text-muted mb-4">
           Deleting your account removes all matters and audit history. This action cannot be undone.
         </p>
         <button
@@ -383,12 +393,15 @@ function SettingsKeys() {
 
   return (
     <div className="flex flex-col gap-8">
-      <p className="prose-p mb-0">
+      <div>
+        <SectionRule label="Provider keys" />
+        <p className="prose-p mb-0 mt-3">
         The hosted site has no shared production model key. To run real
         model calls, bring your own Anthropic or OpenAI key. Keys are
         encrypted and used only for your requests — Legalise does not
         resell model access.
-      </p>
+        </p>
+      </div>
 
       {keys && <ProviderStatus hasKey={keys.length > 0} />}
 
@@ -428,8 +441,8 @@ function SettingsKeys() {
         </div>
       )}
 
-      <form className="flex flex-col gap-6 border-t border-rule pt-8" onSubmit={submit}>
-        <h3 className="text-lg font-semibold text-ink">Add or replace a key</h3>
+      <form className="flex flex-col gap-6 pt-8" onSubmit={submit}>
+        <SectionRule label="Add or replace a key" />
         <p className="text-xs text-muted -mt-3">
           Saving a key writes a <span className="tech-token">user.key.configured</span> audit
           row and switches your model calls from the keyless demo model to your provider.
@@ -494,7 +507,7 @@ function ProviderStatus({ hasKey }: { hasKey: boolean }) {
 function SettingsPreferences() {
   return (
     <div className="flex flex-col gap-6">
-      <h2 className="text-xl font-bold tracking-tight2 text-ink mb-2">Preferences</h2>
+      <SectionRule label="Preferences" />
       <div className="bg-wash p-6 border-l-4 border-ink">
         <div className="eyebrow-sm mb-2">ROADMAP - v0.2</div>
         <p className="prose-p mb-0">

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { MatterDocument } from "../lib/api";
 import { isPublicRoute, navigate, useRoute } from "../lib/route";
-import { Badge } from "../ui/primitives";
+import { CertCard, CertEyebrow, LedgerLine, LedgerRow, SectionRule } from "../ui/certificate";
 import { isTabKey, sidebarActiveFor, type TabKey } from "../matter/tabs/types";
 import { SidebarView, NavIcon, type RailItem } from "../ui/SidebarView";
 import { ChronologyTab } from "../matter/tabs/ChronologyTab";
@@ -165,10 +165,10 @@ export function DemoMatter() {
               className="mb-8 flex items-baseline justify-between gap-4 border-b border-ink pb-2"
               data-testid="demo-masthead"
             >
-              <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
+              <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
                 A matter before the workspace · read-only demo
               </p>
-              <p className="text-[10px] uppercase tracking-[0.25em] text-ink">
+              <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
                 Legalise
               </p>
             </div>
@@ -260,35 +260,23 @@ function DemoWorkflowsTab({
 
   return (
     <div className="max-w-5xl">
-      <h2 className="mb-6 text-xl font-semibold tracking-tight2 text-ink">
-        Skills in this project
-      </h2>
+      <SectionRule label="Skills in this project" />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {workflows.map((w) => (
-          <section key={w.title} className="rounded-card border border-rule/60 bg-paper p-5 shadow-panel hover:border-ink transition-colors">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <div className="text-lg font-semibold tracking-tight2 text-ink">{w.title}</div>
-                <p className="mt-2 text-sm text-prose leading-relaxed">{w.body}</p>
-              </div>
-              <span className="shrink-0 rounded-item border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-widest text-muted">
-                Ready
-              </span>
-            </div>
-            <dl className="mt-5 grid gap-2 border-t border-rule pt-4 text-xs">
-              <div className="flex gap-2">
-                <dt className="w-14 shrink-0 uppercase tracking-widest text-muted">Reads</dt>
-                <dd className="text-ink">{w.reads}</dd>
-              </div>
-              <div className="flex gap-2">
-                <dt className="w-14 shrink-0 uppercase tracking-widest text-muted">Writes</dt>
-                <dd className="text-ink">{w.writes}</dd>
-              </div>
-              <div className="flex gap-2">
-                <dt className="w-14 shrink-0 uppercase tracking-widest text-muted">Record</dt>
-                <dd className="text-ink">{w.last}</dd>
-              </div>
+      <div className="mt-5 grid grid-cols-1 gap-6 md:grid-cols-2">
+        {workflows.map((w, i) => (
+          <CertCard key={w.title}>
+            <CertEyebrow
+              left={`Skill ${String(i + 1).padStart(2, "0")}`}
+              right="Ready"
+            />
+            <h3 className="mt-3 text-[22px] leading-tight tracking-tight2 text-ink">
+              {w.title}
+            </h3>
+            <p className="mt-1 text-xs text-muted">{w.body}</p>
+            <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
+              <LedgerRow label="Reads">{w.reads}</LedgerRow>
+              <LedgerRow label="Writes">{w.writes}</LedgerRow>
+              <LedgerRow label="Record">{w.last}</LedgerRow>
             </dl>
             <div className="mt-5 flex flex-wrap gap-3">
               <button
@@ -299,7 +287,7 @@ function DemoWorkflowsTab({
                 Open in chat
               </button>
             </div>
-          </section>
+          </CertCard>
         ))}
       </div>
 
@@ -348,61 +336,48 @@ function DemoDocumentsTab({
 
   return (
     <div className="max-w-6xl">
-      <h2 className="mb-6 text-xl font-semibold tracking-tight2 text-ink">
-        Documents in this project
-      </h2>
+      <SectionRule label="Documents in this project" />
 
-      <div className="grid gap-5 lg:grid-cols-[360px_minmax(0,1fr)]">
-        <div className="rounded-card border border-rule bg-paper">
-          <div className="border-b border-rule bg-paper-sunken px-4 py-3">
-            <p className="text-[10px] font-semibold uppercase tracking-track2 text-muted">
-              Matter files
-            </p>
-            <label className="mt-3 block text-xs text-muted">
-              <span className="sr-only">Search demo documents</span>
-              <input
-                value={fileQuery}
-                onChange={(event) => setFileQuery(event.target.value)}
-                placeholder="Search files"
-                className="h-9 w-full rounded-item border border-rule bg-paper px-3 text-sm text-ink outline-none focus:border-ink"
-                data-testid="demo-document-list-search"
-              />
-            </label>
-            <p className="mt-2 text-xs text-muted" data-testid="demo-document-list-count">
-              Showing {filteredDocs.length} of {docs.length} files.
-            </p>
-          </div>
-          <div>
-            {filteredDocs.map((d) => {
+      <div className="mt-5 grid gap-5 lg:grid-cols-[420px_minmax(0,1fr)]">
+        <div>
+          <label className="block text-xs text-muted">
+            <span className="sr-only">Search demo documents</span>
+            <input
+              value={fileQuery}
+              onChange={(event) => setFileQuery(event.target.value)}
+              placeholder="Search files"
+              className="h-9 w-full border border-rule bg-paper px-3 text-sm text-ink outline-none focus:border-ink"
+              data-testid="demo-document-list-search"
+            />
+          </label>
+          <p className="mt-2 text-xs text-muted" data-testid="demo-document-list-count">
+            Showing {filteredDocs.length} of {docs.length} files.
+          </p>
+          <div className="mt-1">
+            {filteredDocs.map((d, i) => {
               const active = d.id === inspectedDoc.id;
               return (
-                <div
-                  key={d.id}
-                  className={`border-b border-rule px-4 py-4 transition-colors ${
-                    active ? "bg-wash" : "bg-paper hover:bg-wash"
-                  }`}
-                >
-                  <button
-                    type="button"
-                    onClick={() => onInspect(d.id)}
-                    className="block w-full text-left"
+                <div key={d.id} className={active ? "bg-wash" : ""}>
+                  <LedgerLine
+                    index={i + 1}
+                    label={`${formatBytes(d.size_bytes)} · ${d.uploaded_at.slice(0, 10)}`}
+                    right={
+                      <a
+                        href={`/demo/documents/${encodeURIComponent(d.id)}`}
+                        className="text-sm text-muted hover:text-seal"
+                      >
+                        Open →
+                      </a>
+                    }
                   >
-                    <div className="text-sm font-semibold text-ink">{d.filename}</div>
-                    <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-muted">
-                      {d.tag && <Badge>{d.tag.toUpperCase()}</Badge>}
-                      <span>{formatBytes(d.size_bytes)}</span>
-                      <span>{d.from_disclosure ? "CPR 31" : "Upload"}</span>
-                    </div>
-                    <div className="mt-2 text-[10px] uppercase tracking-track2 text-muted">
-                      Source-ready · {d.sha256.slice(0, 8)}
-                    </div>
-                  </button>
-                  <a
-                    href={`/demo/documents/${encodeURIComponent(d.id)}`}
-                    className="mt-3 inline-flex text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-                  >
-                    Open reader →
-                  </a>
+                    <button
+                      type="button"
+                      onClick={() => onInspect(d.id)}
+                      className="block w-full truncate text-left text-sm text-ink hover:text-seal"
+                    >
+                      {d.filename}
+                    </button>
+                  </LedgerLine>
                 </div>
               );
             })}

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -1,8 +1,9 @@
 /**
  * /help — one quiet screen of plain-English answers.
  *
- * Standing Order (DESIGN.md P26): masthead PageHeader, ruled Q&A list,
- * no accordions, no search. Six questions, short answers, done.
+ * Standing Order (DESIGN.md P26/P27): masthead PageHeader with whisper,
+ * ruled Q&A list with ledger-label questions (0.18em small caps), no
+ * accordions, no search. Six questions, short answers, done.
  */
 
 import type { ReactNode } from "react";
@@ -51,12 +52,18 @@ const QA: { q: string; a: ReactNode }[] = [
 export function Help() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-12 text-ink">
-      <PageHeader eyebrow="How the workspace works" title="Help" />
+      <PageHeader
+        eyebrow="How the workspace works"
+        title="Help"
+        whisper="Plainly stated"
+      />
       <dl>
         {QA.map(({ q, a }) => (
           <div key={q} className="border-b border-rule/60 py-5">
-            <dt className="text-sm font-semibold text-ink">{q}</dt>
-            <dd className="mt-1.5 text-sm leading-relaxed text-muted">{a}</dd>
+            <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">
+              {q}
+            </dt>
+            <dd className="mt-1.5 text-sm leading-relaxed text-prose">{a}</dd>
           </div>
         ))}
       </dl>

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -2,6 +2,7 @@ import { Github } from "lucide-react";
 import { navigate } from "../lib/route";
 import { useAuth } from "../auth/AuthProvider";
 import { Footer } from "../ui/Footer";
+import { SectionRule } from "../ui/certificate";
 
 const DEMO_SLUG = "khan-v-acme-trading-2026";
 
@@ -145,8 +146,8 @@ export function Landing() {
 
       <section className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
         <div className="max-w-page mx-auto">
-          <div className="eyebrow text-muted mb-3">How it works</div>
-          <h2 className="text-3xl md:text-4xl font-bold tracking-tight2 text-ink mb-10 leading-tight max-w-2xl">
+          <SectionRule label="How it works" />
+          <h2 className="mt-5 text-3xl md:text-4xl font-bold tracking-tight2 text-ink mb-10 leading-tight max-w-2xl">
             Six steps, and a record of every one.
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-rule border border-rule">
@@ -155,7 +156,7 @@ export function Landing() {
                 key={s.title}
                 className="bg-paper p-6 md:p-8 hover:bg-wash transition-colors"
               >
-                <div className="tech-token text-xs text-muted mb-4">
+                <div className="text-[10px] uppercase tracking-[0.25em] text-muted mb-4">
                   {String(i + 1).padStart(2, "0")} / 06
                 </div>
                 <h3 className="text-lg font-bold text-ink mb-3 tracking-tight2">
@@ -173,8 +174,8 @@ export function Landing() {
         className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-20"
       >
         <div className="max-w-4xl">
-          <div className="eyebrow text-muted mb-6">What we are building</div>
-          <h2 className="text-3xl md:text-4xl font-bold tracking-tight2 text-ink mb-8 leading-tight">
+          <SectionRule label="What we are building" />
+          <h2 className="mt-5 text-3xl md:text-4xl font-bold tracking-tight2 text-ink mb-8 leading-tight">
             Infrastructure a regulated firm could inspect, insure, and explain.
           </h2>
           <div className="grid gap-8 md:grid-cols-2 text-base leading-relaxed text-prose">
@@ -218,8 +219,8 @@ export function Landing() {
 
       <section className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-16">
         <div className="max-w-3xl">
-          <div className="eyebrow text-muted mb-5">Try it</div>
-          <h2 className="text-3xl md:text-4xl font-bold tracking-tight2 text-ink leading-tight">
+          <SectionRule label="Try it" />
+          <h2 className="mt-5 text-3xl md:text-4xl font-bold tracking-tight2 text-ink leading-tight">
             See a Khan v Acme demo matter with documents, skills, and a record.
           </h2>
           <p className="mt-5 text-base leading-relaxed text-prose">

--- a/frontend/src/lib/route.ts
+++ b/frontend/src/lib/route.ts
@@ -12,6 +12,7 @@
  * older hash-router call sites.
  */
 
+import { useMemo } from "react";
 import { useRouterState } from "@tanstack/react-router";
 import { router } from "../router";
 
@@ -180,9 +181,15 @@ export function routeFromPath(pathname: string, search: string): Route {
 }
 
 export function useRoute(): Route {
-  return useRouterState({
-    select: (s) => routeFromPath(s.location.pathname, s.location.searchStr),
-  });
+  // Select PRIMITIVES, derive the Route in a memo. Selecting the derived
+  // object directly meant a fresh identity on every router-state tick
+  // (loading flags, etc.) — every useRoute consumer re-rendered, and
+  // effects keyed on [route] re-fired into a nested-update cascade
+  // ("Maximum update depth exceeded" on the matter chat page; caught by
+  // the WebKit console audit, present in every engine).
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const searchStr = useRouterState({ select: (s) => s.location.searchStr });
+  return useMemo(() => routeFromPath(pathname, searchStr), [pathname, searchStr]);
 }
 
 /**

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { listMatters, type Matter } from "../lib/api";
 import { postureLabel } from "../lib/posture";
 import { EmptyState, ErrorCallout, PageHeader } from "../ui/primitives";
+import { LedgerLine, SectionRule } from "../ui/certificate";
 
 function formatType(raw: string): string {
   if (!raw) return "-";
@@ -9,14 +10,6 @@ function formatType(raw: string): string {
     .split("_")
     .map((p) => (p.length === 0 ? p : p[0].toUpperCase() + p.slice(1)))
     .join(" ");
-}
-
-function MonoPill({ children }: { children: ReactNode }) {
-  return (
-    <span className="inline-flex items-center rounded-item border border-rule px-2 py-0.5 tech-token uppercase text-[10px] tracking-track2 font-bold text-ink">
-      {children}
-    </span>
-  );
 }
 
 export function MatterList() {
@@ -34,8 +27,14 @@ export function MatterList() {
       <PageHeader
         display
         eyebrow="Matters before the workspace"
-        eyebrowRight={matters ? `${matters.length} matters` : undefined}
+        eyebrowRight={
+          matters
+            ? `${matters.length} matter${matters.length === 1 ? "" : "s"}`
+            : undefined
+        }
         title="Matters"
+        whisper="The cause list"
+        description="Every matter this workspace holds, entered in the order it was opened. An entry records the matter's type, whether it stands open or closed, and the posture of its privilege. Open an entry to take up the matter."
         actions={
           <a
             href="/matters/new"
@@ -50,8 +49,8 @@ export function MatterList() {
 
       {matters && matters.length === 0 && (
         <EmptyState
-          title="No matters yet"
-          body="Create your first matter to begin."
+          title="Nothing entered"
+          body="The cause list holds no matters yet. Open one to make the first entry."
           action={
             <a
               href="/matters/new"
@@ -64,49 +63,44 @@ export function MatterList() {
       )}
 
       {matters && matters.length > 0 && (
-        <div className="border-t border-rule overflow-x-auto">
-          <div className="min-w-[860px]">
-            <div className="grid grid-cols-[2fr_160px_120px_140px_120px_120px] gap-4 px-4 py-3 bg-paper border-b border-ink text-[10px] uppercase tracking-[0.18em] text-muted">
-              <span>Matter</span>
-              <span>Type</span>
-              <span>Status</span>
-              <span>Privilege</span>
-              <span>Opened</span>
-              <span>Retention</span>
-            </div>
-            {matters.map((m) => (
+        <section>
+          <SectionRule
+            label="Schedule of matters"
+            right={String(matters.length)}
+          />
+          <div className="mt-1">
+            {matters.map((m, i) => (
               <a
                 key={m.id}
                 href={`/matters/${m.slug}/assistant`}
-                className="grid grid-cols-[2fr_160px_120px_140px_120px_120px] gap-4 px-4 py-4 border-b border-rule hover:bg-wash transition-colors items-center"
+                className="block transition-colors hover:bg-wash"
               >
-                <span className="min-w-0">
-                  <span className="block text-sm font-semibold text-ink truncate">
-                    {m.title}
-                  </span>
-                  <span className="block text-xs tech-token text-muted truncate mt-1">
+                <LedgerLine
+                  index={i + 1}
+                  label={formatType(m.matter_type)}
+                  right={
+                    <span className="flex items-baseline gap-3">
+                      <span className="text-[10px] uppercase tracking-[0.18em] text-ink">
+                        {m.status}
+                      </span>
+                      <span className="hidden text-[10px] uppercase tracking-[0.18em] text-muted sm:inline">
+                        {postureLabel(m.privilege_posture)}
+                      </span>
+                      <span className="tech-token text-[11px] text-muted">
+                        {m.opened_at.slice(0, 10)}
+                      </span>
+                    </span>
+                  }
+                >
+                  <span className="text-ink">{m.title}</span>
+                  <span className="ml-2 hidden tech-token text-[11px] text-muted sm:inline">
                     {m.slug}
                   </span>
-                </span>
-                <span className="text-sm text-prose truncate">
-                  {formatType(m.matter_type)}
-                </span>
-                <span>
-                  <MonoPill>{m.status}</MonoPill>
-                </span>
-                <span>
-                  <MonoPill>{postureLabel(m.privilege_posture)}</MonoPill>
-                </span>
-                <span className="text-sm tech-token text-ink">
-                  {m.opened_at.slice(0, 10)}
-                </span>
-                <span className="text-sm tech-token text-muted">
-                  {m.retention_until ? m.retention_until.slice(0, 10) : "-"}
-                </span>
+                </LedgerLine>
               </a>
             ))}
           </div>
-        </div>
+        </section>
       )}
     </div>
   );

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -2,7 +2,34 @@ import { useState } from "react";
 import type { FormEvent } from "react";
 import { createMatter } from "../lib/api";
 import { navigate } from "../lib/route";
-import { ErrorCallout, Field, PageHeader } from "../ui/primitives";
+import type { ReactNode } from "react";
+import { ErrorCallout, PageHeader } from "../ui/primitives";
+
+// Ledger-label form field (DESIGN.md P27): labels carry the 0.18em
+// clerk's-ledger tier rather than the generic eyebrow-sm.
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="text-[10px] uppercase tracking-[0.18em] text-muted">
+        {label}
+        {hint && (
+          <span className="ml-2 normal-case tracking-normal text-xs text-muted">
+            ({hint})
+          </span>
+        )}
+      </span>
+      {children}
+    </label>
+  );
+}
 
 export function NewMatter() {
   const [form, setForm] = useState({

--- a/frontend/src/modules-v2/CreateModule.tsx
+++ b/frontend/src/modules-v2/CreateModule.tsx
@@ -16,6 +16,7 @@ import {
   type ValidateManifestResult,
 } from "../lib/api";
 import { PageHeader } from "../ui/primitives";
+import { SectionRule } from "../ui/certificate";
 
 const REQUIRED_FIELDS: { field: string; what: string }[] = [
   { field: "schema_version", what: 'manifest schema, e.g. "2.0.0"' },
@@ -65,9 +66,7 @@ export function CreateModule() {
       />
 
       <section>
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          What a skill is
-        </h2>
+        <SectionRule label="What a skill is" />
         <p className="mt-2 text-sm text-muted">
           A skill is a signed, governed unit of legal work. Its manifest
           declares what it may touch; the runtime enforces those declarations on
@@ -77,9 +76,7 @@ export function CreateModule() {
       </section>
 
       <section className="mt-8">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Required manifest fields
-        </h2>
+        <SectionRule label="Required manifest fields" />
         <dl className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
           {REQUIRED_FIELDS.map((f) => (
             <div key={f.field}>
@@ -98,9 +95,7 @@ export function CreateModule() {
       </section>
 
       <section className="mt-8">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Validate a manifest
-        </h2>
+        <SectionRule label="Validate a manifest" />
         <textarea
           value={text}
           onChange={(e) => setText(e.target.value)}
@@ -153,9 +148,7 @@ export function CreateModule() {
       </section>
 
       <section className="mt-8">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Sign &amp; add locally
-        </h2>
+        <SectionRule label="Sign & add locally" />
         <p className="mt-2 text-sm text-muted">
           A skill must be <span className="text-ink">signed</span> before it can
           be added — signing is a deploy-time / CLI step, not done in the

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -22,7 +22,8 @@ import {
   type LawveSkillRow,
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
-import { Badge, ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
+import { ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
+import { LedgerLine, SectionRule } from "../ui/certificate";
 import { RequestSkillButton } from "./RequestSkillButton";
 
 type ListQuery =
@@ -155,6 +156,7 @@ export function LawveImport() {
       <PageHeader
         eyebrow="Admission — instruct new counsel"
         title="Add a skill"
+        whisper="Before the registrar"
         description="Import a skill from the Lawve catalogue or any public GitHub repository. A skill cannot be added until it is converted, validated, signed, and trusted — and imported scripts are never executed."
       />
 
@@ -174,7 +176,7 @@ export function LawveImport() {
               }}
               className="mb-4"
             >
-              <label className="text-[11px] uppercase tracking-widest text-muted">
+              <label className="text-[10px] uppercase tracking-[0.18em] text-muted">
                 From a GitHub repository
               </label>
               <div className="mt-1 flex gap-2">
@@ -198,7 +200,7 @@ export function LawveImport() {
                 Needs a SKILL.md at the repo root (or pass a /tree/&lt;ref&gt;/&lt;path&gt; URL).
               </p>
             </form>
-            <label className="text-[11px] uppercase tracking-widest text-muted">
+            <label className="text-[10px] uppercase tracking-[0.18em] text-muted">
               From the Lawve catalogue
             </label>
             <input
@@ -231,31 +233,41 @@ export function LawveImport() {
               <span className="text-muted">{filtered.length} of {skills.length}</span>
             </div>
 
-            <ul className="mt-4 space-y-px bg-rule border border-rule">
-              {filtered.map((s) => (
+            {/* The catalogue ledger — index, licence, name + author, chevron.
+                Same scan rhythm as the register's admission lists. */}
+            <ul className="mt-4">
+              {filtered.map((s, i) => (
                 <li key={s.slug}>
                   <button
                     type="button"
                     onClick={() => openSkill(s.slug)}
                     className={
-                      "block w-full bg-paper p-4 text-left hover:bg-wash transition-colors " +
-                      (selected?.slug === s.slug ? "ring-1 ring-ink" : "")
+                      "group block w-full text-left " +
+                      (selected?.slug === s.slug ? "bg-wash" : "")
                     }
                     data-testid={`lawve-card-${s.slug}`}
                   >
-                    <div className="flex items-baseline justify-between gap-3">
-                      <span className="text-sm font-medium text-ink">{s.name}</span>
-                      <span className="shrink-0 text-[10px] uppercase tracking-widest text-muted">
-                        {s.license ?? "licence?"}
+                    <LedgerLine
+                      index={i + 1}
+                      label={s.license ?? "licence ?"}
+                      right={
+                        <span
+                          aria-hidden="true"
+                          className="text-sm text-muted group-hover:text-seal"
+                        >
+                          →
+                        </span>
+                      }
+                    >
+                      <span className="text-ink group-hover:text-seal">
+                        {s.name}
                       </span>
-                    </div>
-                    <p className="mt-1 text-xs text-muted line-clamp-2">{s.description}</p>
-                    <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-muted">
-                      <span>{s.author_name ?? "unknown"}</span>
-                      {s.version && <span>· {s.version}</span>}
-                      {s.has_scripts && <Badge>scripts</Badge>}
-                      {s.has_references && <Badge>refs</Badge>}
-                    </div>
+                      <span className="ml-2 hidden text-[12px] text-muted sm:inline">
+                        {s.author_name ?? "unknown"}
+                        {s.has_scripts ? " · scripts" : ""}
+                        {s.has_references ? " · refs" : ""}
+                      </span>
+                    </LedgerLine>
                   </button>
                 </li>
               ))}
@@ -271,7 +283,10 @@ export function LawveImport() {
             )}
             {selected && (
               <div data-testid="lawve-detail">
-                <h2 className="text-lg font-bold tracking-tight2">{selected.name}</h2>
+                <SectionRule label="The instrument under review" />
+                <h2 className="mt-3 text-[22px] leading-tight tracking-tight2 text-ink">
+                  {selected.name}
+                </h2>
                 <p className="mt-1 text-xs text-muted">
                   {selected.author_name ?? "unknown"} · {selected.version ?? "—"} ·{" "}
                   {selected.license ?? "licence unknown"}
@@ -297,7 +312,7 @@ export function LawveImport() {
                 )}
 
                 <details className="mt-3">
-                  <summary className="cursor-pointer text-xs uppercase tracking-widest text-muted">
+                  <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted">
                     SKILL.md
                   </summary>
                   <pre className="mt-2 max-h-[30vh] overflow-auto rounded-md border border-rule bg-paper px-2 py-1 text-[11px] whitespace-pre-wrap">
@@ -373,19 +388,18 @@ function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string })
   };
 
   return (
-    <div className="mt-5 border-t border-rule pt-4" data-testid="draft-review">
-      <div className="flex items-center justify-between gap-3">
-        <h3 className="text-sm uppercase tracking-widest text-muted">Skill draft</h3>
-        <span
-          className={
-            "rounded-full border px-2 py-0.5 text-xs " +
-            (draft.valid ? "border-ink text-ink" : "border-seal/50 text-seal")
-          }
-          data-testid="draft-trust-state"
-        >
-          {trustState(draft)}
-        </span>
-      </div>
+    <div className="mt-6" data-testid="draft-review">
+      <SectionRule
+        label="Skill draft"
+        right={
+          <span
+            className={draft.valid ? "text-ink" : "text-seal"}
+            data-testid="draft-trust-state"
+          >
+            {trustState(draft)}
+          </span>
+        }
+      />
 
       {draft.warnings.length > 0 && (
         <ul className="mt-3 space-y-1 text-xs">
@@ -427,7 +441,7 @@ function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string })
           admin-gated (the ceremony's enable step is require_admin), so
           non-admins get a clear ask rather than a dead button. */}
       <div className="mt-4 border-t border-rule pt-3">
-        <p className="text-xs uppercase tracking-widest text-muted">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
           Imported skill → skill draft → trust ceremony → added skill → enable per matter
         </p>
         {draft.valid ? (

--- a/frontend/src/modules-v2/ModuleDetail.test.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.test.tsx
@@ -110,8 +110,10 @@ describe("ModuleDetail", () => {
       expect(screen.getByText("Contract Review")).toBeInTheDocument();
     });
     expect(screen.getByText("v0.2.1")).toBeInTheDocument();
-    expect(screen.getByText("by legalise")).toBeInTheDocument();
-    expect(screen.getByText("first_party")).toBeInTheDocument();
+    // Certificate anatomy: publisher (chambers) line + visibility eyebrow.
+    expect(screen.getByText(/legalise \(chambers\)/)).toBeInTheDocument();
+    expect(screen.getByText("first party")).toBeInTheDocument();
+    expect(screen.getByTestId("skill-certificate")).toBeInTheDocument();
     // Capability permission card — raw identifiers stay visible.
     expect(screen.getByText("review")).toBeInTheDocument();
     expect(screen.getByText("matter")).toBeInTheDocument();

--- a/frontend/src/modules-v2/ModuleDetail.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.tsx
@@ -37,7 +37,13 @@ import {
   type V2ManifestEntry,
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
-import { PageHeader } from "../ui/primitives";
+import {
+  CertCard,
+  CertEyebrow,
+  InkBands,
+  LedgerRow,
+  SectionRule,
+} from "../ui/certificate";
 import { RequestSkillButton } from "./RequestSkillButton";
 
 type DetailQuery =
@@ -166,6 +172,10 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
   const description = asString((entry.manifest as Record<string, unknown>).description);
   const sourceUrl = asString((entry.manifest as Record<string, unknown>).source_url);
   const caps = capabilitiesOf(entry);
+  const reads = [...new Set(caps.flatMap((c) => c.reads ?? []))].sort();
+  const writes = [...new Set(caps.flatMap((c) => c.writes ?? []))].sort();
+  const installedRow = installStatus.kind === "installed" ? installStatus.row : null;
+  const revoked = installedRow !== null && !installedRow.enabled;
   const isAdmin = auth.user?.is_superuser === true;
 
   const onInstall = async () => {
@@ -236,78 +246,99 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
-      <PageHeader eyebrow="From the skill library" title={name} subId={entry.module_id} />
-
-      <div className="-mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted">
-        {version && <span>v{version}</span>}
-        {publisher && <span>by {publisher}</span>}
-        {visibility && (
-          <span className="rounded-sm border border-line px-1.5 py-0.5 text-xs">
-            {visibility}
-          </span>
-        )}
-        {sourceUrl && (
-          <a
-            href={sourceUrl}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-          >
-            source
-          </a>
-        )}
+      {/* Masthead — ruled eyebrow row; the certificate below is the hero. */}
+      <div className="flex items-baseline justify-between border-b border-ink pb-2">
+        <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
+          From the skill library
+        </p>
+        <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
+          Legalise
+        </p>
       </div>
 
-      <InstallStatusBadge status={installStatus} />
-
       {description && (
-        <p className="mt-6 text-muted">{description}</p>
+        <p className="mt-8 max-w-xl text-sm leading-relaxed text-prose">
+          {description}
+        </p>
       )}
 
-      {!entry.is_valid && (
-        <div className="mt-6 rounded-md border border-seal/40 bg-seal/5 px-4 py-3">
-          <p className="text-sm font-medium text-seal">Manifest invalid</p>
-          <ul className="mt-2 list-disc pl-5 text-sm text-muted">
-            {entry.validation_errors.map((e, i) => (
-              <li key={i}>
-                <span className="tech-token">{e.path}</span>: {e.message}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {/* What this module needs access to — capabilities framed as a
-          permission summary rather than a raw manifest table. Raw
-          identifiers stay available in small mono so nothing is hidden. */}
-      <section className="mt-10">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          What this skill needs access to
-        </h2>
-        {caps.length === 0 ? (
-          <p className="mt-3 text-sm text-muted">
-            No permissions declared.
+      {/* The certificate — this page is the skill's entry, stated the way
+          the register states it. Every field below is already held by the
+          manifest or the installed row; nothing is invented. */}
+      <div className="mt-8">
+        <CertCard tone={revoked ? "seal" : "ink"} testid="skill-certificate">
+          <CertEyebrow
+            left="Skill"
+            right={visibility ? visibility.replaceAll("_", " ") : undefined}
+          />
+          <h1
+            className={
+              "mt-3 text-[22px] leading-tight tracking-tight2 " +
+              (revoked ? "text-seal line-through decoration-1" : "text-ink")
+            }
+          >
+            {name}
+          </h1>
+          <p className="mt-1 text-xs text-muted">
+            {publisher ? `${publisher} (chambers) · ` : ""}
+            <span className="tech-token">{entry.module_id}</span>
           </p>
-        ) : (
-          <ul className="mt-3 space-y-px bg-rule border border-rule">
-            {caps.map((c, i) => (
-              <CapabilityCard key={c.id ?? i} cap={c} />
-            ))}
-          </ul>
-        )}
-      </section>
-
-      {/* Manifest & signature disclosure (blueprint §4A.5 step 5).
-          Collapsed by default; opens to show signer status, version,
-          add metadata, and validity. Nothing is hidden — these
-          fields are all already returned by the substrate. */}
-      <ManifestDisclosure entry={entry} installStatus={installStatus} />
+          <div className="mt-4 space-y-2">
+            <InkBands label="Reads" values={reads} />
+            <InkBands label="Writes" values={writes} />
+          </div>
+          <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
+            <LedgerRow label="Permission sets">
+              {caps.length}
+              {!entry.is_valid ? " · manifest invalid" : ""}
+            </LedgerRow>
+            <LedgerRow
+              label="Signature"
+              tone={
+                installedRow &&
+                (installedRow.signature_status === "verified" ||
+                  installedRow.signature_status === "structure_verified")
+                  ? "ink"
+                  : "muted"
+              }
+            >
+              {(installedRow?.signature_status ?? "not yet inspected").replaceAll(
+                "_",
+                " ",
+              )}
+            </LedgerRow>
+            {version && <LedgerRow label="Version">v{version}</LedgerRow>}
+            {installStatus.kind !== "unknown" && (
+              <LedgerRow
+                label="Standing"
+                tone={revoked ? "seal" : installedRow ? "ink" : "muted"}
+              >
+                {installedRow
+                  ? installedRow.enabled
+                    ? "Added"
+                    : "Added · disabled"
+                  : "Not added"}
+              </LedgerRow>
+            )}
+            {sourceUrl && (
+              <LedgerRow label="Source">
+                <a
+                  href={sourceUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="tech-token hover:underline"
+                >
+                  {sourceUrl.replace(/^https?:\/\//, "")}
+                </a>
+              </LedgerRow>
+            )}
+          </dl>
+        </CertCard>
+      </div>
 
       {/* Lifecycle controls */}
-      <section className="mt-10">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Lifecycle
-        </h2>
+      <section className="mt-6">
+        <SectionRule label="Lifecycle" />
         <div className="mt-3 flex flex-wrap items-center gap-3">
           {isAdmin ? (
             <>
@@ -387,35 +418,48 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
           <p className="mt-3 text-sm text-muted">{life.message}</p>
         )}
       </section>
-    </div>
-  );
-}
 
-function InstallStatusBadge({ status }: { status: InstallStatus }) {
-  if (status.kind === "unknown") return null;
-  if (status.kind === "not_installed") {
-    return (
-      <p className="mt-4 inline-flex items-center gap-2 border border-rule px-2 py-1 text-xs text-muted">
-        <span className="h-1.5 w-1.5 rounded-full bg-muted" aria-hidden="true" />
-        Not added
-      </p>
-    );
-  }
-  const { row } = status;
-  return (
-    <p
-      className={
-        "mt-4 inline-flex items-center gap-2 border px-2 py-1 text-xs " +
-        (row.enabled ? "border-ink text-ink" : "border-seal/40 text-seal")
-      }
-    >
-      <span
-        className={"h-1.5 w-1.5 rounded-full " + (row.enabled ? "bg-ink" : "bg-seal")}
-        aria-hidden="true"
-      />
-      {row.enabled ? "Added" : "Added · disabled"}
-      <span className="text-muted">· signature {row.signature_status}</span>
-    </p>
+      {!entry.is_valid && (
+        <div className="mt-6 rounded-md border border-seal/40 bg-seal/5 px-4 py-3">
+          <p className="text-sm font-medium text-seal">Manifest invalid</p>
+          <ul className="mt-2 list-disc pl-5 text-sm text-muted">
+            {entry.validation_errors.map((e, i) => (
+              <li key={i}>
+                <span className="tech-token">{e.path}</span>: {e.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* What this module needs access to — capabilities framed as a
+          permission summary rather than a raw manifest table. Raw
+          identifiers stay available in small mono so nothing is hidden. */}
+      <section className="mt-10">
+        <SectionRule
+          label="What this skill needs access to"
+          right={caps.length > 0 ? String(caps.length) : undefined}
+        />
+        {caps.length === 0 ? (
+          <p className="mt-3 text-sm text-muted">
+            No permissions declared.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-px bg-rule border border-rule">
+            {caps.map((c, i) => (
+              <CapabilityCard key={c.id ?? i} cap={c} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Manifest & signature disclosure (blueprint §4A.5 step 5).
+          Collapsed by default; opens to show signer status, version,
+          add metadata, and validity. Nothing is hidden — these
+          fields are all already returned by the substrate. */}
+      <ManifestDisclosure entry={entry} installStatus={installStatus} />
+
+    </div>
   );
 }
 
@@ -427,7 +471,7 @@ function CapabilityCard({ cap }: { cap: CapabilityRow }) {
       <div className="flex items-baseline justify-between gap-3">
         <p className="tech-token text-sm text-ink">{cap.id ?? "—"}</p>
         {cap.scope && (
-          <span className="text-[10px] uppercase tracking-widest text-muted">
+          <span className="text-[10px] uppercase tracking-[0.18em] text-muted">
             {cap.scope}
           </span>
         )}
@@ -436,7 +480,7 @@ function CapabilityCard({ cap }: { cap: CapabilityRow }) {
         {reads.length > 0 && <Access label="Reads" items={reads} />}
         {writes.length > 0 && <Access label="Writes" items={writes} />}
         <div>
-          <dt className="text-xs uppercase tracking-widest text-muted">Network</dt>
+          <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">Network</dt>
           <dd className="mt-0.5 text-muted">
             {cap.external_network
               ? "Needs external network access"
@@ -445,7 +489,7 @@ function CapabilityCard({ cap }: { cap: CapabilityRow }) {
         </div>
         {cap.advice_tier_max && (
           <div>
-            <dt className="text-xs uppercase tracking-widest text-muted">
+            <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">
               Max advice tier
             </dt>
             <dd className="mt-0.5 text-muted">{cap.advice_tier_max}</dd>
@@ -459,7 +503,7 @@ function CapabilityCard({ cap }: { cap: CapabilityRow }) {
 function Access({ label, items }: { label: string; items: string[] }) {
   return (
     <div>
-      <dt className="text-xs uppercase tracking-widest text-muted">{label}</dt>
+      <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">{label}</dt>
       <dd className="mt-0.5 tech-token text-xs text-muted">{items.join(", ")}</dd>
     </div>
   );
@@ -490,7 +534,7 @@ function ManifestDisclosure({
         data-testid="manifest-disclosure-toggle"
         className="flex w-full items-center justify-between border-b border-rule pb-2 text-left"
       >
-        <h2 className="text-sm uppercase tracking-widest text-muted">
+        <h2 className="text-[10px] uppercase tracking-[0.25em] text-muted">
           Manifest &amp; signature
         </h2>
         <span aria-hidden="true" className="text-xs text-muted">
@@ -532,7 +576,7 @@ function ManifestDisclosure({
           )}
           {sourceUrl && (
             <div className="sm:col-span-2">
-              <dt className="text-xs uppercase tracking-widest text-muted">
+              <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">
                 Source
               </dt>
               <dd className="mt-0.5">
@@ -566,7 +610,7 @@ function Field({
 }) {
   return (
     <div>
-      <dt className="text-xs uppercase tracking-widest text-muted">{label}</dt>
+      <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">{label}</dt>
       <dd className={"mt-0.5 " + (mono ? "tech-token text-xs" : "text-sm")}>
         {value}
       </dd>

--- a/frontend/src/modules-v2/ModulesCatalog.test.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.test.tsx
@@ -100,8 +100,10 @@ describe("ModulesCatalog — integrations home", () => {
     expect(
       screen.getByTestId("module-state-examples.contract-review"),
     ).toHaveTextContent(/added/i);
-    expect(screen.getByText("document.body.read")).toBeInTheDocument();
-    expect(screen.getByText("matter.artifact.write")).toBeInTheDocument();
+    // Permissions render as ink bands (P27 certificate anatomy); the
+    // values live in the title attribute for hover/inspection.
+    expect(screen.getAllByTitle("document.body.read").length).toBeGreaterThan(0);
+    expect(screen.getAllByTitle("matter.artifact.write").length).toBeGreaterThan(0);
     expect(screen.getByText("Add skill")).toBeInTheDocument();
     expect(screen.getByText("Create skill")).toBeInTheDocument();
   });

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -25,6 +25,15 @@ import {
   type V2ManifestEntry,
 } from "../lib/api";
 import { PageHeader } from "../ui/primitives";
+import {
+  CertCard,
+  CertEyebrow,
+  Colophon,
+  InkBands,
+  LedgerLine,
+  LedgerRow,
+  SectionRule,
+} from "../ui/certificate";
 import { listLawveSkills, type LawveSkillRow } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
 
@@ -60,11 +69,6 @@ function capabilityStrings(entry: V2ManifestEntry, key: "reads" | "writes"): str
   }
   return [...out].sort();
 }
-function shortPermissionList(values: string[]): string {
-  if (values.length === 0) return "None declared";
-  if (values.length <= 2) return values.join(", ");
-  return `${values.slice(0, 2).join(", ")} +${values.length - 2}`;
-}
 const STATE_LABEL: Record<ModuleState, string> = {
   available: "Available",
   installed: "Added",
@@ -81,16 +85,6 @@ const TAB_LABEL: Record<SkillTab, string> = {
 // V1 ships a Claude-native skill format; every skill in the V2 registry
 // is tested against Sonnet 4.6+, so the badge is unconditional here.
 // When the manifest grows a compatibility field it can move to per-skill.
-function CompatibilityBadge() {
-  return (
-    <span
-      title="Tested against Anthropic Claude Sonnet 4.6 or newer. Legalise can support other approved model providers; the skill format is Claude-native in V1."
-      className="inline-flex items-center gap-1 rounded-full border border-rule px-2 py-0.5 tech-token text-[9px] uppercase tracking-widest text-muted"
-    >
-      Tested with Claude Sonnet 4.6+
-    </span>
-  );
-}
 
 export function ModulesCatalog() {
   // /modules is a public route (anyone can browse). The v2 registry +
@@ -214,6 +208,7 @@ export function ModulesCatalog() {
         eyebrowRight="Legalise"
         display
         title="Skills"
+        whisper="Instruments of practice"
         description={
           authed
             ? "A skill is a piece of legal work — review an NDA, screen a dismissal, draft a letter. Add one from the catalogue, enable it on a matter, run it from Chat. Every run leaves a signed, auditable record."
@@ -279,39 +274,45 @@ export function ModulesCatalog() {
           audit chain holds pending requests. Each row links into the
           importer where the trust ceremony starts. */}
       {authed && isOperator && requests.length > 0 && (
-        <section className="mb-10" data-testid="skill-requests">
-          <h2 className="text-xs uppercase tracking-widest text-muted">
-            Requested by your workspace ({requests.length})
-          </h2>
-          <ul className="mt-3 divide-y divide-rule border border-rule bg-paper">
-            {requests.map((r) => (
-              <li
+        <section className="mb-12" data-testid="skill-requests">
+          <SectionRule
+            label="Requested by your workspace"
+            right={String(requests.length)}
+          />
+          <div className="mt-1">
+            {requests.map((r, i) => (
+              <LedgerLine
                 key={r.module_id}
-                className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
-                data-testid={`skill-request-${r.module_id}`}
+                index={i + 1}
+                label="Requested"
+                testid={`skill-request-${r.module_id}`}
+                right={
+                  <a
+                    href={
+                      r.source === "lawve"
+                        ? // Lawve draft ids are "lawve.{slug}"; the importer
+                          // deep-link takes the bare slug.
+                          `/skills/lawve?skill=${encodeURIComponent(r.module_id.replace(/^lawve\./, ""))}`
+                        : "/skills/lawve"
+                    }
+                    className="text-sm text-muted hover:text-seal"
+                  >
+                    Review &amp; add →
+                  </a>
+                }
               >
-                <div className="min-w-0">
-                  <p className="tech-token text-sm text-ink">{r.module_id}</p>
-                  <p className="mt-0.5 text-[11px] text-muted">
-                    {r.source ? `via ${r.source} · ` : ""}
-                    requested {new Date(r.requested_at).toLocaleDateString()}
-                  </p>
-                </div>
-                <a
-                  href={
-                    r.source === "lawve"
-                      ? // Lawve draft ids are "lawve.{slug}"; the importer
-                        // deep-link takes the bare slug.
-                        `/skills/lawve?skill=${encodeURIComponent(r.module_id.replace(/^lawve\./, ""))}`
-                      : "/skills/lawve"
-                  }
-                  className="shrink-0 text-sm text-muted hover:text-seal"
-                >
-                  Review &amp; add →
-                </a>
-              </li>
+                <span className="tech-token">{r.module_id}</span>
+                <span className="ml-2 text-[11px] text-muted">
+                  {r.source ? `via ${r.source} · ` : ""}
+                  {new Date(r.requested_at).toLocaleDateString("en-GB", {
+                    day: "2-digit",
+                    month: "short",
+                    year: "numeric",
+                  })}
+                </span>
+              </LedgerLine>
             ))}
-          </ul>
+          </div>
         </section>
       )}
 
@@ -320,10 +321,12 @@ export function ModulesCatalog() {
           (Revoked is operator-only). */}
       {authed && (
       <section>
-        <div className="flex flex-wrap items-end justify-between gap-3">
-          <h2 className="text-xs uppercase tracking-widest text-muted">
-            Workspace skills
-          </h2>
+        <SectionRule
+          label="Schedule A — workspace skills"
+          right={modules ? String(modules.length) : undefined}
+        />
+        <div className="mt-2 flex flex-wrap items-end justify-between gap-3">
+          <span aria-hidden="true" />
           {authed && modules && modules.length > 0 && (
             <input
               value={query}
@@ -386,70 +389,58 @@ export function ModulesCatalog() {
                   : "Nothing to add — all reference skills are already trusted in this workspace."}
           </p>
         ) : (
-          <ul className="mt-3 grid grid-cols-1 gap-px bg-rule border border-rule sm:grid-cols-2">
-            {filteredModules?.map((m) => {
+          <ul className="mt-5 grid grid-cols-1 gap-6 sm:grid-cols-2">
+            {filteredModules?.map((m, i) => {
               const st = stateOf(m.module_id);
               const caps = capCount(m);
               const reads = capabilityStrings(m, "reads");
               const writes = capabilityStrings(m, "writes");
               return (
-                <li key={m.module_id} className="bg-paper p-4 hover:bg-wash transition-colors">
+                <li key={m.module_id}>
                   <Link
                     to="/skills/$moduleId"
                     params={{ moduleId: m.module_id }}
-                    className="block"
+                    className="block transition-opacity hover:opacity-80"
                   >
-                    <div className="flex items-baseline justify-between gap-3">
-                      <h3 className="text-sm font-medium text-ink">
+                    <CertCard tone={st === "disabled" ? "seal" : "ink"}>
+                      <CertEyebrow
+                        left={`Skill ${String(i + 1).padStart(2, "0")}`}
+                        right={
+                          <span data-testid={`module-state-${m.module_id}`}>
+                            {STATE_LABEL[st]}
+                          </span>
+                        }
+                        rightTone={
+                          st === "available"
+                            ? "muted"
+                            : st === "installed"
+                              ? "ink"
+                              : "seal"
+                        }
+                      />
+                      <h3 className="mt-3 text-[22px] leading-tight tracking-tight2 text-ink">
                         {manifestStr(m, "name") ?? m.module_id}
                       </h3>
-                      <span
-                        className={
-                          "shrink-0 text-[10px] uppercase tracking-widest " +
-                          (st === "available"
-                            ? "text-muted"
-                            : st === "installed"
-                              ? "text-ink"
-                              : "text-seal")
-                        }
-                        data-testid={`module-state-${m.module_id}`}
-                      >
-                        {STATE_LABEL[st]}
-                      </span>
-                    </div>
-                    <p className="mt-1 tech-token text-[11px] text-muted">
-                      {m.module_id}
-                      {manifestStr(m, "publisher") ? ` · ${manifestStr(m, "publisher")}` : ""}
-                    </p>
-                    <div className="mt-2">
-                      <CompatibilityBadge />
-                    </div>
-                    <p className="mt-2 text-xs text-muted">
-                      {caps} permission set{caps === 1 ? "" : "s"}
-                      {!m.is_valid ? " · manifest invalid" : ""}
-                    </p>
-                    <dl className="mt-3 grid grid-cols-1 gap-2 border-t border-rule pt-3 text-xs sm:grid-cols-2">
-                      <div>
-                        <dt className="tech-token uppercase tracking-widest text-[9px] text-muted">
-                          Reads
-                        </dt>
-                        <dd className="mt-1 text-ink">
-                          {shortPermissionList(reads)}
-                        </dd>
+                      <p className="mt-1 text-xs text-muted">
+                        {manifestStr(m, "publisher")
+                          ? `${manifestStr(m, "publisher")} (chambers) · `
+                          : ""}
+                        <span className="tech-token">{m.module_id}</span>
+                      </p>
+                      <div className="mt-4 space-y-2">
+                        <InkBands label="Reads" values={reads} />
+                        <InkBands label="Writes" values={writes} />
                       </div>
-                      <div>
-                        <dt className="tech-token uppercase tracking-widest text-[9px] text-muted">
-                          Writes
-                        </dt>
-                        <dd className="mt-1 text-ink">
-                          {shortPermissionList(writes)}
-                        </dd>
-                      </div>
-                    </dl>
-                    <p className="mt-3 text-xs text-muted">
-                      Running happens inside a matter after permissions are
-                      granted. Add state here is workspace-level.
-                    </p>
+                      <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
+                        <LedgerRow label="Permission sets">
+                          {caps}
+                          {!m.is_valid ? " · manifest invalid" : ""}
+                        </LedgerRow>
+                        <LedgerRow label="Tested with">
+                          Claude Sonnet 4.6+
+                        </LedgerRow>
+                      </dl>
+                    </CertCard>
                   </Link>
                 </li>
               );
@@ -462,18 +453,18 @@ export function ModulesCatalog() {
       {/* The stocked shelf: the open Lawve catalogue, reviewable and
           addable in two clicks. */}
       {authed && (
-        <section className="mt-10" data-testid="lawve-catalogue">
-          <div className="flex flex-wrap items-end justify-between gap-3">
-            <h2 className="text-xs uppercase tracking-widest text-muted">
-              Catalogue{lawve ? ` (${lawve.length})` : ""}
-            </h2>
-            <Link
-              to="/skills/lawve"
-              className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-            >
-              Open full importer →
-            </Link>
-          </div>
+        <section className="mt-12" data-testid="lawve-catalogue">
+          <SectionRule
+            label="Schedule B — the open catalogue"
+            right={
+              <Link
+                to="/skills/lawve"
+                className="normal-case tracking-normal text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+              >
+                Open full importer →
+              </Link>
+            }
+          />
           {lawve == null ? (
             <p className="mt-3 text-sm text-muted">Loading catalogue…</p>
           ) : lawve.length === 0 ? (
@@ -481,29 +472,33 @@ export function ModulesCatalog() {
               Catalogue unavailable right now.
             </p>
           ) : (
-            <ul className="mt-3 divide-y divide-rule rounded-card border border-rule/60 bg-paper shadow-panel">
-              {lawve.map((s) => (
-                <li key={s.slug} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-ink">{s.name}</p>
-                    <p className="mt-0.5 max-w-2xl truncate text-[13px] text-muted">
-                      {s.description}
-                    </p>
-                    <p className="mt-0.5 text-[11px] text-muted">
-                      {s.author_name ?? "unknown"}
-                      {s.license ? ` · ${s.license}` : ""}
-                    </p>
-                  </div>
-                  <a
-                    href={`/skills/lawve?skill=${encodeURIComponent(s.slug)}`}
-                    className="shrink-0 rounded-item border border-rule px-3 py-1.5 text-xs text-ink hover:border-ink"
-                  >
-                    Review & add →
-                  </a>
-                </li>
+            <div className="mt-1">
+              {lawve.map((s, i) => (
+                <LedgerLine
+                  key={s.slug}
+                  index={i + 1}
+                  label={s.license ?? "licence ?"}
+                  right={
+                    <a
+                      href={`/skills/lawve?skill=${encodeURIComponent(s.slug)}`}
+                      className="text-sm text-muted hover:text-seal"
+                    >
+                      Review &amp; add →
+                    </a>
+                  }
+                >
+                  <span className="text-ink">{s.name}</span>
+                  <span className="ml-2 hidden text-[12px] text-muted sm:inline">
+                    {s.author_name ?? "unknown"}
+                  </span>
+                </LedgerLine>
               ))}
-            </ul>
+            </div>
           )}
+          <Colophon>
+            Skills hold no standing until admitted — review, signature,
+            permissions, gates, then the register.
+          </Colophon>
         </section>
       )}
     </div>

--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -700,8 +700,14 @@ describe("DocumentRichEditor surface", () => {
     // Find is summoned, not standing.
     expect(screen.queryByTestId("document-editor-find-panel")).toBeNull();
     // Format tools are summoned from the single row.
-    fireEvent.click(screen.getByRole("button", { name: "Format" }));
-    expect(await screen.findByRole("button", { name: "Underline" })).toBeInTheDocument();
+    // Generous timeouts: tiptap mount under parallel CI load exceeds the
+    // 1s default (same class as the deflaked trio).
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Format" }, { timeout: 5000 }),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Underline" }, { timeout: 5000 }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Link" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove link" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Align left" })).toBeInTheDocument();
@@ -712,11 +718,14 @@ describe("DocumentRichEditor surface", () => {
     expect(screen.getByRole("button", { name: "Download text" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download DOCX" })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Copy text" }));
-    await waitFor(() => {
-      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-        expect.stringContaining("The employee was dismissed."),
-      );
-    });
+    await waitFor(
+      () => {
+        expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+          expect.stringContaining("The employee was dismissed."),
+        );
+      },
+      { timeout: 5000 },
+    );
     expect(screen.getByTestId("document-editor-copy-status")).toHaveTextContent(
       "Copied working text",
     );

--- a/frontend/src/ui/certificate.tsx
+++ b/frontend/src/ui/certificate.tsx
@@ -1,0 +1,180 @@
+/**
+ * Certificate + ledger primitives — the register idiom (DESIGN.md P27).
+ *
+ * Lifted exactly from /register (CounselRegister.tsx), the ratified
+ * reference: content renders as certificates and ledger entries, placed
+ * like a clerk filled them in. Three letterspacing tiers, never mixed:
+ * masthead rows 0.3em, card eyebrows 0.25em, ledger labels 0.18em.
+ */
+
+import type { ReactNode } from "react";
+
+/** Ruled section header — a schedule line: small caps left, count/right
+ * counterpart in ink. */
+export function SectionRule({
+  label,
+  right,
+}: {
+  label: ReactNode;
+  right?: ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline justify-between border-b border-ink pb-2">
+      <h2 className="text-[10px] uppercase tracking-[0.25em] text-muted">
+        {label}
+      </h2>
+      {right && (
+        <span className="text-[10px] uppercase tracking-[0.25em] text-ink">
+          {right}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Certificate card shell. `tone="seal"` for revoked/refused entries. */
+export function CertCard({
+  children,
+  tone = "ink",
+  testid,
+}: {
+  children: ReactNode;
+  tone?: "ink" | "seal";
+  testid?: string;
+}) {
+  return (
+    <article
+      className={
+        "relative border bg-paper p-5 " +
+        (tone === "seal" ? "border-seal/40" : "border-ink/70")
+      }
+      data-testid={testid}
+    >
+      {children}
+    </article>
+  );
+}
+
+/** Index eyebrow row: "SKILL 01" left, category/state right. */
+export function CertEyebrow({
+  left,
+  right,
+  rightTone = "muted",
+}: {
+  left: ReactNode;
+  right?: ReactNode;
+  rightTone?: "muted" | "ink" | "seal";
+}) {
+  const toneCls =
+    rightTone === "seal"
+      ? "text-seal"
+      : rightTone === "ink"
+        ? "text-ink"
+        : "text-muted";
+  return (
+    <div className="flex items-baseline justify-between">
+      <p className="text-[10px] uppercase tracking-[0.25em] text-muted">{left}</p>
+      {right != null && (
+        <p className={"text-[10px] uppercase tracking-[0.25em] " + toneCls}>
+          {right}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Ledger label/value row inside a certificate dl. */
+export function LedgerRow({
+  label,
+  children,
+  tone = "muted",
+}: {
+  label: ReactNode;
+  children: ReactNode;
+  tone?: "muted" | "ink" | "seal";
+}) {
+  const toneCls =
+    tone === "seal" ? "text-seal" : tone === "ink" ? "text-ink" : "";
+  return (
+    <div className={"flex justify-between gap-3 " + toneCls}>
+      <dt className="uppercase tracking-[0.18em]">{label}</dt>
+      <dd className="min-w-0 truncate text-right">{children}</dd>
+    </div>
+  );
+}
+
+/** Solid ink bands — what the entry may read/write, as material. */
+export function InkBands({
+  label,
+  values,
+}: {
+  label: string;
+  values: string[];
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-12 shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
+        {label}
+      </span>
+      {values.length === 0 ? (
+        <span className="text-[11px] text-muted">—</span>
+      ) : (
+        <span
+          className="flex min-w-0 flex-1 flex-wrap gap-1"
+          title={values.join(", ")}
+        >
+          {values.map((v) => (
+            <span
+              key={v}
+              className="h-2.5 bg-ink"
+              style={{ width: `${Math.min(96, 18 + v.length * 4)}px` }}
+              title={v}
+            />
+          ))}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Numbered ledger line for list pages — the admission-scan rhythm. */
+export function LedgerLine({
+  index,
+  label,
+  children,
+  right,
+  testid,
+}: {
+  index: number;
+  label?: ReactNode;
+  children: ReactNode;
+  right?: ReactNode;
+  testid?: string;
+}) {
+  return (
+    <div
+      className="flex items-baseline gap-4 border-b border-rule/60 py-2.5"
+      data-testid={testid}
+    >
+      <span className="tech-token w-10 shrink-0 text-[11px] text-muted">
+        {String(index).padStart(4, "0")}
+      </span>
+      {label != null && (
+        <span className="w-40 shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
+          {label}
+        </span>
+      )}
+      <span className="min-w-0 flex-1 text-sm text-ink">{children}</span>
+      {right != null && <span className="shrink-0">{right}</span>}
+    </div>
+  );
+}
+
+/** Closing colophon — one institutional sentence, only where earned. */
+export function Colophon({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-14 border-t border-rule pt-3 text-[10px] uppercase tracking-[0.2em] text-muted">
+      {children}
+    </p>
+  );
+}

--- a/frontend/src/ui/primitives.tsx
+++ b/frontend/src/ui/primitives.tsx
@@ -190,6 +190,7 @@ export function PageHeader({
   eyebrow,
   eyebrowRight,
   title,
+  whisper,
   subId,
   description,
   actions,
@@ -199,6 +200,7 @@ export function PageHeader({
   eyebrow?: string;
   eyebrowRight?: string;
   title: ReactNode;
+  whisper?: string;
   subId?: string;
   description?: ReactNode;
   actions?: ReactNode;
@@ -209,11 +211,11 @@ export function PageHeader({
     <header className="mb-8">
       {eyebrow && (
         <div className="flex items-baseline justify-between border-b border-ink pb-2">
-          <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
+          <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
             {eyebrow}
           </p>
           {eyebrowRight && (
-            <p className="text-[10px] uppercase tracking-[0.25em] text-ink">
+            <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
               {eyebrowRight}
             </p>
           )}
@@ -224,15 +226,28 @@ export function PageHeader({
           <h1
             className={
               display
-                ? "font-redaction35 text-[40px] leading-none tracking-tight2 text-ink sm:text-[52px]"
+                ? "font-redaction35 text-[52px] leading-none tracking-tight2 text-ink sm:text-[64px]"
                 : "text-[26px] leading-tight tracking-tight2 text-ink sm:text-[30px]"
             }
           >
             {title}
           </h1>
+          {whisper && (
+            <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-muted">
+              {whisper}
+            </p>
+          )}
           {subId && <p className="mt-2 tech-token text-xs text-muted">{subId}</p>}
           {description && (
-            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted">{description}</p>
+            <p
+              className={
+                display
+                  ? "mt-7 max-w-xl text-sm leading-relaxed text-prose"
+                  : "mt-3 max-w-2xl text-sm leading-relaxed text-muted"
+              }
+            >
+              {description}
+            </p>
           )}
         </div>
         {actions && <div className="shrink-0 pb-1">{actions}</div>}


### PR DESCRIPTION
## P27 — the page bodies finally match the masthead
Ratified direction: /register IS the design language. New shared primitives (`ui/certificate.tsx`) lifted exactly from the register; every section page re-anatomied: monument + whisper + serif prose intro, then content as **certificates and numbered ledgers** — /skills as Schedule A/B, the matters list as the cause list, admin as the roll of practitioners, skill detail as the skill's own certificate, demo files/skills in the same anatomy. Spec in DESIGN.md P27 with exact values; fan-out by 3-agent fleet over the hand-built /skills exemplar; 296 tests green.

## The WebKit pass found a production bug
All surfaces + editor behaviour pass on WebKit (typing, ⌘F, tracked-changes CSS). Its console audit caught **'Maximum update depth exceeded' on the matter chat page — engine-agnostic and live in prod**: `useRoute()`'s selector returned a fresh object every router tick, re-rendering every consumer and cascading the `[route]`-dep effects. Fixed at the source (select primitives, memo the Route) — this also cuts global re-render churn on every page.

Also: editor P25 command-bar test deflaked (parallel-load class), matters-count pluralisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced consistent page layout structure ("register idiom") across admin, settings, catalog, and help sections with certificate cards and ledger-style lists.
  * Added page header subtitles (whisper text) to improve section context.

* **Style**
  * Redesigned matter list, module catalog, and admin pages with modernized card and ledger layouts.
  * Updated section headers and typography throughout the app.

* **Performance**
  * Optimized route handling to reduce unnecessary re-renders.

* **Documentation**
  * Added design specification for new page anatomy standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->