### PR TITLE
P29: the golden loop — demo as one conversation; the record speaks English

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1630,3 +1630,32 @@ What we build:
 Exact values: masthead/monument/whisper/prose tiers per P27 (no new tokens). Architecture page section headers use SectionRule; body text `text-base leading-relaxed text-prose max-w-3xl`; pull-quotes none — restraint.
 Where it lands: TopBar.tsx, Drawer.tsx, Footer.tsx, Landing.tsx, landing/Architecture.tsx (new), landing/About.tsx (new), router/index.tsx, lib/route.ts, app/AppShell.tsx.
 Deliberate divergences: Lavern shows agent-count metrics and an install video in the hero; we show the quickstart command and the refusal thesis instead — the register does not advertise capability counts.
+
+---
+
+## P29 — The golden loop (demo as one conversation; the chat and the record earn their look)
+
+Source: Andy's demo walk, 2026-06-12 (screenshots). The verdict: the demo is a tab museum of gray squares — raw code in the audit drawer, a bespoke document page that never shows the real reading surface, a chat thread that reads as gibberish, and lecture/workbench panels stacking CTAs. Ratified shape: **the demo is one scripted conversation** — the golden loop start to finish in the chat window. The chat, record, and chronology surfaces are the REAL workspace components, so this pass fixes the product, not just the demo.
+
+### 1. The record speaks English first (`AuditTab` + drawer, shared)
+
+- New `matter/auditNarrate.ts`: `narrateEntry(entry) → string` — one plain sentence per action ("Built a chronology of 7 events.", "Uploaded khan-dismissal-letter.pdf.", "Blocked a model call on a paused matter. No content left the workspace."). Unknown actions fall back to the action string.
+- Drawer anatomy top-to-bottom: action title → **the sentence** (`text-sm text-prose leading-relaxed`) → plain rows only (When, human date · Who, "You"/system · Matter, title · Model, if any) → `<details>` **"Technical record"** holding hashes, ids, tokens, latency, raw payload JSON. The technical material survives complete but never leads.
+- Posture values inside narrated text use the user vocabulary (Active/Paused), never the enum.
+- The table keeps its ledger anatomy (it IS the register); the drawer is where meaning lives.
+
+### 2. The chat earns its look (`MessageBubble` + thread, shared)
+
+- User bubble: `rounded-card` (the P21 panel radius), keep bg-wash + border. Square chat bubbles read as unfinished against the rounded shell.
+- Assistant turn: drop the gray left-border block; plain prose on the panel with a quiet meta line, `rounded-card` only on the output row and chips. Meta line: `Assistant · N sources` — "saved to Activity" leaves (every turn says it; the output row's Activity link already carries it).
+- Citation chips + suggestion buttons: `rounded-item`, unchanged anatomy.
+- Spacing: turns separated by `space-y-6`; thread column stays ≤760px.
+
+### 3. The demo is the loop (demo-only)
+
+- The thread IS the demo: summarise NDA (output row) → dismissal date (chronology citation) → **pause for without-prejudice talks** → **the refusal, struck on the record** → resume when talks conclude → the witness-statement summary now succeeds → close on "Open the Record". Copy uses Active/Paused only — the `C_paused` enum never appears in chat text.
+- Demo document page strips to the P25 reading anatomy: quiet back link, title, one meta line (tag · size · uploaded), the document body (multi-paragraph, looks like a document), document facts as ledger rows at the foot. DELETED: Document Workbench panel, "What happens in the workspace" lecture list, the chip salad, the second search box.
+- DELETED from the demo: nothing else gains a CTA. The rail keeps Chat / Files / Skills + the single posture state + one "Create a workspace" footer link.
+
+Where it lands: matter/auditNarrate.ts (new), matter/tabs/AuditTab.tsx, matter/MessageBubble.tsx, matter/tabs/AssistantTab.tsx (spacing only), demo/snapshot.ts, demo/DemoMatter.tsx.
+Deliberate divergences: the demo document page does NOT mount the real editor stack (ProseMirror, ~200 kB lazy) — the demo is read-only by design; it borrows the P25 reading anatomy instead.

--- a/docs/handovers/TEST_SLIM_ORDER_2026-06-12.md
+++ b/docs/handovers/TEST_SLIM_ORDER_2026-06-12.md
@@ -1,0 +1,121 @@
+# Work order: slim the backend test suite
+
+Date: 2026-06-12. Owner: Andy. Executor: rebuild agents.
+Baseline: master `7a683fd`. Backend tests today: 113 files, 28,885 lines.
+Target: ~20k lines with *better* protection of what actually ships, not less.
+
+## Why
+
+The suite is thickest where the product is oldest and thinnest where it is
+shown. ~7k lines still reference modules cut in `70b235c` (pre_motion,
+contract_review, letters, tabular_review, case_law). ~1.3k lines test
+primitives whose enforcement status is unclear (state machine, advice
+boundary). Meanwhile the golden loop — chat → tool call → skill run →
+sign-off, the flow on the landing page — has no dedicated test file and no
+e2e. This order reallocates: build the safety net first, then prune under it.
+
+## Ground rules (read before touching anything)
+
+1. **Never weaken governance coverage.** Tests for posture gate, audit
+   completeness, ACL sweep, grants, sign-off, encryption, capability
+   enforcement are the product. They may be *reorganised*, never thinned.
+2. **Classify before deleting.** A test referencing `pre_motion` may be
+   exercising the plugin bridge against `examples/modules/pre_motion/` —
+   that is live coverage of the plugin runtime, not dead code. The question
+   for every candidate is: *what app code path does this exercise today?*
+   If the answer is a real path in `backend/app/`, it stays (possibly
+   renamed). If the answer is "a module that no longer exists except as
+   fixture vocabulary," it goes.
+3. **One PR per phase below.** Each PR must show the line-count delta and a
+   green run of the full suite. No combined mega-PR.
+4. **Check the CI shard boundary** (`.github/workflows/ci.yml` — the shard
+   split hard-codes a test filename). Any phase that deletes or renames
+   files must confirm sharding still balances, or fix the split to be
+   computed from the file list.
+5. Update `docs/` references in the same PR if a deleted test file is named
+   anywhere (TESTING docs, handovers INDEX is historical — leave it).
+
+## Phase 0 — Safety net first (do before any deletion)
+
+* Write `frontend/e2e/golden-loop.spec.ts`: signup → seeded Khan matter →
+  chat is default surface → deterministic summary prompt (stub-echo model)
+  → output row renders → Sources pane lists the cited document → sign-off →
+  Activity shows `output.signed` with `signer_is_author: true`. Reuse the
+  `first-run.spec.ts` scaffolding. Add `data-testid` where needed in the
+  same PR (test plumbing only, no UI change).
+* Extract the assistant cases from `test_smoke_evals.py` into a dedicated
+  `backend/tests/test_assistant_pipeline.py`; add the three missing
+  branches: parse-failure fallback, tool-error path, empty tool registry.
+* Acceptance: both files gate CI; killing the sign-off route makes the e2e
+  fail.
+
+## Phase 1 — Classify the cut-module references
+
+For each file below, label every test function A (exercises live app code —
+keep), B (exercises the plugin bridge via examples/ — keep, rename to say
+so), or C (exercises deleted built-ins or exists only to feed them fixtures
+— delete). Produce the classification table in the PR description.
+
+Files, by reference density:
+
+| File | Lines | Refs |
+|---|---|---|
+| test_smoke_evals.py | 1,350 | 13 |
+| test_phase10_invocations_api.py | 728 | 13 |
+| test_phase7_grants_api.py | 624 | 13 |
+| test_provider_audit_completeness.py | 414 | 8 |
+| test_phase8_posture_gate.py | 519 | 7 |
+| test_phase6_r2_fixes.py | 593 | 6 |
+| test_phase13b_audit_gap_fill.py | 533 | 5 |
+| test_phase11_admin_role.py | 405 | 4 |
+| test_phase6_vertical_slice.py | 392 | 3 |
+| test_declared_capabilities_resolver.py | 200 | 3 |
+| test_phase10_runtime.py | 461 | 2 |
+| test_export.py | 416 | 1 |
+| test_observability.py, test_module_validate_endpoint.py, test_audit_module_kwarg.py, test_source_anchors.py | <300 ea | 1 ea |
+
+Expectation: posture gate / grants / audit files are mostly A-B (keep);
+smoke_evals and the phase6/phase10 files carry most of the C weight.
+
+## Phase 2 — Resolve the dormant primitives
+
+* `test_phase1_state_machine.py` (712) and `test_phase1_advice_boundary.py`
+  (612): first **verify enforcement status in current code** — note that
+  `core/prompt_runtime.py` and `core/posture_gate.py` now reference
+  advice_boundary, so the June 10 "declared, not enforced" finding may be
+  stale for it.
+* If enforced: keep, rename to `test_advice_boundary.py` etc., trim to the
+  enforced surface.
+* If still dormant: move the file to `backend/tests/dormant/` excluded from
+  CI collection, with a header comment naming the feature flag / roadmap
+  item that revives it. Do not delete — these are spec-by-test for v0.2.
+
+## Phase 3 — Kill phase-name duplication
+
+46 of 113 files are named `test_phaseN_*`. Rename survivors to
+module-based names (`test_posture_gate.py`, `test_grants_api.py`,
+`test_invocations_api.py`, …), merging where two phase files test the same
+module. While merging, delete duplicate assertions — the same behaviour
+re-tested across phases is the main source of bloat. Rule of thumb during
+merge: a behaviour earns one test per distinct failure mode, not one per
+phase it was touched in.
+
+Add a short `backend/tests/README.md` mapping module → test file, so the
+next agent can see coverage at a glance.
+
+## Phase 4 — Lock it in
+
+* Add `pytest --cov` with the report published as a CI artifact (audit item
+  C2) so the reallocation is visible, not asserted.
+* Post a before/after table in the final PR: files, lines, runtime of the
+  suite, coverage of `backend/app/core/` and `backend/app/modules/`.
+
+## Acceptance for the whole order
+
+1. Golden-loop e2e and assistant pipeline tests exist and gate CI.
+2. No test references a module that exists neither in `backend/app/` nor in
+   `examples/` — grep proof in the final PR.
+3. Governance coverage (posture, audit, ACL, grants, sign-off, encryption)
+   line count is >= today's. Everything else may shrink.
+4. Suite total around 20k lines; full run no slower than today.
+5. CI green on every intermediate PR — never land a red step.

--- a/frontend/src/demo/DemoMatter.test.tsx
+++ b/frontend/src/demo/DemoMatter.test.tsx
@@ -42,7 +42,7 @@ describe("DemoMatter document search", () => {
     expect(demoDocumentMatches(doc, "witness")).toBe(false);
   });
 
-  it("shows a no-sign-in document workbench rail in the public reader", () => {
+  it("renders the stripped public reader: title, document body, facts — no workbench chrome", () => {
     const docs = [
       {
         id: "doc-1",
@@ -61,23 +61,13 @@ describe("DemoMatter document search", () => {
     render(<DemoDocumentReader documentId="doc-1" docs={docs} />);
 
     expect(screen.getByRole("heading", { name: "dismissal-letter.pdf" })).toBeInTheDocument();
-    expect(screen.getByTestId("demo-document-workbench-rail")).toHaveTextContent(
-      "This file is ready to use.",
-    );
-    expect(screen.getByTestId("demo-document-workbench-rail").closest("aside")).toHaveClass(
-      "order-1",
-    );
-    expect(screen.getByTestId("demo-document-reader").closest("section")).toHaveClass(
-      "order-2",
-    );
-    expect(screen.getByRole("link", { name: /Run a skill with this file/i })).toHaveAttribute(
-      "href",
-      "/demo/workflows",
-    );
-    expect(screen.getByRole("link", { name: /View the Record/i })).toHaveAttribute(
-      "href",
-      "/demo/audit",
-    );
+    expect(screen.getByTestId("demo-document-reader")).toBeInTheDocument();
+    // P29 §3: the workbench rail and lecture list are gone.
+    expect(screen.queryByTestId("demo-document-workbench-rail")).not.toBeInTheDocument();
+    expect(screen.queryByText(/What happens in the workspace/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Run a skill with this file/i })).not.toBeInTheDocument();
+    // Facts render as plain rows, humanised.
+    expect(screen.getByText("PDF")).toBeInTheDocument();
     expect(screen.queryByText(/sign in/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -402,21 +402,12 @@ function DemoDocumentsTab({
                 Extracted text preview. Skills and source chips point back to this reader.
               </p>
             </div>
-            <div className="flex flex-wrap items-center gap-2">
-              <a
-                href={`/demo/documents/${encodeURIComponent(inspectedDoc.id)}`}
-                className="rounded-item border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-seal hover:border-seal"
-              >
-                Open full reader
-              </a>
-              <button
-                type="button"
-                onClick={() => navigate("/demo/workflows")}
-                className="rounded-item border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
-              >
-                View skills
-              </button>
-            </div>
+            <a
+              href={`/demo/documents/${encodeURIComponent(inspectedDoc.id)}`}
+              className="rounded-item border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-seal hover:border-seal"
+            >
+              Open full reader
+            </a>
           </div>
           <div className="border-b border-rule bg-paper-sunken px-5 py-3">
             <div className="flex flex-wrap items-center justify-between gap-3">
@@ -456,9 +447,6 @@ function DemoDocumentsTab({
                 <span key={`${index}-${segment.text.slice(0, 8)}`}>{segment.text}</span>
               ),
             )}
-          </div>
-          <div className="border-t border-rule px-5 py-4 text-xs leading-5 text-muted">
-            Original files, extracted text, edit versions, redactions, and record links live on this document surface in the working product.
           </div>
         </section>
       </div>
@@ -503,188 +491,131 @@ export function DemoDocumentReader({
     );
   }
 
+  // P29 §3: the reading surface, stripped to the P25 anatomy — back link,
+  // title, one meta line, the document, facts as ledger rows at the foot.
+  // No workbench panel, no lecture list, no chip salad.
   return (
-    <div className="mx-auto max-w-[1160px]">
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+    <div className="mx-auto max-w-[820px]">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <a
           href="/demo/documents"
           className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
         >
-          ← Back to demo documents
+          ← Files
         </a>
-        <a
-          href="/demo/audit"
-          className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-        >
-          View demo Record →
-        </a>
+        <label className="min-w-[200px] text-xs text-muted">
+          <span className="sr-only">Search document</span>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search this document"
+            className="h-9 w-full rounded-item border border-rule bg-paper px-3 text-sm text-ink outline-none focus:border-ink"
+            data-testid="demo-document-search"
+          />
+        </label>
       </div>
 
-      <header className="rounded-card border border-rule bg-paper px-5 py-5 sm:px-6">
-        <p className="text-[11px] font-semibold uppercase tracking-widest text-muted">
-          Demo document
-        </p>
-        <h1 className="mt-2 text-3xl font-semibold tracking-tight2 text-ink sm:text-4xl">
+      <header>
+        <h1 className="text-3xl font-semibold tracking-tight2 text-ink sm:text-4xl">
           {doc.filename}
         </h1>
-        <div className="mt-4 flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-track2 text-muted">
-          {doc.tag && (
-            <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1">
-              {doc.tag}
-            </span>
-          )}
-          <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1">
-            {doc.from_disclosure ? "CPR 31 disclosure" : "uploaded"}
-          </span>
-          <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1">
-            {formatBytes(doc.size_bytes)}
-          </span>
-          <span className="rounded-item border border-rule bg-paper-sunken px-2 py-1">
-            source-ready
-          </span>
-        </div>
+        <p className="mt-2 text-xs text-muted">
+          {[
+            doc.tag,
+            doc.from_disclosure ? "CPR 31 disclosure" : "uploaded",
+            formatBytes(doc.size_bytes),
+            doc.uploaded_at.slice(0, 10),
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </p>
+        {query.trim() && (
+          <p className="mt-2 text-xs text-muted" data-testid="demo-document-search-count">
+            {matchCount
+              ? `${matchCount} match${matchCount === 1 ? "" : "es"}`
+              : "No matches"}
+          </p>
+        )}
       </header>
 
-      <main className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <section className="order-2 min-h-[680px] rounded-card border border-rule bg-paper lg:order-1">
-          <div className="border-b border-rule px-5 py-3">
-            <div className="flex flex-wrap items-end justify-between gap-3">
-              <div>
-                <h2 className="text-sm font-semibold text-ink">Extracted text</h2>
-                <p className="mt-0.5 text-xs text-muted">
-                  Read-only public sample. Search it like a project file.
-                </p>
-              </div>
-              <label className="min-w-[220px] text-xs text-muted">
-                <span className="sr-only">Search document</span>
-                <input
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
-                  placeholder="Search document"
-                  className="h-9 w-full rounded-item border border-rule bg-paper px-3 text-sm text-ink outline-none focus:border-ink"
-                  data-testid="demo-document-search"
-                />
-              </label>
-            </div>
-            {query.trim() && (
-              <p className="mt-2 text-xs text-muted" data-testid="demo-document-search-count">
-                {matchCount
-                  ? `${matchCount} match${matchCount === 1 ? "" : "es"}`
-                  : "No matches"}
-              </p>
-            )}
-          </div>
-          <div
-            className="px-7 py-7 text-[16px] leading-8 text-ink whitespace-pre-wrap sm:px-10"
-            data-testid="demo-document-reader"
-          >
-            {searchSegments.map((segment, index) =>
-              segment.match ? (
-                <mark
-                  key={`${segment.text}-${index}`}
-                  className="bg-[#FFF4B8] px-0.5"
-                  data-testid="demo-document-search-match"
-                >
-                  {segment.text}
-                </mark>
-              ) : (
-                <span key={`${index}-${segment.text.slice(0, 8)}`}>{segment.text}</span>
-              ),
-            )}
-          </div>
-        </section>
+      <div
+        className="mt-8 border-t border-rule pt-8 text-[16px] leading-8 text-ink whitespace-pre-wrap"
+        data-testid="demo-document-reader"
+      >
+        {searchSegments.map((segment, index) =>
+          segment.match ? (
+            <mark
+              key={`${segment.text}-${index}`}
+              className="bg-[#FFF4B8] px-0.5"
+              data-testid="demo-document-search-match"
+            >
+              {segment.text}
+            </mark>
+          ) : (
+            <span key={`${index}-${segment.text.slice(0, 8)}`}>{segment.text}</span>
+          ),
+        )}
+      </div>
 
-        <aside className="order-1 space-y-4 lg:order-2">
-          <section className="rounded-card border border-ink bg-paper p-4" data-testid="demo-document-workbench-rail">
-            <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
-              Document workbench
-            </p>
-            <h2 className="mt-1 text-sm font-semibold text-ink">This file is ready to use.</h2>
-            <p className="mt-2 text-sm leading-6 text-muted">
-              This public demo lets you read the source, open the skills that use it,
-              and inspect the record without creating an account.
-            </p>
-            <div className="mt-4 grid gap-2 text-sm">
-              <a
-                href="/demo/workflows"
-                className="flex items-center justify-between rounded-item border border-ink bg-ink px-3 py-2 font-semibold text-paper hover:bg-seal hover:border-seal"
-              >
-                <span>Run a skill with this file</span>
-                <span aria-hidden="true">→</span>
-              </a>
-              <a
-                href="/demo/audit"
-                className="flex items-center justify-between rounded-item border border-rule bg-paper-sunken px-3 py-2 font-semibold text-ink hover:border-ink"
-              >
-                <span>View the Record</span>
-                <span aria-hidden="true">→</span>
-              </a>
-              <a
-                href="/demo/documents"
-                className="flex items-center justify-between rounded-item border border-rule bg-paper-sunken px-3 py-2 font-semibold text-ink hover:border-ink"
-              >
-                <span>Open other files</span>
-                <span aria-hidden="true">→</span>
-              </a>
-            </div>
-          </section>
-          <section className="rounded-card border border-rule bg-paper p-4">
-            <h2 className="text-sm font-semibold text-ink">What happens in the workspace</h2>
-            <ol className="mt-3 space-y-2 text-sm leading-6 text-muted">
-              <li><span className="font-semibold text-ink">1.</span> Read or search the document.</li>
-              <li><span className="font-semibold text-ink">2.</span> Open a skill that uses the file.</li>
-              <li><span className="font-semibold text-ink">3.</span> Inspect the produced output.</li>
-              <li><span className="font-semibold text-ink">4.</span> Open the Record to see what happened.</li>
-            </ol>
-          </section>
-          <section className="rounded-card border border-rule bg-paper p-4">
-            <details>
-              <summary className="cursor-pointer text-sm font-semibold text-ink">
-                Document facts
-              </summary>
-            <dl className="mt-3 space-y-3 text-sm">
-              <DemoReaderFact label="Type" value={doc.mime_type} />
-              <DemoReaderFact
-                label="Uploaded"
-                value={doc.uploaded_at.replace("T", " ").slice(0, 16)}
-              />
-              <DemoReaderFact label="SHA-256" value={doc.sha256} mono />
-            </dl>
-            </details>
-          </section>
-        </aside>
-      </main>
-    </div>
-  );
-}
-
-function DemoReaderFact({
-  label,
-  value,
-  mono = false,
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div>
-      <dt className="text-[10px] font-semibold uppercase tracking-track2 text-muted">
-        {label}
-      </dt>
-      <dd className={`mt-1 break-words text-ink ${mono ? "tech-token text-xs" : ""}`}>
-        {value}
-      </dd>
+      <footer className="mt-12 border-t border-rule pt-4">
+        <dl className="space-y-1 text-[11px] text-muted">
+          <LedgerRow label="Type">
+            {doc.mime_type.includes("wordprocessingml")
+              ? "Word document"
+              : doc.mime_type === "application/pdf"
+                ? "PDF"
+                : doc.mime_type}
+          </LedgerRow>
+          <LedgerRow label="Uploaded">
+            {doc.uploaded_at.replace("T", " ").slice(0, 16)}
+          </LedgerRow>
+          <LedgerRow label="SHA-256">
+            <span className="tech-token">{doc.sha256.slice(0, 16)}…</span>
+          </LedgerRow>
+        </dl>
+        <p className="mt-4 text-xs text-muted">
+          In the working product this surface carries the original file, edit
+          versions, redlines, and record links.
+        </p>
+      </footer>
     </div>
   );
 }
 
 function demoDocumentExtract(doc: MatterDocument): string {
   if (doc.filename.includes("dismissal")) {
-    return "Acme Trading Ltd confirms dismissal with effect from 12 March 2026. The reason given is alleged breach of the company social-media policy. The letter refers to a disciplinary meeting chaired by the same manager named in Ms Khan's earlier grievance.";
+    return [
+      "ACME TRADING LTD\nUnit 4, Riverside Industrial Estate, Leeds LS10 1AB",
+      "12 March 2026\n\nMs Jasmine Khan\n[address withheld in this demo]",
+      "Dear Ms Khan,",
+      "RE: TERMINATION OF EMPLOYMENT",
+      "I am writing to confirm the outcome of the disciplinary hearing held on 10 March 2026. The panel found that your conduct in publishing material on social media on 5 March 2026 amounted to a serious breach of the Company's Social Media and Communications Policy (section 4.2).",
+      "The Company has decided that your employment will terminate with effect from 12 March 2026. You will be paid in lieu of your notice period.",
+      "The disciplinary meeting was chaired by Mr D. Howarth, Warehouse Operations Manager. The panel considered your written representations and the investigation report dated 6 March 2026.",
+      "You have the right to appeal this decision in writing within five working days.",
+      "Yours sincerely,\nHR Department\nAcme Trading Ltd",
+    ].join("\n\n");
   }
   if (doc.filename.includes("witness")) {
-    return "Ms Khan says the social-media post was made from a private account, outside working hours, to a closed audience. She had raised a grievance six weeks earlier about her line manager's conduct toward female warehouse staff.";
+    return [
+      "IN THE EMPLOYMENT TRIBUNAL\nCASE NO: 2406432/2026\n\nBETWEEN: JASMINE KHAN (Claimant) and ACME TRADING LTD (Respondent)",
+      "WITNESS STATEMENT OF JASMINE KHAN",
+      "1. I make this statement from my own knowledge save where otherwise stated.",
+      "2. I was employed by the Respondent from 8 November 2022 until my dismissal on 12 March 2026, most recently as a warehouse team coordinator. My disciplinary record was clean throughout.",
+      "3. On 29 January 2026 I raised a written grievance concerning the conduct of my line manager, Mr Howarth, toward female members of the warehouse team. HR acknowledged the grievance on 18 February 2026 and appointed Mr Howarth's own department to investigate it.",
+      "4. The Instagram post relied on by the Respondent was made on 5 March 2026 from my personal account, outside working hours. The account is private, with an audience of 47 approved followers. None of them are customers, suppliers, or people named in the post. The post did not identify the Respondent.",
+      "5. The disciplinary meeting on 10 March 2026 was chaired by Mr Howarth — the manager who was the subject of my grievance six weeks earlier.",
+      "I believe the facts stated in this witness statement are true.",
+    ].join("\n\n");
   }
-  return "The synthetic mutual NDA contains indefinite confidentiality obligations, broad mutual indemnity language, a data-protection clause, and no governing law or jurisdiction clause.";
+  return [
+    "MUTUAL NON-DISCLOSURE AGREEMENT",
+    "This Agreement is made between Acme Trading Ltd and North Mill Consulting Limited (each a \"Party\").",
+    "1. CONFIDENTIAL INFORMATION. Each Party may disclose to the other information relating to its business, products, customers, and operations. All such information is \"Confidential Information\".",
+    "2. OBLIGATIONS. Each Party shall hold the other's Confidential Information in strict confidence. The obligations in this clause survive termination of this Agreement indefinitely.",
+    "3. INDEMNITY. Each Party shall indemnify the other against all losses, costs, and claims howsoever arising in connection with any breach of this Agreement, without limit.",
+    "4. DATA PROTECTION. Each Party confirms it complies with applicable data protection law.",
+    "5. TERM. This Agreement runs for three years from the date of signature.",
+    "[No governing law or jurisdiction clause appears in the document.]",
+  ].join("\n\n");
 }

--- a/frontend/src/demo/snapshot.ts
+++ b/frontend/src/demo/snapshot.ts
@@ -43,7 +43,9 @@ const MATTER: Matter = {
     "Ms Khan was dismissed by Acme Trading Ltd on 12 March 2026, after three years and four months of continuous service. The stated reason was conduct — a single alleged breach of the company's social-media policy — but the dismissal followed a documented grievance Ms Khan had raised six weeks earlier concerning her line manager's pattern of conduct toward female members of the warehouse team.\n\nOur case is that the conduct reason is pretextual. The real reason for dismissal falls within s.103A ERA 1996 (protected disclosure) or, in the alternative, constitutes victimisation under s.27 Equality Act 2010. The Burchell test fails on the second and third limbs: the investigator was the manager who was the subject of Ms Khan's prior grievance, and the sanction sat outside the band of reasonable responses given a clean disciplinary record and Iceland Frozen Foods proportionality.",
   pivot_fact:
     "The social-media post the respondent treats as gross misconduct was a private comment on a personal Instagram account, set to a closed audience of 47 followers, none of whom were customers, suppliers, or named in the post.",
-  privilege_posture: "C_paused",
+  // The thread walks pause → refusal → resume; the matter ends resumed
+  // so the rail shows Active and the loop reads complete (P29 §3).
+  privilege_posture: "B_mixed",
   default_model_id: "claude-sonnet-4-6",
   required_provider: "anthropic",
   facts: {
@@ -403,6 +405,43 @@ const AUDIT: AuditEntry[] = [
       decision: "blocked before dispatch — no content left the workspace",
     },
   },
+  // Resume + the re-run that now succeeds — the loop closes on the record.
+  {
+    id: "audit-26",
+    timestamp: "2026-04-06T14:21:08Z",
+    actor_id: ID.user,
+    matter_id: ID.matter,
+    action: "matter.privilege.changed",
+    module: null,
+    resource_type: "matter",
+    resource_id: ID.matter,
+    model_used: null,
+    prompt_hash: null,
+    response_hash: null,
+    token_count: null,
+    latency_ms: 19,
+    payload: {
+      from: "C_paused",
+      to: "B_mixed",
+      reason: "settlement talks concluded",
+    },
+  },
+  {
+    id: "audit-27",
+    timestamp: "2026-04-06T14:22:41Z",
+    actor_id: ID.user,
+    matter_id: ID.matter,
+    action: "document.summarise",
+    module: "assistant",
+    resource_type: "document",
+    resource_id: ID.witness,
+    model_used: "claude-sonnet-4-6",
+    prompt_hash: "gh78ij90",
+    response_hash: "op67qr89",
+    token_count: 1_842,
+    latency_ms: 3_912,
+    payload: { document: "witness-statement-khan.docx" },
+  },
 ];
 
 const CHRONOLOGY: ChronologyResponse = {
@@ -612,7 +651,7 @@ const ASSISTANT_MESSAGES: AssistantMessage[] = [
     id: "asst-msg-04",
     role: "assistant",
     content:
-      "12 March 2026. Acme dismissed Ms Khan citing a social-media policy breach — see [chron:ev-05]. That date is the EDT for limitation purposes; ACAS Day A was filed on 2 May, so the s.207B extended ET1 deadline lands on 3 July 2026.",
+      "12 March 2026. Acme dismissed Ms Khan citing a social-media policy breach [chron:ev-05]. That date is the EDT for limitation purposes; ACAS Day A was filed on 2 May, so the s.207B extended ET1 deadline lands on 3 July 2026.",
     suggested_actions: [
       {
         type: "view_chronology",
@@ -634,11 +673,11 @@ const ASSISTANT_MESSAGES: AssistantMessage[] = [
     id: "asst-msg-06",
     role: "assistant",
     content:
-      "Done — privilege posture is now C_paused. Until you resume, no document content reaches any model: the gate blocks the call before dispatch, and every blocked attempt lands on the record.",
+      "Done, the matter is paused. Until you resume it, no document content reaches any model: the gate blocks the call before it is sent, and every blocked attempt lands on the record.",
     suggested_actions: [
       {
         type: "view_audit",
-        label: "See the posture change on the record",
+        label: "See the pause on the record",
         params: {},
       },
     ],
@@ -655,15 +694,51 @@ const ASSISTANT_MESSAGES: AssistantMessage[] = [
     id: "asst-msg-08",
     role: "assistant",
     content:
-      "I can't — this matter is paused. The privilege gate refused the model call before any content left the workspace (C_paused, set for the settlement talks). The refusal is recorded on the matter record with the same fidelity as every approval. Resume the matter from its settings when the talks conclude.",
+      "I can't. This matter is paused, so the gate refused the model call before any content left the workspace. The refusal is recorded with the same fidelity as every approval. Resume the matter when the talks conclude.",
     suggested_actions: [
       {
         type: "view_audit",
-        label: "See the blocked entry",
+        label: "See the refusal on the record",
         params: {},
       },
     ],
     created_at: "2026-04-06T12:05:31Z",
+  },
+  {
+    id: "asst-msg-09",
+    role: "user",
+    content: "Talks concluded — resume the matter.",
+    suggested_actions: [],
+    created_at: "2026-04-06T14:21:08Z",
+  },
+  {
+    id: "asst-msg-10",
+    role: "assistant",
+    content:
+      "Resumed. Model access is back on for this matter, and the pause, the blocked attempt, and this resumption are all on the record.",
+    suggested_actions: [],
+    created_at: "2026-04-06T14:21:12Z",
+  },
+  {
+    id: "asst-msg-11",
+    role: "user",
+    content: "summarise the witness statement",
+    suggested_actions: [],
+    created_at: "2026-04-06T14:22:30Z",
+  },
+  {
+    id: "asst-msg-12",
+    role: "assistant",
+    content:
+      `Summary of witness-statement-khan.docx: Ms Khan says the Instagram post treated as gross misconduct was made from a private account, outside working hours, to a closed audience of 47 [doc:${ID.witness}]. She had raised a grievance about her line manager six weeks before the dismissal, and the same manager chaired the disciplinary meeting. Nothing in the statement suggests any customer, supplier, or colleague saw the post.`,
+    suggested_actions: [
+      {
+        type: "view_audit",
+        label: "Open the Record",
+        params: {},
+      },
+    ],
+    created_at: "2026-04-06T14:22:41Z",
   },
 ];
 

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -68,9 +68,11 @@ export function MessageBubble({
 }
 
 function UserMessage({ content, compact }: { content: string; compact: boolean }) {
+  // rounded-card matches the P21 panel radius — square bubbles read as
+  // unfinished against the rounded shell (P29 §2).
   const cls = compact
-    ? "max-w-[90%] bg-wash border border-rule px-3 py-2 text-xs text-ink whitespace-pre-wrap leading-relaxed"
-    : "max-w-[560px] bg-wash border border-rule px-4 py-3 text-sm text-ink whitespace-pre-wrap leading-relaxed";
+    ? "max-w-[90%] rounded-card bg-wash border border-rule px-3 py-2 text-xs text-ink whitespace-pre-wrap leading-relaxed"
+    : "max-w-[560px] rounded-card bg-wash border border-rule px-4 py-3 text-[15px] text-ink whitespace-pre-wrap leading-relaxed";
   return (
     <div className="flex justify-end">
       <div className={cls}>{content}</div>
@@ -99,20 +101,14 @@ function AssistantMessageView({
 
   return (
     <div className="flex justify-start">
-      <div
-        className={
-          (compact
-            ? "max-w-full"
-            : "w-full border-l-2 border-rule bg-paper px-4 py-3") +
-          " flex flex-col gap-2"
-        }
-      >
+      {/* P29 §2: assistant turns are plain prose on the panel — no gray
+          block, no left border. The output row and chips carry the chrome. */}
+      <div className={(compact ? "max-w-full" : "w-full") + " flex flex-col gap-2"}>
         <div className={`tech-token ${metaSizing} text-muted`}>
           Assistant{!compact && modelLabel(message) ? ` · ${modelLabel(message)}` : ""}
           {!compact && sourceCount > 0
             ? ` · ${sourceCount} source${sourceCount === 1 ? "" : "s"}`
             : ""}
-          {" · saved to Activity"}
         </div>
         <div className={`${proseSizing} text-ink leading-relaxed whitespace-pre-wrap`}>
           {text}
@@ -127,7 +123,7 @@ function AssistantMessageView({
                   c.kind === "doc" ? onDocChip(c.id) : onChronChip(c.id)
                 }
                 title={c.full}
-                className={`inline-flex items-center border border-rule bg-paper text-ink px-2 py-0.5 tech-token ${
+                className={`inline-flex items-center rounded-item border border-rule bg-paper text-ink px-2 py-0.5 tech-token ${
                   compact ? "text-[10px]" : "text-[11px]"
                 } hover:border-ink transition-colors`}
               >
@@ -209,7 +205,7 @@ function AssistantOutputRow({
 
   return (
     <div
-      className="mt-2 flex flex-wrap items-center gap-2 rounded-md border border-rule bg-paper px-3 py-2"
+      className="mt-2 flex flex-wrap items-center gap-2 rounded-card border border-rule bg-paper px-3 py-2"
       data-testid="assistant-output-row"
     >
       <span

--- a/frontend/src/matter/auditNarrate.ts
+++ b/frontend/src/matter/auditNarrate.ts
@@ -1,0 +1,115 @@
+/**
+ * Plain-English narration for audit entries (DESIGN.md P29 §1).
+ *
+ * One sentence per action: what happened, in the user's vocabulary.
+ * The technical material (hashes, ids, raw payload) stays in the
+ * drawer's "Technical record" disclosure — complete, but never leading.
+ * Posture values narrate as Active/Paused, never the enum.
+ */
+
+import type { AuditEntry } from "../lib/api";
+import { posturePaused } from "../lib/posture";
+
+function payloadStr(entry: AuditEntry, key: string): string | null {
+  const v = (entry.payload ?? {})[key];
+  return typeof v === "string" ? v : null;
+}
+
+function payloadNum(entry: AuditEntry, key: string): number | null {
+  const v = (entry.payload ?? {})[key];
+  return typeof v === "number" ? v : null;
+}
+
+/** One plain sentence for what this entry records. */
+export function narrateEntry(entry: AuditEntry): string {
+  const a = entry.action;
+
+  if (a === "matter.create") return "Opened the matter.";
+
+  if (a === "document.upload") {
+    const f = payloadStr(entry, "filename");
+    return f ? `Uploaded ${f}.` : "Uploaded a document.";
+  }
+  if (a === "document.extract") {
+    return "Extracted the document text so it can be read, searched, and cited.";
+  }
+  if (a === "document.anonymise") {
+    const n = payloadNum(entry, "entities");
+    return n != null
+      ? `Anonymised the document — ${n} personal identifier${n === 1 ? "" : "s"} replaced.`
+      : "Anonymised the document.";
+  }
+
+  if (a === "chronology.build") {
+    const n = payloadNum(entry, "events");
+    return n != null
+      ? `Built a chronology of ${n} events from the matter documents.`
+      : "Built a chronology from the matter documents.";
+  }
+  if (a === "chronology.gate.confirm") {
+    return "Confirmed the CPR 31.22 acknowledgement before working with disclosure material.";
+  }
+
+  if (a.startsWith("pre_motion.stage.")) {
+    const stage = a.slice("pre_motion.stage.".length);
+    const agents = payloadNum(entry, "sub_agents");
+    return agents != null
+      ? `Ran the ${stage} stage of the pre-motion assessment (${agents} parallel passes).`
+      : `Ran the ${stage} stage of the pre-motion assessment.`;
+  }
+  if (a === "pre_motion.export.pdf") {
+    return "Exported the pre-motion assessment as a PDF.";
+  }
+
+  if (a === "contract_review.run") {
+    const doc = payloadStr(entry, "document");
+    return doc
+      ? `Reviewed ${doc} clause by clause.`
+      : "Ran a contract review.";
+  }
+
+  if (a === "review.create") {
+    const title = payloadStr(entry, "title");
+    return title ? `Opened a review: ${title}.` : "Opened a review.";
+  }
+  if (a === "review.run") {
+    const run = payloadNum(entry, "cells_run");
+    const failed = payloadNum(entry, "cells_failed");
+    if (run != null) {
+      return failed
+        ? `Ran the review — ${run} checks, ${failed} flagged.`
+        : `Ran the review — ${run} checks, none flagged.`;
+    }
+    return "Ran the review.";
+  }
+
+  if (a === "matter.privilege.changed") {
+    const to = payloadStr(entry, "to");
+    const reason = payloadStr(entry, "reason");
+    const verb = to && posturePaused(to) ? "Paused" : "Resumed";
+    return reason
+      ? `${verb} the matter — ${reason}.`
+      : `${verb} the matter.`;
+  }
+  if (a.startsWith("posture_gate.") && a.endsWith(".blocked")) {
+    return "Blocked a model call because the matter is paused. No content left the workspace.";
+  }
+
+  if (a === "output.signed") return "Signed the output — a named person took responsibility for it.";
+  if (a === "output.signed_with_observations") {
+    return "Signed the output with observations recorded.";
+  }
+  if (a === "output.sign_rejected") return "Rejected the output at sign-off.";
+
+  if (a === "document.summarise") {
+    const doc = payloadStr(entry, "document");
+    return doc ? `Summarised ${doc}.` : "Summarised a document.";
+  }
+
+  if (a === "module.enabled") return "Enabled a skill on this matter.";
+  if (a === "module.grant.created") return "Granted a skill permission to run.";
+  if (a === "module.grant.revoked") return "Revoked a skill's permission.";
+
+  // Honest fallback: the action string, undecorated.
+  return a;
+}

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -496,7 +496,7 @@ export function AssistantTab({
 
         <div
           ref={scrollRef}
-          className="min-h-0 flex-1 space-y-5 overflow-y-auto border-t border-rule py-5"
+          className="min-h-0 flex-1 space-y-6 overflow-y-auto border-t border-rule py-6"
         >
         {!loaded && (
           <p className="tech-token text-xs text-muted flex items-center gap-2">

--- a/frontend/src/matter/tabs/AuditTab.tsx
+++ b/frontend/src/matter/tabs/AuditTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { AuditEntry, Matter } from "../../lib/api";
 import { LoadingLine } from "../../ui/primitives";
+import { narrateEntry } from "../auditNarrate";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -127,6 +128,17 @@ export function AuditTab({ audit, matter }: { audit: AuditEntry[] | null; matter
   );
 }
 
+const DRAWER_MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+
+// "2026-04-04T13:02:09Z" → "4 April 2026, 13:02"
+function humanTimestamp(iso: string): string {
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/);
+  if (!m) return iso;
+  const month = Number(m[2]);
+  if (month < 1 || month > 12) return iso;
+  return `${Number(m[3])} ${DRAWER_MONTHS[month - 1]} ${m[1]}, ${m[4]}:${m[5]}`;
+}
+
 function AuditDetailDrawer({
   entry,
   matter,
@@ -138,6 +150,10 @@ function AuditDetailDrawer({
 }) {
   const payloadKeys = Object.keys(entry.payload ?? {});
   const hasPayload = payloadKeys.length > 0;
+  const isBlocked =
+    entry.action.includes(".blocked") ||
+    entry.action.includes(".refused") ||
+    entry.action.includes(".denied");
 
   return (
     <>
@@ -150,12 +166,14 @@ function AuditDetailDrawer({
         role="dialog"
         aria-modal="true"
         aria-label="Audit entry detail"
-        className="fixed top-0 right-0 z-50 h-screen w-[420px] max-w-full bg-paper border-l border-rule p-6 overflow-y-auto"
+        className="fixed top-0 right-0 z-50 h-screen w-[420px] max-w-full bg-paper border-l border-rule p-6 overflow-y-auto md:m-3 md:h-[calc(100vh-24px)] md:rounded-panel md:border md:shadow-panel"
       >
-        <div className="flex items-start justify-between gap-4 mb-6">
-          <div>
-            <div className="eyebrow mb-2">Audit entry</div>
-            <h3 className="text-lg font-bold text-ink leading-tight">{entry.action}</h3>
+        <div className="flex items-start justify-between gap-4 mb-5">
+          <div className="min-w-0">
+            <div className="eyebrow mb-2">{isBlocked ? "Refused entry" : "Audit entry"}</div>
+            <h3 className={"text-lg font-bold leading-tight break-words " + (isBlocked ? "text-seal" : "text-ink")}>
+              {entry.action}
+            </h3>
           </div>
           <button
             type="button"
@@ -169,30 +187,52 @@ function AuditDetailDrawer({
           </button>
         </div>
 
-        <dl className="grid grid-cols-[110px_1fr] gap-y-3 gap-x-4 tech-token text-[12px] mb-6">
-          <Row label="Timestamp" value={entry.timestamp} />
-          <Row label="Module" value={entry.module ?? "-"} />
-          <Row label="Action" value={entry.action} />
-          <ActorRow actor={entry.actor_id} />
-          <ResourceRow entry={entry} />
-          <MatterIdRow matterId={entry.matter_id} matter={matter} />
-          <Row label="Model" value={entry.model_used ?? "-"} />
-          <Row label="Tokens" value={entry.token_count != null ? String(entry.token_count) : "-"} />
-          <Row label="Latency" value={entry.latency_ms != null ? `${entry.latency_ms}ms` : "-"} />
-          <Row label="Prompt hash" value={entry.prompt_hash ?? "-"} mono break />
-          <Row label="Response hash" value={entry.response_hash ?? "-"} mono break />
-          <Row label="Entry id" value={entry.id} mono break />
+        {/* What happened, in English, before any identifier. */}
+        <p className="mb-6 text-sm leading-relaxed text-prose" data-testid="audit-narration">
+          {narrateEntry(entry)}
+        </p>
+
+        <dl className="grid grid-cols-[90px_1fr] gap-y-3 gap-x-4 text-[13px] mb-6 border-t border-rule pt-4">
+          <PlainRow label="When" value={humanTimestamp(entry.timestamp)} />
+          <PlainRow label="Who" value={entry.actor_id ? "Workspace user" : "System"} />
+          {matter?.title && <PlainRow label="Matter" value={matter.title} />}
+          {entry.model_used && <PlainRow label="Model" value={entry.model_used} />}
         </dl>
 
-        {hasPayload && (
-          <div>
-            <div className="eyebrow mb-2">Payload</div>
-          <pre className="rounded-card tech-token text-xs bg-wash border border-rule p-3 overflow-x-auto whitespace-pre-wrap break-all">
+        {/* The complete technical material — present, never leading. */}
+        <details className="border-t border-rule pt-4">
+          <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted hover:text-ink">
+            Technical record
+          </summary>
+          <dl className="mt-4 grid grid-cols-[110px_1fr] gap-y-3 gap-x-4 tech-token text-[12px]">
+            <Row label="Timestamp" value={entry.timestamp} />
+            <Row label="Module" value={entry.module ?? "-"} />
+            <Row label="Action" value={entry.action} />
+            <ActorRow actor={entry.actor_id} />
+            <ResourceRow entry={entry} />
+            <MatterIdRow matterId={entry.matter_id} matter={matter} />
+            <Row label="Tokens" value={entry.token_count != null ? String(entry.token_count) : "-"} />
+            <Row label="Latency" value={entry.latency_ms != null ? `${entry.latency_ms}ms` : "-"} />
+            <Row label="Prompt hash" value={entry.prompt_hash ?? "-"} mono break />
+            <Row label="Response hash" value={entry.response_hash ?? "-"} mono break />
+            <Row label="Entry id" value={entry.id} mono break />
+          </dl>
+          {hasPayload && (
+            <pre className="mt-4 rounded-card tech-token text-xs bg-wash border border-rule p-3 overflow-x-auto whitespace-pre-wrap break-all">
               {JSON.stringify(entry.payload, null, 2)}
             </pre>
-          </div>
-        )}
+          )}
+        </details>
       </aside>
+    </>
+  );
+}
+
+function PlainRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="text-[10px] uppercase tracking-[0.18em] text-muted self-center">{label}</dt>
+      <dd className="text-ink break-words">{value}</dd>
     </>
   );
 }


### PR DESCRIPTION
## What

Andy's demo walk (2026-06-12) found the demo a tab museum of gray squares: raw code in the audit drawer, a bespoke document page, gibberish chat, stacked CTAs. The ratified shape: **the demo is one scripted conversation** — and since the chat/record surfaces are the real workspace components, this fixes the product, not just the demo.

- **The record speaks English first**: new `auditNarrate.ts` (one plain sentence per action); the drawer leads with the sentence + plain rows; hashes/ids/payload live in a collapsed *Technical record*. Refused entries get the seal treatment.
- **The chat earns its look**: rounded user bubbles, assistant turns as plain prose, rounded chips/output rows, quieter meta line.
- **The demo is the loop**: summarise → cite → pause → **refusal struck on the record** → resume → the re-run succeeds → Open the Record. `C_paused` scrubbed from chat copy.
- **The reader reads like a document**: P25 anatomy, multi-paragraph fixtures (tribunal-style witness statement, dismissal letter, NDA), facts as ledger rows. Workbench panel + lecture list deleted.
- Spec: DESIGN.md **P29**.

## Verification

297/297 vitest, tsc clean, live Playwright walk of /demo chat + audit drawer + reader (screenshots in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)