### PR TITLE
P30 fixes: cut the masthead eyebrow rows; restore the /admin/audit shell; left-align the register

### DIFF
--- a/frontend/src/admin/AdminAuditView.tsx
+++ b/frontend/src/admin/AdminAuditView.tsx
@@ -131,11 +131,9 @@ export function AdminAuditView() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
+    <div className="max-w-4xl px-6 py-12 text-ink">
       <PageHeader
         display
-        eyebrow="Workspace records"
-        eyebrowRight="Legalise"
         title="Workspace audit"
         whisper="The workspace record"
         description="What the workspace did when no matter was before it — admission ceremonies, settings key operations, role changes, and the viewing of this very page. Entries bound to a matter live with the matter; nothing renders here that the audit chain does not hold."
@@ -285,9 +283,8 @@ export function AdminAuditView() {
 
 function AdminRequiredShell() {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
+    <div className="max-w-2xl px-6 py-16 text-ink">
       <PageHeader
-        eyebrow="Workspace records"
         title="Admin required"
         description="The workspace audit surface requires superuser. Ask your workspace administrator if you need access."
       />

--- a/frontend/src/admin/AdminUserDetail.tsx
+++ b/frontend/src/admin/AdminUserDetail.tsx
@@ -172,7 +172,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
-      <PageHeader eyebrow="Workspace administration" eyebrowRight={user.role} title={user.email} subId={user.id} />
+      <PageHeader title={user.email} subId={user.id} />
 
       <CertCard testid="practitioner-card">
         <CertEyebrow
@@ -301,7 +301,6 @@ function AdminRequiredShell() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
       <PageHeader
-        eyebrow="Workspace administration"
         title="Admin required"
         description="Per-user admin surface requires superuser. Ask your workspace administrator if you need access."
       />

--- a/frontend/src/admin/AdminUsersList.tsx
+++ b/frontend/src/admin/AdminUsersList.tsx
@@ -87,12 +87,6 @@ export function AdminUsersList() {
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <PageHeader
         display
-        eyebrow="Workspace administration"
-        eyebrowRight={
-          q.status === "ready"
-            ? `${q.users.length} user${q.users.length === 1 ? "" : "s"}`
-            : undefined
-        }
         title="Users"
         whisper="The roll of practitioners"
         description="Every practitioner admitted to this workspace, entered in the order the roll holds them. The roll records; it does not act. A role is changed on the practitioner's own page, and the substrate exposes no bulk operations."
@@ -201,7 +195,6 @@ function AdminRequiredShell() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
       <PageHeader
-        eyebrow="Workspace administration"
         title="Admin required"
         description="The admin users surface requires superuser. Ask your workspace administrator if you need access."
       />

--- a/frontend/src/app/AppHome.tsx
+++ b/frontend/src/app/AppHome.tsx
@@ -93,8 +93,6 @@ function FirstRunEmptyState() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
       <PageHeader
-        eyebrow="Fresh workspace"
-        eyebrowRight="Legalise"
         title="No accounts yet"
         description="Register the first account to begin. In the local quickstart, that account is verified, seeded with Khan v Acme, and promoted to workspace admin automatically. Deployments that disable auto-admin will show the host-side bootstrap CLI command after signup."
       />
@@ -126,8 +124,6 @@ function BootstrapRequiredState() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
       <PageHeader
-        eyebrow="Bootstrap required"
-        eyebrowRight="Legalise"
         title="Administrator not yet bootstrapped"
         description="Accounts exist in this workspace but no administrator has been designated yet. Run the bootstrap command on the host to promote an existing user. This step is deliberately host-side; the UI does not expose a self-promotion path."
       />

--- a/frontend/src/auth/ForgotPassword.tsx
+++ b/frontend/src/auth/ForgotPassword.tsx
@@ -27,7 +27,6 @@ export function ForgotPassword() {
   if (sent) {
     return (
       <AuthCard
-        eyebrow="The workspace"
         heading="Check your email"
         intro="If an account exists for that address, a reset link is on its way."
       >
@@ -40,7 +39,6 @@ export function ForgotPassword() {
 
   return (
     <AuthCard
-      eyebrow="The workspace"
       heading="Reset your password"
       intro="Enter your account email. We'll send a one-time reset link."
     >

--- a/frontend/src/auth/ResetPassword.tsx
+++ b/frontend/src/auth/ResetPassword.tsx
@@ -31,7 +31,6 @@ export function ResetPassword({ token }: { token: string | null }) {
   if (!token) {
     return (
       <AuthCard
-        eyebrow="The workspace"
         heading="Missing token"
         intro="This page expects a one-time token from the reset email link."
       >
@@ -45,7 +44,6 @@ export function ResetPassword({ token }: { token: string | null }) {
   if (done) {
     return (
       <AuthCard
-        eyebrow="The workspace"
         heading="Password updated"
         intro="Your new password is set. Sign in to continue."
       >
@@ -58,7 +56,6 @@ export function ResetPassword({ token }: { token: string | null }) {
 
   return (
     <AuthCard
-      eyebrow="The workspace"
       heading="Choose a new password"
       intro="At least 8 characters. The reset link expires soon, so finish here."
     >

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -52,8 +52,6 @@ export function Settings({ tab }: { tab: SettingsTab }) {
     <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-12">
       <PageHeader
         display
-        eyebrow="Your account"
-        eyebrowRight="Legalise"
         title="Settings"
         whisper="Your account at the registry"
         description="The account holds your profile, your provider keys, and your defaults. Your name appears in audit rows; key changes are themselves recorded."

--- a/frontend/src/auth/SignUp.tsx
+++ b/frontend/src/auth/SignUp.tsx
@@ -34,7 +34,6 @@ export function SignUp() {
 
   return (
     <AuthCard
-      eyebrow="Before the registrar"
       heading="Sign up"
       intro="Create a workspace. You'll add an Anthropic or OpenAI key after email verification."
     >

--- a/frontend/src/auth/Verify.tsx
+++ b/frontend/src/auth/Verify.tsx
@@ -49,7 +49,6 @@ export function Verify({ token }: { token: string | null }) {
   if (status === "ok") {
     return (
       <AuthCard
-        eyebrow="Before the registrar"
         heading="Email verified"
         intro="Your account is active. Open your workspace to get started."
       >

--- a/frontend/src/auth/VerifyPending.tsx
+++ b/frontend/src/auth/VerifyPending.tsx
@@ -29,7 +29,6 @@ export function VerifyPending() {
 
   return (
     <AuthCard
-      eyebrow="Before the registrar"
       heading="Check your inbox"
       intro="We sent a verification link to your email. Click it to activate your account."
     >

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -98,8 +98,6 @@ export function DemoLoop() {
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="A matter before the workspace · guided loop"
-        eyebrowRight="Legalise"
         title="Watch the governed loop"
         description="Watch the full supervised-autonomy loop run end to end — no provider key needed. This is a keyless demonstration matter modelled on the Khan v Acme employment dispute; real Khan remains the full workspace matter. Bring a real provider key (Settings → Keys) to run real models on your own matters."
       />

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -53,7 +53,6 @@ export function Help() {
   return (
     <div className="mx-auto max-w-2xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="How the workspace works"
         title="Help"
         whisper="Plainly stated"
       />

--- a/frontend/src/landing/About.tsx
+++ b/frontend/src/landing/About.tsx
@@ -17,17 +17,9 @@ export function About() {
   return (
     <div className="max-w-page mx-auto">
       <div className="px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
-        {/* Masthead */}
+        {/* Masthead — the monument carries the page alone (P30). */}
         <header>
-          <div className="flex items-baseline justify-between border-b border-ink pb-2">
-            <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
-              Legalise · About
-            </p>
-            <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
-              London
-            </p>
-          </div>
-          <h1 className="mt-10 font-redaction35 text-[52px] sm:text-[72px] leading-none tracking-tight2 text-ink">
+          <h1 className="font-redaction35 text-[52px] sm:text-[72px] leading-none tracking-tight2 text-ink">
             Andy Bird
           </h1>
           <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-muted">

--- a/frontend/src/landing/Architecture.tsx
+++ b/frontend/src/landing/Architecture.tsx
@@ -70,17 +70,9 @@ export function Architecture() {
   return (
     <div className="max-w-page mx-auto">
       <div className="px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
-        {/* Masthead */}
+        {/* Masthead — the monument carries the page alone (P30). */}
         <header>
-          <div className="flex items-baseline justify-between border-b border-ink pb-2">
-            <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
-              Legalise · Architecture
-            </p>
-            <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
-              Open source · Apache 2.0
-            </p>
-          </div>
-          <h1 className="mt-10 font-redaction35 text-[52px] sm:text-[72px] leading-none tracking-tight2 text-ink">
+          <h1 className="font-redaction35 text-[52px] sm:text-[72px] leading-none tracking-tight2 text-ink">
             Standing
           </h1>
           <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-muted">

--- a/frontend/src/lib/route.test.ts
+++ b/frontend/src/lib/route.test.ts
@@ -24,6 +24,10 @@ describe("routeFromPath", () => {
     expect(routeFromPath("/about", "")).toEqual({ name: "about" });
   });
 
+  it("/admin/audit → adminAudit (P30: was falling through to landing, losing the shell)", () => {
+    expect(routeFromPath("/admin/audit", "")).toEqual({ name: "adminAudit" });
+  });
+
   it("/auth/signin → signin", () => {
     expect(routeFromPath("/auth/signin", "")).toEqual({ name: "signin" });
   });

--- a/frontend/src/lib/route.ts
+++ b/frontend/src/lib/route.ts
@@ -53,7 +53,8 @@ export type Route =
   | { name: "matterDocumentDetail"; slug: string; documentId: string }
   | { name: "matterLifecycle"; slug: string }
   | { name: "adminUsers" }
-  | { name: "adminUserDetail"; userId: string };
+  | { name: "adminUserDetail"; userId: string }
+  | { name: "adminAudit" };
 
 function parseQuery(search: string): URLSearchParams {
   const q = search.indexOf("?");
@@ -110,6 +111,9 @@ export function routeFromPath(pathname: string, search: string): Route {
 
   if (path === "/app") return { name: "appHome" };
   if (path === "/help") return { name: "help" };
+  // Missing from the shim until P30 — /admin/audit fell through to
+  // {name:"landing"}, which is CHROMELESS, so the page lost the sidebar.
+  if (path === "/admin/audit") return { name: "adminAudit" };
   if (path === "/admin/users") return { name: "adminUsers" };
   const adminUserMatch = path.match(/^\/admin\/users\/([^/]+)$/);
   if (adminUserMatch) return { name: "adminUserDetail", userId: adminUserMatch[1] };

--- a/frontend/src/matter/MatterLifecycle.tsx
+++ b/frontend/src/matter/MatterLifecycle.tsx
@@ -58,7 +58,6 @@ export function MatterLifecycle({ slug }: { slug: string }) {
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="The matter's lifecycle"
         title="Working pack"
         subId={matter.slug}
         description="Download the governed matter record, then close or delete only if needed. Exporting the working pack is the normal final step."

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -26,12 +26,6 @@ export function MatterList() {
     <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-14">
       <PageHeader
         display
-        eyebrow="Matters before the workspace"
-        eyebrowRight={
-          matters
-            ? `${matters.length} matter${matters.length === 1 ? "" : "s"}`
-            : undefined
-        }
         title="Matters"
         whisper="The cause list"
         description="Every matter this workspace holds, entered in the order it was opened. An entry records the matter's type, whether it stands open or closed, and the posture of its privilege. Open an entry to take up the matter."

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -61,7 +61,7 @@ export function NewMatter() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 sm:px-6 py-12">
-      <PageHeader eyebrow="Open a new matter" title="New matter." />
+      <PageHeader title="New matter." />
 
       <form onSubmit={submit} className="space-y-6">
         <Field label="Title" hint="becomes the slug">

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -270,8 +270,6 @@ export function ReconstructionView({ slug }: { slug: string }) {
   return (
     <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="The matter record"
-        eyebrowRight={slug}
         title="What happened here"
         actions={
           <div className="flex flex-wrap gap-2">

--- a/frontend/src/modules-v2/CounselRegister.tsx
+++ b/frontend/src/modules-v2/CounselRegister.tsx
@@ -93,17 +93,8 @@ export function CounselRegister() {
   }, [auth.user]);
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-14 text-ink">
-      <div className="flex items-baseline justify-between border-b border-ink pb-2">
-        <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
-          The register of AI counsel · series 1
-        </p>
-        <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
-          Legalise
-        </p>
-      </div>
-
-      <h1 className="mt-8 font-redaction35 text-[64px] leading-none tracking-tight2 sm:text-[88px]">
+    <div className="max-w-4xl px-6 py-14 text-ink">
+      <h1 className="font-redaction35 text-[64px] leading-none tracking-tight2 sm:text-[88px]">
         Standing
       </h1>
       <p className="mt-2 text-[11px] uppercase tracking-[0.3em] text-muted">

--- a/frontend/src/modules-v2/CreateModule.tsx
+++ b/frontend/src/modules-v2/CreateModule.tsx
@@ -60,7 +60,6 @@ export function CreateModule() {
   return (
     <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="Author a skill"
         title="Create a skill"
         description="Build your own Legalise skill. This page explains the manifest and validates a candidate against the same rules the add-skill path uses — it does not add or sign."
       />

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -154,7 +154,6 @@ export function LawveImport() {
   return (
     <div className="mx-auto max-w-5xl px-6 py-12 text-ink">
       <PageHeader
-        eyebrow="Admission — instruct new counsel"
         title="Add a skill"
         whisper="Before the registrar"
         description="Import a skill from the Lawve catalogue or any public GitHub repository. A skill cannot be added until it is converted, validated, signed, and trusted — and imported scripts are never executed."

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -204,8 +204,6 @@ export function ModulesCatalog() {
   return (
     <div className="mx-auto max-w-5xl px-6 py-14 text-ink">
       <PageHeader
-        eyebrow="The skill library"
-        eyebrowRight="Legalise"
         display
         title="Skills"
         whisper="Instruments of practice"

--- a/frontend/src/ui/primitives.tsx
+++ b/frontend/src/ui/primitives.tsx
@@ -182,13 +182,11 @@ export function DescItem({
 // editorial only). eyebrow + h1 + optional mono sub-id + optional
 // description + optional right-aligned actions slot. `children` renders
 // below the header for an optional metadata strip.
-// Standing Order masthead (DESIGN.md P26). Every page opens like a page
-// from the register: a ruled eyebrow line (letterspaced small caps left,
-// optional counterpart right), then the headline in Redaction display.
+// Standing Order masthead (DESIGN.md P26, revised P30): the headline in
+// Redaction display carries the page alone — the ruled eyebrow row was
+// cut 2026-06-12 (it only repeated the page name above the monument).
 // `display` escalates to the monument tier for section homes.
 export function PageHeader({
-  eyebrow,
-  eyebrowRight,
   title,
   whisper,
   subId,
@@ -197,8 +195,6 @@ export function PageHeader({
   display = false,
   children,
 }: {
-  eyebrow?: string;
-  eyebrowRight?: string;
   title: ReactNode;
   whisper?: string;
   subId?: string;
@@ -209,19 +205,7 @@ export function PageHeader({
 }) {
   return (
     <header className="mb-8">
-      {eyebrow && (
-        <div className="flex items-baseline justify-between border-b border-ink pb-2">
-          <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
-            {eyebrow}
-          </p>
-          {eyebrowRight && (
-            <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
-              {eyebrowRight}
-            </p>
-          )}
-        </div>
-      )}
-      <div className="mt-5 flex items-end justify-between gap-4">
+      <div className="flex items-end justify-between gap-4">
         <div className="min-w-0">
           <h1
             className={


### PR DESCRIPTION
- The ruled eyebrow row above every monument headline only repeated the
  page name — removed from PageHeader and the inline mastheads
  (/register, /architecture, /about). The monument carries the page.
- /admin/audit was missing from the lib/route.ts shim, fell through to
  {name:'landing'} (chromeless) and lost the sidebar — same class of
  bug as the PR #181 install-route gap. Shim entry + test added.
- /register and the workspace audit page were centered columns; both
  now sit left like the rest of the ledger.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
