### PR TITLE
P27 finish: matter inner surfaces, artifacts as certificates, auth masthead

### DIFF
--- a/frontend/src/auth/AuthCard.tsx
+++ b/frontend/src/auth/AuthCard.tsx
@@ -1,7 +1,13 @@
 import type { ReactNode } from "react";
 
+/**
+ * Auth shell — light Standing Order alignment (DESIGN.md P27).
+ * Ruled eyebrow row above the title (masthead tier, 0.3em), then the
+ * heading and a bordered card. Quiet by design: no monument headline,
+ * no seal — the registrar's desk, not the register itself.
+ */
 export function AuthCard({
-  eyebrow: _eyebrow,
+  eyebrow,
   heading,
   intro,
   children,
@@ -13,11 +19,48 @@ export function AuthCard({
 }) {
   return (
     <div className="max-w-md mx-auto px-4 sm:px-6 py-16">
+      {eyebrow && (
+        <div className="mb-8 flex items-baseline justify-between border-b border-ink pb-2">
+          <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
+            {eyebrow}
+          </p>
+          <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
+            Legalise
+          </p>
+        </div>
+      )}
       <h1 className="text-3xl sm:text-4xl font-bold tracking-tight2 text-ink mb-4 leading-[1.1]">
         {heading}
       </h1>
       {intro && <p className="prose-p mb-8">{intro}</p>}
       <div className="border border-rule p-6 sm:p-8">{children}</div>
     </div>
+  );
+}
+
+/** Form field with a ledger-tier label (0.18em — the dl-label tier). */
+export function LedgerField({
+  label,
+  hint,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  htmlFor?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label htmlFor={htmlFor} className="flex flex-col gap-2">
+      <span className="text-[10px] uppercase tracking-[0.18em] text-muted">
+        {label}
+        {hint && (
+          <span className="ml-2 text-xs normal-case tracking-normal">
+            ({hint})
+          </span>
+        )}
+      </span>
+      {children}
+    </label>
   );
 }

--- a/frontend/src/auth/ForgotPassword.tsx
+++ b/frontend/src/auth/ForgotPassword.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { forgotPassword } from "../lib/api";
-import { AuthCard } from "./AuthCard";
-import { ErrorCallout, Field, inputCls, primaryBtn } from "../ui/primitives";
+import { AuthCard, LedgerField } from "./AuthCard";
+import { ErrorCallout, inputCls, primaryBtn } from "../ui/primitives";
 
 export function ForgotPassword() {
   const [email, setEmail] = useState("");
@@ -27,11 +27,11 @@ export function ForgotPassword() {
   if (sent) {
     return (
       <AuthCard
-        eyebrow="AUTH - FORGOT PASSWORD"
+        eyebrow="The workspace"
         heading="Check your email"
         intro="If an account exists for that address, a reset link is on its way."
       >
-        <a href="/auth/signin" className="text-sm text-muted hover:text-ink">
+        <a href="/auth/signin" className="text-sm text-muted hover:text-seal">
           Back to sign in
         </a>
       </AuthCard>
@@ -40,12 +40,12 @@ export function ForgotPassword() {
 
   return (
     <AuthCard
-      eyebrow="AUTH - FORGOT PASSWORD"
+      eyebrow="The workspace"
       heading="Reset your password"
       intro="Enter your account email. We'll send a one-time reset link."
     >
       <form className="flex flex-col gap-6" onSubmit={submit}>
-        <Field label="Email">
+        <LedgerField label="Email">
           <input
             type="email"
             autoComplete="email"
@@ -54,14 +54,14 @@ export function ForgotPassword() {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             className={inputCls}
           />
-        </Field>
+        </LedgerField>
         {error && <ErrorCallout message={error} />}
         <button type="submit" disabled={busy} className={primaryBtn}>
           {busy ? "Sending…" : "Send reset link"}
         </button>
       </form>
       <p className="text-sm text-muted mt-6">
-        <a href="/auth/signin" className="hover:text-ink underline">
+        <a href="/auth/signin" className="hover:text-seal underline">
           Back to sign in
         </a>
       </p>

--- a/frontend/src/auth/ResetPassword.tsx
+++ b/frontend/src/auth/ResetPassword.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { resetPassword } from "../lib/api";
-import { AuthCard } from "./AuthCard";
-import { ErrorCallout, Field, inputCls, primaryBtn } from "../ui/primitives";
+import { AuthCard, LedgerField } from "./AuthCard";
+import { ErrorCallout, inputCls, primaryBtn } from "../ui/primitives";
 
 export function ResetPassword({ token }: { token: string | null }) {
   const [password, setPassword] = useState("");
@@ -31,11 +31,11 @@ export function ResetPassword({ token }: { token: string | null }) {
   if (!token) {
     return (
       <AuthCard
-        eyebrow="AUTH - RESET PASSWORD"
+        eyebrow="The workspace"
         heading="Missing token"
         intro="This page expects a one-time token from the reset email link."
       >
-        <a href="/auth/forgot" className="text-sm text-muted hover:text-ink">
+        <a href="/auth/forgot" className="text-sm text-muted hover:text-seal">
           Request a new reset link
         </a>
       </AuthCard>
@@ -45,7 +45,7 @@ export function ResetPassword({ token }: { token: string | null }) {
   if (done) {
     return (
       <AuthCard
-        eyebrow="AUTH - RESET PASSWORD"
+        eyebrow="The workspace"
         heading="Password updated"
         intro="Your new password is set. Sign in to continue."
       >
@@ -58,12 +58,12 @@ export function ResetPassword({ token }: { token: string | null }) {
 
   return (
     <AuthCard
-      eyebrow="AUTH - RESET PASSWORD"
+      eyebrow="The workspace"
       heading="Choose a new password"
       intro="At least 8 characters. The reset link expires soon, so finish here."
     >
       <form className="flex flex-col gap-6" onSubmit={submit}>
-        <Field label="New password">
+        <LedgerField label="New password">
           <input
             type="password"
             autoComplete="new-password"
@@ -73,7 +73,7 @@ export function ResetPassword({ token }: { token: string | null }) {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
             className={inputCls}
           />
-        </Field>
+        </LedgerField>
         {error && <ErrorCallout message={error} />}
         <button type="submit" disabled={busy} className={primaryBtn}>
           {busy ? "Updating…" : "Update password"}

--- a/frontend/src/auth/SignIn.tsx
+++ b/frontend/src/auth/SignIn.tsx
@@ -3,8 +3,8 @@ import type { ChangeEvent, FormEvent } from "react";
 import { navigate } from "../lib/route";
 import { requestVerifyToken } from "../lib/api";
 import { useAuth } from "./AuthProvider";
-import { AuthCard } from "./AuthCard";
-import { ErrorCallout, Field, inputCls, primaryBtn } from "../ui/primitives";
+import { AuthCard, LedgerField } from "./AuthCard";
+import { ErrorCallout, inputCls, primaryBtn } from "../ui/primitives";
 
 type ResendState = "idle" | "sending" | "sent" | "error";
 
@@ -58,9 +58,9 @@ export function SignIn() {
   };
 
   return (
-    <AuthCard eyebrow="AUTH - SIGN IN" heading="Sign in" intro="Bring your own Anthropic or OpenAI key after signing in.">
+    <AuthCard eyebrow="The workspace" heading="Sign in" intro="Bring your own Anthropic or OpenAI key after signing in.">
       <form className="flex flex-col gap-6" onSubmit={submit}>
-        <Field label="Email" htmlFor="signin-email">
+        <LedgerField label="Email" htmlFor="signin-email">
           <input
             id="signin-email"
             name="email"
@@ -71,8 +71,8 @@ export function SignIn() {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             className={inputCls}
           />
-        </Field>
-        <Field label="Password" htmlFor="signin-password">
+        </LedgerField>
+        <LedgerField label="Password" htmlFor="signin-password">
           <input
             id="signin-password"
             name="password"
@@ -83,7 +83,7 @@ export function SignIn() {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
             className={inputCls}
           />
-        </Field>
+        </LedgerField>
         {error && <ErrorCallout message={error} />}
         {needsVerify && (
           <div className="rounded-md border border-rule bg-wash p-4 text-sm">

--- a/frontend/src/auth/SignUp.tsx
+++ b/frontend/src/auth/SignUp.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { navigate } from "../lib/route";
 import { useAuth } from "./AuthProvider";
-import { AuthCard } from "./AuthCard";
-import { ErrorCallout, Field, inputCls, primaryBtn } from "../ui/primitives";
+import { AuthCard, LedgerField } from "./AuthCard";
+import { ErrorCallout, inputCls, primaryBtn } from "../ui/primitives";
 
 export function SignUp() {
   const auth = useAuth();
@@ -34,12 +34,12 @@ export function SignUp() {
 
   return (
     <AuthCard
-      eyebrow="AUTH - SIGN UP"
+      eyebrow="Before the registrar"
       heading="Sign up"
       intro="Create a workspace. You'll add an Anthropic or OpenAI key after email verification."
     >
       <form className="flex flex-col gap-6" onSubmit={submit}>
-        <Field label="Name" hint="optional - shown in audit rows">
+        <LedgerField label="Name" hint="optional - shown in audit rows">
           <input
             type="text"
             autoComplete="name"
@@ -47,8 +47,8 @@ export function SignUp() {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
             className={inputCls}
           />
-        </Field>
-        <Field label="Email">
+        </LedgerField>
+        <LedgerField label="Email">
           <input
             type="email"
             autoComplete="email"
@@ -57,8 +57,8 @@ export function SignUp() {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
             className={inputCls}
           />
-        </Field>
-        <Field label="Password" hint="at least 8 characters">
+        </LedgerField>
+        <LedgerField label="Password" hint="at least 8 characters">
           <input
             type="password"
             autoComplete="new-password"
@@ -68,7 +68,7 @@ export function SignUp() {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
             className={inputCls}
           />
-        </Field>
+        </LedgerField>
         {error && <ErrorCallout message={error} />}
         <button type="submit" disabled={busy} className={primaryBtn}>
           {busy ? "Creating account…" : "Create account"}

--- a/frontend/src/auth/Verify.tsx
+++ b/frontend/src/auth/Verify.tsx
@@ -40,7 +40,7 @@ export function Verify({ token }: { token: string | null }) {
 
   if (status === "pending") {
     return (
-      <AuthCard eyebrow="AUTH - VERIFY EMAIL" heading="Verifying…">
+      <AuthCard eyebrow="Before the registrar" heading="Verifying…">
         <LoadingLine label="checking your token" />
       </AuthCard>
     );
@@ -49,7 +49,7 @@ export function Verify({ token }: { token: string | null }) {
   if (status === "ok") {
     return (
       <AuthCard
-        eyebrow="AUTH - VERIFY EMAIL"
+        eyebrow="Before the registrar"
         heading="Email verified"
         intro="Your account is active. Open your workspace to get started."
       >
@@ -61,10 +61,10 @@ export function Verify({ token }: { token: string | null }) {
   }
 
   return (
-    <AuthCard eyebrow="AUTH - VERIFY EMAIL" heading="Verification failed">
+    <AuthCard eyebrow="Before the registrar" heading="Verification failed">
       {error && <ErrorCallout message={error} />}
       <p className="text-sm text-muted mt-6">
-        <a href="/auth/verify-pending" className="hover:text-ink underline">
+        <a href="/auth/verify-pending" className="hover:text-seal underline">
           Request a new link
         </a>
       </p>

--- a/frontend/src/auth/VerifyPending.tsx
+++ b/frontend/src/auth/VerifyPending.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { requestVerifyToken } from "../lib/api";
 import { useAuth } from "./AuthProvider";
-import { AuthCard } from "./AuthCard";
-import { ErrorCallout, Field, inputCls, primaryBtn } from "../ui/primitives";
+import { AuthCard, LedgerField } from "./AuthCard";
+import { ErrorCallout, inputCls, primaryBtn } from "../ui/primitives";
 
 export function VerifyPending() {
   const auth = useAuth();
@@ -29,7 +29,7 @@ export function VerifyPending() {
 
   return (
     <AuthCard
-      eyebrow="AUTH - VERIFY EMAIL"
+      eyebrow="Before the registrar"
       heading="Check your inbox"
       intro="We sent a verification link to your email. Click it to activate your account."
     >
@@ -37,7 +37,7 @@ export function VerifyPending() {
         <p className="prose-p mb-0">A new link is on its way.</p>
       ) : (
         <form className="flex flex-col gap-6" onSubmit={resend}>
-          <Field label="Email" hint="resend the link if needed">
+          <LedgerField label="Email" hint="resend the link if needed">
             <input
               type="email"
               required
@@ -45,7 +45,7 @@ export function VerifyPending() {
               onChange={(e: ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
               className={inputCls}
             />
-          </Field>
+          </LedgerField>
           {error && <ErrorCallout message={error} />}
           <button type="submit" disabled={busy || !email} className={primaryBtn}>
             {busy ? "Sending…" : "Resend link"}
@@ -53,7 +53,7 @@ export function VerifyPending() {
         </form>
       )}
       <p className="text-sm text-muted mt-6">
-        <a href="/auth/signin" className="hover:text-ink underline">
+        <a href="/auth/signin" className="hover:text-seal underline">
           Back to sign in
         </a>
       </p>

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -3,6 +3,9 @@
  *
  * Hits `GET /api/matters/{slug}/artifacts/{id}` (returns ArtifactSummary
  * fields + parsed `payload`). Kind-aware rendering via ArtifactPreview.
+ * The header block is the artifact's certificate (DESIGN.md P27): a
+ * CertCard with the kind eyebrow, 22px title, and a ledger of
+ * created / prepared-by / sign-off status / pinned hash.
  *
  * Deep-link to Activity: this page links to the legacy audit route,
  * `/matters/{slug}/audit?invocation_id=<id>`. The query-param contract
@@ -22,7 +25,8 @@ import {
   type Signoff,
 } from "../lib/api";
 import { ArtifactPreview } from "./ArtifactPreview";
-import { DescItem as DT, PageHeader } from "../ui/primitives";
+import { DescItem as DT } from "../ui/primitives";
+import { CertCard, CertEyebrow, LedgerRow, SectionRule } from "../ui/certificate";
 
 type Query =
   | { status: "loading" }
@@ -111,17 +115,58 @@ export function ArtifactDetail({
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
-      <PageHeader
-        eyebrow="A signed output"
-        title={outputLabel(a.kind)}
-        subId={a.id}
-        description="Review the output, check its sources, and sign it when you are ready to take professional ownership."
-      />
+      {/* The artifact's certificate header — its entry in the record
+          (DESIGN.md P27). Inner surface: the matter shell owns the page,
+          so the header is a CertCard, not a masthead. */}
+      <CertCard testid="artifact-cert">
+        <CertEyebrow left="Output" right={a.kind} />
+        <h1 className="mt-3 text-[22px] leading-tight tracking-tight2">
+          {outputLabel(a.kind)}
+        </h1>
+        <p className="mt-1 tech-token text-[11px] text-muted">{a.id}</p>
+        <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
+          <LedgerRow label="Created">
+            {a.created_at.replace("T", " ").slice(0, 19)}
+          </LedgerRow>
+          <LedgerRow label="Prepared by">
+            <span className="tech-token">
+              {a.module_id} · {a.capability_id}
+            </span>
+          </LedgerRow>
+          <LedgerRow
+            label="Sign-off"
+            tone={
+              signoff == null
+                ? "muted"
+                : signoff.decision === "rejected"
+                  ? "seal"
+                  : "ink"
+            }
+          >
+            {signoff === undefined
+              ? "Checking…"
+              : signoff === null
+                ? "Draft — unsigned"
+                : signoff.decision === "rejected"
+                  ? "Rejected"
+                  : signoff.decision === "signed_with_observations"
+                    ? "Signed with observations"
+                    : "Signed"}
+          </LedgerRow>
+          {signoff != null && (
+            <LedgerRow label="Hash (pinned)">
+              <span className="tech-token" title={signoff.artifact_hash}>
+                {signoff.artifact_hash}
+              </span>
+            </LedgerRow>
+          )}
+        </dl>
+      </CertCard>
 
       {/* Sign-off status + the hero action. Author sign-off (distinct from
           supervisor review): the solicitor takes ownership of this output. */}
-      <section className="mt-8 rounded-card border border-rule bg-paper p-4" data-testid="signoff-status">
-        <h2 className="text-sm uppercase tracking-widest text-muted">Sign-off</h2>
+      <section className="mt-10" data-testid="signoff-status">
+        <SectionRule label="Sign-off" />
         {signoff === undefined ? (
           <p className="mt-2 text-sm text-muted">Checking sign-off status…</p>
         ) : signoff === null ? (
@@ -149,7 +194,7 @@ export function ArtifactDetail({
           <Link
             to="/matters/$slug/artifacts/$artifactId/sign"
             params={{ slug, artifactId }}
-            className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-sm text-paper hover:bg-seal"
+            className="inline-flex items-center bg-ink px-4 py-2 text-sm text-paper hover:bg-seal"
             data-testid="signoff-cta"
           >
             {signoff ? "Review & sign again" : "Review & sign"}
@@ -166,16 +211,14 @@ export function ArtifactDetail({
         </div>
       </section>
 
-      <section className="mt-8">
-        <h2 className="text-sm uppercase tracking-widest text-muted">
-          Output
-        </h2>
+      <section className="mt-10">
+        <SectionRule label="The output" />
         <ArtifactPreview payload={a.payload} kindHint={a.kind} matterSlug={slug} />
       </section>
 
       {REVIEW_ELIGIBLE_KINDS.includes(a.kind) && (
-        <details className="mt-8 rounded-card border border-rule p-4">
-          <summary className="cursor-pointer text-sm uppercase tracking-widest text-muted">
+        <details className="mt-8 border border-rule p-4">
+          <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted">
             Optional separate review
           </summary>
           <div className="mt-3">
@@ -210,7 +253,7 @@ export function ArtifactDetail({
                     }
                   }}
                   disabled={review.kind === "busy"}
-                  className="mt-3 inline-flex items-center rounded-md bg-ink px-4 py-2 text-sm text-paper hover:bg-seal disabled:opacity-50"
+                  className="mt-3 inline-flex items-center bg-ink px-4 py-2 text-sm text-paper hover:bg-seal disabled:opacity-50"
                 >
                   {review.kind === "busy" ? "Requesting…" : "Request review"}
                 </button>
@@ -224,7 +267,7 @@ export function ArtifactDetail({
       )}
 
       <details className="mt-8 border border-line bg-paper-sunken p-4">
-        <summary className="cursor-pointer text-sm uppercase tracking-widest text-muted">
+        <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted">
           Technical record
         </summary>
         <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-2 text-sm">

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -2,9 +2,14 @@
  * Outputs list page — `/matters/{slug}/artifacts`.
  *
  * Hits `GET /api/matters/{slug}/artifacts` and renders the list as a
- * table, with a per-row sign-off badge (Draft / Signed / Signed
- * (obs.) / Rejected) derived from current sign-offs. The substrate
- * returns rows desc by created_at, so no client-side sort is needed.
+ * ledger (DESIGN.md P27): each artifact is a numbered LedgerLine with
+ * its kind as the 0.18em label and the current sign-off status as a
+ * small-caps mark on the right (Draft / Signed / Signed · obs. /
+ * Rejected) derived from current sign-offs. The substrate returns rows
+ * desc by created_at, so no client-side sort is needed.
+ *
+ * This is an inner matter surface — the matter shell owns the page, so
+ * there is no masthead here, only the SectionRule + ledger anatomy.
  *
  * Audit-trail deep-links live on artifact detail, not on this list.
  * Reads do NOT emit audit (substrate-verified at artifacts.py).
@@ -13,7 +18,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { listArtifacts, listSignoffs, type ArtifactSummary } from "../lib/api";
-import { PageHeader } from "../ui/primitives";
+import { LedgerLine, SectionRule } from "../ui/certificate";
 
 type Query =
   | { status: "loading" }
@@ -38,24 +43,35 @@ function outputLabel(kind: string): string {
   }
 }
 
-function SignoffBadge({ decision }: { decision: string | undefined }) {
-  if (decision === "signed" || decision === "signed_with_observations") {
-    return (
-      <span className="inline-flex items-center rounded-full border border-ink px-2 py-0.5 text-[11px] text-ink">
-        {decision === "signed_with_observations" ? "Signed (obs.)" : "Signed"}
-      </span>
-    );
-  }
-  if (decision === "rejected") {
-    return (
-      <span className="inline-flex items-center rounded-full border border-seal/50 px-2 py-0.5 text-[11px] text-seal">
-        Rejected
-      </span>
-    );
-  }
+// Small-caps sign-off mark for the ledger's right column. Signed states
+// read in ink; rejected carries the seal; unsigned drafts stay muted.
+function SignoffMark({
+  id,
+  decision,
+}: {
+  id: string;
+  decision: string | undefined;
+}) {
+  const label =
+    decision === "signed"
+      ? "Signed"
+      : decision === "signed_with_observations"
+        ? "Signed · obs."
+        : decision === "rejected"
+          ? "Rejected"
+          : "Draft";
+  const tone =
+    decision === "rejected"
+      ? "text-seal"
+      : decision
+        ? "text-ink"
+        : "text-muted";
   return (
-    <span className="inline-flex items-center rounded-full border border-line px-2 py-0.5 text-[11px] text-muted">
-      Draft
+    <span
+      className={"text-[10px] uppercase tracking-[0.18em] " + tone}
+      data-testid={`signoff-badge-${id}`}
+    >
+      {label}
     </span>
   );
 }
@@ -90,71 +106,56 @@ export function ArtifactsList({ slug }: { slug: string }) {
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
-      <PageHeader
-        eyebrow="Signed work of the matter"
-        title="Signed outputs"
-        subId={slug}
+      <SectionRule
+        label="Signed outputs"
+        right={q.status === "ready" ? String(q.rows.length) : undefined}
       />
 
       {q.status === "loading" && (
-        <p className="mt-8 text-sm text-muted">Loading signed outputs…</p>
+        <p className="mt-4 text-sm text-muted">Loading signed outputs…</p>
       )}
       {q.status === "error" && (
-        <p className="mt-8 text-sm text-seal">
+        <p className="mt-4 text-sm text-seal">
           Could not load signed outputs: {q.message}
         </p>
       )}
       {q.status === "ready" && q.rows.length === 0 && (
-        <p className="mt-8 text-sm text-muted">
+        <p className="mt-4 text-sm text-muted">
           No signed outputs yet on this matter. Run a skill to produce one.
         </p>
       )}
       {q.status === "ready" && q.rows.length > 0 && (
-        <div className="mt-8 overflow-x-auto rounded-md border border-line">
-          <table className="min-w-full text-sm">
-            <thead className="text-[10px] uppercase tracking-[0.18em] text-muted">
-              <tr className="border-b border-ink">
-                <th className="px-3 py-2 text-left">Output</th>
-                <th className="px-3 py-2 text-left">Sign-off</th>
-                <th className="px-3 py-2 text-left">Produced by</th>
-                <th className="px-3 py-2 text-left">Created</th>
-                <th className="px-3 py-2 text-right"> </th>
-              </tr>
-            </thead>
-            <tbody>
-              {q.rows.map((r) => (
-                <tr key={r.id} className="border-t border-line">
-                  <td className="px-3 py-2">
-                    <span className="font-medium">{outputLabel(r.kind)}</span>
-                    <span className="mt-0.5 block tech-token text-[11px] text-muted">
-                      {r.kind}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2" data-testid={`signoff-badge-${r.id}`}>
-                    <SignoffBadge decision={signoffs.get(r.id)} />
-                  </td>
-                  <td className="px-3 py-2">
-                    <span className="tech-token text-xs">{r.module_id}</span>
-                    <span className="mt-0.5 block tech-token text-[11px] text-muted">
-                      {r.capability_id}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2 text-xs text-muted">
-                    {r.created_at.slice(0, 19).replace("T", " ")}
-                  </td>
-                  <td className="px-3 py-2 text-right">
-                    <Link
-                      to="/matters/$slug/artifacts/$artifactId"
-                      params={{ slug, artifactId: r.id }}
-                      className="text-xs underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-                    >
-                      Open
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="mt-1">
+          {q.rows.map((r, i) => (
+            <LedgerLine
+              key={r.id}
+              index={i + 1}
+              label={r.kind}
+              right={
+                <span className="flex items-baseline gap-3">
+                  <SignoffMark id={r.id} decision={signoffs.get(r.id)} />
+                  <span className="hidden tech-token text-[11px] text-muted sm:inline">
+                    {r.created_at.slice(0, 10)}
+                  </span>
+                  <Link
+                    to="/matters/$slug/artifacts/$artifactId"
+                    params={{ slug, artifactId: r.id }}
+                    className="text-[11px] text-muted hover:text-seal"
+                  >
+                    Open →
+                  </Link>
+                </span>
+              }
+            >
+              <span className="text-ink">{outputLabel(r.kind)}</span>
+              <span className="ml-2 hidden tech-token text-[11px] text-muted sm:inline">
+                {r.module_id}
+              </span>
+              <span className="ml-1 hidden tech-token text-[11px] text-muted sm:inline">
+                {r.capability_id}
+              </span>
+            </LedgerLine>
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1471,22 +1471,22 @@ export function DocumentDetail({
               data-testid="document-next-step"
             >
               <details
-                className="mt-3 rounded-card border border-rule bg-paper-sunken p-3"
+                className="mt-3"
                 data-testid="document-review-queue"
                 open={reviewQueueTotal > 0}
               >
-                <summary className="cursor-pointer text-sm font-semibold text-ink">
+                <summary className="cursor-pointer border-b border-ink pb-2 text-[10px] uppercase tracking-[0.25em] text-muted">
                   {reviewQueueTotal === 0
                     ? "Nothing waiting in the review queue"
                     : `${reviewQueueTotal} review item${
                         reviewQueueTotal === 1 ? "" : "s"
                       } waiting`}
                 </summary>
-                <div className="mt-3 grid gap-2 text-sm">
+                <div className="mt-1 grid text-sm">
                   <button
                     type="button"
                     onClick={() => openWorkbenchView(activeEditResult ? "redlines" : "versions")}
-                    className="flex items-center justify-between rounded-item border border-rule bg-paper px-3 py-2 text-left hover:border-ink"
+                    className="flex items-baseline justify-between border-b border-rule/60 py-2.5 text-left hover:text-seal"
                   >
                     <span>Proposed redlines</span>
                     <span className="font-semibold text-ink">{pendingEdits}</span>
@@ -1496,7 +1496,7 @@ export function DocumentDetail({
                     onClick={() =>
                       notesRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" })
                     }
-                    className="flex items-center justify-between rounded-item border border-rule bg-paper px-3 py-2 text-left hover:border-ink"
+                    className="flex items-baseline justify-between border-b border-rule/60 py-2.5 text-left hover:text-seal"
                   >
                     <span>Open review notes</span>
                     <span className="font-semibold text-ink">{openComments.length}</span>
@@ -1504,13 +1504,13 @@ export function DocumentDetail({
                   <button
                     type="button"
                     onClick={() => openWorkbenchView("versions")}
-                    className="flex items-center justify-between rounded-item border border-rule bg-paper px-3 py-2 text-left hover:border-ink"
+                    className="flex items-baseline justify-between border-b border-rule/60 py-2.5 text-left hover:text-seal"
                   >
                     <span>Saved versions</span>
                     <span className="font-semibold text-ink">{versions.length}</span>
                   </button>
                   {activeEditSessions.length > 1 && (
-                    <p className="border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
+                    <p className="mt-3 border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
                       Another session is open. Coordinate before saving a new version.
                     </p>
                   )}
@@ -1525,7 +1525,7 @@ export function DocumentDetail({
             >
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                  <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
                     Document skills
                   </p>
                   <h2 className="mt-1 text-sm font-semibold text-ink">
@@ -1535,7 +1535,7 @@ export function DocumentDetail({
                     Skills use the same project runner as Chat, with {doc.filename} already in context.
                   </p>
                 </div>
-                <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
                   {documentSkills.length === 0
                     ? "No skills"
                     : `${documentSkills.length} ready`}
@@ -1610,7 +1610,7 @@ export function DocumentDetail({
                               "Runs against this document and writes an output to Activity."}
                           </span>
                         </span>
-                        <span className="shrink-0 rounded-item border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
+                        <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
                           Recommended
                         </span>
                       </span>
@@ -1623,17 +1623,17 @@ export function DocumentDetail({
                     </button>
                   )}
                   {secondaryDocumentSkills.length > 0 && (
-                    <details className="rounded-card border border-rule bg-paper-sunken p-3">
-                      <summary className="cursor-pointer text-sm font-medium text-ink">
+                    <details>
+                      <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted hover:text-ink">
                         More document skills ({secondaryDocumentSkills.length})
                       </summary>
-                      <div className="mt-3 space-y-2">
+                      <div className="mt-1">
                         {secondaryDocumentSkills.map((skill) => (
                           <button
                             key={`${skill.moduleId}:${skill.capabilityId}`}
                             type="button"
                             onClick={() => openDocumentSkill(skill)}
-                            className="w-full rounded-item border border-rule bg-paper px-3 py-2 text-left hover:border-ink"
+                            className="w-full border-b border-rule/60 py-2.5 text-left hover:text-seal"
                           >
                             <span className="block text-sm font-semibold text-ink">
                               {skill.title}
@@ -1667,13 +1667,13 @@ export function DocumentDetail({
               <summary className="cursor-pointer list-none">
                 <span className="flex items-start justify-between gap-3">
                   <span>
-                    <span className="block text-sm font-semibold text-ink">Suggest edits</span>
+                    <span className="block text-[10px] uppercase tracking-[0.25em] text-muted">Suggest edits</span>
                     <span className="mt-1 block text-sm leading-6 text-muted">
                       Ask the model to propose redlines. Nothing changes until you review and save.
                     </span>
                   </span>
                   {activeEditResult && (
-                    <span className="shrink-0 rounded-item border border-ink bg-paper px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-ink">
+                    <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-ink">
                       Ready
                     </span>
                   )}
@@ -1686,7 +1686,7 @@ export function DocumentDetail({
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                      <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
                         Redlines ready
                       </p>
                       <p className="mt-1 text-sm font-semibold text-ink">
@@ -1738,41 +1738,41 @@ export function DocumentDetail({
               <summary className="cursor-pointer list-none">
                 <span className="flex items-start justify-between gap-3">
                   <span>
-                    <span className="block text-sm font-semibold text-ink">File state</span>
+                    <span className="block text-[10px] uppercase tracking-[0.25em] text-muted">File state</span>
                     <span className="mt-1 block text-sm leading-6 text-muted">
                       Versions, people, redaction, and file details.
                     </span>
                   </span>
-                  <span className="shrink-0 rounded-item border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                  <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
                     v{latestVersion?.version_number ?? 1}
                   </span>
                 </span>
               </summary>
-              <dl className="mt-4 grid grid-cols-3 gap-2 text-center text-xs">
-                <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                  <dt className="uppercase tracking-track2 text-muted">Pending</dt>
-                  <dd className="mt-1 text-lg font-semibold text-ink">{pendingEdits}</dd>
+              <dl className="mt-4 space-y-1 text-[11px] text-muted">
+                <div className="flex justify-between gap-3 border-b border-rule/60 py-1">
+                  <dt className="uppercase tracking-[0.18em]">Pending</dt>
+                  <dd className="font-semibold text-ink">{pendingEdits}</dd>
                 </div>
-                <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                  <dt className="uppercase tracking-track2 text-muted">Accepted</dt>
-                  <dd className="mt-1 text-lg font-semibold text-ink">{acceptedEdits}</dd>
+                <div className="flex justify-between gap-3 border-b border-rule/60 py-1">
+                  <dt className="uppercase tracking-[0.18em]">Accepted</dt>
+                  <dd className="font-semibold text-ink">{acceptedEdits}</dd>
                 </div>
-                <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                  <dt className="uppercase tracking-track2 text-muted">Rejected</dt>
-                  <dd className="mt-1 text-lg font-semibold text-ink">{rejectedEdits}</dd>
+                <div className="flex justify-between gap-3 border-b border-rule/60 py-1">
+                  <dt className="uppercase tracking-[0.18em]">Rejected</dt>
+                  <dd className="font-semibold text-ink">{rejectedEdits}</dd>
                 </div>
               </dl>
               <div className="mt-4 space-y-3 text-sm">
-                <details className="rounded-card border border-rule bg-paper-sunken p-3" open={hasConcurrentSession}>
-                  <summary className="cursor-pointer font-medium text-ink">
+                <details open={hasConcurrentSession}>
+                  <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted hover:text-ink">
                     Editing now · {activeEditSessions.length || 1} active
                   </summary>
-                  <div className="mt-3 space-y-2">
+                  <div className="mt-1">
                     {activeEditSessions.length > 0 ? (
                       activeEditSessions.map((session) => (
                         <div
                           key={session.id}
-                          className="flex items-center justify-between gap-3 rounded-item border border-rule bg-paper px-3 py-2 text-sm"
+                          className="flex items-baseline justify-between gap-3 border-b border-rule/60 py-2.5 text-sm"
                         >
                           <span className="font-medium text-ink">{session.user_label}</span>
                           <span className="text-xs text-muted">
@@ -1781,18 +1781,18 @@ export function DocumentDetail({
                         </div>
                       ))
                     ) : (
-                      <p className="text-sm text-muted">You are editing this document.</p>
+                      <p className="py-2 text-sm text-muted">You are editing this document.</p>
                     )}
                     {hasConcurrentSession && (
-                      <p className="border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
+                      <p className="mt-3 border border-amber-300 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900">
                         Another session is active. Agree who saves the next version before applying edits.
                       </p>
                     )}
                   </div>
                 </details>
 
-                <details className="rounded-card border border-rule bg-paper-sunken p-3">
-                  <summary className="cursor-pointer font-medium text-ink">
+                <details>
+                  <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted hover:text-ink">
                     Redaction
                   </summary>
                   <p className="mt-3 text-sm text-muted">
@@ -1808,16 +1808,16 @@ export function DocumentDetail({
                   </div>
                 </details>
 
-                <div className="rounded-card border border-rule bg-paper-sunken p-3">
+                <div>
                   <button
                     type="button"
                     onClick={() => setShowDetails((v) => !v)}
                     aria-expanded={showDetails}
                     data-testid="document-details-toggle"
-                    className="flex w-full items-center justify-between text-left font-medium text-ink"
+                    className="flex w-full items-baseline justify-between text-left text-[10px] uppercase tracking-[0.18em] text-muted hover:text-ink"
                   >
                     <span>File details</span>
-                    <span aria-hidden="true" className="text-xs text-muted">
+                    <span aria-hidden="true" className="normal-case tracking-normal text-xs text-muted">
                       {showDetails ? "Hide" : "Show"}
                     </span>
                   </button>
@@ -1853,32 +1853,32 @@ export function DocumentDetail({
             >
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <h2 className="text-sm font-semibold text-ink">Review notes</h2>
+                  <h2 className="text-[10px] uppercase tracking-[0.25em] text-muted">Review notes</h2>
                   <p className="mt-1 text-sm leading-6 text-muted">
                     Mark points for human review. Select text in the editor to anchor a note
                     to the current document body.
                   </p>
                 </div>
-                <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
                   {openComments.length} open
                 </span>
               </div>
-              <dl className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
-                <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                  <dt className="uppercase tracking-track2 text-muted">Open</dt>
-                  <dd className="mt-1 text-base font-semibold text-ink">
+              <dl className="mt-3 space-y-1 text-[11px] text-muted">
+                <div className="flex justify-between gap-3 border-b border-rule/60 py-1">
+                  <dt className="uppercase tracking-[0.18em]">Open</dt>
+                  <dd className="font-semibold text-ink">
                     {openComments.length}
                   </dd>
                 </div>
-                <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                  <dt className="uppercase tracking-track2 text-muted">Anchored</dt>
-                  <dd className="mt-1 text-base font-semibold text-ink">
+                <div className="flex justify-between gap-3 border-b border-rule/60 py-1">
+                  <dt className="uppercase tracking-[0.18em]">Anchored</dt>
+                  <dd className="font-semibold text-ink">
                     {anchoredComments.length}
                   </dd>
                 </div>
-                <div className="rounded-card border border-rule bg-paper-sunken p-2">
-                  <dt className="uppercase tracking-track2 text-muted">Resolved</dt>
-                  <dd className="mt-1 text-base font-semibold text-ink">
+                <div className="flex justify-between gap-3 border-b border-rule/60 py-1">
+                  <dt className="uppercase tracking-[0.18em]">Resolved</dt>
+                  <dd className="font-semibold text-ink">
                     {resolvedComments.length}
                   </dd>
                 </div>
@@ -1887,7 +1887,7 @@ export function DocumentDetail({
                 <summary className="cursor-pointer list-none">
                   <span className="flex items-start justify-between gap-3">
                     <span>
-                      <span className="block text-sm font-semibold text-ink">Add note</span>
+                      <span className="block text-[10px] uppercase tracking-[0.18em] text-ink">Add note</span>
                       <span className="mt-1 block text-xs leading-5 text-muted">
                         {selectedQuote
                           ? "Use the selected passage below, or edit the quote before saving."
@@ -1895,11 +1895,11 @@ export function DocumentDetail({
                       </span>
                     </span>
                     {selectedAnchor ? (
-                      <span className="rounded-item border border-ink bg-paper px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-ink">
+                      <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-ink">
                         Anchored
                       </span>
                     ) : (
-                      <span className="text-xs font-semibold text-muted">Open</span>
+                      <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">Open</span>
                     )}
                   </span>
                 </summary>
@@ -1909,7 +1909,7 @@ export function DocumentDetail({
                       className="rounded-card border border-rule bg-paper p-3 text-sm"
                       data-testid="document-selected-quote"
                     >
-                      <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                      <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
                         Selected passage
                       </p>
                       <p className="mt-2 max-h-24 overflow-hidden leading-6 text-muted">
@@ -1940,7 +1940,7 @@ export function DocumentDetail({
                       </div>
                     </div>
                   )}
-                  <label className="grid gap-1 text-xs font-semibold uppercase tracking-track2 text-muted">
+                  <label className="grid gap-1 text-[10px] uppercase tracking-[0.18em] text-muted">
                     Quote
                     <textarea
                       value={commentQuote}
@@ -1950,7 +1950,7 @@ export function DocumentDetail({
                       className="w-full resize-y rounded-item border border-rule bg-paper px-3 py-2 font-sans text-sm font-normal normal-case tracking-normal text-ink outline-none focus:border-ink"
                     />
                   </label>
-                  <label className="grid gap-1 text-xs font-semibold uppercase tracking-track2 text-muted">
+                  <label className="grid gap-1 text-[10px] uppercase tracking-[0.18em] text-muted">
                     Note
                     <textarea
                       value={commentBody}
@@ -1976,7 +1976,7 @@ export function DocumentDetail({
                   <p className="text-sm text-muted">No review notes yet.</p>
                 )}
                 {openComments.length > 0 && (
-                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+                  <p className="border-b border-rule/60 pb-1 text-[10px] uppercase tracking-[0.18em] text-muted">
                     Open notes
                   </p>
                 )}
@@ -1986,11 +1986,11 @@ export function DocumentDetail({
                     className="rounded-card border border-rule bg-paper p-3 text-sm"
                   >
                     <div className="mb-2 flex items-center justify-between gap-3">
-                      <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
+                      <span className="text-[10px] uppercase tracking-[0.18em] text-muted">
                         Open note
                       </span>
                       {comment.anchor_start !== null && comment.anchor_end !== null && (
-                        <span className="rounded-item border border-ink bg-paper px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-ink">
+                        <span className="text-[10px] uppercase tracking-[0.18em] text-ink">
                           Anchored
                         </span>
                       )}
@@ -2009,7 +2009,7 @@ export function DocumentDetail({
                     )}
                     {editingCommentId === comment.id ? (
                       <div className="space-y-2">
-                        <label className="grid gap-1 text-xs font-semibold uppercase tracking-track2 text-muted">
+                        <label className="grid gap-1 text-[10px] uppercase tracking-[0.18em] text-muted">
                           Edit note
                           <textarea
                             value={editingCommentBody}
@@ -2064,8 +2064,8 @@ export function DocumentDetail({
                   </article>
                 ))}
                 {resolvedComments.length > 0 && (
-                  <details className="rounded-card border border-rule bg-paper-sunken p-3">
-                    <summary className="cursor-pointer text-sm font-medium text-muted">
+                  <details>
+                    <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted hover:text-ink">
                       Resolved notes ({resolvedComments.length})
                     </summary>
                     <div className="mt-3 space-y-2">

--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -20,6 +20,7 @@ import {
   type V2ManifestEntry,
 } from "../lib/api";
 import { GenericSkillRunner } from "./GenericSkillRunner";
+import { CertEyebrow, SectionRule } from "../ui/certificate";
 import {
   manifestCapabilities,
   manifestText,
@@ -164,12 +165,6 @@ export function MatterSkillsTab({ slug }: Props) {
 
   return (
     <section>
-      <header className="mb-6">
-        <h2 className="text-xl font-semibold tracking-tight2 text-ink">
-          Skills
-        </h2>
-      </header>
-
       {error && (
         <p className="mb-4 text-sm text-seal" data-testid="matter-skills-error">
           {error}
@@ -207,7 +202,7 @@ export function MatterSkillsTab({ slug }: Props) {
           ))}
           {runnableSkills.length === 0 && enabledModules.length === 0 && (
             <p className="text-sm text-muted">
-              No skills are enabled on this matter yet.
+              No skills hold standing in this matter yet.
             </p>
           )}
         </div>
@@ -221,7 +216,8 @@ export function MatterSkillsTab({ slug }: Props) {
         />
         {availableModules.length === 0 ? (
           <p className="mt-3 text-sm text-muted" data-testid="available-empty">
-            Nothing waiting. Add skills from the library.{" "}
+            Nothing awaits enablement here. Skills trusted in the workspace
+            appear in this section.{" "}
             <Link
               to="/skills"
               className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
@@ -266,11 +262,19 @@ export function MatterSkillsTab({ slug }: Props) {
   );
 }
 
-function SectionHeader({ title, hint }: { title: string; hint: string }) {
+function SectionHeader({
+  title,
+  hint,
+  right,
+}: {
+  title: string;
+  hint: string;
+  right?: string;
+}) {
   return (
-    <div className="border-b border-rule pb-2">
-      <h3 className="text-sm uppercase tracking-widest text-muted">{title}</h3>
-      <p className="mt-1 text-xs text-muted">{hint}</p>
+    <div>
+      <SectionRule label={title} right={right} />
+      <p className="mt-2 text-xs text-muted">{hint}</p>
     </div>
   );
 }
@@ -310,31 +314,27 @@ function EnabledModuleRow({
 
   return (
     <article
-      className="rounded-card border border-rule/60 bg-paper shadow-panel p-4"
+      className="border border-rule/60 bg-paper p-4"
       data-testid={`enabled-module-${entry.module_id}`}
     >
-      <div className="flex flex-wrap items-baseline justify-between gap-3">
+      <CertEyebrow left="Skill" right="Needs setup" />
+      <div className="mt-2 flex flex-wrap items-baseline justify-between gap-3">
         <div>
           <p className="text-sm font-semibold text-ink">{name}</p>
           <p className="mt-0.5 tech-token text-[11px] text-muted">
             {entry.module_id}
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-muted">
-            Needs setup
-          </span>
-          <button
-            type="button"
-            onClick={onRevoke}
-            disabled={revoking}
-            className="rounded-md px-3 py-1 text-xs text-muted hover:text-seal disabled:opacity-50"
-          >
-            {revoking ? "Revoking…" : "Revoke"}
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={onRevoke}
+          disabled={revoking}
+          className="shrink-0 px-3 py-1 text-xs text-muted hover:text-seal disabled:opacity-50"
+        >
+          {revoking ? "Revoking…" : "Revoke"}
+        </button>
       </div>
-      <dl className="mt-3 grid grid-cols-2 gap-3 text-[11px] sm:grid-cols-3">
+      <dl className="mt-3 grid grid-cols-2 gap-3 border-t border-rule pt-3 text-[11px] sm:grid-cols-3">
         <Meta label="Reads" value={friendlyCapabilitySummary(reads)} />
         <Meta label="Writes" value={friendlyCapabilitySummary(writes)} />
         <Meta label="Status" value="Needs setup" />
@@ -366,15 +366,15 @@ function AvailableModuleRow({
 
   return (
     <article
-      className="rounded-card border border-rule/60 bg-paper shadow-panel p-4"
+      className="border border-rule/60 bg-paper p-4"
       data-testid={`available-module-${entry.module_id}`}
     >
-      <div className="flex flex-wrap items-baseline justify-between gap-3">
+      <CertEyebrow left="Skill" right={publisher ?? undefined} />
+      <div className="mt-2 flex flex-wrap items-baseline justify-between gap-3">
         <div>
           <p className="text-sm font-semibold text-ink">{name}</p>
           <p className="mt-0.5 tech-token text-[11px] text-muted">
             {entry.module_id}
-            {publisher ? ` · ${publisher}` : ""}
           </p>
         </div>
         <button
@@ -388,7 +388,7 @@ function AvailableModuleRow({
           Enable in matter
         </button>
       </div>
-      <dl className="mt-3 grid grid-cols-2 gap-3 text-[11px] sm:grid-cols-3">
+      <dl className="mt-3 grid grid-cols-2 gap-3 border-t border-rule pt-3 text-[11px] sm:grid-cols-3">
         <Meta label="Reads" value={friendlyCapabilitySummary(reads)} />
         <Meta label="Writes" value={friendlyCapabilitySummary(writes)} />
         <Meta label="Project actions" value={String(matterCaps.length)} />
@@ -416,7 +416,7 @@ function Meta({
 }) {
   return (
     <div>
-      <dt className="tech-token uppercase tracking-widest text-[9px] text-muted">
+      <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">
         {label}
       </dt>
       <dd className={"mt-1 " + (tone ?? "text-ink")}>{value}</dd>
@@ -488,7 +488,7 @@ function EnableSkillModal({
       }}
     >
       <div className="w-full max-w-[480px] rounded-card border border-rule/60 bg-paper shadow-panel p-5 shadow-xl">
-        <p className="text-[11px] uppercase tracking-widest text-muted">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
           Enable skill
         </p>
         <h2 id="enable-skill-title" className="mt-1 text-lg font-semibold text-ink">
@@ -584,7 +584,7 @@ function Block({
 }) {
   return (
     <section className="mt-4 border-t border-rule pt-3">
-      <p className="text-[11px] uppercase tracking-widest text-muted">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
         {label}
       </p>
       <div className="mt-2">{children}</div>
@@ -595,7 +595,7 @@ function Block({
 function Pair({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-[10px] uppercase tracking-widest text-muted">
+      <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">
         {label}
       </dt>
       <dd className="mt-0.5 text-xs text-ink">{value}</dd>

--- a/frontend/src/matter/SignOff.tsx
+++ b/frontend/src/matter/SignOff.tsx
@@ -4,7 +4,9 @@
  * The hero gate: a solicitor reads an AI-prepared output and takes
  * professional ownership of it — "do you stand behind this output?" Full
  * surface, not a modal: the output on one side, the decision + reasoning +
- * an explicit "I have reviewed this" affirmation on the other.
+ * an explicit "I have reviewed this" affirmation on the other. Reads as
+ * executing an instrument (DESIGN.md P27): SectionRule "The instrument"
+ * over the artifact's CertCard summary, "The decision" over the controls.
  *
  * This is author sign-off — the signer may be the artifact author. It is
  * NOT supervisor review (that's the firm-mode path under Approvals). Copy
@@ -21,7 +23,23 @@ import {
   type SignoffDecision,
 } from "../lib/api";
 import { ArtifactPreview } from "./ArtifactPreview";
-import { ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
+import { ErrorCallout, LoadingLine } from "../ui/primitives";
+import { CertCard, CertEyebrow, SectionRule } from "../ui/certificate";
+
+function outputLabel(kind: string): string {
+  switch (kind) {
+    case "findings_pack":
+      return "Findings pack";
+    case "motion_draft":
+      return "Draft motion";
+    case "evidence_list":
+      return "Evidence list";
+    case "skill_response":
+      return "Skill response";
+    default:
+      return kind.replace(/_/g, " ");
+  }
+}
 
 const DECISIONS: { value: SignoffDecision; label: string; help: string }[] = [
   { value: "signed", label: "Sign", help: "I have reviewed this and I stand behind it." },
@@ -72,7 +90,7 @@ function SignoffCoverage({ payload }: { payload: Record<string, unknown> }) {
   const quoteMissing = anchors.some((a) => a.quote_found_in_source === false);
   const zero = anchors.length === 0;
   return (
-    <div className="mt-4 rounded-md border border-line px-3 py-2 text-xs" data-testid="signoff-source-coverage">
+    <div className="mt-4 border border-line px-3 py-2 text-xs" data-testid="signoff-source-coverage">
       <p className="font-medium text-ink">Source coverage</p>
       {zero ? (
         <p className="mt-1 text-seal" data-testid="signoff-no-sources">
@@ -147,34 +165,37 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10 text-ink">
-      <PageHeader
-        eyebrow="Professional sign-off"
-        title="Review and sign this output"
-        description="You are taking professional ownership of this AI-prepared output. Read it, then record your decision. The exact output is hashed and pinned to your signature."
-      />
-
       {artifact === null ? (
         <LoadingLine label="loading output" />
       ) : (
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1.3fr_1fr]">
-          {/* The output under review */}
+          {/* The instrument under execution (DESIGN.md P27): the artifact
+              summary as a certificate, the payload below it. */}
           <section>
-            <h2 className="text-xs uppercase tracking-widest text-muted">
-              Prepared output — {artifact.kind}
-            </h2>
-            <p className="mt-1 text-[11px] text-muted">
-              Prepared by <span className="tech-token">{artifact.module_id}</span> ·{" "}
-              <span className="tech-token">{artifact.capability_id}</span>. The output
-              payload below is hashed and pinned on sign — this is what your
-              signature attaches to.
-            </p>
+            <SectionRule label="The instrument" />
+            <div className="mt-4">
+              <CertCard>
+                <CertEyebrow left="Output" right={artifact.kind} />
+                <h2 className="mt-3 text-[22px] leading-tight tracking-tight2">
+                  {outputLabel(artifact.kind)}
+                </h2>
+                <p className="mt-1 text-xs text-muted">
+                  Prepared by <span className="tech-token">{artifact.module_id}</span> ·{" "}
+                  <span className="tech-token">{artifact.capability_id}</span>. The output
+                  payload below is hashed and pinned on sign — this is what your
+                  signature attaches to.
+                </p>
+              </CertCard>
+            </div>
             <div data-testid="signoff-artifact">
               <ArtifactPreview payload={artifact.payload} kindHint={artifact.kind} matterSlug={slug} />
             </div>
           </section>
 
           {/* The decision desk */}
-          <section className="lg:sticky lg:top-6 self-start rounded-md border border-rule bg-paper p-4">
+          <section className="lg:sticky lg:top-6 self-start">
+            <SectionRule label="The decision" />
+            <div className="mt-4 border border-rule bg-paper p-4">
             <h2 className="text-sm font-medium">Do you stand behind this output?</h2>
 
             <div className="mt-3 space-y-2">
@@ -182,7 +203,7 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
                 <label
                   key={d.value}
                   className={
-                    "block cursor-pointer rounded-md border p-3 text-sm " +
+                    "block cursor-pointer border p-3 text-sm " +
                     (decision === d.value ? "border-ink" : "border-rule hover:border-ink/50")
                   }
                 >
@@ -203,7 +224,7 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
             </div>
 
             <div className="mt-4">
-              <label className="text-xs uppercase tracking-widest text-muted">
+              <label className="text-[10px] uppercase tracking-[0.18em] text-muted">
                 Reasoning {reasoningNeeded ? "(required)" : "(optional)"}
               </label>
               <textarea
@@ -211,7 +232,7 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
                 onChange={(e) => setReasoning(e.target.value)}
                 rows={4}
                 placeholder="What did you change, what would you change, or why are you signing despite it? This becomes part of the permanent record."
-                className="mt-1 w-full rounded-md border border-rule bg-paper px-3 py-2 text-sm"
+                className="mt-1 w-full border border-rule bg-paper px-3 py-2 text-sm"
                 data-testid="signoff-reasoning"
               />
             </div>
@@ -236,7 +257,7 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
               type="button"
               onClick={submit}
               disabled={!canSubmit}
-              className="mt-4 inline-flex w-full items-center justify-center rounded-md bg-ink px-4 py-2 text-sm text-paper hover:bg-seal disabled:opacity-50"
+              className="mt-4 inline-flex w-full items-center justify-center bg-ink px-4 py-2 text-sm text-paper hover:bg-seal disabled:opacity-50"
               data-testid="signoff-submit"
             >
               {submitting
@@ -258,6 +279,7 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
                 Cancel
               </Link>
             </p>
+            </div>
           </section>
         </div>
       )}

--- a/frontend/src/matter/SignOffConfirmation.tsx
+++ b/frontend/src/matter/SignOffConfirmation.tsx
@@ -1,15 +1,19 @@
 /**
  * /matters/:slug/signoffs/:signoffId — sign-off confirmation / record.
  *
- * Renders the sign-off exactly as it sits in the permanent record:
- * signer, timestamp, decision, reasoning, the pinned artifact hash. Loads
- * by id so a reload / deep-link is stable. Copy stays inside the boundary.
+ * Renders the sign-off exactly as it sits in the permanent record — the
+ * executed certificate (DESIGN.md P27): a CertCard with the decision as
+ * the eyebrow's right mark (rejected carries the seal), then signer,
+ * timestamp, output, reasoning, and the pinned artifact hash as ledger
+ * rows. Loads by id so a reload / deep-link is stable. Copy stays
+ * inside the boundary.
  */
 
 import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { getSignoff, type Signoff } from "../lib/api";
-import { ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
+import { ErrorCallout, LoadingLine } from "../ui/primitives";
+import { CertCard, CertEyebrow, LedgerRow } from "../ui/certificate";
 
 const DECISION_LABEL: Record<string, string> = {
   signed: "Signed",
@@ -56,40 +60,65 @@ export function SignOffConfirmation({
 
   return (
     <div className="mx-auto max-w-2xl px-6 py-12 text-ink">
-      <PageHeader
-        eyebrow="Sign-off record"
-        title={rejected ? "Draft rejected — recorded" : "Signed in Legalise"}
-        description={
-          rejected
+      {/* The executed certificate. Seal tone only for a rejection — the
+          one refused state this record can hold. */}
+      <CertCard tone={rejected ? "seal" : "ink"} testid="signoff-record">
+        <CertEyebrow
+          left="Sign-off record"
+          right={DECISION_LABEL[signoff.decision] ?? signoff.decision}
+          rightTone={rejected ? "seal" : "ink"}
+        />
+        <h1 className="mt-3 text-[22px] leading-tight tracking-tight2">
+          {rejected ? "Draft rejected — recorded" : "Signed in Legalise"}
+        </h1>
+        <p className="mt-1 text-xs text-muted">
+          {rejected
             ? "This draft was not signed. The decision and reasoning are part of the matter's permanent audit trail."
-            : "This records your professional ownership of the output. It is permanent and forms part of the matter's audit trail."
-        }
-      />
+            : "This records your professional ownership of the output. It is permanent and forms part of the matter's audit trail."}
+        </p>
 
-      <dl className="mt-6 divide-y divide-rule rounded-md border border-rule" data-testid="signoff-record">
-        <Row label="Decision">
-          <span className="font-medium">{DECISION_LABEL[signoff.decision] ?? signoff.decision}</span>
-          {!signoff.is_current && (
-            <span className="ml-2 text-[11px] text-muted">(superseded by a later sign-off)</span>
-          )}
-        </Row>
-        <Row label="Signed by">
-          {signoff.signer_email ?? signoff.signer_id}
-          {signoff.signer_is_author && (
-            <span className="ml-2 text-[11px] text-muted">(author — self-signed, not independent review)</span>
-          )}
-        </Row>
-        <Row label="When">{signoff.signed_at.replace("T", " ").slice(0, 19)}</Row>
-        <Row label="Output">
-          <span className="tech-token text-xs">
-            {signoff.kind} · {signoff.module_id} / {signoff.capability_id}
-          </span>
-        </Row>
-        {signoff.reasoning && <Row label="Reasoning">{signoff.reasoning}</Row>}
-        <Row label="Output hash (pinned)">
-          <span className="break-all tech-token text-[11px]">{signoff.artifact_hash}</span>
-        </Row>
-      </dl>
+        <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
+          <LedgerRow label="Signed by" tone="ink">
+            {signoff.signer_email ?? signoff.signer_id}
+          </LedgerRow>
+          <LedgerRow label="When">
+            {signoff.signed_at.replace("T", " ").slice(0, 19)}
+          </LedgerRow>
+          <LedgerRow label="Output">
+            <span className="tech-token">
+              {signoff.kind} · {signoff.module_id} / {signoff.capability_id}
+            </span>
+          </LedgerRow>
+        </dl>
+
+        {(signoff.signer_is_author || !signoff.is_current) && (
+          <p className="mt-2 text-[11px] text-muted">
+            {signoff.signer_is_author &&
+              "Author — self-signed, not independent review. "}
+            {!signoff.is_current && "Superseded by a later sign-off."}
+          </p>
+        )}
+
+        {signoff.reasoning && (
+          <div className="mt-3 border-t border-rule pt-3">
+            <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
+              Reasoning
+            </p>
+            <p className="mt-1 text-sm leading-relaxed text-ink">
+              {signoff.reasoning}
+            </p>
+          </div>
+        )}
+
+        <div className="mt-3 border-t border-rule pt-3">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-muted">
+            Output hash (pinned)
+          </p>
+          <p className="mt-1 break-all tech-token text-[11px]">
+            {signoff.artifact_hash}
+          </p>
+        </div>
+      </CertCard>
 
       <p className="mt-4 text-xs text-muted">
         The output hash pins the exact payload that was signed — the record cannot
@@ -114,15 +143,6 @@ export function SignOffConfirmation({
           See it in Activity →
         </Link>
       </div>
-    </div>
-  );
-}
-
-function Row({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:gap-4">
-      <dt className="w-40 shrink-0 text-xs uppercase tracking-widest text-muted">{label}</dt>
-      <dd className="text-sm">{children}</dd>
     </div>
   );
 }

--- a/frontend/src/matter/tabs/ApprovalsTab.tsx
+++ b/frontend/src/matter/tabs/ApprovalsTab.tsx
@@ -19,7 +19,8 @@ import {
   type SupervisorReview,
 } from "../../lib/api";
 import { ArtifactPreview } from "../ArtifactPreview";
-import { Badge, EmptyState, ErrorCallout, LoadingLine } from "../../ui/primitives";
+import { EmptyState, ErrorCallout, LoadingLine } from "../../ui/primitives";
+import { LedgerLine, SectionRule } from "../../ui/certificate";
 
 type Query =
   | { status: "loading" }
@@ -79,12 +80,13 @@ export function ApprovalsTab({ slug }: { slug: string }) {
 
       {pending.length > 0 && (
         <section className="mt-8">
-          <h3 className="text-xs uppercase tracking-widest text-muted">Pending</h3>
-          <ul className="mt-3 space-y-px bg-rule border border-rule">
-            {pending.map((r) => (
+          <SectionRule label="Pending" right={String(pending.length)} />
+          <ul className="mt-1">
+            {pending.map((r, i) => (
               <ReviewRow
                 key={r.id}
                 review={r}
+                index={i + 1}
                 open={openId === r.id}
                 onToggle={() => setOpenId(openId === r.id ? null : r.id)}
                 slug={slug}
@@ -100,12 +102,13 @@ export function ApprovalsTab({ slug }: { slug: string }) {
 
       {decided.length > 0 && (
         <section className="mt-8">
-          <h3 className="text-xs uppercase tracking-widest text-muted">Decided</h3>
-          <ul className="mt-3 space-y-px bg-rule border border-rule">
-            {decided.map((r) => (
+          <SectionRule label="Decided" right={String(decided.length)} />
+          <ul className="mt-1">
+            {decided.map((r, i) => (
               <ReviewRow
                 key={r.id}
                 review={r}
+                index={i + 1}
                 open={openId === r.id}
                 onToggle={() => setOpenId(openId === r.id ? null : r.id)}
                 slug={slug}
@@ -121,40 +124,59 @@ export function ApprovalsTab({ slug }: { slug: string }) {
 
 function ReviewRow({
   review,
+  index,
   open,
   onToggle,
   slug,
   onDecided,
 }: {
   review: SupervisorReview;
+  index: number;
   open: boolean;
   onToggle: () => void;
   slug: string;
   onDecided: () => void;
 }) {
   const isPending = review.state === "pending";
+  // Seal at rest only for refusals — a rejected review is the record
+  // testifying against the output.
+  const stateTone = review.state === "rejected" ? "text-seal" : "text-muted";
   return (
-    <li className="bg-paper p-4">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex w-full items-center justify-between gap-3 text-left"
+    <li className="bg-paper">
+      <LedgerLine
+        index={index}
+        label={review.capability_id}
+        right={
+          <span className="flex items-baseline gap-3">
+            <span className="tech-token text-[11px] text-muted">
+              {review.requested_at.slice(0, 16).replace("T", " ")}
+            </span>
+            <span
+              className={`text-[10px] uppercase tracking-[0.18em] ${stateTone}`}
+            >
+              {STATE_LABEL[review.state] ?? review.state}
+            </span>
+          </span>
+        }
       >
-        <div className="min-w-0">
-          <p className="text-sm text-ink">{review.kind}</p>
-          <p className="tech-token text-[11px] text-muted truncate">
-            {review.capability_id} · {review.requested_at.slice(0, 16).replace("T", " ")}
-          </p>
-        </div>
-        <Badge>{STATE_LABEL[review.state] ?? review.state}</Badge>
-      </button>
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          className="block w-full truncate text-left text-sm text-ink hover:text-seal"
+        >
+          {review.kind}
+        </button>
+      </LedgerLine>
       {open && (
-        <ReviewScreen
-          review={review}
-          slug={slug}
-          editable={isPending}
-          onDecided={onDecided}
-        />
+        <div className="pb-4">
+          <ReviewScreen
+            review={review}
+            slug={slug}
+            editable={isPending}
+            onDecided={onDecided}
+          />
+        </div>
       )}
     </li>
   );
@@ -218,21 +240,21 @@ function ReviewScreen({
 
       <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-2 text-xs">
         <div>
-          <dt className="uppercase tracking-widest text-muted">Output hash</dt>
+          <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">Output hash</dt>
           <dd className="mt-0.5 tech-token text-muted break-all">{review.artifact_hash}</dd>
         </div>
         <div>
-          <dt className="uppercase tracking-widest text-muted">Invocation</dt>
+          <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">Invocation</dt>
           <dd className="mt-0.5 tech-token text-muted">{review.invocation_id}</dd>
         </div>
         {!editable && (
           <>
             <div>
-              <dt className="uppercase tracking-widest text-muted">Decision</dt>
+              <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">Decision</dt>
               <dd className="mt-0.5 text-ink">{STATE_LABEL[review.state]}</dd>
             </div>
             <div>
-              <dt className="uppercase tracking-widest text-muted">Note</dt>
+              <dt className="text-[10px] uppercase tracking-[0.18em] text-muted">Note</dt>
               <dd className="mt-0.5 text-muted">{review.note || "—"}</dd>
             </div>
           </>
@@ -248,7 +270,7 @@ function ReviewScreen({
 
       {editable && (
         <div className="mt-4">
-          <label className="block text-xs uppercase tracking-widest text-muted">
+          <label className="block text-[10px] uppercase tracking-[0.18em] text-muted">
             Note
             <textarea
               value={note}

--- a/frontend/src/matter/tabs/AuditTab.tsx
+++ b/frontend/src/matter/tabs/AuditTab.tsx
@@ -51,7 +51,7 @@ export function AuditTab({ audit, matter }: { audit: AuditEntry[] | null; matter
   return (
     <div>
       <div className="flex items-center gap-3 px-4 py-3 border-b border-t border-rule bg-paper text-[11px] tech-token">
-        <span className="text-muted uppercase tracking-track2 text-[9px]">Filter</span>
+        <span className="text-muted uppercase tracking-[0.18em] text-[10px]">Filter</span>
         <select
           value={moduleFilter}
           onChange={(e) => setModuleFilter(e.target.value)}
@@ -102,17 +102,17 @@ export function AuditTab({ audit, matter }: { audit: AuditEntry[] | null; matter
                   key={e.id}
                   onClick={() => setSelectedId(e.id)}
                   className={
-                    "w-full text-left grid grid-cols-[170px_100px_180px_140px_70px_70px_1fr] gap-4 px-4 py-3 border-b border-rule transition-colors tech-token text-[11px] items-center " +
+                    "w-full text-left grid grid-cols-[170px_100px_180px_140px_70px_70px_1fr] gap-4 px-4 py-2.5 border-b border-rule/60 transition-colors text-[11px] items-baseline " +
                     (isSelected ? "bg-wash" : "hover:bg-wash")
                   }
                 >
-                  <span className="text-ink">{e.timestamp.slice(0, 19).replace("T", " ")}</span>
-                  <span className="text-prose truncate">{e.module ?? "-"}</span>
-                  <span className={(isBlocked ? "text-seal line-through decoration-1" : "text-ink") + " font-bold truncate"}>{e.action}</span>
-                  <span className="text-prose truncate">{e.model_used ?? "-"}</span>
-                  <span className="text-ink">{e.token_count ?? "-"}</span>
-                  <span className="text-ink">{e.latency_ms != null ? `${e.latency_ms}ms` : "-"}</span>
-                  <span className="text-muted truncate">{(e.prompt_hash ?? "-").slice(0, 8)}</span>
+                  <span className="tech-token text-muted">{e.timestamp.slice(0, 19).replace("T", " ")}</span>
+                  <span className="text-[10px] uppercase tracking-[0.18em] text-muted truncate">{e.module ?? "-"}</span>
+                  <span className={"tech-token truncate " + (isBlocked ? "text-seal line-through decoration-1" : "text-ink")}>{e.action}</span>
+                  <span className="tech-token text-prose truncate">{e.model_used ?? "-"}</span>
+                  <span className="tech-token text-ink">{e.token_count ?? "-"}</span>
+                  <span className="tech-token text-ink">{e.latency_ms != null ? `${e.latency_ms}ms` : "-"}</span>
+                  <span className="tech-token text-muted truncate">{(e.prompt_hash ?? "-").slice(0, 8)}</span>
                 </button>
               );
             })}

--- a/frontend/src/matter/tabs/ChronologyTab.tsx
+++ b/frontend/src/matter/tabs/ChronologyTab.tsx
@@ -71,14 +71,14 @@ function ChronologyTable({
         return (
           <div
             key={e.id}
-            className="relative h-[22px] grid grid-cols-[110px_50px_1fr_220px] gap-4 items-center px-4 hover:bg-wash transition-colors text-[11px] tech-token border-b border-rule"
+            className="relative grid grid-cols-[110px_50px_1fr_220px] gap-4 items-baseline px-4 py-2.5 hover:bg-wash transition-colors text-[11px] tech-token border-b border-rule/60"
           >
             <div
               className="absolute right-0 top-0 bottom-0 bg-[#00A35C]/15 pointer-events-none"
               style={{ width: sigBarWidth }}
               aria-hidden="true"
             />
-            <span className="text-ink z-10 font-bold">{e.event_date}</span>
+            <span className="text-ink z-10">{e.event_date}</span>
             <span className="text-muted z-10">{e.significance}</span>
             {e.redacted ? (
               <span className="text-seal italic z-10 truncate">{e.description}</span>

--- a/frontend/src/matter/tabs/DocumentsTab.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import type { ChangeEvent, DragEvent } from "react";
 import { Link } from "@tanstack/react-router";
 import { FileUp } from "lucide-react";
 import type { MatterDocument } from "../../lib/api";
 import { UploadError } from "../../lib/api";
-import { Badge, EmptyState, ErrorCallout, LoadingLine } from "../../ui/primitives";
+import { EmptyState, ErrorCallout, LoadingLine } from "../../ui/primitives";
+import { LedgerLine, SectionRule } from "../../ui/certificate";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n}B`;
@@ -119,10 +120,6 @@ export function DocumentsTab({
   const inputCls =
     "bg-paper border border-rule px-3 py-2 text-[16px] focus:border-ink focus:outline-none transition-colors min-h-[40px] font-sans text-ink";
   const totalBytes = docs?.reduce((total, d) => total + d.size_bytes, 0) ?? 0;
-  const openNoteCount =
-    docs?.reduce((total, d) => total + (d.open_comment_count ?? 0), 0) ?? 0;
-  const pendingEditCount =
-    docs?.reduce((total, d) => total + (d.pending_edit_count ?? 0), 0) ?? 0;
   const filteredDocs =
     docs?.filter((d) => {
       const query = documentQuery.trim().toLowerCase();
@@ -230,18 +227,12 @@ export function DocumentsTab({
       )}
       {docs && docs.length > 0 && (
         <div>
-          <div className="mb-4 flex flex-wrap items-baseline justify-between gap-3">
-            <h2 className="text-xl font-semibold tracking-tight2 text-ink">
-              Documents
-            </h2>
-            <p className="text-[13px] text-muted">
-              {docs.length} file{docs.length === 1 ? "" : "s"} · {formatBytes(totalBytes)}
-              {openNoteCount > 0 ? ` · ${openNoteCount} open note${openNoteCount === 1 ? "" : "s"}` : ""}
-              {pendingEditCount > 0 ? ` · ${pendingEditCount} pending change${pendingEditCount === 1 ? "" : "s"}` : ""}
-            </p>
-          </div>
+          <SectionRule
+            label="Documents"
+            right={`${docs.length} file${docs.length === 1 ? "" : "s"} · ${formatBytes(totalBytes)}`}
+          />
           <div
-            className="mb-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]"
+            className="mb-4 mt-5 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]"
             data-testid="document-library-controls"
           >
             <label className="sr-only" htmlFor="document-search">Search documents</label>
@@ -275,12 +266,8 @@ export function DocumentsTab({
               ))}
             </div>
           </div>
-          <div
-            className="grid gap-3 md:grid-cols-2"
-            data-testid="document-library-cards"
-          >
-            {filteredDocs?.map((d) => {
-              const typeLabel = deriveType(d);
+          <div data-testid="document-library-cards">
+            {filteredDocs?.map((d, i) => {
               const openNotes = d.open_comment_count ?? 0;
               const versions = d.version_count ?? 0;
               const pendingEdits = d.pending_edit_count ?? 0;
@@ -290,46 +277,50 @@ export function DocumentsTab({
                 pendingEdits > 0 ? plural(pendingEdits, "pending change") : null,
               ].filter(Boolean);
               return (
-                <Link
+                <LedgerLine
                   key={d.id}
-                  to="/matters/$slug/documents/$documentId"
-                  params={{ slug, documentId: d.id }}
-                  className="group rounded-card border border-rule/60 bg-paper p-5 shadow-panel transition-colors hover:border-ink"
-                  title={`SHA-256 ${d.sha256}`}
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="min-w-0">
-                      <p className="truncate text-base font-semibold text-ink">
-                        {d.filename}
-                      </p>
-                      <p className="mt-1 truncate text-[13px] text-muted">
-                        {d.from_disclosure ? "CPR 31 disclosure" : "Upload"} · {formatBytes(d.size_bytes)} · {formatDate(d.uploaded_at)}
-                      </p>
-                    </div>
-                    <Badge>{typeLabel}</Badge>
-                  </div>
-                  {workStatus.length > 0 && (
-                    <div className="mt-3 flex flex-wrap gap-2" aria-label={`Workbench status for ${d.filename}`}>
-                      {workStatus.map((item) => (
+                  index={i + 1}
+                  label={`${formatBytes(d.size_bytes)} · ${formatDate(d.uploaded_at)}`}
+                  right={
+                    <span className="flex items-baseline gap-3">
+                      {workStatus.length > 0 && (
                         <span
-                          key={item}
-                          className="rounded-item bg-paper-sunken px-2 py-1 text-xs font-medium text-ink"
+                          className="flex items-baseline gap-1.5 text-[11px] text-muted"
+                          aria-label={`Workbench status for ${d.filename}`}
                         >
-                          {item}
+                          {workStatus.map((item, j) => (
+                            <Fragment key={item}>
+                              {j > 0 && <span aria-hidden="true">·</span>}
+                              <span>{item}</span>
+                            </Fragment>
+                          ))}
                         </span>
-                      ))}
-                    </div>
-                  )}
-                  <div className="mt-3 text-right text-xs text-muted group-hover:text-seal">
-                    Open →
-                  </div>
-                </Link>
+                      )}
+                      <Link
+                        to="/matters/$slug/documents/$documentId"
+                        params={{ slug, documentId: d.id }}
+                        className="text-sm text-muted hover:text-seal"
+                      >
+                        Open →
+                      </Link>
+                    </span>
+                  }
+                >
+                  <Link
+                    to="/matters/$slug/documents/$documentId"
+                    params={{ slug, documentId: d.id }}
+                    className="block truncate text-left text-sm text-ink hover:text-seal"
+                    title={`SHA-256 ${d.sha256}`}
+                  >
+                    {d.filename}
+                  </Link>
+                </LedgerLine>
               );
             })}
             {filteredDocs?.length === 0 && (
-              <div className="rounded-card border border-rule bg-paper px-4 py-6 text-sm text-muted md:col-span-2">
+              <p className="px-1 py-5 text-sm text-muted">
                 No documents match this search. Clear the query or switch filters.
-              </div>
+              </p>
             )}
           </div>
         </div>


### PR DESCRIPTION
The finishing pass on the design — the surfaces P25/P26 fenced off, now matching the register idiom:

- **Files tab = ledger** (consistent with the demo's), **Activity = Admin-Audit treatment** (seal strike preserved), Approvals/Chronology/matter-Skills aligned.
- **Artifacts as certificates** — the thematically right move: signed-outputs list as a ledger with sign-off marks, artifact detail headed by its certificate, **sign-off as executing an instrument**, confirmation as the executed certificate (seal-toned on refusal).
- **Auth pages** get the ruled eyebrow + ledger field labels.
- Mobile sanity at 375px verified; console-error audit clean; 296 tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)