### PR TITLE
About: LinkedIn, X, and email marks on the builder card

### DIFF
--- a/frontend/src/landing/About.tsx
+++ b/frontend/src/landing/About.tsx
@@ -12,6 +12,35 @@ import { CertCard, CertEyebrow, Colophon, LedgerRow, SectionRule } from "../ui/c
 
 const GITHUB_PROFILE = "https://github.com/b1rdmania";
 const REPO = "https://github.com/b1rdmania/legalise";
+const LINKEDIN = "https://www.linkedin.com/in/andrew-bird-nomos/";
+const X_PROFILE = "https://x.com/b1rdmania";
+
+/** Brand marks lucide doesn't carry (X) or styles poorly (LinkedIn).
+ * Official glyph paths, currentColor, sized to match the Github icon. */
+function XMark({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+function LinkedInMark({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+function MailMark({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+      <rect x="2" y="4" width="20" height="16" rx="2" />
+      <path d="m22 7-10 6L2 7" />
+    </svg>
+  );
+}
 
 export function About() {
   return (
@@ -104,7 +133,26 @@ export function About() {
                   href="mailto:andy@legalise.dev"
                   className="flex items-center gap-2 text-xs text-ink transition-colors hover:text-seal"
                 >
+                  <MailMark />
                   andy@legalise.dev
+                </a>
+                <a
+                  href={LINKEDIN}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 text-xs text-ink transition-colors hover:text-seal"
+                >
+                  <LinkedInMark />
+                  andrew-bird-nomos
+                </a>
+                <a
+                  href={X_PROFILE}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 text-xs text-ink transition-colors hover:text-seal"
+                >
+                  <XMark />
+                  @b1rdmania
                 </a>
                 <a
                   href={GITHUB_PROFILE}


### PR DESCRIPTION
Official glyph paths at the Github icon's size; the record card now
carries every channel: mail, LinkedIn, X, GitHub profile, repo.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
