### PR TITLE
P32: one page shell — every workspace page on the same geometry

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1659,3 +1659,13 @@ Source: Andy's demo walk, 2026-06-12 (screenshots). The verdict: the demo is a t
 
 Where it lands: matter/auditNarrate.ts (new), matter/tabs/AuditTab.tsx, matter/MessageBubble.tsx, matter/tabs/AssistantTab.tsx (spacing only), demo/snapshot.ts, demo/DemoMatter.tsx.
 Deliberate divergences: the demo document page does NOT mount the real editor stack (ProseMirror, ~200 kB lazy) — the demo is read-only by design; it borrows the P25 reading anatomy instead.
+
+---
+
+## P32 — One shell
+
+Source: Andy, 2026-06-12 — "the alignment, the size of the header, the left and right, and the borders on every single page are completely different." Audit found ~46 page wrappers across 8 geometries (max-w-2xl/3xl/4xl/5xl/page · py-12/14/16 · centered and left mixed since P30).
+
+The rule: every routed workspace page sits in `.page-shell` (index.css): `max-w-5xl px-6 sm:px-10 py-12 text-ink`, left-aligned. Pages cap inner content (forms, prose) themselves; the shell and its section rules stay constant. Header tiers unchanged (P27: monument for section homes, standard for sub-pages).
+
+NOT touched: the matter chat shell (P22 geometry), the document editor surface (P25 measure), TopBar, the demo shell, marketing pages (P28 own grid).

--- a/frontend/src/admin/AdminAuditView.tsx
+++ b/frontend/src/admin/AdminAuditView.tsx
@@ -131,7 +131,7 @@ export function AdminAuditView() {
   }
 
   return (
-    <div className="max-w-4xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         display
         title="Workspace audit"
@@ -283,7 +283,7 @@ export function AdminAuditView() {
 
 function AdminRequiredShell() {
   return (
-    <div className="max-w-2xl px-6 py-16 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Admin required"
         description="The workspace audit surface requires superuser. Ask your workspace administrator if you need access."

--- a/frontend/src/admin/AdminUserDetail.tsx
+++ b/frontend/src/admin/AdminUserDetail.tsx
@@ -104,7 +104,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
   }
   if (q.status === "loading") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12 text-sm text-muted">
+      <div className="page-shell text-sm text-muted">
         Loading user…
       </div>
     );
@@ -112,7 +112,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
   if (q.status === "admin_required") return <AdminRequiredShell />;
   if (q.status === "not_found") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <h1 className="text-xl font-bold tracking-tight2">User not found</h1>
         <p className="mt-3 text-sm">
           <Link
@@ -127,7 +127,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
   }
   if (q.status === "error") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <h1 className="text-xl font-bold tracking-tight2">Could not load user</h1>
         <p className="mt-3 text-sm text-muted">{q.message}</p>
       </div>
@@ -171,7 +171,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
   };
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader title={user.email} subId={user.id} />
 
       <CertCard testid="practitioner-card">
