### PR TITLE
Skill shelf: facets, search, and honest Lawve attribution

### DIFF
--- a/backend/app/api/lawve_import.py
+++ b/backend/app/api/lawve_import.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from app.core.auth import current_user
 from app.core.github_import import build_github_draft, get_remote_skill
+from app.core.lawve_directory import LAWVE_SKILLS_URL, directory_count
 from app.core.lawve_import import (
     LawveSourceError,
     build_draft,
@@ -53,6 +54,24 @@ async def list_lawve_skills() -> dict:
             502,
             detail={"error": "lawve_source_unavailable", "message": str(exc)},
         )
+
+
+@router.get("/external/lawve/directory-count")
+async def lawve_directory_count() -> dict:
+    """Distinct published skills on lawve.ai (sitemap count, 1h cache).
+
+    Public + read-only — it feeds the shelf footer's honest gap strip
+    ("N skills on Lawve · M importable here today"). The frontend hides
+    the strip on 502 rather than guessing a number.
+    """
+    try:
+        count = await directory_count()
+    except LawveSourceError as exc:
+        raise HTTPException(
+            502,
+            detail={"error": "lawve_directory_unavailable", "message": str(exc)},
+        )
+    return {"source": "lawve.ai", "skills_url": LAWVE_SKILLS_URL, "count": count}
 
 
 @router.get("/external/lawve/skills/{slug}")

