### PR TITLE
P33: the demo reads like a workspace; one back affordance everywhere

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1669,3 +1669,11 @@ Source: Andy, 2026-06-12 — "the alignment, the size of the header, the left an
 The rule: every routed workspace page sits in `.page-shell` (index.css): `max-w-5xl px-6 sm:px-10 py-12 text-ink`, left-aligned. Pages cap inner content (forms, prose) themselves; the shell and its section rules stay constant. Header tiers unchanged (P27: monument for section homes, standard for sub-pages).
 
 NOT touched: the matter chat shell (P22 geometry), the document editor surface (P25 measure), TopBar, the demo shell, marketing pages (P28 own grid).
+
+---
+
+## P33 — The demo reads like a workspace; one way back
+
+Source: Andy's demo walk #2, 2026-06-12. Items: the demo masthead eyebrow row (the last survivor of P30's cull) goes; the sidebar wordmark links home and grows (21→26px); the rail gains a Matters cause-list so the shell reads like a real workspace (Khan open + two companions that expand in place with honest posture notes — the demo still follows one matter end to end and says so); the demo Skills tab explains itself (what a skill is, the admitted certificates, How a skill arrives: import → admission → run, link to /skills).
+
+The back rule, app-wide: detail / form / error pages carry ONE affordance — a quiet `← {Parent}` text link, first element inside the page shell, top-left, styled exactly as DocumentDetail's reference link (text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal). List/home pages carry nothing. Drawers keep the top-right X. Auth flows stay stack-shaped. No page may be a dead end — error branches included.