@@ -299,7 +299,7 @@ export function AdminUserDetail({ userId }: { userId: string }) {
 
 function AdminRequiredShell() {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Admin required"
         description="Per-user admin surface requires superuser. Ask your workspace administrator if you need access."

--- a/frontend/src/admin/AdminUsersList.tsx
+++ b/frontend/src/admin/AdminUsersList.tsx
@@ -84,7 +84,7 @@ export function AdminUsersList() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         display
         title="Users"
@@ -193,7 +193,7 @@ export function AdminUsersList() {
 
 function AdminRequiredShell() {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Admin required"
         description="The admin users surface requires superuser. Ask your workspace administrator if you need access."

--- a/frontend/src/app/AppHome.tsx
+++ b/frontend/src/app/AppHome.tsx
@@ -91,7 +91,7 @@ export function AppHome() {
 
 function FirstRunEmptyState() {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="No accounts yet"
         description="Register the first account to begin. In the local quickstart, that account is verified, seeded with Khan v Acme, and promoted to workspace admin automatically. Deployments that disable auto-admin will show the host-side bootstrap CLI command after signup."
@@ -122,7 +122,7 @@ function FirstRunEmptyState() {
 
 function BootstrapRequiredState() {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Administrator not yet bootstrapped"
         description="Accounts exist in this workspace but no administrator has been designated yet. Run the bootstrap command on the host to promote an existing user. This step is deliberately host-side; the UI does not expose a self-promotion path."
@@ -186,7 +186,7 @@ function CenteredLoader({ label }: { label: string }) {
 
 function CenteredError({ message }: { message: string }) {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-16 text-ink">
+    <div className="page-shell">
       <h1 className="text-2xl font-bold tracking-tight2">Could not load workspace state</h1>
       <p className="mt-4 text-sm text-muted">{message}</p>
       <p className="mt-4 text-sm text-muted">

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -34,7 +34,7 @@ export function Settings({ tab }: { tab: SettingsTab }) {
 
   if (auth.loading || !auth.user) {
     return (
-      <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-12">
+      <div className="page-shell">
         <LoadingLine label="loading account" />
       </div>
     );
@@ -49,7 +49,7 @@ export function Settings({ tab }: { tab: SettingsTab }) {
   ];
 
   return (
-    <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-12">
+    <div className="page-shell">
       <PageHeader
         display
         title="Settings"

--- a/frontend/src/demo/DemoLoop.tsx
+++ b/frontend/src/demo/DemoLoop.tsx
@@ -96,7 +96,7 @@ export function DemoLoop() {
   };
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Watch the governed loop"
         description="Watch the full supervised-autonomy loop run end to end — no provider key needed. This is a keyless demonstration matter modelled on the Khan v Acme employment dispute; real Khan remains the full workspace matter. Bring a real provider key (Settings → Keys) to run real models on your own matters."

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -51,7 +51,7 @@ const QA: { q: string; a: ReactNode }[] = [
 
 export function Help() {
   return (
-    <div className="mx-auto max-w-2xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Help"
         whisper="Plainly stated"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -387,3 +387,13 @@
     display: none !important;
   }
 }
+
+@layer components {
+  /* P32 — the one page shell. Every routed workspace page sits in this
+     geometry: left-aligned, one width, one gutter, one vertical rhythm.
+     Pages cap inner content (forms, prose) themselves; the shell and
+     its rules stay constant. */
+  .page-shell {
+    @apply max-w-5xl px-6 sm:px-10 py-12 text-ink;
+  }
+}

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -87,14 +87,14 @@ export function ArtifactDetail({
 
   if (q.status === "loading") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12 text-sm text-muted">
+      <div className="page-shell text-sm text-muted">
         Loading artifact…
       </div>
     );
   }
   if (q.status === "error") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <h1 className="text-xl font-bold tracking-tight2">Output not found</h1>
         <p className="mt-3 text-sm text-muted">{q.message}</p>
         <p className="mt-4 text-sm">
@@ -114,7 +114,7 @@ export function ArtifactDetail({
   const auditHref = `/matters/${encodeURIComponent(slug)}/audit?invocation_id=${encodeURIComponent(a.invocation_id)}`;
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
+    <div className="page-shell">
       {/* The artifact's certificate header — its entry in the record
           (DESIGN.md P27). Inner surface: the matter shell owns the page,
           so the header is a CertCard, not a masthead. */}

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -105,7 +105,7 @@ export function ArtifactsList({ slug }: { slug: string }) {
   }, [slug]);
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <SectionRule
         label="Signed outputs"
         right={q.status === "ready" ? String(q.rows.length) : undefined}

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -446,14 +446,14 @@ export function DocumentDetail({
 
   if (q.status === "loading") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <LoadingLine label="loading document" />
       </div>
     );
   }
   if (q.status === "not_found") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <h1 className="text-xl font-bold tracking-tight2">Document not found</h1>
         <p className="mt-3 text-sm">
           <Link
@@ -469,7 +469,7 @@ export function DocumentDetail({
   }
   if (q.status === "error") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <ErrorCallout message={q.message} />
       </div>
     );

--- a/frontend/src/matter/MatterLifecycle.tsx
+++ b/frontend/src/matter/MatterLifecycle.tsx
@@ -40,14 +40,14 @@ export function MatterLifecycle({ slug }: { slug: string }) {
 
   if (error && !matter) {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <ErrorCallout message={error} />
       </div>
     );
   }
   if (!matter) {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <LoadingLine label="loading matter" />
       </div>
     );
@@ -56,7 +56,7 @@ export function MatterLifecycle({ slug }: { slug: string }) {
   const isClosed = matter.status === "closed";
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Working pack"
         subId={matter.slug}

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -23,7 +23,7 @@ export function MatterList() {
   }, []);
 
   return (
-    <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-14">
+    <div className="page-shell">
       <PageHeader
         display
         title="Matters"

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -60,7 +60,7 @@ export function NewMatter() {
     "bg-paper border border-rule px-4 py-3 text-[16px] sm:text-[17px] focus:border-ink focus:outline-none transition-colors min-h-[44px] font-sans text-ink w-full";
 
   return (
-    <div className="max-w-2xl mx-auto px-4 sm:px-6 py-12">
+    <div className="page-shell">
       <PageHeader title="New matter." />
 
       <form onSubmit={submit} className="space-y-6">

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -268,7 +268,7 @@ export function ReconstructionView({ slug }: { slug: string }) {
   }, [visibleEntries]);
 
   return (
-    <div className="mx-auto max-w-4xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="What happened here"
         actions={

--- a/frontend/src/matter/SignOff.tsx
+++ b/frontend/src/matter/SignOff.tsx
@@ -157,7 +157,7 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
 
   if (loadErr) {
     return (
-      <div className="mx-auto max-w-2xl px-6 py-12">
+      <div className="page-shell">
         <ErrorCallout message={`Artifact not found: ${loadErr}`} />
       </div>
     );

--- a/frontend/src/matter/SignOffConfirmation.tsx
+++ b/frontend/src/matter/SignOffConfirmation.tsx
@@ -43,14 +43,14 @@ export function SignOffConfirmation({
 
   if (err) {
     return (
-      <div className="mx-auto max-w-2xl px-6 py-12">
+      <div className="page-shell">
         <ErrorCallout message={`Sign-off not found: ${err}`} />
       </div>
     );
   }
   if (signoff === null) {
     return (
-      <div className="mx-auto max-w-2xl px-6 py-12">
+      <div className="page-shell">
         <LoadingLine label="loading sign-off record" />
       </div>
     );
@@ -59,7 +59,7 @@ export function SignOffConfirmation({
   const rejected = signoff.decision === "rejected";
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-12 text-ink">
+    <div className="page-shell">
       {/* The executed certificate. Seal tone only for a rejection — the
           one refused state this record can hold. */}
       <CertCard tone={rejected ? "seal" : "ink"} testid="signoff-record">

--- a/frontend/src/modules-v2/CounselRegister.tsx
+++ b/frontend/src/modules-v2/CounselRegister.tsx
@@ -93,7 +93,7 @@ export function CounselRegister() {
   }, [auth.user]);
 
   return (
-    <div className="max-w-4xl px-6 py-14 text-ink">
+    <div className="page-shell">
       <h1 className="font-redaction35 text-[64px] leading-none tracking-tight2 sm:text-[88px]">
         Standing
       </h1>

--- a/frontend/src/modules-v2/CreateModule.tsx
+++ b/frontend/src/modules-v2/CreateModule.tsx
@@ -58,7 +58,7 @@ export function CreateModule() {
   };
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Create a skill"
         description="Build your own Legalise skill. This page explains the manifest and validates a candidate against the same rules the add-skill path uses — it does not add or sign."

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -312,14 +312,14 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
 
   if (phase.kind === "loading") {
     return (
-      <div className="mx-auto max-w-2xl px-6 py-14 text-sm text-muted">
+      <div className="page-shell text-sm text-muted">
         Opening the record…
       </div>
     );
   }
   if (phase.kind === "error" || !ceremony) {
     return (
-      <div className="mx-auto max-w-2xl px-6 py-14">
+      <div className="page-shell">
         <h1 className="text-xl font-bold tracking-tight2">Ceremony not found</h1>
         <p className="mt-3 text-sm text-muted">
           {phase.kind === "error" ? phase.message : "No ceremony loaded."}
@@ -333,7 +333,7 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
   const refused = phase.kind === "refused";
 
   return (
-    <div className="mx-auto max-w-2xl px-6 py-14 text-ink">
+    <div className="page-shell">
       <p className="text-[10px] uppercase tracking-[0.25em] text-muted">
         The register of AI counsel — admission
       </p>

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -152,7 +152,7 @@ export function LawveImport() {
   };
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-12 text-ink">
+    <div className="page-shell">
       <PageHeader
         title="Add a skill"
         whisper="Before the registrar"

--- a/frontend/src/modules-v2/ModuleDetail.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.tsx
@@ -150,14 +150,14 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
 
   if (q.status === "loading") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12 text-sm text-muted">
+      <div className="page-shell text-sm text-muted">
         Loading skill…
       </div>
     );
   }
   if (q.status === "error") {
     return (
-      <div className="mx-auto max-w-3xl px-6 py-12">
+      <div className="page-shell">
         <h1 className="text-xl font-bold tracking-tight2">Skill not found</h1>
         <p className="mt-3 text-sm text-muted">{q.message}</p>
       </div>
@@ -245,7 +245,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
   };
 
   return (
-    <div className="mx-auto max-w-3xl px-6 py-12 text-ink">
+    <div className="page-shell">
       {/* Masthead — ruled eyebrow row; the certificate below is the hero. */}
       <div className="flex items-baseline justify-between border-b border-ink pb-2">
         <p className="text-[10px] uppercase tracking-[0.3em] text-muted">

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -202,7 +202,7 @@ export function ModulesCatalog() {
   }, [modules, tab, tabCounts.installed, tabCounts.available]);
 
   return (
-    <div className="mx-auto max-w-5xl px-6 py-14 text-ink">
+    <div className="page-shell">
       <PageHeader
         display
         title="Skills"


### PR DESCRIPTION
Andy: page alignment, header size, gutters and borders differ on every live page. Audit found ~46 page wrappers across 8 geometries. All routed workspace pages now sit in one `.page-shell` class (max-w-5xl, px-6 sm:px-10, py-12, left-aligned); inner content caps itself. Chat shell / editor / TopBar / demo / marketing untouched. Spec: DESIGN.md P32. 298/298 tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)