### PR TITLE
Docs currency pass: TRUST / MANIFESTO / ROADMAP match the shipped product

### DIFF
--- a/docs/MANIFESTO.md
+++ b/docs/MANIFESTO.md
@@ -48,7 +48,7 @@ Legalise records the path. The audit trail is not the product. It is the receipt
 
 Three states. `A_cleared`, `B_mixed`, `C_paused`. Each matter carries one. The gateway reads the posture before every model call and decides which providers can serve it.
 
-Cloud providers are commodities behind the gateway, not direct dependencies of any module. Local models (Ollama) exist from day one for `C_paused` matters.
+Cloud providers are commodities behind the gateway, not direct dependencies of any module. Local models (Ollama) exist from day one for `B_mixed` matters, where local-preferred routing keeps work in-tenant. `C_paused` permits no model call at all.
 
 If the posture rules and the providers configured for a matter cannot serve a call, the gateway refuses it. The refusal is audited. Privilege is not a soft setting.
 
@@ -62,7 +62,7 @@ No dependencies on provider-specific features unless the gateway can offer a cle
 
 Python, FastAPI, Postgres, React 19, Tailwind. Nothing on this list surprises anyone in 2030.
 
-The novelty is the composition. Privilege-aware gateway. Adversarial premortem pipelines. Audit-first model dispatch. Matter folder represented as markdown on disk so it survives any future database migration. We optimise for the parts of the system that don't care which model you used in 2026 versus 2030.
+The novelty is the composition. Privilege-aware gateway. Hash-chained audit trail. Audit-first model dispatch. A skill admission ceremony with pinned-SHA provenance. Matter folder represented as markdown on disk so it survives any future database migration. We optimise for the parts of the system that don't care which model you used in 2026 versus 2030.
 
 ## Human-in-the-loop, permanently
 
@@ -88,12 +88,12 @@ Translating US patterns into Anglicised vocabulary produces software that breaks
 
 The core is Apache-2.0 forever. Self-host on any infrastructure. Run any models. Fork. Modify.
 
-We do not gate the matter spine, audit log, plugin bridge, or any v0.1 module behind a commercial tier. If a commercial tier ever exists, it sells managed operations and certifications. Not functionality.
+We do not gate the matter spine, audit log, skill import path (Lawve catalogue or any public GitHub repo at a pinned SHA), or any module behind a commercial tier. If a commercial tier ever exists, it sells managed operations and certifications. Not functionality.
 
 ## What we won't do
 
 - Replace solicitor sign-off.
