### PR TITLE
Fluff cut Phase B: free wins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,9 @@ rg -n "—|–" frontend/src/ README.md EXECUTIVE_SUMMARY.md ARCHITECTURE.md doc
 
 # No __pycache__ or .pyc tracked.
 git ls-files | rg "__pycache__|\.pyc$"
+
+# Sweep stray bytecode dirs left behind by deleted code paths (dry-run first with -n).
+git clean -fdX backend/
 ```
 
 Both should return empty. Em-dashes inside seeded legal-content

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "legalise-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-router": "^1.85.0",
         "@tiptap/extension-color": "^3.25.0",
         "@tiptap/extension-highlight": "^3.25.0",
@@ -2022,32 +2021,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
-      "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.100.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.10.tgz",
-      "integrity": "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.100.10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "deploy": "npm run build && wrangler pages deploy dist --project-name legalise --branch master --commit-hash \"$(git rev-parse HEAD)\""
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.85.0",
     "@tiptap/extension-color": "^3.25.0",
     "@tiptap/extension-highlight": "^3.25.0",


### PR DESCRIPTION
Executes Phase B of `docs/handovers/FLUFF_CUT_ORDER_2026-06-12.md` (one PR, three free wins). Cut from master `84adb7e`.

## B1 — Remove `@tanstack/react-query`
- Verified zero usage first: `grep -rn "useQuery\|QueryClient\|react-query" frontend/src` returns nothing. All `@tanstack/*` imports are `@tanstack/react-router`, which is a different package and stays.
- Removed from `frontend/package.json` + lockfile via `npm uninstall` (2 packages out of node_modules; 27 lockfile lines gone).
- **Bundle delta: 0 kB.** Built master baseline and post-removal — every chunk hash and size identical (the `tanstack-Cq95evWg.js` 87.69 kB chunk is react-router). Vite tree-shaking had already excluded react-query, so the audit's "~50 kB drop" estimate doesn't materialise; the win is dependency hygiene and install weight, not shipped bytes.

## B2 — `__pycache__` hygiene
- `find backend -name __pycache__ -not -path "*/.venv/*"` → no stray dirs exist; `git ls-files | grep pycache` → none tracked. Nothing to delete.
- `.gitignore` already covers `__pycache__/` (line 4).
- CONTRIBUTING.md had the tracked-bytecode check but no sweep guidance — added a one-line `git clean -fdX backend/` note to the voice-checks block.

## B3 — Stale ARCHITECTURE.md spots (audit D1/D2)
Both already fixed on master, verified rather than re-edited:
- No `lib/modules.ts` reference remains anywhere in ARCHITECTURE.md (or any tracked .md).
- The `backend/app/agents/` paragraph already reads "was never wired up and has been deleted" — and the directory is confirmed gone from the tree.
No doc change needed.

## Deltas
- Source: 3 files changed, +3 / −28 lines (net −25).
- Bundle: 0 kB (see B1).
- Dependencies: −2 packages.

## Verification
- `npx tsc --noEmit` clean.
- `npx vitest run` — 37 files, 298 tests, all passed.
- `npx vite build` green.
- Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)