### PR TITLE
Public skill shelf: the anonymous /skills page stocks the catalogue

### DIFF
--- a/backend/app/api/lawve_import.py
+++ b/backend/app/api/lawve_import.py
@@ -5,8 +5,11 @@ convert one into a Legalise module DRAFT.
 `/api/modules/external/github/...` — inspect + convert a SKILL.md from
 any public GitHub repository (the generic drop-in path).
 
-Authed. Read-only: no DB writes, no audit rows, no install. The draft
-must still be signed + installed through the existing trust ceremony.
+Catalogue BROWSING (the two lawve GETs) is public: it serves the open
+Lawve catalogue — public GitHub data behind a small TTL cache — so the
+anonymous /skills page can stock its shelf. Conversion to a draft stays
+authed, and the draft must still be signed + installed through the
+existing trust ceremony. No DB writes, no audit rows on the read path.
 """
 
 from __future__ import annotations
@@ -42,7 +45,7 @@ class DraftRequest(BaseModel):
 
 
 @router.get("/external/lawve/skills")
-async def list_lawve_skills(user: User = Depends(current_user)) -> dict:
+async def list_lawve_skills() -> dict:
     try:
         return await list_skills()
     except LawveSourceError as exc:
@@ -53,7 +56,7 @@ async def list_lawve_skills(user: User = Depends(current_user)) -> dict:
 
 
 @router.get("/external/lawve/skills/{slug}")
-async def get_lawve_skill(slug: str, user: User = Depends(current_user)) -> dict:
+async def get_lawve_skill(slug: str) -> dict:
     try:
         detail = await get_skill(slug)
     except LawveSourceError as exc:

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -449,18 +449,28 @@ export function ModulesCatalog() {
       )}
 
       {/* The stocked shelf: the open Lawve catalogue, reviewable and
-          addable in two clicks. */}
-      {authed && (
-        <section className="mt-12" data-testid="lawve-catalogue">
+          addable in two clicks. Public — the anonymous /skills page is
+          a real library, not three boxes (the catalogue GETs are open;
+          importing still requires a workspace). */}
+      <section className="mt-12" data-testid="lawve-catalogue">
           <SectionRule
             label="Schedule B — the open catalogue"
             right={
-              <Link
-                to="/skills/lawve"
-                className="normal-case tracking-normal text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-              >
-                Open full importer →
-              </Link>
+              authed ? (
+                <Link
+                  to="/skills/lawve"
+                  className="normal-case tracking-normal text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                >
+                  Open full importer →
+                </Link>
+              ) : (
+                <a
+                  href="/auth/signup"
+                  className="normal-case tracking-normal text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                >
+                  Create a workspace to import →
+                </a>
+              )
             }
           />
           {lawve == null ? (
@@ -497,8 +507,7 @@ export function ModulesCatalog() {
             Skills hold no standing until admitted — review, signature,
             permissions, gates, then the register.
           </Colophon>
-        </section>
-      )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
The two Lawve catalogue GETs drop their session requirement (they
serve public GitHub data behind the existing 300s TTL cache); drafting
and importing stay authed. ModulesCatalog renders Schedule B for
anonymous visitors, with the importer link swapping to a create-a-
workspace CTA. Demo visitors clicking through to /skills now find a
library, not three boxes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