-- Add a chatbot as the primary surface.
+- Ship a chat surface that floats outside the matter file. Chat is the front door to a governed matter workspace, never a loose prompt window.
 - Take dependencies on closed proprietary APIs without an open alternative.
 - Ship a feature that breaks audit-row contract or privilege-posture dispatch.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,9 @@ Shipped surfaces:
 - **BYO model keys**, AES-256-GCM-encrypted per user. Legalise itself does
   not provide model access.
 - **Two module runtimes:** first-party native modules (`examples.contract-review`,
-  `examples.pre-motion`), and a `prompt` runtime for Lawve `SKILL.md` imports.
+  `examples.pre-motion`), and a `prompt` runtime for `SKILL.md` imports from
+  the Lawve catalogue or any public GitHub repo (the generic importer at
+  `backend/app/core/github_import.py`).
 - **Source anchors v1** across both runtimes. Server-known anchors for every
   loaded document, independent of the model; optional `quote_found_in_source`
   flag for model-supplied quotes (normalised substring check against the
@@ -42,9 +44,34 @@ Shipped surfaces:
 - **Audit reconstruction.** Ordered timeline merged from audit, state-machine,
   and advice-boundary sources, with decision events in the foreground lane.
 - **Module catalogue + add-skill trust ceremony** with declared/granted capabilities,
-  per-skill trust posture, `module.json` schema validation. (The public
-  submission flow and the filesystem plugin path were removed 2026-06-11;
-  skills now arrive via the Lawve catalogue or GitHub-repo import.)
+  per-skill trust posture, `module.json` schema validation. Skills arrive
+  only by import: the Lawve catalogue or a GitHub repo at a pinned SHA
+  (the filesystem plugin path was removed 2026-06-11).
+- **Signed manifests.** ed25519 manifest signatures with two honest grades:
+  `verified` (cryptographic check against a registered publisher key) and
+  `structure_verified` (shape-only). Publishers without a registered key
+  cannot reach `verified`.
+- **Hash-chained audit log** with a third-party verify endpoint
+  (`GET /api/matters/{slug}/audit/chain`) that recomputes every link from
+  the raw rows and reports the head plus any breaks.
+- **Inline tracked changes.** AI-proposed edits render in the document
+  editor as tracked changes: deletions struck, insertions marked, each
+  accepted or rejected by a human.
+- **Author and signer separation.** `SIGNOFF_AUTHOR_MUST_DIFFER` blocks an
+  author from signing their own output (off by default so a sole
+  practitioner can sign their own work).
+- **Object storage.** S3-compatible storage abstraction is the default
+  backend (`backend/app/core/storage.py`): MinIO in local compose,
+  Cloudflare R2 hosted. Fly filesystem is cache and matter
+  materialisation only, never source of truth.
+- **Job runner.** arq + Redis with a `jobs` table as source of truth.
+  Long-running module runs survive client disconnects and instance
+  restarts; a dedicated worker process group runs alongside the HTTP app.
+- **Migration discipline.** Migrations run as a deploy release step
+  (`release_command = "alembic upgrade head"`), not at app boot.
+- **Hosted evaluation limits.** legalise.dev enforces generous free
+  evaluation limits (matters, documents, storage, daily runs, active
+  jobs) with a usage endpoint. Self-hosting removes hosted limits.
 - **fastapi-users cookie sessions** + email verification.
 - Smoke evals + real-DB E2E coverage across auth, chronology, modules,
   matters, documents, audit, workspace skills, capabilities,
@@ -54,24 +81,10 @@ Shipped surfaces:
 
 Theme: serious backend substrate before broader public launch pressure.
 
-The direction is fixed. Feature work should pause until these backend
-foundations are either shipped or explicitly deferred by reviewer sign-off:
+The direction is fixed. The object storage, job runner, migration
+discipline, and hosted-limit foundations have shipped (see Shipped
+surfaces above). What remains before live-matter posture:
 
-- **Real object storage.** Uploaded binaries and generated artefacts move
-  to an S3-compatible storage abstraction. Local compose uses MinIO; hosted
-  production uses Cloudflare R2. Fly filesystem becomes cache and matter
-  materialisation only, never source of truth.
-- **Job runner: `arq` + Redis + `jobs` table as source of truth.** No
-  re-debate of Dramatiq / RQ. Long-running module runs move off
-  router-local `asyncio.create_task` onto the job runner. Redis carries
-  queue metadata; Postgres stores job state and result pointers.
-- **Migration discipline.** Production app boot should not mutate schema.
-  Migrations move to a deploy/release step. The app should fail fast if
-  schema is behind.
-- **Hosted evaluation limits.** legalise.dev gets generous free evaluation
-  limits: matters, documents, total storage, daily workflow runs, active
-  jobs, generated artefacts, and public module submissions. Self-hosting
-  removes hosted limits.
 - **Matter export / delete.** Export a matter with documents, generated
   artefacts, audit, and redaction mode. Delete/archive is owner-scoped,
   refuses while jobs run, and records audit/retention consequences.
@@ -94,10 +107,6 @@ foundations are either shipped or explicitly deferred by reviewer sign-off:
   from `backend/app/core/audit_actions.py`.
 - **`sse-starlette` swap.** Bespoke SSE frames replace with library
   inside the job-runner work.
-- **Multi-instance Redis-backed rate limiter** for the submission flow.
-  Current code uses an in-memory token bucket (single Fly instance is sufficient for evaluation).
-- **GitHub App for the submission flow.** v0.1 uses a `b1rdmania`-scoped
-  PAT. v0.2 replaces with an auto-rotating installation token.
 - **Assistant prompt hardening.** v0.1 ships a conservative built-in
   system prompt. v0.2 can add prompt versioning, richer source selection,
   and provider-native structured responses.
@@ -110,17 +119,20 @@ Other work already on the roadmap:
 - Enterprise SSO via WorkOS or Stytch (Microsoft 365, Google Workspace, SAML, SCIM)
 - MCP-runtime skills (imported skills exposing MCP servers)
 - Vector search over matter documents (pgvector + ingest pipeline)
-- Real audit-log export with hash chain; WORM enforcement on `audit_entries`
+- Audit-log export bundle carrying the chain head (the hash chain and
+  third-party verify endpoint shipped; the export bundle remains)
+- WORM role enforcement on `audit_entries`: revoke UPDATE/DELETE for a
+  dedicated app role (the trigger guard is already live)
 - Status page at `status.legalise.dev`
 - Cyber Essentials Plus certification target
 - DPIA summary published as a public artefact
 - Anthropic / OpenAI UK addenda signed and referenced from the processor list
-- CPR 31.22 gate coverage extended beyond chronology (skill inputs, plugin invocations)
+- CPR 31.22 gate coverage extended beyond chronology (skill inputs, imported-skill invocations)
 - Audit-tab UI filter by `module` column (or Phase E polish, whichever lands first)
 
 ## v0.3+
 
-Theme: signed identity, submission infrastructure, and portability.
+Theme: publisher trust and portability.
 
 - **Matter export / import.** Two explicit modes on the wire:
   `full_internal` (full audit + payloads + bodies; same-posture guard)
@@ -129,12 +141,11 @@ Theme: signed identity, submission infrastructure, and portability.
   placeholders; `cpr_31_22_locked` flags preserved). Deferred from v0.1
   because at v0.1 there's no real second user or second matter to
   pressure-test the wire format against.
