### PR TITLE
Fluff E: anonymisation as optional extra; pgvector stated honestly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         working-directory: backend
         run: |
           pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,anonymisation]"
 
       - name: Verify uv lockfile is in sync with pyproject
         working-directory: backend
@@ -174,7 +174,7 @@ jobs:
         working-directory: backend
         run: |
           pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,anonymisation]"
 
       - name: Start MinIO
         run: |
@@ -268,7 +268,7 @@ jobs:
         working-directory: backend
         run: |
           pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,anonymisation]"
 
       - name: Run alembic migrations against the test DB
         working-directory: backend

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,7 +16,7 @@
 | Backend language | Python 3.12 | Strongest AI ecosystem (Anthropic SDK, agent frameworks, document libraries). Largest London talent pool. |
 | Web framework | FastAPI | Async-native, OpenAPI for free, mature, ports to production scale without rewrite. |
 | ORM + migrations | SQLAlchemy 2 + Alembic | Boring, durable, audit-friendly. |
-| Database | PostgreSQL 16 | One store for relational, JSONB, and full-text. pgvector extension available but unused in v0.1 (vector search is roadmap). Will run in 30 years. |
+| Database | PostgreSQL 16 | One store for relational, JSONB, and full-text. pgvector extension is enabled by the default migrations but unused in v0.1 — pre-provisioned for v0.2 vector search; nothing reads or writes it today. Will run in 30 years. |
 | Storage | MinIO (S3 API) | Self-hostable; swap for Cloudflare R2 in cloud. UK data residency requirement met by deployment region. |
 | Frontend | React 19 + Vite + TanStack Router | Modern but stable. Hot reload, fast build, no Next.js framework lock-in. |
 | Styling | Tailwind + Shadcn primitives | Solicitor-legible defaults, customisable, no design-system rebuild needed. |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml ./
-RUN pip install --upgrade pip && pip install -e .
+# The `anonymisation` extra (Presidio + spaCy) is optional in pyproject
+# but installed here: the demo/dev image ships batteries-included. A slim
+# deploy can drop the extra (and the model download below); the
+# anonymisation endpoints then return 503 with install guidance instead
+# of crashing.
+RUN pip install --upgrade pip && pip install -e ".[anonymisation]"
 
 # spaCy NER model for the Phase C anonymisation pipeline (Presidio).
 # Distributed outside PyPI; install after the editable install above.

--- a/backend/app/modules/anonymisation/presidio_engine.py
+++ b/backend/app/modules/anonymisation/presidio_engine.py
@@ -4,11 +4,13 @@ Lazy singleton — Presidio + spaCy together resident is ~50MB, so we
 avoid loading at import time. Calls to `analyse()` are the only public
 entry point.
 
-Presidio is an optional install — `presidio-analyzer` and a spaCy model
-must be present for this module to do real work. We wrap the imports in
-a try/except so the module still imports in environments that do not
-have the wheels (CI smoke, frontend-only dev). The first real `analyse`
-call in that state raises a clean `RuntimeError` with install guidance.
+Presidio is an optional install — the `anonymisation` extra
+(`pip install -e ".[anonymisation]"`) plus a spaCy model must be present
+for this module to do real work. We wrap the imports in a try/except so
+the module still imports in environments that do not have the wheels
+(slim deploys, frontend-only dev). The first real `analyse` call in that
+state raises a clean `RuntimeError` with install guidance, which the
+anonymisation routes translate into a 503.
 
 Model selection: the `PRESIDIO_MODEL` env var lets production swap in
 `en_core_web_lg` (~560MB) for higher recall. Defaults to