--- a/frontend/src/admin/AdminUserDetail.tsx
+++ b/frontend/src/admin/AdminUserDetail.tsx
@@ -113,21 +113,29 @@ export function AdminUserDetail({ userId }: { userId: string }) {
   if (q.status === "not_found") {
     return (
       <div className="page-shell">
-        <h1 className="text-xl font-bold tracking-tight2">User not found</h1>
-        <p className="mt-3 text-sm">
+        <p className="mb-6">
           <Link
             to="/admin/users"
-            className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+            className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
           >
             ← All users
           </Link>
         </p>
+        <h1 className="text-xl font-bold tracking-tight2">User not found</h1>
       </div>
     );
   }
   if (q.status === "error") {
     return (
       <div className="page-shell">
+        <p className="mb-6">
+          <Link
+            to="/admin/users"
+            className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+          >
+            ← All users
+          </Link>
+        </p>
         <h1 className="text-xl font-bold tracking-tight2">Could not load user</h1>
         <p className="mt-3 text-sm text-muted">{q.message}</p>
       </div>
@@ -172,6 +180,14 @@ export function AdminUserDetail({ userId }: { userId: string }) {
 
   return (
     <div className="page-shell">
+      <p className="mb-6">
+        <Link
+          to="/admin/users"
+          className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+        >
+          ← All users
+        </Link>
+      </p>
       <PageHeader title={user.email} subId={user.id} />
 
       <CertCard testid="practitioner-card">
@@ -285,14 +301,6 @@ export function AdminUserDetail({ userId }: { userId: string }) {
         )}
       </section>
 
-      <section className="mt-10">
-        <Link
-          to="/admin/users"
-          className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-        >
-          ← All users
-        </Link>
-      </section>
     </div>
   );
 }

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -73,23 +73,32 @@ function formatBytes(n: number): string {
   return `${(n / 1024 / 1024).toFixed(1)}M`;
 }
 
+// The demo gains one surface the workspace tabs don't have: the cause
+// list, so the rail reads like a real workspace (P33).
+type DemoTab = TabKey | "matters";
+
+function demoTabFromRoute(routeTab: string | undefined): DemoTab | null {
+  if (routeTab === "matters") return "matters";
+  if (routeTab && isTabKey(routeTab)) return routeTab as TabKey;
+  return null;
+}
+
 export function DemoMatter() {
   const route = useRoute();
-  const initialTab: TabKey =
+  const initialTab: DemoTab =
     route.name === "demoDocument"
       ? "documents"
-      : route.name === "demo" && route.tab && isTabKey(route.tab)
-      ? (route.tab as TabKey)
-      : "assistant";
-  const [tab, setTab] = useState<TabKey>(initialTab);
+      : (route.name === "demo" && demoTabFromRoute(route.tab)) || "assistant";
+  const [tab, setTab] = useState<DemoTab>(initialTab);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [inspectedDocId, setInspectedDocId] = useState<string | null>(null);
 
   useEffect(() => {
     if (route.name === "demoDocument") {
       setTab("documents");
-    } else if (route.name === "demo" && route.tab && isTabKey(route.tab)) {
-      setTab(route.tab as TabKey);
+    } else if (route.name === "demo" && route.tab) {
+      const next = demoTabFromRoute(route.tab);
+      if (next) setTab(next);
     } else if (route.name === "demo" && !route.tab) {
       setTab("assistant");
     }
@@ -102,7 +111,7 @@ export function DemoMatter() {
     }
   }, [route]);
 
-  const setTabAndHash = (next: TabKey) => {
+  const setTabAndHash = (next: DemoTab) => {
     setTab(next);
     setMobileNavOpen(false);
     const target = `/demo/${next}`;
@@ -116,14 +125,24 @@ export function DemoMatter() {
 
   const [showSoF, setShowSoF] = useState(false);
 
-  // Anonymous demo rail: no Matters / Skill library / Settings / Help —
-  // they all dead-end at the sign-in wall. One quiet CTA instead.
+  // P33: the rail reads like the real workspace — a Matters section
+  // above the open matter. Settings / Help still stay out (they
+  // dead-end at the sign-in wall); one quiet CTA instead.
+  const globalItems: RailItem[] = [
+    {
+      key: "matters",
+      label: "Matters",
+      icon: <NavIcon name="matters" />,
+      active: tab === "matters",
+      onSelect: () => setTabAndHash("matters"),
+    },
+  ];
   const matterItems: RailItem[] = [
     ...DEMO_NAV.map((t) => ({
       key: t.key,
       label: t.label,
       icon: <NavIcon name={t.key} />,
-      active: sidebarActiveFor(tab) === t.key,
+      active: tab !== "matters" && sidebarActiveFor(tab as TabKey) === t.key,
       onSelect: () => setTabAndHash(t.key),
     })),
   ];
@@ -132,7 +151,8 @@ export function DemoMatter() {
     <>
       <div className="min-h-screen md:h-screen bg-canvas text-ink md:flex md:gap-3 md:p-3 md:overflow-hidden">
         <SidebarView
-          globalItems={[]}
+          brandHref="/"
+          globalItems={globalItems}
           matterTitle={matter.title}
           matterPosture={posturePill(matter.privilege_posture)}
           matterItems={matterItems}
@@ -161,17 +181,9 @@ export function DemoMatter() {
           </button>
         </div>
         <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
-            <div
-              className="mb-8 flex items-baseline justify-between gap-4 border-b border-ink pb-2"
-              data-testid="demo-masthead"
-            >
-              <p className="text-[10px] uppercase tracking-[0.3em] text-muted">
-                A matter before the workspace · read-only demo
-              </p>
-              <p className="text-[10px] uppercase tracking-[0.3em] text-ink">
-                Legalise
-              </p>
-            </div>
+            {tab === "matters" && route.name !== "demoDocument" && (
+              <DemoMattersTab onOpenKhan={() => setTabAndHash("assistant")} />
+            )}
             {tab === "assistant" && (
               <div className="space-y-6">
                 <p className="mx-auto w-full max-w-[760px] text-[13px] text-muted" data-testid="demo-readonly-strip">
@@ -227,6 +239,107 @@ export function DemoMatter() {
   );
 }
 
+// -- Matters (the cause list, demo variant) ---------------------------------
+// The rail reads like a real workspace: several matters, one open. The
+// other entries expand in place — honest detail without pretending the
+// demo follows more than one matter end to end.
+
+const OTHER_MATTERS: Array<{
+  title: string;
+  matter_type: string;
+  opened: string;
+  posture: "Active" | "Paused";
+  note: string;
+}> = [
+  {
+    title: "Reyes v Brightline Logistics Ltd",
+    matter_type: "employment_tribunal",
+    opened: "2026-03-18",
+    posture: "Paused",
+    note: "Paused for without-prejudice talks. The gate is holding model access closed; every blocked attempt would land on this matter's record.",
+  },
+  {
+    title: "Okafor — director's loan account dispute",
+    matter_type: "civil",
+    opened: "2026-05-07",
+    posture: "Active",
+    note: "Documents uploaded, chronology built, letter before action in draft awaiting review and sign-off.",
+  },
+];
+
+function DemoMattersTab({ onOpenKhan }: { onOpenKhan: () => void }) {
+  const [expanded, setExpanded] = useState<number | null>(null);
+  return (
+    <div className="max-w-5xl">
+      <SectionRule label="The cause list" right="3 matters" />
+      <div className="mt-5">
+        <LedgerLine
+          index={1}
+          label="employment_tribunal"
+          right={
+            <span className="text-[10px] uppercase tracking-[0.18em] text-ink">
+              Active · open
+            </span>
+          }
+        >
+          <button
+            type="button"
+            onClick={onOpenKhan}
+            className="text-left text-sm text-ink underline-offset-4 hover:text-seal hover:underline"
+          >
+            Khan v Acme Trading Ltd
+          </button>
+        </LedgerLine>
+        {OTHER_MATTERS.map((m, i) => (
+          <div key={m.title}>
+            <LedgerLine
+              index={i + 2}
+              label={m.matter_type}
+              right={
+                <span
+                  className={
+                    "text-[10px] uppercase tracking-[0.18em] " +
+                    (m.posture === "Paused" ? "text-seal" : "text-muted")
+                  }
+                >
+                  {m.posture}
+                </span>
+              }
+            >
+              <button
+                type="button"
+                onClick={() => setExpanded(expanded === i ? null : i)}
+                className="text-left text-sm text-ink underline-offset-4 hover:text-seal hover:underline"
+              >
+                {m.title}
+              </button>
+            </LedgerLine>
+            {expanded === i && (
+              <div className="border-b border-rule/60 bg-wash px-14 py-3 text-sm leading-relaxed text-prose">
+                {m.note}
+                <span className="mt-1 block text-xs text-muted">
+                  Opened {m.opened}. The public demo follows Khan v Acme end to
+                  end; this matter is here so the workspace reads true.
+                </span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <p className="mt-8 border-t border-rule pt-4 text-xs text-muted">
+        In a workspace this list is yours.{" "}
+        <a
+          href="/auth/signup"
+          className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+        >
+          Create a workspace
+        </a>{" "}
+        to open your own matters.
+      </p>
+    </div>
+  );
+}
+
 function DemoWorkflowsTab({
   onOpen,
 }: {
@@ -260,9 +373,16 @@ function DemoWorkflowsTab({
 
   return (
     <div className="max-w-5xl">
-      <SectionRule label="Skills in this project" />
+      <SectionRule label="Skills in this project" right="2 admitted" />
+      <p className="mt-5 max-w-xl text-sm leading-relaxed text-prose">
+        A skill is a small piece of legal work: review an NDA, test a claim,
+        draft a letter. Each one declares what it may read and write before
+        it is allowed to run, and everything it does lands on the matter
+        record. These two are admitted on Khan v Acme — run either from
+        chat.
+      </p>
 
-      <div className="mt-5 grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-2">
         {workflows.map((w, i) => (
           <CertCard key={w.title}>
             <CertEyebrow
@@ -291,10 +411,31 @@ function DemoWorkflowsTab({
         ))}
       </div>
 
-      <p className="mt-8 border-t border-rule pt-4 text-xs text-muted">
-        Installation and setup stay behind the scenes in this public demo. The
-        previews show the outputs and record trail without asking you to sign in.
-      </p>
+      <div className="mt-10">
+        <SectionRule label="How a skill arrives" right="Admission" />
+        <div className="mt-4">
+          <LedgerLine index={1} label="Import">
+            Point the workspace at any public GitHub repo with a SKILL.md, or
+            pick one from the Lawve catalogue. It is read at a pinned commit.
+          </LedgerLine>
+          <LedgerLine index={2} label="Admission">
+            A live scan checks the manifest, permissions, and source, then
+            halts at one human decision: approve and enable, or refuse.
+          </LedgerLine>
+          <LedgerLine index={3} label="Run">
+            Enable it on a matter and run it from chat. Output, sources, and
+            sign-off land on the record.
+          </LedgerLine>
+        </div>
+        <p className="mt-6 text-sm text-prose">
+          <a
+            href="/skills"
+            className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+          >
+            Browse the public skill library →
+          </a>
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -95,17 +95,17 @@ export function ArtifactDetail({
   if (q.status === "error") {
     return (
       <div className="page-shell">
-        <h1 className="text-xl font-bold tracking-tight2">Output not found</h1>
-        <p className="mt-3 text-sm text-muted">{q.message}</p>
-        <p className="mt-4 text-sm">
+        <p className="mb-6">
           <Link
             to="/matters/$slug/artifacts"
             params={{ slug }}
-            className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+            className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
           >
-            ← All signed outputs
+            ← Signed outputs
           </Link>
         </p>
+        <h1 className="text-xl font-bold tracking-tight2">Output not found</h1>
+        <p className="mt-3 text-sm text-muted">{q.message}</p>
       </div>
     );
   }
@@ -115,6 +115,15 @@ export function ArtifactDetail({
 
   return (
     <div className="page-shell">
+      <p className="mb-6">
+        <Link
+          to="/matters/$slug/artifacts"
+          params={{ slug }}
+          className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+        >
+          ← Signed outputs
+        </Link>
+      </p>
       {/* The artifact's certificate header — its entry in the record
           (DESIGN.md P27). Inner surface: the matter shell owns the page,
           so the header is a CertCard, not a masthead. */}
@@ -293,13 +302,6 @@ export function ArtifactDetail({
       </details>
 
       <section className="mt-10 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
-        <Link
-          to="/matters/$slug/artifacts"
-          params={{ slug }}
-          className="text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-        >
-          ← All signed outputs
-        </Link>
         <a
           href={auditHref}
           className="text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"

--- a/frontend/src/matter/MatterDetail.tsx
+++ b/frontend/src/matter/MatterDetail.tsx
@@ -133,13 +133,15 @@ export function MatterDetail({ slug }: { slug: string }) {
   if (error && !matter) {
     return (
       <div className="max-w-page mx-auto px-4 sm:px-6 lg:px-10 py-12">
+        <p className="mb-6">
+          <a
+            href="/matters"
+            className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+          >
+            ← Matters
+          </a>
+        </p>
         <ErrorCallout message={error} />
-        <a
-          href="/matters"
-          className="text-sm text-muted hover:text-seal transition-colors"
-        >
-          Back to matters
-        </a>
       </div>
     );
   }

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -61,6 +61,14 @@ export function NewMatter() {
 
   return (
     <div className="page-shell">
+      <p className="mb-6">
+        <a
+          href="/matters"
+          className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+        >
+          ← Matters
+        </a>
+      </p>
       <PageHeader title="New matter." />
 
       <form onSubmit={submit} className="space-y-6">
@@ -117,12 +125,6 @@ export function NewMatter() {
           >
             {submitting ? "Creating…" : "Create matter"}
           </button>
-          <a
-            href="/matters"
-            className="text-sm text-muted hover:text-seal transition-colors"
-          >
-            Cancel
-          </a>
         </div>
       </form>
     </div>

--- a/frontend/src/modules-v2/CreateModule.tsx
+++ b/frontend/src/modules-v2/CreateModule.tsx
@@ -59,6 +59,14 @@ export function CreateModule() {
 
   return (
     <div className="page-shell">
+      <p className="mb-6">
+        <a
+          href="/skills"
+          className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+        >
+          ← Skills
+        </a>
+      </p>
       <PageHeader
         title="Create a skill"
         description="Build your own Legalise skill. This page explains the manifest and validates a candidate against the same rules the add-skill path uses — it does not add or sign."

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -310,16 +310,29 @@ export function InstallCeremony({ ceremonyId }: { ceremonyId: string }) {
     }
   };
 
+  const backLink = (
+    <p className="mb-6">
+      <Link
+        to="/skills"
+        className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+      >
+        ← Skills
+      </Link>
+    </p>
+  );
+
   if (phase.kind === "loading") {
     return (
-      <div className="page-shell text-sm text-muted">
-        Opening the record…
+      <div className="page-shell">
+        {backLink}
+        <p className="text-sm text-muted">Opening the record…</p>
       </div>
     );
   }
   if (phase.kind === "error" || !ceremony) {
     return (
       <div className="page-shell">
+        {backLink}
         <h1 className="text-xl font-bold tracking-tight2">Ceremony not found</h1>
         <p className="mt-3 text-sm text-muted">
           {phase.kind === "error" ? phase.message : "No ceremony loaded."}

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import {
   draftGithubModule,
   draftLawveModule,
@@ -153,6 +153,14 @@ export function LawveImport() {
 
   return (
     <div className="page-shell">
+      <p className="mb-6">
+        <Link
+          to="/skills"
+          className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+        >
+          ← Skills
+        </Link>
+      </p>
       <PageHeader
         title="Add a skill"
         whisper="Before the registrar"

--- a/frontend/src/modules-v2/ModuleDetail.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.tsx
@@ -26,7 +26,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import {
   getModuleV2,
   listInstalledModules,
@@ -148,16 +148,29 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
     };
   }, [moduleId, life.kind]);
 
+  const backLink = (
+    <p className="mb-6">
+      <Link
+        to="/skills"
+        className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+      >
+        ← Skills
+      </Link>
+    </p>
+  );
+
   if (q.status === "loading") {
     return (
-      <div className="page-shell text-sm text-muted">
-        Loading skill…
+      <div className="page-shell">
+        {backLink}
+        <p className="text-sm text-muted">Loading skill…</p>
       </div>
     );
   }
   if (q.status === "error") {
     return (
       <div className="page-shell">
+        {backLink}
         <h1 className="text-xl font-bold tracking-tight2">Skill not found</h1>
         <p className="mt-3 text-sm text-muted">{q.message}</p>
       </div>
@@ -246,6 +259,7 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
 
   return (
     <div className="page-shell">
+      {backLink}
       {/* Masthead — ruled eyebrow row; the certificate below is the hero. */}
       <div className="flex items-baseline justify-between border-b border-ink pb-2">
         <p className="text-[10px] uppercase tracking-[0.3em] text-muted">

--- a/frontend/src/ui/SidebarView.tsx
+++ b/frontend/src/ui/SidebarView.tsx
@@ -125,12 +125,12 @@ export function SidebarView({
           {brandHref ? (
             <a href={brandHref} aria-label="Legalise" className="flex items-center gap-2.5 hover:opacity-70 transition-opacity">
               <BrandMark />
-              <span className="font-redaction35 text-[21px] leading-none tracking-tight2 text-ink">Legalise.</span>
+              <span className="font-redaction35 text-[26px] leading-none tracking-tight2 text-ink">Legalise.</span>
             </a>
           ) : (
             <span className="flex items-center gap-2.5">
               <BrandMark />
-              <span className="font-redaction35 text-[21px] leading-none tracking-tight2 text-ink">Legalise.</span>
+              <span className="font-redaction35 text-[26px] leading-none tracking-tight2 text-ink">Legalise.</span>
             </span>
           )}
           {closeButton && <span className="ml-auto">{closeButton}</span>}


### PR DESCRIPTION
Andy's demo walk #2, all five items:

- Demo masthead eyebrow row cut (P30's last survivor); sidebar wordmark 26px and links home
- Rail gains **Matters** — the cause list: Khan open, two companion matters expanding in place with honest posture notes
- Demo **Skills** tab explains itself: what a skill is, the two admitted certificates, *How a skill arrives* (import → admission → run), link to the public library
- **One back rule app-wide**: `← {Parent}`, top-left, first element, DocumentDetail's reference style — applied to MatterDetail/ArtifactDetail/ModuleDetail/CreateModule/LawveImport/NewMatter/AdminUserDetail/InstallCeremony, including error branches (no page is a dead end)
- Spec: DESIGN.md P33

tsc clean, 298/298 vitest, demo surfaces walked at 3010 (cause list + skills screenshots in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)