-- **Signed module manifests.** Manifest signatures (minisign or
-  sigstore over the SKILL.md + manifest). Firms allow skills signed
-  by `b1rdmania` or by their own internal signer. Today provenance is
-  the git SHA you pinned; v0.3 adds cryptographic identity.
-- **GitHub-App-based submission flow** with installation tokens scoped
-  per submitting firm.
+- **Publisher web of trust.** ed25519 manifest signatures shipped early
+  (VERIFIED / STRUCTURE_VERIFIED grades, `backend/app/core/signing.py`).
+  What remains is key distribution: firms register their own internal
+  signers, publisher keys move out of the in-repo registry, and key
+  rotation gets a ceremony.
 - **Additional modules:** discrimination quantum (Vento bands),
   settlement-agreement review as a workspace module, contract-review
   redlined `.docx` output, interim relief / freezing-order drafting,
@@ -186,20 +197,16 @@ Theme: signed identity, submission infrastructure, and portability.
 - A public claim boundary for evals. Evals are evidence of a tested posture, not
   proof that the system gives legal advice.
 
-## Chat shape: Model B (docked assistant) — decided direction, post-v0.5
+## Chat shape: shipped
 
-The matter shell is currently Model C (Chat is one nav item) yet names Chat the
-default landing — a chat-primary claim wired as chat-incidental. To consult the
-assistant about a document you navigate away from it, which is backwards for
-supervised autonomy. The decided destination is **Model B**: the substance
-(documents / record) stays centre, the assistant is **docked alongside**, both
-co-visible during the review-and-sign loop (NotebookLM's Sources · Chat · Output
-shape). Not Model A (chat-as-canvas) — that buries the documents-of-record
-substance. This is an IA/layout move, not a skin change: the v0.5 panel shell,
-rail, and tokens survive it; only the main panel's contents change. Bridge =
-a collapsible docked chat present alongside Documents/Record before the full
-two/three-pane build. Sequenced after the cleanup programme; it overlaps the
-"collapse bespoke tabs into the generic runner" cut directly.
+The chat-led matter shell shipped. Chat is the default landing surface
+inside the matter frame, with Files, Skills, Activity, and signed outputs
+alongside, and the bespoke module tabs collapsed into the generic runner.
+Chat never floats outside the matter file: every conversation belongs to
+one matter, one posture, one audit log. The remaining open question is
+layout, not direction: a docked assistant co-visible with the document
+under review (NotebookLM's Sources · Chat · Output shape) stays a
+candidate refinement for the review-and-sign loop, not a committed cut.
 
 ## Permanently out of scope
 

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -40,7 +40,7 @@ practitioner can still sign their own work as themselves.
   remain personally accountable to the SRA.
 - Not a substitute for client KYC, conflict-checks, or money-laundering
   obligations under MLR 2017. Those remain the firm's responsibility.
-- Not a court-filing platform. ET1 / N1 PDF rendering is on the v0.3 roadmap
+- Not a court-filing platform. ET1 PDF rendering is on the v0.3 roadmap
   but does not file.
 - **Not certified** against any framework today. No SOC 2, no ISO 27001, no
   Cyber Essentials. See Section 4 for the planned sequencing.
@@ -63,17 +63,17 @@ reading the architecture.
 - **Retention is recorded, not enforced.** Every matter has a
   `retention_until` field; nothing actively sweeps and deletes when that
   date passes.
-- **Audit log is append-only by convention, not by Postgres grant.** A
-  superuser with DB access could in principle alter rows. WORM grants
-  land v0.2.
+- **Audit WORM is trigger-enforced, not yet role-enforced.** A Postgres
+  trigger rejects UPDATE and DELETE on `audit_entries`, and every row is
+  hash-chained so any out-of-band rewrite is detectable. The remaining
+  work is operational: split the migration and application database
+  roles so the REVOKE on the app role takes effect.
 - **Application-layer encryption of stored prompts/responses is not yet
   implemented.** We rely on Neon/Fly/R2 at-rest encryption defaults.
-- **Uploaded and generated artefacts are moving to real object storage.**
-  The intended production shape is R2/S3-compatible storage as source of
-  truth, with Fly filesystem used only for cache and matter materialisation.
-- **Long-running workflows are not yet durable jobs.** Current SSE surfaces
-  are acceptable for evaluation. Live-client posture requires a jobs table
-  and worker so results survive client disconnects and instance restarts.
+- **One deployment is one workspace.** There is no organisation or
+  multi-tenant model in the beta. Teams that need separation run one
+  deployment each. This is deliberate scope, recorded in the README
+  Status section and `OPERATIONS.md`.
 - **UK residency is partial.** Backend (Fly `lhr`) and Postgres (Neon
   London) are in the UK. Cloudflare R2 placement is EU (Western Europe),
   not UK-specific. Anthropic and OpenAI commercial APIs are US-served
@@ -102,7 +102,7 @@ solicitor ──▶ Legalise frontend (browser)
               Legalise backend (Fly.io, region: lhr — London)
                 │
                 ├─▶ Postgres (Neon, region: London/lhr)              ── matter rows, audit rows, users
-                ├─▶ Cloudflare R2 (jurisdiction: EU)                  ── document blobs (v0.2: binary uploads)
+                ├─▶ Cloudflare R2 (jurisdiction: EU)                  ── document blobs
                 ├─▶ Model gateway
                 │     ├─ A_cleared / B_mixed posture
                 │     │     ├─▶ Anthropic API (US, UK addendum)        ── if Anthropic model requested
@@ -216,22 +216,24 @@ work or was refused at the door:
   `chronology.gate.confirmed`) plus an **HTTP forensic row** written
   by the audit middleware (`http.{method}` + path + status code).
 - **Model-backed successful module runs** add `model.call` rows from