@@ -75,9 +77,9 @@ def _build_engine() -> Any:
     """
     if not _PRESIDIO_AVAILABLE:
         raise RuntimeError(
-            "Presidio is not installed. Install with: "
-            "`pip install presidio-analyzer presidio-anonymizer spacy && "
-            "python -m spacy download en_core_web_sm`. "
+            "anonymisation extra not installed. Install with: "
+            '`pip install -e ".[anonymisation]" && '
+            "python -m spacy download en_core_web_sm` (from backend/). "
             f"(Underlying import error: {_IMPORT_ERROR!r})"
         )
 

--- a/backend/app/tools/doctor.py
+++ b/backend/app/tools/doctor.py
@@ -502,6 +502,26 @@ def check_provider_mode() -> CheckResult:
     )
 
 
+def check_anonymisation_engine() -> CheckResult:
+    """Optional-extra probe — never fails (missing extra is a valid slim
+    install; the endpoints degrade to 503 with install guidance)."""
+    from app.modules.anonymisation import presidio_engine
+
+    if presidio_engine.is_available():
+        return CheckResult(
+            "anonymisation.engine",
+            "ok",
+            "presidio importable (anonymisation extra installed)",
+        )
+    return CheckResult(
+        "anonymisation.engine",
+        "note",
+        "anonymisation extra not installed — anonymise endpoints will 503; "
+        'install with `pip install -e ".[anonymisation]" && '
+        "python -m spacy download en_core_web_sm`",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -543,6 +563,9 @@ async def _run_all(*, create_bucket: bool) -> int:
 
     # Provider mode — diagnostic only.
     results.append(check_provider_mode())
+
+    # Anonymisation extra — diagnostic only (optional install).
+    results.append(check_anonymisation_engine())
 
     await engine.dispose()
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,9 +34,6 @@ dependencies = [
   "fastapi-users[sqlalchemy]>=14.0.1,<15.0.0",
   "cryptography>=44.0.0,<49.0.0",
   "resend>=2.5.0",
-  "presidio-analyzer>=2.2.358",
-  "presidio-anonymizer>=2.2.358",
-  "spacy>=3.7",
   "pyyaml>=6.0",
   # Pin <1.2 - 1.2 broke `frontmatter.dump(post, BytesIO)` by tightening
   # the buffer type contract (now requires bytes-only). `submissions.py`
@@ -46,6 +43,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Anonymisation engine (Presidio + spaCy). Heavyweight — the wheel stack
+# is ~80MB installed before the spaCy model (`en_core_web_sm`, ~12MB,
+# downloaded separately) — so it is an extra, not a base dependency. The
+# base install boots without it: the anonymisation endpoints return 503
+# with install guidance (guard in app/modules/anonymisation/
+# presidio_engine.py). The Docker image, dev compose, and CI all install
+# this extra; only a bespoke slim deploy should omit it.
+anonymisation = [
+  "presidio-analyzer>=2.2.358",
+  "presidio-anonymizer>=2.2.358",
+  "spacy>=3.7",
+]
 dev = [
   "ruff>=0.8.0",
   "mypy>=1.13.0",

--- a/backend/tests/test_anonymisation_optional.py
+++ b/backend/tests/test_anonymisation_optional.py
@@ -1,0 +1,118 @@
+"""The anonymisation stack (Presidio + spaCy) is an optional extra.
+
+`pyproject.toml` ships it under `[project.optional-dependencies]
+anonymisation`; the base install boots without it. These tests simulate
+the missing-extra environment by patching the import-guard flag in
+`presidio_engine` (the test venv has the extra installed, so the happy
+path is exercised by the rest of the suite) and assert the degrade
+contract:
+
+- `analyse()` raises a clean RuntimeError naming the extra, at call
+  time, not import time;
+- the POST /api/documents/{id}/anonymise route translates that into a
+  503 with install guidance, for both `presidio` and the default `auto`
+  engine;
+- `legalise doctor` reports the missing extra as a note (slim installs
+  are valid), never a fail.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from app.modules.anonymisation import presidio_engine
+from app.tools.doctor import check_anonymisation_engine
+
+EMAIL = "anon-optional@example.com"
+PASSWORD = "anon-optional-password-1"
+
+
+@pytest.fixture
+def _extra_missing(monkeypatch):
+    """Simulate the anonymisation extra not being installed."""
+    monkeypatch.setattr(presidio_engine, "_PRESIDIO_AVAILABLE", False)
+    monkeypatch.setattr(
+        presidio_engine,
+        "_IMPORT_ERROR",
+        ModuleNotFoundError("No module named 'presidio_analyzer'"),
+    )
+    # Drop any engine singleton built by earlier tests so the guard fires.
+    monkeypatch.setattr(presidio_engine, "_engine", None)
+
+
+def test_module_imports_without_extra_and_reports_unavailable(_extra_missing):
+    """The guard is at module load — `is_available()` is a cheap probe."""
+    assert presidio_engine.is_available() is False
+
+
+def test_analyse_raises_clean_runtime_error_naming_the_extra(_extra_missing):
+    with pytest.raises(RuntimeError) as excinfo:
+        presidio_engine.analyse("Mr Khan of 1 High Street, SW1A 1AA")
+    message = str(excinfo.value)
+    assert "anonymisation extra not installed" in message
+    assert "[anonymisation]" in message  # install guidance names the extra
+
+
+def test_analyse_empty_text_short_circuits_even_without_extra(_extra_missing):
+    """Empty input never touches the engine, installed or not."""
+    assert presidio_engine.analyse("") == []
+
+
+def test_doctor_notes_missing_extra_without_failing(_extra_missing):
+    result = check_anonymisation_engine()
+    assert result.status == "note"
+    assert "anonymisation extra not installed" in result.detail
+
+
+def test_doctor_reports_ok_when_extra_installed(monkeypatch):
+    monkeypatch.setattr(presidio_engine, "_PRESIDIO_AVAILABLE", True)
+    result = check_anonymisation_engine()
+    assert result.status == "ok"
+
+
+async def _signup_and_upload_text(client) -> str:
+    """Returns a document id with an extracted text body."""
+    reg = await client.post(
+        "/auth/register", json={"email": EMAIL, "password": PASSWORD}
+    )
+    assert reg.status_code == 201, reg.text
+    login = await client.post(
+        "/auth/login",
+        data={"username": EMAIL, "password": PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert login.status_code == 204, login.text
+
+    create = await client.post(
+        "/api/matters", json={"title": "Anonymisation Optional Matter"}
+    )
+    assert create.status_code == 201, create.text
+    slug = create.json()["slug"]
+
+    text = "Letter before claim. Mr Aamir Khan, NI number QQ123456C, SW1A 1AA."
+    resp = await client.post(
+        f"/api/matters/{slug}/documents",
+        files={"file": ("letter.txt", io.BytesIO(text.encode("utf-8")), "text/plain")},
+        data={"tag": "draft"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine_choice", ["presidio", "auto"])
+async def test_post_anonymise_returns_503_when_extra_missing(
+    client, _extra_missing, engine_choice
+) -> None:
+    """The endpoint degrades with a clear 503, not a 500 crash."""
+    doc_id = await _signup_and_upload_text(client)
+
+    resp = await client.post(
+        f"/api/documents/{doc_id}/anonymise", json={"engine": engine_choice}
+    )
+    assert resp.status_code == 503, resp.text
+    detail = resp.json()["detail"]
+    assert "anonymisation engine unavailable" in detail
+    assert "anonymisation extra not installed" in detail

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1187,8 +1187,6 @@ dependencies = [
     { name = "jsonschema" },
     { name = "openai" },
     { name = "pdfplumber" },
-    { name = "presidio-analyzer" },
-    { name = "presidio-anonymizer" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1199,13 +1197,17 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis" },
     { name = "resend" },
-    { name = "spacy" },
     { name = "sqlalchemy" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.optional-dependencies]
+anonymisation = [
+    { name = "presidio-analyzer" },
+    { name = "presidio-anonymizer" },
+    { name = "spacy" },
+]
 dev = [
     { name = "httpx" },
     { name = "mypy" },
@@ -1231,8 +1233,8 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "openai", specifier = ">=1.57.0,<2.0.0" },
     { name = "pdfplumber", specifier = ">=0.11" },
-    { name = "presidio-analyzer", specifier = ">=2.2.358" },
-    { name = "presidio-anonymizer", specifier = ">=2.2.358" },
+    { name = "presidio-analyzer", marker = "extra == 'anonymisation'", specifier = ">=2.2.358" },
+    { name = "presidio-anonymizer", marker = "extra == 'anonymisation'", specifier = ">=2.2.358" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.3" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
@@ -1247,12 +1249,12 @@ requires-dist = [
     { name = "redis", specifier = ">=5.2.0" },
     { name = "resend", specifier = ">=2.5.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "spacy", specifier = ">=3.7" },
+    { name = "spacy", marker = "extra == 'anonymisation'", specifier = ">=3.7" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
     { name = "structlog", specifier = ">=24.4.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["anonymisation", "dev"]
 
 [[package]]
 name = "librt"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     profiles: ["local-models"]
 
   backend:
+    # backend/Dockerfile installs the optional `anonymisation` extra
+    # (Presidio + spaCy + model) — the dev/demo image is batteries-included.
     build: ../backend
     # Read repo-root .env so values a forker sets in their copy of
     # .env.example actually reach the container. Without this, the


### PR DESCRIPTION
Executes Phase E of `docs/handovers/FLUFF_CUT_ORDER_2026-06-12.md`.

## E1 — Presidio + spaCy become the `anonymisation` extra

- `backend/pyproject.toml`: `presidio-analyzer`, `presidio-anonymizer`, `spacy` move from base dependencies to `[project.optional-dependencies] anonymisation`. `uv.lock` regenerated (`uv lock --check` green).
- The import guard already lived at module load in `presidio_engine.py`; its error now names the extra: first `analyse()` call without the wheels raises `RuntimeError("anonymisation extra not installed. Install with: ...")`, which the anonymise routes already map to **503** (never a per-request crash — the module imports cleanly without the wheels).
- **Batteries stay included where they should**: `backend/Dockerfile` installs `.[anonymisation]` + the `en_core_web_sm` model (so the dev/demo compose image is unchanged in behaviour), and all three backend CI jobs install `.[dev,anonymisation]` so the anonymisation tests still run with the extra present.
- `legalise doctor` gains an `anonymisation.engine` check: `ok` when importable, `note` with the install command when missing. Never `fail` — a slim install is a valid state.

### Image size delta (measured, not estimated)

Built both variants locally from `backend/Dockerfile`:

| variant | size |
|---|---|
| with `anonymisation` extra + model (shipped image) | 1.09 GB |
| base install, no extra, no model | 784 MB |
| **delta** | **306 MB** |

### How the degrade path is tested

New `backend/tests/test_anonymisation_optional.py` (7 tests) simulates the missing extra by patching the import-guard flag (`_PRESIDIO_AVAILABLE`) — the test venv has the extra installed, so the rest of the suite exercises the installed path:

- `analyse()` raises a clean RuntimeError naming the extra (call time, not import time)
- `POST /api/documents/{id}/anonymise` returns **503** with install guidance for both `presidio` and the default `auto` engine
- doctor reports `note` (missing) / `ok` (installed), never `fail`

## E2 — pgvector stated honestly

One line in `ARCHITECTURE.md`: pgvector is enabled by the default migrations but unused in v0.1 — pre-provisioned for v0.2 vector search. Migrations untouched (documentation option from the work order).

## Verification

- Full backend suite: **792 passed**, 11 skipped, 1 xfailed. The 24 failures are pre-existing local-worktree environment issues (`examples.modules` path resolution + macOS sandbox `preexec_fn`) — identical on clean master in the same environment, zero overlap with this change.
- Anonymise route ACL tests + new optional-extra tests all green.
- Zero behaviour change when the extra is present (it is present in the image, compose, and CI).

Line delta: +184 / −23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)