--- a/backend/app/core/lawve_directory.py
+++ b/backend/app/core/lawve_directory.py
@@ -1,0 +1,65 @@
+"""Lawve directory size — the honest gap strip.
+
+lawve.ai is the catalogue of record for legal skills; the GitHub
+marketplace repo we import from carries a subset. The shelf footer
+states that gap plainly ("N skills on Lawve · M importable here
+today"), so this module counts published skill pages on lawve.ai by
+reading its public sitemap.
+
+Design mirrors `lawve_import`:
+- One fetch seam (`_fetch_sitemap`) so tests stub a single function.
+- Pure parse helper (`count_skills_in_sitemap`) unit-tested offline.
+- Small in-process TTL cache (1 hour — the directory moves slowly).
+- An identified User-Agent, so Lawve can see who is reading and why.
+- Failure raises `LawveSourceError`; callers degrade silently.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import httpx
+
+from app.core.lawve_import import LawveSourceError
+
+LAWVE_SITEMAP_URL = "https://lawve.ai/sitemap.xml"
+LAWVE_SKILLS_URL = "https://lawve.ai/en/skills"
+_USER_AGENT = "legalise.dev catalogue (github.com/b1rdmania/legalise)"
+
+_TTL_SECONDS = 3600.0
+_cache: tuple[float, int] | None = None
+
+# A skill detail page: /en/skills/{slug}. The bare /en/skills index and
+# deeper paths (none exist today) are excluded; slugs are deduplicated.
+_SKILL_LOC = re.compile(r"<loc>\s*https://lawve\.ai/en/skills/([^<\s/]+)\s*</loc>")
+
+
+def count_skills_in_sitemap(xml_text: str) -> int:
+    """Count distinct /en/skills/{slug} detail pages in a sitemap body."""
+    return len({m.group(1) for m in _SKILL_LOC.finditer(xml_text)})
+
+
+async def _fetch_sitemap() -> str:
+    """GET the lawve.ai sitemap. The single seam tests stub."""
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                LAWVE_SITEMAP_URL, headers={"User-Agent": _USER_AGENT}
+            )
+    except httpx.HTTPError as exc:
+        raise LawveSourceError(f"fetch failed: {LAWVE_SITEMAP_URL}: {exc}") from exc
+    if resp.status_code >= 400:
+        raise LawveSourceError(f"lawve.ai {resp.status_code} for {LAWVE_SITEMAP_URL}")
+    return resp.text
+
+
+async def directory_count() -> int:
+    """Distinct published skills on lawve.ai, cached for an hour."""
+    global _cache
+    now = time.monotonic()
+    if _cache is not None and (now - _cache[0]) < _TTL_SECONDS:
+        return _cache[1]
+    count = count_skills_in_sitemap(await _fetch_sitemap())
+    _cache = (now, count)
+    return count

--- a/backend/app/core/lawve_import.py
+++ b/backend/app/core/lawve_import.py
@@ -181,6 +181,14 @@ def _flags_for(slug: str, paths: list[str]) -> dict[str, bool]:
 
 
 def _row(plugin: dict, slug: str, ref: str, flags: dict[str, bool]) -> dict:
+    # Listing facets are marketplace.json fields only — deliberately.
+    # Surveyed all 42 SKILL.md frontmatters in the catalogue (2026-06-12):
+    # the vocabulary is exactly `name`, `description`,
+    # `metadata: {author, license, version}` — no tags, jurisdiction, or
+    # category fields exist. Fetching every SKILL.md per listing would
+    # cost ~42 raw GETs on a cold cache and surface nothing the
+    # marketplace doesn't already carry, so we don't. If the upstream
+    # vocabulary grows, add the field here with an honest null default.
     author = plugin.get("author") or {}
     return {
         "source": "lawve",
@@ -193,6 +201,10 @@ def _row(plugin: dict, slug: str, ref: str, flags: dict[str, bool]) -> dict:
         "author_name": author.get("name") if isinstance(author, dict) else None,
         "license": plugin.get("license"),
         "source_path": plugin.get("source"),
+        # The catalogue directory name doubles as the lawve.ai slug
+        # (verified against the live /en/skills/{slug} sitemap), so every
+        # row can attribute its source with a direct outbound link.
+        "lawve_url": f"https://lawve.ai/en/skills/{slug}",
         **flags,
     }
 

--- a/backend/tests/test_lawve_directory.py
+++ b/backend/tests/test_lawve_directory.py
@@ -1,0 +1,62 @@
+"""Lawve directory count — sitemap parse + fetch seam tests (offline)."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.core.lawve_directory as lwd
+from app.core.lawve_import import LawveSourceError
+
+_SITEMAP = """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://lawve.ai/en</loc></url>
+<url><loc>https://lawve.ai/en/skills</loc></url>
+<url><loc>https://lawve.ai/fr/skills</loc></url>
+<url><loc>https://lawve.ai/en/skills/contract-review-anthropic</loc></url>
+<url><loc>https://lawve.ai/en/skills/nda-review-jamie-tso</loc></url>
+<url><loc>https://lawve.ai/en/skills/nda-review-jamie-tso</loc></url>
+<url><loc>https://lawve.ai/fr/skills/contract-review-anthropic</loc></url>
+<url><loc>https://lawve.ai/en/mcp-servers/some-server</loc></url>
+</urlset>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    lwd._cache = None
+    yield
+    lwd._cache = None
+
+
+def test_count_skills_counts_only_en_detail_pages_deduped() -> None:
+    # /en/skills index, /fr/* mirrors, and mcp-server pages don't count;
+    # the duplicated slug counts once.
+    assert lwd.count_skills_in_sitemap(_SITEMAP) == 2
+
+
+def test_count_skills_empty_sitemap_is_zero() -> None:
+    assert lwd.count_skills_in_sitemap("<urlset></urlset>") == 0
+
+
+@pytest.mark.asyncio
+async def test_directory_count_caches_the_fetch(monkeypatch) -> None:
+    calls = {"n": 0}
+
+    async def _fake() -> str:
+        calls["n"] += 1
+        return _SITEMAP
+
+    monkeypatch.setattr(lwd, "_fetch_sitemap", _fake)
+    assert await lwd.directory_count() == 2
+    assert await lwd.directory_count() == 2
+    assert calls["n"] == 1  # second read served from the 1h TTL cache
+
+
+@pytest.mark.asyncio
+async def test_directory_count_propagates_source_error(monkeypatch) -> None:
+    async def _boom() -> str:
+        raise LawveSourceError("lawve.ai 503 for sitemap")
+
+    monkeypatch.setattr(lwd, "_fetch_sitemap", _boom)
+    with pytest.raises(LawveSourceError):
+        await lwd.directory_count()

--- a/backend/tests/test_lawve_import.py
+++ b/backend/tests/test_lawve_import.py
@@ -180,3 +180,47 @@ async def test_warnings_license_and_scripts() -> None:
 
     scripted = await lwv.build_draft("office-processor")
     assert any(w["code"] == "script_review" for w in scripted["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser (pure, fixture text)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_frontmatter_full_vocabulary() -> None:
+    # The real catalogue vocabulary (surveyed across all 42 skills):
+    # name, description, metadata{author, license, version}. Nothing else.
+    fm, body = lwv._parse_frontmatter(_SKILL_MD)
+    assert fm["name"] == "contract-review-anthropic"
+    assert fm["metadata"] == {
+        "author": "Anthropic",
+        "license": "Apache-2.0",
+        "version": "2026.01.30",
+    }
+    assert body.startswith("# Contract Review Skill")
+
+
+def test_parse_frontmatter_missing_returns_empty() -> None:
+    text = "# No frontmatter here\nJust a body."
+    fm, body = lwv._parse_frontmatter(text)
+    assert fm == {}
+    assert body == text
+
+
+def test_parse_frontmatter_malformed_yaml_is_tolerated() -> None:
+    text = "---\n: : not yaml [\n---\nbody"
+    fm, body = lwv._parse_frontmatter(text)
+    assert fm == {}
+    assert body == "body"
+
+
+@pytest.mark.asyncio
+async def test_list_rows_carry_lawve_attribution_url() -> None:
+    # Catalogue directory name == lawve.ai slug (verified against the
+    # live sitemap), so every row links back to its directory page.
+    res = await lwv.list_skills()
+    by_slug = {r["slug"]: r for r in res["skills"]}
+    assert (
+        by_slug["contract-review-anthropic"]["lawve_url"]
+        == "https://lawve.ai/en/skills/contract-review-anthropic"
+    )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -150,6 +150,8 @@ export interface LawveSkillRow {
   author_name: string | null;
   license: string | null;
   source_path: string | null;
+  /** Direct attribution link to the skill's lawve.ai directory page. */
+  lawve_url?: string | null;
   has_references: boolean;
   has_scripts: boolean;
   script_review_required: boolean;
@@ -178,6 +180,19 @@ export interface LawveDraftResult {
 export const listLawveSkills = () =>
   apiFetch(`${API}/modules/external/lawve/skills`).then((r) =>
     jsonOrThrow<{ source: string; repo: string; ref: string | null; skills: LawveSkillRow[] }>(r),
+  );
+
+// The honest gap strip — how many skills the lawve.ai directory lists
+// versus how many are importable here today. Public; cached 1h
+// server-side; callers hide the strip on failure.
+export interface LawveDirectoryCount {
+  source: string;
+  skills_url: string;
+  count: number;
+}
+export const getLawveDirectoryCount = () =>
+  apiFetch(`${API}/modules/external/lawve/directory-count`).then((r) =>
+    jsonOrThrow<LawveDirectoryCount>(r),
   );
 
 export const getLawveSkill = (slug: string) =>

--- a/frontend/src/modules-v2/ModulesCatalog.test.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.test.tsx
@@ -14,7 +14,7 @@ import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/rea
 import { router as productionRouter } from "../router";
 import { AuthProvider } from "../auth/AuthProvider";
 import * as api from "../lib/api";
-import type { V2ManifestEntry } from "../lib/api";
+import type { LawveSkillRow, V2ManifestEntry } from "../lib/api";
 
 function refModule(over: Partial<V2ManifestEntry> = {}): V2ManifestEntry {
   return {
@@ -35,6 +35,41 @@ function refModule(over: Partial<V2ManifestEntry> = {}): V2ManifestEntry {
     validation_errors: [],
     ...over,
   };
+}
+
+function lawveRow(over: Partial<LawveSkillRow> = {}): LawveSkillRow {
+  const slug = over.slug ?? "contract-review-anthropic";
+  return {
+    source: "lawve",
+    repo: "lawve-ai/awesome-legal-skills",
+    ref: "abc123sha",
+    slug,
+    name: slug,
+    description: "A catalogue skill.",
+    version: "2026.01.30",
+    author_name: "Anthropic",
+    license: "Apache-2.0",
+    source_path: `./skills/${slug}`,
+    lawve_url: `https://lawve.ai/en/skills/${slug}`,
+    has_references: false,
+    has_scripts: false,
+    script_review_required: false,
+    ...over,
+  };
+}
+
+function mockLawveShelf(rows: LawveSkillRow[], directoryCount = 170) {
+  vi.spyOn(api, "listLawveSkills").mockResolvedValue({
+    source: "lawve",
+    repo: "lawve-ai/awesome-legal-skills",
+    ref: "abc123sha",
+    skills: rows,
+  });
+  vi.spyOn(api, "getLawveDirectoryCount").mockResolvedValue({
+    source: "lawve.ai",
+    skills_url: "https://lawve.ai/en/skills",
+    count: directoryCount,
+  });
 }
 
 function mountAt(path = "/skills") {
@@ -229,6 +264,112 @@ describe("ModulesCatalog — integrations home", () => {
       expect(screen.getByText("Add skill")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("skill-requests")).toBeNull();
+  });
+
+  it("Schedule B: shelf facets, sort, Lawve attribution, and the gap strip", async () => {
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+    mockLawveShelf([
+      lawveRow(),
+      lawveRow({
+        slug: "nda-review-jamie-tso",
+        name: "nda-review-jamie-tso",
+        author_name: "Jamie Tso",
+        license: "AGPL-3.0",
+      }),
+    ]);
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByTestId("shelf-search")).toBeInTheDocument();
+    });
+    expect(screen.getByText("contract-review-anthropic")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-count")).toHaveTextContent("2 of 2");
+
+    // Quiet outbound attribution per row — catalogue dir name == slug.
+    expect(
+      screen
+        .getByTestId("shelf-lawve-link-contract-review-anthropic")
+        .getAttribute("href"),
+    ).toBe("https://lawve.ai/en/skills/contract-review-anthropic");
+
+    // Licence facet narrows the ledger.
+    fireEvent.change(screen.getByTestId("shelf-license-filter"), {
+      target: { value: "AGPL-3.0" },
+    });
+    expect(screen.queryByText("contract-review-anthropic")).toBeNull();
+    expect(screen.getByText("nda-review-jamie-tso")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-count")).toHaveTextContent("1 of 2");
+    fireEvent.change(screen.getByTestId("shelf-license-filter"), {
+      target: { value: "" },
+    });
+
+    // Author facet exists with the real authors.
+    expect(screen.getByTestId("shelf-author-filter")).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("shelf-author-filter"), {
+      target: { value: "Jamie Tso" },
+    });
+    expect(screen.getByTestId("shelf-count")).toHaveTextContent("1 of 2");
+    fireEvent.change(screen.getByTestId("shelf-author-filter"), {
+      target: { value: "" },
+    });
+
+    // Sort control offers name / author / licence.
+    expect(screen.getByTestId("shelf-sort")).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("shelf-sort"), {
+      target: { value: "licence" },
+    });
+    expect(screen.getByTestId("shelf-count")).toHaveTextContent("2 of 2");
+
+    // Search empties honestly.
+    fireEvent.change(screen.getByTestId("shelf-search"), {
+      target: { value: "zzzzz" },
+    });
+    expect(
+      screen.getByText("No catalogue skills match that filter."),
+    ).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("shelf-search"), {
+      target: { value: "" },
+    });
+
+    // The honest gap strip: directory size vs importable today.
+    await waitFor(() => {
+      expect(screen.getByTestId("shelf-gap-strip")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("shelf-gap-strip")).toHaveTextContent(
+      "170 skills on Lawve · 2 importable here today",
+    );
+  });
+
+  it("Schedule B: gap strip hides when the directory count fails", async () => {
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+    vi.spyOn(api, "listLawveSkills").mockResolvedValue({
+      source: "lawve",
+      repo: "lawve-ai/awesome-legal-skills",
+      ref: "abc123sha",
+      skills: [lawveRow()],
+    });
+    vi.spyOn(api, "getLawveDirectoryCount").mockRejectedValue(new Error("502"));
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByText("contract-review-anthropic")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("shelf-gap-strip")).toBeNull();
+  });
+
+  it("Schedule B: the shelf stocks for anonymous browsers too", async () => {
+    vi.spyOn(api, "getCurrentUser").mockRejectedValue(new Error("401"));
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+    mockLawveShelf([lawveRow()]);
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByText("contract-review-anthropic")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("shelf-search")).toBeInTheDocument();
   });
 
   it("renders without the retired open-skill-library browse section", async () => {

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -34,11 +34,20 @@ import {
   LedgerRow,
   SectionRule,
 } from "../ui/certificate";
-import { listLawveSkills, type LawveSkillRow } from "../lib/api";
+import {
+  getLawveDirectoryCount,
+  listLawveSkills,
+  type LawveDirectoryCount,
+  type LawveSkillRow,
+} from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
 
 type ModuleState = "available" | "installed" | "disabled";
 type SkillTab = "installed" | "available" | "revoked";
+// Shelf sort keys. The catalogue's real metadata is marketplace.json's
+// name / author / licence (the SKILL.md frontmatter vocabulary carries
+// nothing beyond it — surveyed upstream), so those are the facets.
+type ShelfSort = "name" | "author" | "licence";
 
 // "disabled" in the substrate (InstalledModule.enabled === false) is the
 // user-facing "Revoked" state per blueprint §7: a skill that was
@@ -95,9 +104,13 @@ export function ModulesCatalog() {
   const [modules, setModules] = useState<V2ManifestEntry[] | null>(null);
   const [installed, setInstalled] = useState<Map<string, InstalledModule>>(new Map());
   const [lawve, setLawve] = useState<LawveSkillRow[] | null>(null);
+  // The honest gap strip — lawve.ai directory size vs importable here.
+  // Degrades silently: null hides the strip entirely.
+  const [directory, setDirectory] = useState<LawveDirectoryCount | null>(null);
 
+  // The shelf is public (the catalogue GETs are open), so it stocks for
+  // anonymous browsers too — no auth gate on these reads.
   useEffect(() => {
-    if (!authed) return;
     let cancelled = false;
     listLawveSkills()
       .then((res) => {
@@ -106,11 +119,17 @@ export function ModulesCatalog() {
       .catch(() => {
         if (!cancelled) setLawve([]);
       });
+    getLawveDirectoryCount()
+      .then((res) => {
+        if (!cancelled && typeof res?.count === "number" && res.count > 0) {
+          setDirectory(res);
+        }
+      })
+      .catch(() => undefined);
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authed]);
+  }, []);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [tab, setTab] = useState<SkillTab>("installed");
@@ -191,6 +210,47 @@ export function ModulesCatalog() {
     }
     return counts;
   }, [installed, modules]);
+
+  // Schedule B shelf controls — client-side search, facets, and sort
+  // over the open catalogue, in the importer's filter idiom.
+  const [shelfQuery, setShelfQuery] = useState("");
+  const [shelfLicense, setShelfLicense] = useState("");
+  const [shelfAuthor, setShelfAuthor] = useState("");
+  const [shelfSort, setShelfSort] = useState<ShelfSort>("name");
+
+  const shelfLicenses = useMemo(
+    () =>
+      [...new Set((lawve ?? []).map((s) => s.license).filter((l): l is string => !!l))].sort(),
+    [lawve],
+  );
+  const shelfAuthors = useMemo(
+    () =>
+      [...new Set((lawve ?? []).map((s) => s.author_name).filter((a): a is string => !!a))].sort(),
+    [lawve],
+  );
+  const shelf = useMemo(() => {
+    const term = shelfQuery.trim().toLowerCase();
+    const rows = (lawve ?? []).filter((s) => {
+      if (shelfLicense && s.license !== shelfLicense) return false;
+      if (shelfAuthor && s.author_name !== shelfAuthor) return false;
+      if (!term) return true;
+      return (
+        s.name.toLowerCase().includes(term) ||
+        s.description.toLowerCase().includes(term) ||
+        (s.author_name ?? "").toLowerCase().includes(term) ||
+        (s.license ?? "").toLowerCase().includes(term)
+      );
+    });
+    const key = (s: LawveSkillRow) =>
+      shelfSort === "author"
+        ? (s.author_name ?? "")
+        : shelfSort === "licence"
+          ? (s.license ?? "")
+          : s.name;
+    return rows.sort(
+      (a, b) => key(a).localeCompare(key(b)) || a.name.localeCompare(b.name),
+    );
+  }, [lawve, shelfQuery, shelfLicense, shelfAuthor, shelfSort]);
 
   // Default to Added if anything is already trusted, otherwise show
   // Available so a fresh workspace lands on the discovery view.
@@ -480,28 +540,122 @@ export function ModulesCatalog() {
               Catalogue unavailable right now.
             </p>
           ) : (
-            <div className="mt-1">
-              {lawve.map((s, i) => (
-                <LedgerLine
-                  key={s.slug}
-                  index={i + 1}
-                  label={s.license ?? "licence ?"}
-                  right={
-                    <a
-                      href={`/skills/lawve?skill=${encodeURIComponent(s.slug)}`}
-                      className="text-sm text-muted hover:text-seal"
-                    >
-                      Review &amp; add →
-                    </a>
-                  }
+            <>
+              {/* Shelf controls — search, licence/author facets, sort.
+                  Facets are the catalogue's real metadata (the upstream
+                  SKILL.md frontmatter carries nothing beyond name /
+                  description / author / licence / version). */}
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+                <input
+                  value={shelfQuery}
+                  onChange={(e) => setShelfQuery(e.target.value)}
+                  placeholder="Search the catalogue"
+                  aria-label="Search the catalogue"
+                  className="min-h-[34px] w-48 border border-rule bg-paper px-3 text-[13px] text-ink focus:border-ink focus:outline-none"
+                  data-testid="shelf-search"
+                />
+                <select
+                  value={shelfLicense}
+                  onChange={(e) => setShelfLicense(e.target.value)}
+                  className="rounded-md border border-rule bg-paper px-2 py-1 text-ink"
+                  aria-label="Filter by licence"
+                  data-testid="shelf-license-filter"
                 >
-                  <span className="text-ink">{s.name}</span>
-                  <span className="ml-2 hidden text-[12px] text-muted sm:inline">
-                    {s.author_name ?? "unknown"}
-                  </span>
-                </LedgerLine>
-              ))}
-            </div>
+                  <option value="">any licence</option>
+                  {shelfLicenses.map((l) => (
+                    <option key={l} value={l}>{l}</option>
+                  ))}
+                </select>
+                <select
+                  value={shelfAuthor}
+                  onChange={(e) => setShelfAuthor(e.target.value)}
+                  className="rounded-md border border-rule bg-paper px-2 py-1 text-ink"
+                  aria-label="Filter by author"
+                  data-testid="shelf-author-filter"
+                >
+                  <option value="">any author</option>
+                  {shelfAuthors.map((a) => (
+                    <option key={a} value={a}>{a}</option>
+                  ))}
+                </select>
+                <select
+                  value={shelfSort}
+                  onChange={(e) => setShelfSort(e.target.value as ShelfSort)}
+                  className="rounded-md border border-rule bg-paper px-2 py-1 text-ink"
+                  aria-label="Sort catalogue"
+                  data-testid="shelf-sort"
+                >
+                  <option value="name">sort: name</option>
+                  <option value="author">sort: author</option>
+                  <option value="licence">sort: licence</option>
+                </select>
+                <span className="text-muted" data-testid="shelf-count">
+                  {shelf.length} of {lawve.length}
+                </span>
+              </div>
+              <div className="mt-1">
+                {shelf.length === 0 ? (
+                  <p className="mt-3 text-sm text-muted">
+                    No catalogue skills match that filter.
+                  </p>
+                ) : (
+                  shelf.map((s, i) => (
+                    <LedgerLine
+                      key={s.slug}
+                      index={i + 1}
+                      label={s.license ?? "licence ?"}
+                      right={
+                        <span className="flex items-baseline gap-4">
+                          {s.lawve_url && (
+                            <a
+                              href={s.lawve_url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="hidden text-[12px] text-muted hover:text-seal sm:inline"
+                              data-testid={`shelf-lawve-link-${s.slug}`}
+                            >
+                              View on Lawve →
+                            </a>
+                          )}
+                          <a
+                            href={`/skills/lawve?skill=${encodeURIComponent(s.slug)}`}
+                            className="text-sm text-muted hover:text-seal"
+                          >
+                            Review &amp; add →
+                          </a>
+                        </span>
+                      }
+                    >
+                      <span className="text-ink">{s.name}</span>
+                      <span className="ml-2 hidden text-[12px] text-muted sm:inline">
+                        {s.author_name ?? "unknown"}
+                      </span>
+                    </LedgerLine>
+                  ))
+                )}
+              </div>
+              {/* The honest gap strip — the directory is larger than the
+                  importable feed today; say so plainly. Hidden whenever
+                  the count could not be fetched. */}
+              {directory && (
+                <p
+                  className="mt-3 text-[11px] text-muted"
+                  data-testid="shelf-gap-strip"
+                >
+                  {directory.count} skills on{" "}
+                  <a
+                    href={directory.skills_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                  >
+                    Lawve
+                  </a>{" "}
+                  · {lawve.length} importable here today · the catalogue feed
+                  is being arranged
+                </p>
+              )}
+            </>
           )}
           <Colophon>
             Skills hold no standing until admitted — review, signature,


### PR DESCRIPTION
Tier (a) of the Lawve-integration memo — the cheap shelf wins.

**Shelf UX (Schedule B, /skills).** Client-side search + licence/author facets + name/author/licence sort, in the importer's filter idiom on the existing LedgerLine anatomy. Empty-filter state says so. Also un-gates the catalogue fetch from auth — the GETs went public in #198, but the shelf was still only stocking for signed-in users.

**Attribution.** Every row links out quietly: "View on Lawve →" to `https://lawve.ai/en/skills/{slug}`. Mapping verified against the live sitemap on real examples (contract-review-anthropic, nda-review-jamie-tso, statute-analysis-rafal-fryc) — catalogue directory name == lawve.ai slug.

**The honest gap strip.** New public `GET /api/modules/external/lawve/directory-count` reads the lawve.ai sitemap (User-Agent `legalise.dev catalogue (github.com/b1rdmania/legalise)`, 1h in-process TTL), counts distinct `/en/skills/{slug}` pages (170 today). Footer: "170 skills on Lawve · 42 importable here today · the catalogue feed is being arranged", linking to lawve.ai/en/skills. The strip hides silently if the fetch fails.

**Frontmatter facets — what actually existed.** Surveyed all 42 SKILL.md frontmatters in `lawve-ai/awesome-legal-skills`: the vocabulary is exactly `name`, `description`, `metadata: {author, license, version}`. No tags, jurisdiction, or category fields exist upstream. So the listing facets stay marketplace.json-only (documented in `_row`); per-listing SKILL.md fetches would cost ~42 raw GETs on a cold cache and surface nothing new. Rows gain only `lawve_url`.

**Tests.** Backend: frontmatter parser fixtures + sitemap counter (dedupe, /fr exclusion, TTL cache, error propagation; fetch seam stubbed, no live network). Frontend: ModulesCatalog tests for facets/sort/search, attribution href, gap strip (and its silent failure), anonymous shelf. `tsc --noEmit` + full vitest (301) + `pytest -k lawve` (14) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)