-  the gateway. Pre-Motion produces nine of them per run (one per
-  agent in the four-stage pipeline). Each `model.call` carries
+  the gateway, one per provider call (the example Pre-Motion skill
+  makes one call per run). Each `model.call` carries
   `model_used`, `prompt_hash`, `response_hash`, `token_count`, and
   `latency_ms`. The prompt and response themselves are **not** stored
   in the audit row, only their SHA-256 hashes.
 - **Requests blocked before semantic work commits** — for example a
-  C_paused plugin invocation, a C_paused Pre-Motion run, or a
-  validation rejection at the router boundary — produce **only the
+  C_paused skill run or a validation rejection at the router
+  boundary — produce **only the
   HTTP forensic row**, carrying the failure status (typically 409 or
   400). Blocked attempts are still traceable via the path and
   status, but they do not write a "started/blocked" semantic row.
   The trade-off is transactional integrity: semantic rows commit
   only when the semantic operation commits.
 
-The `audit_entries` table is append-only by convention today. WORM
-enforcement (Postgres-level revocation of UPDATE/DELETE) lands v0.2.
+The `audit_entries` table is append-only by enforcement: a Postgres
+trigger rejects UPDATE and DELETE on every row. The remaining hardening
+is operational, not code: split the migration and application database
+roles so the app role also loses UPDATE/DELETE by grant.
 
 **Third-party verification.** Every audit row is hash-chained: an
 append-only `audit_chain` table links each entry to the previous one
@@ -365,6 +367,7 @@ unless they prefer anonymity.
 | 2026-05-13 | Sweep: "Compliant by design" → "Designed against principles"; gaps promoted to §3 (read this first); compliance table reframed as planned sequencing, not achieved assurance; insurance note added |
 | 2026-05-14 | Added §9 skill provenance and approval: Git review as approval trail, `PLUGINS_REPO_REF` pinning, and `plugin.invoked` audit provenance |
 | 2026-06-11 | Filesystem plugin path removed; §1/§9 reframed around the import path (Lawve + GitHub) — pinned-SHA provenance, trust ceremony as the only install route |
+| 2026-06-12 | Currency pass: audit WORM recorded as trigger-enforced with hash chain (role split remains); object storage and durable jobs removed from §3 gaps (shipped); single-workspace scope added to §3; Pre-Motion audit-row count corrected; R2 v0.2 marker dropped |
 
 This file changes when the architecture changes. `git log docs/TRUST.md`
 is the canonical history.


### PR DESCRIPTION
The public /architecture page links these three docs. Each had claims that the June work made stale, mostly in the unsafe-looking direction (gaps listed as open that are closed). Every fix below was verified against code before editing.

## Fixes

| Doc | Was | Now | Verified against |
|---|---|---|---|
| TRUST §3/§8 | Audit "append-only by convention, WORM lands v0.2" | Trigger-enforced + hash-chained today; remaining work is the migration/app role split | `alembic/versions/0011_audit_worm.py`, `0030_audit_hash_chain.py` |
| TRUST §3 | Artefacts "moving to" object storage | Removed from gaps (S3/R2 backend is the default) | `core/storage.py` |
| TRUST §3 | Workflows "not yet durable jobs" | Removed from gaps (arq worker + jobs table shipped) | `backend/fly.toml`, `core/jobs.py`, `models/job.py`, `api/jobs.py` |
| TRUST §3 | (missing) | Single-workspace scope added: one deployment is one workspace | README Status, `OPERATIONS.md` |
| TRUST §8 | "Pre-Motion produces nine model.call rows per run" | One provider call per run | `examples/modules/pre_motion/capability.py` |
| TRUST §8 | "C_paused plugin invocation, C_paused Pre-Motion run" | "C_paused skill run" | PR #175/#180 |
| TRUST §4 | R2 "(v0.2: binary uploads)" marker | Dropped, R2 is live | `core/storage.py` |
| TRUST §2 | "ET1 / N1 PDF rendering" on v0.3 roadmap | ET1 only, aligned with ROADMAP | ROADMAP v0.3 |
| MANIFESTO | "plugin bridge" never gated | Skill import path (Lawve / GitHub at pinned SHA) | PR #180 |
| MANIFESTO | Won't "add a chatbot as the primary surface" | Won't ship a chat surface that floats outside the matter file | PR #172 (chat-led shell shipped) |
| MANIFESTO | "Adversarial premortem pipelines" as novel composition | Hash-chained audit trail + admission ceremony | PR #175 (pipeline cut) |
| MANIFESTO | Ollama "for C_paused matters" | Ollama serves B_mixed; C_paused permits no model call | `TRUST.md` posture table, gateway |
| ROADMAP | Signed manifests as v0.3 | Shipped (ed25519 VERIFIED / STRUCTURE_VERIFIED); v0.3 item becomes publisher web of trust / key distribution | `core/signing.py`, migration 0031, PR #185 |
| ROADMAP | "audit export with hash chain; WORM enforcement" as one item | Split: chain + verify endpoint shipped (PR #183); export bundle and role split remain | `api/matters.py` chain endpoint |
| ROADMAP | Submission-flow items (rate limiter, GitHub App, v0.3 theme/bullet, hosted-limits phrase) | Removed; importer uses an optional read-only token, no PAT | `core/github_import.py`, `core/config.py` |
| ROADMAP | Locked-direction "feature work should pause" list | Object storage, job runner, migration discipline, hosted limits moved to shipped | `core/storage.py`, `fly.toml` release_command + worker, `core/limits.py`, `api/usage.py` |
| ROADMAP | "Chat shape: Model B, post-v0.5" written pre-#172 | Restated as shipped (chat-led shell, bespoke tabs collapsed); docked layout stays a candidate refinement | PRs #172, #175 |
| ROADMAP | "(skill inputs, plugin invocations)" | "imported-skill invocations" | PR #180 |
| ROADMAP | Shipped list | Added June work: inline tracked changes, signature grades, SIGNOFF_AUTHOR_MUST_DIFFER, chain verification | frontend tracked-changes stack, `core/signoff.py` |

TRUST §14 change log gets a dated line for the pass. SECURITY.md untouched (current). `grep -n "plugin bridge\|submission flow" docs/*.md` returns nothing (handovers/ left as historical record).

One nuance found during verification: migration 0011's REVOKE is conditional (fires only when a `legalise_app` role exists, "trigger-only" operator decision in the migration docstring), so the docs say trigger-enforced with the role split as the remaining operational work rather than claiming the grant revocation is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)