### PR TITLE
Fluff C3: DocumentRichEditor split along its seams (editor is core)

### DIFF
--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -23,10 +23,8 @@ import { buildVersionDiff, buildVersionDiffSummary } from "./VersionDiff";
 import {
   clearDocumentLocalDraft,
   documentOutlineFromJson,
-  documentStatsFromText,
   editorJsonToPlainText,
   findNormalizedRange,
-  firstImageFile,
   isEditableWordDocument,
   readDocumentLocalDraft,
   textToEditorHtml,
@@ -36,15 +34,9 @@ import {
 } from "./editorText";
 
 export {
-  clearDocumentLocalDraft,
-  documentOutlineFromJson,
-  documentStatsFromText,
-  editorJsonToPlainText,
-  findNormalizedRange,
-  findNormalizedRanges,
-  isEditableWordDocument,
-  readDocumentLocalDraft,
-  textToEditorHtml,
+  clearDocumentLocalDraft, documentOutlineFromJson, documentStatsFromText,
+  editorJsonToPlainText, findNormalizedRange, findNormalizedRanges,
+  isEditableWordDocument, readDocumentLocalDraft, textToEditorHtml,
   writeDocumentLocalDraft,
 } from "./editorText";
 export type { TiptapNode } from "./editorText";
@@ -66,13 +58,20 @@ import {
 
 export type { DocumentNoteHighlight } from "./reviewNotes";
 
-import { documentEditorExtensions } from "./editorExtensions";
+import {
+  documentEditorExtensions,
+  documentEditorProps,
+} from "./editorExtensions";
 import {
   useClipboardActions,
   useFindInDocument,
   useTrackedChangeResolution,
 } from "./editorHooks";
-import { FormatToolbar, ViewModeButton } from "./editorChrome";
+import {
+  CommandBarRow,
+  editorStatusLabelFor,
+  FormatToolbar,
+} from "./editorChrome";
 import {
   DraftNotices,
   EditorSideRail,
@@ -259,25 +258,9 @@ export function DocumentRichEditor({
         trackChangesExtension,
       }),
       content,
-      editorProps: {
-        attributes: {
-          class:
-            "legalise-document-editor min-h-[760px] border border-rule bg-paper px-9 py-12 text-[16px] leading-8 outline-none shadow-[0_18px_50px_rgba(0,0,0,0.08)] sm:px-14",
-        },
-        handlePaste: (_view, event) => {
-          const file = firstImageFile(event.clipboardData?.files);
-          if (!file) return false;
-          void uploadAndInsertEditorImage(file);
-          return true;
-        },
-        handleDrop: (_view, event) => {
-          const file = firstImageFile(event.dataTransfer?.files);
-          if (!file) return false;
-          event.preventDefault();
-          void uploadAndInsertEditorImage(file);
-          return true;
-        },
-      },
+      editorProps: documentEditorProps((file) =>
+        void uploadAndInsertEditorImage(file),
+      ),
       onUpdate: ({ editor: activeEditor }) => {
         const json = activeEditor.getJSON() as TiptapNode;
         const plainText = editorJsonToPlainText(json);
@@ -508,23 +491,14 @@ export function DocumentRichEditor({
     [workingDiffParts],
   );
   const showWorkingDiff = dirty && workingDiffSummary.changed;
-  const sharedDraftLabel =
-    draftLoadState === "loading"
-      ? "Loading shared draft"
-      : draftSaveState === "saving"
-        ? "Saving shared draft"
-        : draftSaveState === "saved"
-          ? `Shared draft saved${serverDraft ? ` · r${serverDraft.version_counter}` : ""}`
-          : draftSaveState === "error"
-            ? "Local fallback active"
-            : "Shared draft ready";
-  const editorStatusLabel = dirty
-    ? sharedDraftLabel
-    : savedMessage
-      ? savedMessage
-      : latestVersionNumber
-        ? `Saved v${latestVersionNumber}`
-        : "Extracted text";
+  const editorStatusLabel = editorStatusLabelFor({
+    dirty,
+    draftLoadState,
+    draftSaveState,
+    serverDraftCounter: serverDraft ? serverDraft.version_counter : null,
+    savedMessage,
+    latestVersionNumber,
+  });
   const canvasMaxWidth = canvasMode === "page" ? "max-w-[820px]" : "max-w-[1040px]";
 
   async function save(): Promise<DocumentVersionRead | null> {
@@ -659,138 +633,39 @@ export function DocumentRichEditor({
         className="sticky top-0 z-10 border-b border-rule bg-paper/95 backdrop-blur"
         data-testid="document-editor-command-bar"
       >
-        <div className="flex flex-wrap items-center gap-1.5 px-4 py-2.5 text-[13px]">
-          <div
-            className="flex items-center gap-1 border-r border-rule pr-2"
-            aria-label="Document view"
-            data-testid="document-editor-view-mode"
-          >
-            <ViewModeButton active={canvasMode === "page"} onClick={() => setCanvasMode("page")}>
-              Page
-            </ViewModeButton>
-            <ViewModeButton active={canvasMode === "wide"} onClick={() => setCanvasMode("wide")}>
-              Wide
-            </ViewModeButton>
-          </div>
-          <button
-            type="button"
-            onClick={() => setFormatOpen((current) => !current)}
-            aria-expanded={formatOpen}
-            className="inline-flex h-8 items-center rounded-item border border-rule px-3 text-xs text-muted hover:border-ink hover:text-ink"
-          >
-            Format
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setFindOpen((current) => {
-                const next = !current;
-                if (next) {
-                  requestAnimationFrame(() => findInputRef.current?.focus());
-                }
-                return next;
-              });
-            }}
-            aria-expanded={findOpen}
-            className="inline-flex h-8 items-center rounded-item border border-rule px-3 text-xs text-muted hover:border-ink hover:text-ink"
-          >
-            Find
-          </button>
-          {proposedEdits.length > 0 && (
-            <button
-              type="button"
-              onClick={() => setRedlinesVisible((current) => !current)}
-              aria-pressed={redlinesVisible}
-              data-testid="document-editor-redlines-toggle"
-              className={`inline-flex h-8 items-center rounded-item border px-3 text-xs ${
-                redlinesVisible
-                  ? "border-ink bg-paper text-ink"
-                  : "border-rule bg-paper text-muted hover:border-ink hover:text-ink"
-              }`}
-            >
-              Redlines ({proposedEdits.length})
-            </button>
-          )}
-          <span className="ml-2 inline-flex items-center gap-2 text-xs text-muted">
-            <span
-              className={`h-2 w-2 rounded-full ${
-                draftSaveState === "error"
-                  ? "bg-red-700"
-                  : dirty
-                    ? "bg-amber-500"
-                    : "bg-emerald-700"
-              }`}
-              aria-hidden="true"
-            />
-            {editorStatusLabel}
-          </span>
-          {sourceLabel?.startsWith("Viewing saved version") && (
-            <span className="text-xs text-muted">{sourceLabel}</span>
-          )}
-          <div className="ml-auto flex items-center gap-1.5">
-            <button
-              type="button"
-              onClick={save}
-              disabled={!canSave}
-              className="inline-flex h-8 items-center rounded-item border border-ink bg-ink px-3 text-xs text-paper disabled:border-rule disabled:bg-paper-sunken disabled:text-muted"
-            >
-              {saving ? "Saving…" : "Save version"}
-            </button>
-            <details className="relative" data-testid="document-editor-more">
-              <summary className="inline-flex h-8 cursor-pointer list-none items-center rounded-item border border-rule px-3 text-xs text-muted hover:border-ink hover:text-ink">
-                More
-              </summary>
-              <div className="absolute right-0 z-20 mt-1 grid min-w-44 gap-1 rounded-card border border-rule bg-paper p-1.5 shadow-panel">
-                <button
-                  type="button"
-                  onClick={() => void saveAndDownloadDocx()}
-                  disabled={!canDownloadDocx}
-                  className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
-                >
-                  {downloadingDocx ? "Preparing…" : dirty ? "Save & download DOCX" : "Download DOCX"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void copyWorkingText()}
-                  disabled={!plainText.trim()}
-                  className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
-                >
-                  Copy text
-                </button>
-                <button
-                  type="button"
-                  onClick={downloadWorkingText}
-                  disabled={!plainText.trim()}
-                  className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
-                >
-                  Download text
-                </button>
-                <span
-                  className="inline-flex h-8 items-center px-2 text-xs text-muted"
-                  data-testid="document-editor-word-count"
-                >
-                  {documentStatsFromText(plainText).words.toLocaleString()} words
-                </span>
-                <button
-                  type="button"
-                  onClick={() => window.print()}
-                  disabled={!plainText.trim()}
-                  className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
-                >
-                  Print / PDF
-                </button>
-                <button
-                  type="button"
-                  onClick={reset}
-                  disabled={!dirty || saving}
-                  className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
-                >
-                  Reset
-                </button>
-              </div>
-            </details>
-          </div>
-        </div>
+        <CommandBarRow
+          canvasMode={canvasMode}
+          onSetCanvasMode={setCanvasMode}
+          formatOpen={formatOpen}
+          onToggleFormat={() => setFormatOpen((current) => !current)}
+          findOpen={findOpen}
+          onToggleFind={() => {
+            setFindOpen((current) => {
+              const next = !current;
+              if (next) {
+                requestAnimationFrame(() => findInputRef.current?.focus());
+              }
+              return next;
+            });
+          }}
+          proposedEditCount={proposedEdits.length}
+          redlinesVisible={redlinesVisible}
+          onToggleRedlines={() => setRedlinesVisible((current) => !current)}
+          draftSaveError={draftSaveState === "error"}
+          dirty={dirty}
+          editorStatusLabel={editorStatusLabel}
+          sourceLabel={sourceLabel}
+          onSave={save}
+          canSave={canSave}
+          saving={saving}
+          onSaveAndDownloadDocx={saveAndDownloadDocx}
+          canDownloadDocx={canDownloadDocx}
+          downloadingDocx={downloadingDocx}
+          onCopyWorkingText={copyWorkingText}
+          onDownloadWorkingText={downloadWorkingText}
+          plainText={plainText}
+          onReset={reset}
+        />
         {formatOpen && (
           <FormatToolbar
             editor={editor}

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -4,7 +4,6 @@ import {
   useRef,
   useState,
   type ChangeEvent,
-  type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { type Content } from "@tiptap/core";
@@ -27,11 +26,9 @@ import {
   documentStatsFromText,
   editorJsonToPlainText,
   findNormalizedRange,
-  findNormalizedRanges,
   firstImageFile,
   isEditableWordDocument,
   readDocumentLocalDraft,
-  selectedEditorText,
   textToEditorHtml,
   writeDocumentLocalDraft,
   type DocumentLocalDraft,
@@ -53,23 +50,15 @@ export {
 export type { TiptapNode } from "./editorText";
 
 import {
-  applyProposedEditToEditor,
-  locateProposedEditInDoc,
-  TRACK_CHANGES_PLUGIN_KEY,
   trackChangesDecorationsExtension,
   type DocumentProposedEdit,
   type TrackChangeHandlers,
-  type TrackChangesPluginState,
 } from "./trackedChanges";
 
 export { locateProposedEditInDoc } from "./trackedChanges";
 export type { DocumentProposedEdit, ProposedEditLocation } from "./trackedChanges";
 
-import {
-  FIND_DECORATIONS_PLUGIN_KEY,
-  findDecorationsExtension,
-  type FindDecorationState,
-} from "./findDecorations";
+import { findDecorationsExtension } from "./findDecorations";
 import {
   reviewNoteDecorationsExtension,
   type DocumentNoteHighlight,
@@ -78,6 +67,11 @@ import {
 export type { DocumentNoteHighlight } from "./reviewNotes";
 
 import { documentEditorExtensions } from "./editorExtensions";
+import {
+  useClipboardActions,
+  useFindInDocument,
+  useTrackedChangeResolution,
+} from "./editorHooks";
 import { FormatToolbar, ViewModeButton } from "./editorChrome";
 import {
   DraftNotices,
@@ -142,11 +136,7 @@ export function DocumentRichEditor({
   const [uploadingImage, setUploadingImage] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedMessage, setSavedMessage] = useState<string | null>(null);
-  const [copiedMessage, setCopiedMessage] = useState<string | null>(null);
-  const [findQuery, setFindQuery] = useState("");
-  const [findOpen, setFindOpen] = useState(false);
   const [formatOpen, setFormatOpen] = useState(false);
-  const [activeFindIndex, setActiveFindIndex] = useState(0);
   const [localDraft, setLocalDraft] = useState<DocumentLocalDraft | null>(null);
   const [serverDraft, setServerDraft] = useState<DocumentWorkingDraftRead | null>(null);
   const [draftLoadState, setDraftLoadState] = useState<"loading" | "ready" | "error">("loading");
@@ -156,10 +146,6 @@ export function DocumentRichEditor({
   const [originalImportState, setOriginalImportState] = useState<OriginalImportState>("idle");
   const [draftBaselineText, setDraftBaselineText] = useState(initialText);
   const [canvasMode, setCanvasMode] = useState<DocumentCanvasMode>("page");
-  const [redlinesVisible, setRedlinesVisible] = useState(true);
-  const [trackBusy, setTrackBusy] = useState(false);
-  const [trackNotice, setTrackNotice] = useState<string | null>(null);
-  const findInputRef = useRef<HTMLInputElement | null>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const draftSaveTimerRef = useRef<number | null>(null);
   const dirtyRef = useRef(false);
@@ -458,25 +444,44 @@ export function DocumentRichEditor({
       !downloadingDocx &&
       (dirty || latestVersionId),
   );
-  const findMatches = useMemo(
-    () => findNormalizedRanges(plainText, findQuery),
-    [plainText, findQuery],
-  );
-  const activeFindMatch = findMatches[activeFindIndex] ?? findMatches[0] ?? null;
-  const findPreview =
-    activeFindMatch && plainText
-      ? plainText
-          .slice(
-            Math.max(0, activeFindMatch.start - 70),
-            Math.min(plainText.length, activeFindMatch.end + 90),
-          )
-          .replace(/\s+/g, " ")
-          .trim()
-      : null;
-  const findPositionLabel =
-    findMatches.length > 0
-      ? `${activeFindIndex + 1} / ${findMatches.length}`
-      : null;
+  const {
+    findQuery,
+    setFindQuery,
+    findOpen,
+    setFindOpen,
+    findInputRef,
+    findMatches,
+    findPreview,
+    findPositionLabel,
+    moveFind,
+    handleFindKeyDown,
+  } = useFindInDocument({ editor, plainText, canSave, save });
+  const {
+    redlinesVisible,
+    setRedlinesVisible,
+    trackBusy,
+    trackNotice,
+    anchoredProposedEditCount,
+    resolveAllProposedEdits,
+  } = useTrackedChangeResolution({
+    editor,
+    proposedEdits,
+    proposedEditsKey,
+    plainText,
+    onResolveProposedEdit,
+    setError,
+    trackHandlersRef,
+  });
+  const {
+    copiedMessage,
+    copyWorkingText,
+    copySelectedQuote,
+    copyEditorSelection,
+    highlightEditorSelection,
+    setEditorLink,
+    insertEditorImageUrl,
+    downloadWorkingText,
+  } = useClipboardActions({ editor, plainText, selectedQuote, filename });
   const outlineItems = useMemo(
     () => documentOutlineFromJson(currentEditorJson, plainText),
     [currentEditorJson, plainText],
@@ -521,122 +526,6 @@ export function DocumentRichEditor({
         ? `Saved v${latestVersionNumber}`
         : "Extracted text";
   const canvasMaxWidth = canvasMode === "page" ? "max-w-[820px]" : "max-w-[1040px]";
-
-  useEffect(() => {
-    setActiveFindIndex(0);
-  }, [findQuery]);
-
-  useEffect(() => {
-    if (activeFindIndex >= findMatches.length) setActiveFindIndex(0);
-  }, [activeFindIndex, findMatches.length]);
-
-  useEffect(() => {
-    if (!editor) return;
-    const activeIndex =
-      findMatches.length === 0
-        ? 0
-        : Math.min(activeFindIndex, Math.max(0, findMatches.length - 1));
-    editor.view.dispatch(
-      editor.state.tr.setMeta(FIND_DECORATIONS_PLUGIN_KEY, {
-        query: findQuery,
-        activeIndex,
-      } satisfies FindDecorationState),
-    );
-    if (findQuery.trim().length >= 3 && findMatches.length > 0) {
-      window.requestAnimationFrame(() => {
-        if (editor.isDestroyed) return;
-        editor.view.dom
-          .querySelector('[data-find-match="active"]')
-          ?.scrollIntoView({ block: "center", inline: "nearest" });
-      });
-    }
-  }, [activeFindIndex, editor, findMatches.length, findQuery]);
-
-  // A fresh batch of proposed edits always starts visible.
-  useEffect(() => {
-    setRedlinesVisible(true);
-  }, [proposedEditsKey]);
-
-  useEffect(() => {
-    if (!editor) return;
-    editor.view.dispatch(
-      editor.state.tr.setMeta(TRACK_CHANGES_PLUGIN_KEY, {
-        edits: proposedEdits,
-        visible: redlinesVisible,
-      } satisfies TrackChangesPluginState),
-    );
-    // proposedEditsKey stands in for the array identity.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, proposedEditsKey, redlinesVisible]);
-
-  const anchoredProposedEditCount = useMemo(() => {
-    if (!editor || proposedEdits.length === 0) return 0;
-    return proposedEdits.filter((edit) =>
-      locateProposedEditInDoc(editor.state.doc, edit),
-    ).length;
-    // plainText tracks document changes; proposedEditsKey tracks the list.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, proposedEditsKey, plainText]);
-
-  async function resolveProposedEditInline(
-    edit: DocumentProposedEdit,
-    action: "accept" | "reject",
-  ) {
-    if (!editor || !onResolveProposedEdit || trackBusy) return;
-    setTrackBusy(true);
-    setError(null);
-    try {
-      await onResolveProposedEdit(edit.id, action);
-      if (action === "accept") {
-        const applied = applyProposedEditToEditor(editor, edit);
-        if (!applied) {
-          setTrackNotice(
-            "Accepted on the record. The text could not be applied in place " +
-              "here — it lands when the final redline is decided.",
-          );
-        }
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setTrackBusy(false);
-    }
-  }
-
-  // "Accept all" / "Reject all" still resolve one edit at a time so each
-  // decision lands as its own audit row — and they only touch edits the
-  // user can SEE inline (anchored). Unanchored edits stay pending in the
-  // suggested-edits rail; one click never decides an unseen change. The
-  // anchor is re-checked per iteration because applying one edit can
-  // unanchor the next.
-  async function resolveAllProposedEdits(action: "accept" | "reject") {
-    if (!editor || !onResolveProposedEdit || trackBusy) return;
-    setTrackBusy(true);
-    setError(null);
-    try {
-      for (const edit of [...proposedEdits]) {
-        if (!locateProposedEditInDoc(editor.state.doc, edit)) continue;
-        await onResolveProposedEdit(edit.id, action);
-        if (action === "accept") {
-          const applied = applyProposedEditToEditor(editor, edit);
-          if (!applied) {
-            setTrackNotice(
-              "Some accepted changes could not be applied in place — they " +
-                "land when the final redline is decided.",
-            );
-          }
-        }
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setTrackBusy(false);
-    }
-  }
-
-  trackHandlersRef.current = {
-    resolve: (edit, action) => void resolveProposedEditInline(edit, action),
-  };
 
   async function save(): Promise<DocumentVersionRead | null> {
     if (!editor || !canSave) return null;
@@ -739,58 +628,6 @@ export function DocumentRichEditor({
     setLocalDraft(null);
   }
 
-  async function copyWorkingText() {
-    if (!plainText.trim()) return;
-    await window.navigator.clipboard.writeText(plainText);
-    setCopiedMessage("Copied working text");
-    window.setTimeout(() => setCopiedMessage(null), 2000);
-  }
-
-  async function copySelectedQuote() {
-    if (!selectedQuote?.trim()) return;
-    await window.navigator.clipboard.writeText(selectedQuote.trim());
-    setCopiedMessage("Copied selected passage");
-    window.setTimeout(() => setCopiedMessage(null), 2000);
-  }
-
-  async function copyEditorSelection() {
-    const selection = selectedEditorText(editor);
-    if (!selection) return;
-    await window.navigator.clipboard.writeText(selection);
-    setCopiedMessage("Copied selected passage");
-    window.setTimeout(() => setCopiedMessage(null), 2000);
-  }
-
-  function highlightEditorSelection() {
-    if (!editor || !selectedEditorText(editor)) return;
-    editor.chain().focus().toggleHighlight().run();
-  }
-
-  function setEditorLink() {
-    if (!editor) return;
-    const currentHref = typeof editor.getAttributes("link").href === "string"
-      ? editor.getAttributes("link").href
-      : "";
-    const nextHref = window.prompt("Paste link URL. Leave blank to remove the link.", currentHref);
-    if (nextHref === null) return;
-    const trimmed = nextHref.trim();
-    if (!trimmed) {
-      editor.chain().focus().extendMarkRange("link").unsetLink().run();
-      return;
-    }
-    editor.chain().focus().extendMarkRange("link").setLink({ href: trimmed }).run();
-  }
-
-  function insertEditorImageUrl() {
-    if (!editor) return;
-    const src = window.prompt("Paste image URL");
-    if (src === null) return;
-    const trimmed = src.trim();
-    if (!trimmed) return;
-    const alt = window.prompt("Image description", "")?.trim() ?? "";
-    editor.chain().focus().setImage({ src: trimmed, alt }).run();
-  }
-
   async function uploadAndInsertEditorImage(file: File) {
     if (!editor) return;
     setUploadingImage(true);
@@ -815,51 +652,6 @@ export function DocumentRichEditor({
     if (!file) return;
     await uploadAndInsertEditorImage(file);
   }
-
-  function downloadWorkingText() {
-    const blob = new Blob([plainText], { type: "text/plain;charset=utf-8" });
-    const url = window.URL.createObjectURL(blob);
-    const anchor = window.document.createElement("a");
-    anchor.href = url;
-    anchor.download = `${filename.replace(/\.[^.]+$/, "") || "document"}-working-copy.txt`;
-    window.document.body.append(anchor);
-    anchor.click();
-    anchor.remove();
-    window.URL.revokeObjectURL(url);
-  }
-
-  const moveFind = (direction: 1 | -1) => {
-    if (findMatches.length === 0) return;
-    setActiveFindIndex((current) =>
-      (current + direction + findMatches.length) % findMatches.length,
-    );
-  };
-  const handleFindKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
-    if (event.key !== "Enter") return;
-    event.preventDefault();
-    moveFind(event.shiftKey ? -1 : 1);
-  };
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (!event.metaKey && !event.ctrlKey) return;
-      const key = event.key.toLowerCase();
-      if (key === "f") {
-        event.preventDefault();
-        setFindOpen(true);
-        requestAnimationFrame(() => {
-          findInputRef.current?.focus();
-          findInputRef.current?.select();
-        });
-      }
-      if (key === "s") {
-        event.preventDefault();
-        if (canSave) void save();
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  });
 
   return (
     <section className="min-h-[760px] rounded-card border border-rule bg-paper" data-testid="document-editor">

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { EditorContent, useEditor, type Editor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import { Extension, type Content, type JSONContent } from "@tiptap/core";
+import { Extension, type Content } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
@@ -40,20 +40,37 @@ import {
   type DocumentWorkingDraftRead,
 } from "../../lib/api";
 import { buildVersionDiff, buildVersionDiffSummary } from "./VersionDiff";
+import {
+  clearDocumentLocalDraft,
+  documentOutlineFromJson,
+  documentStatsFromText,
+  editorJsonToPlainText,
+  findNormalizedRange,
+  findNormalizedRanges,
+  firstImageFile,
+  isEditableWordDocument,
+  readDocumentLocalDraft,
+  selectedEditorText,
+  textToEditorHtml,
+  writeDocumentLocalDraft,
+  type DocumentLocalDraft,
+  type TiptapNode,
+} from "./editorText";
 
-export type TiptapNode = JSONContent;
+export {
+  clearDocumentLocalDraft,
+  documentOutlineFromJson,
+  documentStatsFromText,
+  editorJsonToPlainText,
+  findNormalizedRange,
+  findNormalizedRanges,
+  isEditableWordDocument,
+  readDocumentLocalDraft,
+  textToEditorHtml,
+  writeDocumentLocalDraft,
+} from "./editorText";
+export type { TiptapNode } from "./editorText";
 
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
-
-type TextRange = { start: number; end: number };
-type OutlineItem = { id: string; label: string; query: string };
-type DocumentStats = { words: number; chars: number; blocks: number };
 type DocumentCanvasMode = "page" | "wide";
 type OriginalImportState = "idle" | "loading" | "ready" | "error";
 type WorkingDiffPart = ReturnType<typeof buildVersionDiff>[number];
@@ -65,20 +82,6 @@ const EDITOR_TEXT_COLORS = [
   { label: "Blue text", value: "#245B8A" },
 ] as const;
 const SHARED_DRAFT_POLL_MS = 15_000;
-type DocumentLocalDraft = {
-  documentId: string;
-  filename: string;
-  savedAt: string;
-  plainText: string;
-  json: TiptapNode;
-};
-
-function firstImageFile(files: FileList | File[] | null | undefined): File | null {
-  for (const file of Array.from(files ?? [])) {
-    if (file.type.startsWith("image/")) return file;
-  }
-  return null;
-}
 
 type FindDecorationState = {
   activeIndex: number;
@@ -398,200 +401,6 @@ function trackChangesDecorationsExtension(handlersRef: {
       ];
     },
   });
-}
-
-function selectedEditorText(editor: Editor | null): string {
-  if (!editor) return "";
-  const { from, to } = editor.state.selection;
-  if (from === to) return "";
-  return editor.state.doc.textBetween(from, to, " ").replace(/\s+/g, " ").trim();
-}
-
-export function findNormalizedRanges(
-  text: string,
-  needle: string | null | undefined,
-): TextRange[] {
-  const target = needle?.trim().replace(/\s+/g, " ").toLowerCase();
-  if (!target || target.length < 3) return [];
-
-  let normalised = "";
-  const starts: number[] = [];
-  const ends: number[] = [];
-
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    if (/\s/.test(ch)) {
-      if (normalised.length === 0) continue;
-      if (normalised.endsWith(" ")) {
-        ends[ends.length - 1] = i + 1;
-      } else {
-        normalised += " ";
-        starts.push(i);
-        ends.push(i + 1);
-      }
-      continue;
-    }
-    normalised += ch.toLowerCase();
-    starts.push(i);
-    ends.push(i + 1);
-  }
-
-  const searchable = normalised.trimEnd();
-  const ranges: TextRange[] = [];
-  let from = 0;
-  while (from < searchable.length) {
-    const index = searchable.indexOf(target, from);
-    if (index === -1) break;
-    const endIndex = index + target.length - 1;
-    ranges.push({ start: starts[index], end: ends[endIndex] });
-    from = index + Math.max(target.length, 1);
-  }
-  return ranges;
-}
-
-export function findNormalizedRange(
-  text: string,
-  needle: string | null | undefined,
-): TextRange | null {
-  return findNormalizedRanges(text, needle)[0] ?? null;
-}
-
-function escapeWithOptionalMark(text: string, range: TextRange | null): string {
-  if (!range || range.end <= range.start) return escapeHtml(text);
-  const matched = text.slice(range.start, range.end);
-  if (/\n{2,}/.test(matched)) return escapeHtml(text);
-  return [
-    escapeHtml(text.slice(0, range.start)),
-    '<mark data-source-anchor="true">',
-    escapeHtml(matched),
-    "</mark>",
-    escapeHtml(text.slice(range.end)),
-  ].join("");
-}
-
-export function textToEditorHtml(
-  text: string,
-  sourceHighlight?: string | null,
-): string {
-  const trimmed = text.trim();
-  if (!trimmed) return "<p></p>";
-  const range = findNormalizedRange(trimmed, sourceHighlight);
-  const html = escapeWithOptionalMark(trimmed, range)
-    .replace(/\n{2,}/g, "</p><p>")
-    .replace(/\n/g, "<br />");
-  return `<p>${html}</p>`;
-}
-
-function plainTextFromNode(node: TiptapNode): string {
-  if (node.type === "text") return node.text ?? "";
-  if (node.type === "hardBreak") return "\n";
-  if (node.type === "image") return node.attrs?.alt ? `[image: ${node.attrs.alt}]\n\n` : "[image]\n\n";
-  const children = node.content?.map(plainTextFromNode).join("") ?? "";
-  if (node.type === "paragraph" || node.type === "heading") return `${children}\n\n`;
-  if (node.type === "taskItem") {
-    return `${node.attrs?.checked ? "[x]" : "[ ]"} ${children.trimEnd()}\n`;
-  }
-  if (node.type === "listItem") return `${children.trimEnd()}\n`;
-  if (node.type === "tableCell" || node.type === "tableHeader") return children.trim();
-  if (node.type === "tableRow") {
-    return `${node.content?.map(plainTextFromNode).join("\t") ?? ""}\n`;
-  }
-  if (node.type === "table") return `${children}\n`;
-  return children;
-}
-
-export function editorJsonToPlainText(json: TiptapNode): string {
-  return plainTextFromNode(json).replace(/\n{3,}/g, "\n\n").trim();
-}
-
-export function isEditableWordDocument(filename: string, mimeType?: string | null): boolean {
-  return (
-    /\.docx$/i.test(filename) ||
-    mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-  );
-}
-
-function firstTextFromNode(node: TiptapNode): string {
-  if (node.type === "text") return node.text ?? "";
-  return node.content?.map(firstTextFromNode).join("") ?? "";
-}
-
-function documentOutlineFromText(text: string): OutlineItem[] {
-  const blocks = text
-    .split(/\n{2,}/)
-    .map((block) => block.replace(/\s+/g, " ").trim())
-    .filter((block) => block.length >= 12);
-  return blocks.slice(0, 12).map((block, index) => {
-    const compact = block.length > 76 ? `${block.slice(0, 73).trimEnd()}...` : block;
-    return {
-      id: `${index}-${compact}`,
-      label: compact,
-      query: block.slice(0, 96),
-    };
-  });
-}
-
-export function documentOutlineFromJson(
-  json: TiptapNode | null | undefined,
-  fallbackText: string,
-): OutlineItem[] {
-  const headingItems =
-    json?.content?.flatMap((node, index): OutlineItem[] => {
-      if (node.type !== "heading") return [];
-      const text = firstTextFromNode(node).replace(/\s+/g, " ").trim();
-      if (!text) return [];
-      return [{
-        id: `heading-${index}-${text}`,
-        label: text.length > 76 ? `${text.slice(0, 73).trimEnd()}...` : text,
-        query: text,
-      }];
-    }) ?? [];
-  return headingItems.length > 0 ? headingItems.slice(0, 12) : documentOutlineFromText(fallbackText);
-}
-
-export function documentStatsFromText(text: string): DocumentStats {
-  const trimmed = text.trim();
-  return {
-    words: trimmed ? trimmed.split(/\s+/).length : 0,
-    chars: text.length,
-    blocks: trimmed ? trimmed.split(/\n{2,}/).filter(Boolean).length : 0,
-  };
-}
-
-function draftStorageKey(documentId: string): string {
-  return `legalise.documentDraft.${documentId}`;
-}
-
-export function readDocumentLocalDraft(documentId: string): DocumentLocalDraft | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.localStorage.getItem(draftStorageKey(documentId));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<DocumentLocalDraft>;
-    if (
-      parsed.documentId !== documentId ||
-      !parsed.json ||
-      typeof parsed.plainText !== "string" ||
-      typeof parsed.savedAt !== "string"
-    ) {
-      window.localStorage.removeItem(draftStorageKey(documentId));
-      return null;
-    }
-    return parsed as DocumentLocalDraft;
-  } catch {
-    window.localStorage.removeItem(draftStorageKey(documentId));
-    return null;
-  }
-}
-
-export function writeDocumentLocalDraft(draft: DocumentLocalDraft): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(draftStorageKey(draft.documentId), JSON.stringify(draft));
-}
-
-export function clearDocumentLocalDraft(documentId: string): void {
-  if (typeof window === "undefined") return;
-  window.localStorage.removeItem(draftStorageKey(documentId));
 }
 
 function ToolbarButton({

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -7,7 +7,6 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { BubbleMenu } from "@tiptap/react/menus";
 import { type Content } from "@tiptap/core";
 
 import {
@@ -79,11 +78,17 @@ import {
 export type { DocumentNoteHighlight } from "./reviewNotes";
 
 import { documentEditorExtensions } from "./editorExtensions";
+import { FormatToolbar, ViewModeButton } from "./editorChrome";
 import {
-  FormatToolbar,
-  renderWorkingDiffParts,
-  ViewModeButton,
-} from "./editorChrome";
+  DraftNotices,
+  EditorSideRail,
+  FindPanel,
+  RedlinesPanel,
+  ReviewMapPanel,
+  SelectionBubbleMenu,
+  SelectionRibbon,
+  WorkingDiffPanel,
+} from "./EditorPanels";
 
 type DocumentCanvasMode = "page" | "wide";
 type OriginalImportState = "idle" | "loading" | "ready" | "error";
@@ -1005,103 +1010,27 @@ export function DocumentRichEditor({
           />
         )}
         {(findOpen || findQuery.trim()) && (
-        <div
-          className="flex flex-wrap items-center gap-3 border-t border-rule bg-paper px-4 py-2.5"
-          data-testid="document-editor-find-panel"
-        >
-          <label
-            htmlFor={`find-${documentId}`}
-            className="text-xs font-semibold uppercase tracking-track2 text-muted"
-          >
-            Find
-          </label>
-          <input
-            ref={findInputRef}
-            id={`find-${documentId}`}
-            type="search"
-            value={findQuery}
-            onChange={(event) => setFindQuery(event.target.value)}
-            onKeyDown={handleFindKeyDown}
-            placeholder="Search this document"
-            className="min-h-[34px] min-w-[220px] flex-1 border border-rule bg-paper-sunken px-3 text-sm outline-none focus:border-ink"
+          <FindPanel
+            documentId={documentId}
+            findInputRef={findInputRef}
+            findQuery={findQuery}
+            setFindQuery={setFindQuery}
+            onFindKeyDown={handleFindKeyDown}
+            matchCount={findMatches.length}
+            moveFind={moveFind}
+            findPositionLabel={findPositionLabel}
+            findPreview={findPreview}
           />
-          <span className="text-xs text-muted" data-testid="document-editor-find-count">
-            {findQuery.trim().length >= 3
-              ? `${findMatches.length} match${findMatches.length === 1 ? "" : "es"}`
-              : "Type 3+ characters"}
-          </span>
-          <button
-            type="button"
-            onClick={() => moveFind(-1)}
-            disabled={findMatches.length === 0}
-            className="border border-rule px-2 py-1 text-xs text-muted hover:border-ink hover:text-ink disabled:opacity-40"
-          >
-            Previous
-          </button>
-          <button
-            type="button"
-            onClick={() => moveFind(1)}
-            disabled={findMatches.length === 0}
-            className="border border-rule px-2 py-1 text-xs text-muted hover:border-ink hover:text-ink disabled:opacity-40"
-          >
-            Next
-          </button>
-          {findMatches.length > 0 && (
-            <span className="text-xs text-muted" data-testid="document-editor-find-position">
-              {findPositionLabel}
-            </span>
-          )}
-          {findQuery && (
-            <button
-              type="button"
-              onClick={() => setFindQuery("")}
-              className="text-xs text-muted underline underline-offset-4 hover:text-ink"
-            >
-              Clear
-            </button>
-          )}
-          {findPreview && (
-            <p
-              className="basis-full text-xs leading-5 text-muted"
-              data-testid="document-editor-find-preview"
-            >
-              Match {findPositionLabel}: {findPreview}
-            </p>
-          )}
-        </div>
         )}
         {redlinesVisible && proposedEdits.length > 0 && (
-        <div
-          className="flex flex-wrap items-center gap-3 border-t border-rule bg-paper px-4 py-2 text-xs text-muted"
-          data-testid="document-editor-redlines-panel"
-        >
-          <span>
-            {proposedEdits.length} proposed change
-            {proposedEdits.length === 1 ? "" : "s"}
-            {anchoredProposedEditCount < proposedEdits.length
-              ? ` · ${proposedEdits.length - anchoredProposedEditCount} not anchored in this text — review in the suggested-edits list`
-              : ""}
-            {trackNotice ? ` · ${trackNotice}` : ""}
-          </span>
-          <span className="ml-auto flex items-center gap-1.5">
-            <button
-              type="button"
-              onClick={() => void resolveAllProposedEdits("accept")}
-              disabled={trackBusy || !onResolveProposedEdit}
-              className="inline-flex h-7 items-center rounded-item border border-ink bg-ink px-2.5 text-xs text-paper hover:bg-seal disabled:border-rule disabled:bg-paper-sunken disabled:text-muted"
-            >
-              {trackBusy ? "Working…" : "Accept all"}
-            </button>
-            <button
-              type="button"
-              onClick={() => void resolveAllProposedEdits("reject")}
-              disabled={trackBusy || !onResolveProposedEdit}
-              className="inline-flex h-7 items-center rounded-item border border-rule bg-paper px-2.5 text-xs text-muted hover:border-seal hover:text-seal disabled:opacity-40"
-            >
-              Reject all
-            </button>
-          </span>
-        </div>
+          <RedlinesPanel
+            proposedEditCount={proposedEdits.length}
+            anchoredProposedEditCount={anchoredProposedEditCount}
+            trackNotice={trackNotice}
+            trackBusy={trackBusy}
+            canResolve={Boolean(onResolveProposedEdit)}
+            onResolveAll={resolveAllProposedEdits}
+          />
         )}
       </div>
 
@@ -1114,187 +1043,47 @@ export function DocumentRichEditor({
         </p>
       )}
       {selectedQuote && (
-        <div
-          className="flex flex-wrap items-center justify-between gap-3 border-b border-ink bg-paper px-5 py-3"
-          data-testid="document-editor-selection-ribbon"
-        >
-          <div className="min-w-0">
-            <p className="text-[11px] font-semibold uppercase tracking-track2 text-ink">
-              Selected passage
-            </p>
-            <p className="mt-1 max-w-3xl truncate text-sm text-muted">{selectedQuote}</p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              onClick={() => void copySelectedQuote()}
-              className="border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
-            >
-              Copy
-            </button>
-            <button
-              type="button"
-              onClick={() => setFindQuery(selectedQuote)}
-              className="border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
-            >
-              Find in document
-            </button>
-            {onCreateNoteFromSelection && (
-              <button
-                type="button"
-                onClick={onCreateNoteFromSelection}
-                className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-seal"
-              >
-                Add review note
-              </button>
-            )}
-            {onRunSkillFromSelection && (
-              <button
-                type="button"
-                onClick={onRunSkillFromSelection}
-                className="border border-ink bg-paper px-3 py-2 text-xs font-semibold text-ink hover:bg-paper-sunken"
-              >
-                Run skill
-              </button>
-            )}
-          </div>
-        </div>
+        <SelectionRibbon
+          selectedQuote={selectedQuote}
+          onCopySelectedQuote={copySelectedQuote}
+          onFindInDocument={() => setFindQuery(selectedQuote)}
+          onCreateNoteFromSelection={onCreateNoteFromSelection}
+          onRunSkillFromSelection={onRunSkillFromSelection}
+        />
       )}
-      {draftSaveState === "error" && (
-        <div
-          className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-300 bg-amber-50 px-5 py-2 text-xs leading-5 text-amber-900"
-          data-testid="document-server-draft-error"
-        >
-          <span>
-            {draftConflict ??
-              "Shared draft could not be saved. The browser copy is preserved locally; try saving again before leaving this file."}
-          </span>
-          <button
-            type="button"
-            onClick={() =>
-              loadSharedDraftFromServer({
-                allowWordImport: false,
-                reloadedMessage: "Shared draft reloaded",
-              }).catch((err) => {
-                setDraftSaveState("error");
-                setError(err instanceof Error ? err.message : String(err));
-              })
-            }
-            className="border border-amber-900 bg-paper px-3 py-1.5 text-xs font-semibold text-amber-950 hover:bg-amber-100"
-          >
-            Reload shared draft
-          </button>
-        </div>
-      )}
-      {remoteDraftNotice && (
-        <div
-          className="flex flex-wrap items-center justify-between gap-3 border-b border-rule bg-paper-sunken px-5 py-2 text-xs leading-5 text-muted"
-          data-testid="document-remote-draft-notice"
-        >
-          <span>{remoteDraftNotice}</span>
-          <button
-            type="button"
-            onClick={() =>
-              loadSharedDraftFromServer({
-                allowWordImport: false,
-                reloadedMessage: "Shared draft reloaded",
-              }).catch((err) => {
-                setRemoteDraftNotice(null);
-                setError(err instanceof Error ? err.message : String(err));
-              })
-            }
-            className="border border-rule bg-paper px-3 py-1.5 text-xs font-semibold text-ink hover:border-ink"
-          >
-            Reload shared draft
-          </button>
-        </div>
-      )}
-      {originalImportState === "loading" && (
-        <p className="border-b border-rule bg-paper-sunken px-5 py-2 text-xs text-muted">
-          Importing Word structure into the editable working copy...
-        </p>
-      )}
-      {originalImportState === "ready" && (
-        <p
-          className="border-b border-rule bg-paper-sunken px-5 py-2 text-xs text-muted"
-          data-testid="document-word-import-ready"
-        >
-          Word structure imported into the shared draft. Save a version when the edit is ready.
-        </p>
-      )}
-      {originalImportState === "error" && (
-        <p
-          className="border-b border-amber-300 bg-amber-50 px-5 py-2 text-xs leading-5 text-amber-900"
-          data-testid="document-word-import-fallback"
-        >
-          Word structure could not be imported here, so the editor is using extracted text.
-        </p>
-      )}
-      {localDraft && (
-        <div
-          className="flex flex-wrap items-center justify-between gap-3 border-b border-rule bg-amber-50 px-5 py-3 text-sm text-ink"
-          data-testid="document-local-draft-banner"
-        >
-          <span>
-            Unsaved local draft from{" "}
-            {new Date(localDraft.savedAt).toLocaleString()}. Restore it or discard it.
-          </span>
-          <span className="flex gap-2">
-            <button
-              type="button"
-              onClick={restoreLocalDraft}
-              className="border border-ink bg-paper px-3 py-1.5 text-xs font-semibold text-ink hover:bg-ink hover:text-paper"
-            >
-              Restore draft
-            </button>
-            <button
-              type="button"
-              onClick={discardLocalDraft}
-              className="border border-rule bg-paper px-3 py-1.5 text-xs font-semibold text-muted hover:border-ink hover:text-ink"
-            >
-              Discard
-            </button>
-          </span>
-        </div>
-      )}
+      <DraftNotices
+        draftSaveError={draftSaveState === "error"}
+        draftConflict={draftConflict}
+        onReloadAfterError={() =>
+          loadSharedDraftFromServer({
+            allowWordImport: false,
+            reloadedMessage: "Shared draft reloaded",
+          }).catch((err) => {
+            setDraftSaveState("error");
+            setError(err instanceof Error ? err.message : String(err));
+          })
+        }
+        remoteDraftNotice={remoteDraftNotice}
+        onReloadAfterNotice={() =>
+          loadSharedDraftFromServer({
+            allowWordImport: false,
+            reloadedMessage: "Shared draft reloaded",
+          }).catch((err) => {
+            setRemoteDraftNotice(null);
+            setError(err instanceof Error ? err.message : String(err));
+          })
+        }
+        originalImportState={originalImportState}
+        localDraft={localDraft}
+        onRestoreLocalDraft={restoreLocalDraft}
+        onDiscardLocalDraft={discardLocalDraft}
+      />
       {showWorkingDiff && (
-        <div
-          className="border-b border-rule bg-paper px-5 py-3"
-          data-testid="document-working-diff"
-        >
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
-                Unsaved changes
-              </p>
-              <p className="mt-1 text-sm text-ink">
-                Review the working copy before saving it as a new document version.
-              </p>
-            </div>
-            <dl className="flex flex-wrap gap-2 text-xs">
-              <div className="border border-rule bg-paper-sunken px-3 py-2">
-                <dt className="tech-token uppercase tracking-track2 text-muted">Added</dt>
-                <dd className="mt-1 font-semibold text-green-900">
-                  {workingDiffSummary.insertedChars.toLocaleString()} chars
-                </dd>
-              </div>
-              <div className="border border-rule bg-paper-sunken px-3 py-2">
-                <dt className="tech-token uppercase tracking-track2 text-muted">Removed</dt>
-                <dd className="mt-1 font-semibold text-red-900">
-                  {workingDiffSummary.deletedChars.toLocaleString()} chars
-                </dd>
-              </div>
-            </dl>
-          </div>
-          <details className="mt-3 border border-rule bg-paper-sunken">
-            <summary className="cursor-pointer px-3 py-2 text-xs font-semibold text-ink">
-              Preview redline before saving
-            </summary>
-            <div className="max-h-[260px] overflow-auto border-t border-rule bg-paper p-4 text-sm leading-7">
-              {renderWorkingDiffParts(workingDiffParts)}
-            </div>
-          </details>
-        </div>
+        <WorkingDiffPanel
+          workingDiffParts={workingDiffParts}
+          insertedChars={workingDiffSummary.insertedChars}
+          deletedChars={workingDiffSummary.deletedChars}
+        />
       )}
       {error && (
         <p className="border-b border-red-800 bg-red-50 px-5 py-3 text-sm text-red-900">
@@ -1302,205 +1091,38 @@ export function DocumentRichEditor({
         </p>
       )}
       {noteAnchorSummaries.length > 0 && (
-        <div
-          className="border-b border-rule bg-paper px-5 py-3"
-          data-testid="document-editor-review-map"
-        >
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
-                Review map
-              </p>
-              <p className="mt-1 text-sm text-ink">
-                {locatedNoteCount} of {noteAnchorSummaries.length} note anchor
-                {noteAnchorSummaries.length === 1 ? "" : "s"} located in this working copy.
-              </p>
-            </div>
-            <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
-              Anchored notes
-            </span>
-          </div>
-          <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
-            {noteAnchorSummaries.map((note) => (
-              <button
-                key={note.id}
-                type="button"
-                onClick={() => setFindQuery(note.quote)}
-                className={`min-w-[220px] max-w-[280px] border px-3 py-2 text-left text-xs leading-5 ${
-                  note.located
-                    ? "border-ink bg-paper text-ink"
-                    : "border-amber-300 bg-amber-50 text-amber-950"
-                }`}
-              >
-                <span className="block font-semibold">{note.label}</span>
-                <span className="mt-1 block max-h-10 overflow-hidden text-muted">
-                  {note.quote}
-                </span>
-                <span className="mt-2 block tech-token uppercase tracking-track2">
-                  {note.located ? "Located" : "Not located"}
-                </span>
-              </button>
-            ))}
-          </div>
-        </div>
+        <ReviewMapPanel
+          noteAnchorSummaries={noteAnchorSummaries}
+          locatedNoteCount={locatedNoteCount}
+          onJumpToNote={setFindQuery}
+        />
       )}
       <div className="grid min-h-[620px] lg:grid-cols-[240px_minmax(0,1fr)]">
-        <aside className="border-b border-rule bg-paper px-5 py-5 lg:border-b-0 lg:border-r">
-          <div className="space-y-5">
-            {sourceHighlight && (
-              <div>
-                <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
-                  Source passage
-                </p>
-                <p className="mt-2 text-sm leading-6 text-muted">
-                  {sourceRange ? "Located in this version." : "Not located in this version."}
-                </p>
-                <button
-                  type="button"
-                  onClick={() => setFindQuery(sourceHighlight)}
-                  className="mt-2 text-xs font-medium text-ink underline underline-offset-4 hover:text-muted"
-                >
-                  Search cited text
-                </button>
-              </div>
-            )}
-            {selectedQuote && (
-              <div
-                className="border border-ink bg-paper p-3"
-                data-testid="document-editor-selected-passage"
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <p className="text-[11px] font-semibold uppercase tracking-track2 text-ink">
-                    Selected passage
-                  </p>
-                  <span className="border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
-                    {selectedQuoteAnchored ? "Anchored" : "Unanchored"}
-                  </span>
-                </div>
-                <p className="mt-2 max-h-28 overflow-hidden text-xs leading-5 text-muted">
-                  {selectedQuote}
-                </p>
-                <button
-                  type="button"
-                  onClick={() => void copySelectedQuote()}
-                  className="mt-3 w-full border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
-                >
-                  Copy passage
-                </button>
-                {onCreateNoteFromSelection && (
-                  <button
-                    type="button"
-                    onClick={onCreateNoteFromSelection}
-                    className="mt-2 w-full border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-seal"
-                  >
-                    Add review note
-                  </button>
-                )}
-              </div>
-            )}
-            {noteHighlights.length > 0 && (
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
-                Review notes
-              </p>
-              {noteHighlights.length > 0 ? (
-                <div className="mt-2 space-y-2" data-testid="document-editor-note-rail">
-                  {noteHighlights.map((note) => (
-                    <button
-                      key={note.id}
-                      type="button"
-                      onClick={() => setFindQuery(note.quote)}
-                      className="block w-full border border-rule bg-paper px-3 py-2 text-left text-xs leading-5 text-muted hover:border-ink hover:text-ink"
-                    >
-                      <span className="block font-medium text-ink">{note.label}</span>
-                      <span className="mt-1 block max-h-10 overflow-hidden">{note.quote}</span>
-                    </button>
-                  ))}
-                </div>
-              ) : null}
-            </div>
-            )}
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
-                Outline
-              </p>
-              {outlineItems.length > 0 ? (
-                <nav className="mt-2 space-y-1" aria-label="Document outline">
-                  {outlineItems.map((item) => (
-                    <button
-                      key={item.id}
-                      type="button"
-                      onClick={() => setFindQuery(item.query)}
-                      className="block w-full border-l border-transparent py-1 pl-2 text-left text-xs leading-5 text-muted hover:border-ink hover:text-ink"
-                    >
-                      {item.label}
-                    </button>
-                  ))}
-                </nav>
-              ) : (
-                <p className="mt-2 text-sm text-muted">No outline yet.</p>
-              )}
-            </div>
-          </div>
-        </aside>
+        <EditorSideRail
+          sourceHighlight={sourceHighlight}
+          sourceLocated={Boolean(sourceRange)}
+          selectedQuote={selectedQuote}
+          selectedQuoteAnchored={selectedQuoteAnchored}
+          onCopySelectedQuote={copySelectedQuote}
+          onCreateNoteFromSelection={onCreateNoteFromSelection}
+          noteHighlights={noteHighlights}
+          outlineItems={outlineItems}
+          onFind={setFindQuery}
+        />
         <div
           className="bg-[linear-gradient(180deg,#f7f7f4_0%,#efefea_100%)] px-4 py-8 sm:px-8 sm:py-10"
           data-testid="document-editor-canvas"
         >
           <div className={`mx-auto ${canvasMaxWidth}`}>
             {editor && (
-              <BubbleMenu
+              <SelectionBubbleMenu
                 editor={editor}
-                shouldShow={({ editor: bubbleEditor }) =>
-                  selectedEditorText(bubbleEditor).length >= 3
-                }
-                options={{ placement: "top", offset: 8 }}
-              >
-                <div
-                  className="flex items-center gap-1 border border-ink bg-paper px-1.5 py-1 shadow-[0_10px_30px_rgba(0,0,0,0.12)]"
-                  data-testid="document-editor-selection-menu"
-                >
-                  <button
-                    type="button"
-                    onClick={() => void copyEditorSelection()}
-                    className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
-                  >
-                    Copy
-                  </button>
-                  <button
-                    type="button"
-                    onClick={highlightEditorSelection}
-                    className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
-                  >
-                    Highlight
-                  </button>
-                  <button
-                    type="button"
-                    onClick={setEditorLink}
-                    className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
-                  >
-                    Link
-                  </button>
-                  {onCreateNoteFromSelection && (
-                    <button
-                      type="button"
-                      onClick={onCreateNoteFromSelection}
-                      className="bg-ink px-2 py-1 text-xs font-semibold text-paper hover:bg-seal"
-                    >
-                      Add note
-                    </button>
-                  )}
-                  {onRunSkillFromSelection && (
-                    <button
-                      type="button"
-                      onClick={onRunSkillFromSelection}
-                      className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
-                    >
-                      Run skill
-                    </button>
-                  )}
-                </div>
-              </BubbleMenu>
+                onCopyEditorSelection={copyEditorSelection}
+                onHighlightSelection={highlightEditorSelection}
+                onSetLink={setEditorLink}
+                onCreateNoteFromSelection={onCreateNoteFromSelection}
+                onRunSkillFromSelection={onRunSkillFromSelection}
+              />
             )}
             <EditorContent editor={editor} />
           </div>

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import { Extension, type Content } from "@tiptap/core";
+import { type Content } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
@@ -24,8 +24,6 @@ import { Table } from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
 import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
-import { Plugin, PluginKey } from "prosemirror-state";
-import { Decoration, DecorationSet } from "prosemirror-view";
 
 import {
   commitDocumentWorkingDraft,
@@ -83,6 +81,18 @@ import {
 export { locateProposedEditInDoc } from "./trackedChanges";
 export type { DocumentProposedEdit, ProposedEditLocation } from "./trackedChanges";
 
+import {
+  FIND_DECORATIONS_PLUGIN_KEY,
+  findDecorationsExtension,
+  type FindDecorationState,
+} from "./findDecorations";
+import {
+  reviewNoteDecorationsExtension,
+  type DocumentNoteHighlight,
+} from "./reviewNotes";
+
+export type { DocumentNoteHighlight } from "./reviewNotes";
+
 type DocumentCanvasMode = "page" | "wide";
 type OriginalImportState = "idle" | "loading" | "ready" | "error";
 type WorkingDiffPart = ReturnType<typeof buildVersionDiff>[number];
@@ -94,101 +104,6 @@ const EDITOR_TEXT_COLORS = [
   { label: "Blue text", value: "#245B8A" },
 ] as const;
 const SHARED_DRAFT_POLL_MS = 15_000;
-
-type FindDecorationState = {
-  activeIndex: number;
-  query: string;
-};
-export type DocumentNoteHighlight = {
-  id: string;
-  label: string;
-  quote: string;
-  status: "open" | "resolved";
-};
-const FIND_DECORATIONS_PLUGIN_KEY = new PluginKey<FindDecorationState>(
-  "legaliseDocumentFind",
-);
-
-function findDecorationsExtension() {
-  return Extension.create({
-    name: "legaliseDocumentFind",
-    addProseMirrorPlugins() {
-      return [
-        new Plugin<FindDecorationState>({
-          key: FIND_DECORATIONS_PLUGIN_KEY,
-          state: {
-            init: () => ({ query: "", activeIndex: 0 }),
-            apply(transaction, previous) {
-              return transaction.getMeta(FIND_DECORATIONS_PLUGIN_KEY) ?? previous;
-            },
-          },
-          props: {
-            decorations(state) {
-              const pluginState = FIND_DECORATIONS_PLUGIN_KEY.getState(state);
-              const query = pluginState?.query?.trim() ?? "";
-              if (query.length < 3) return DecorationSet.empty;
-              const decorations: Decoration[] = [];
-              let matchIndex = 0;
-              state.doc.descendants((node, position) => {
-                if (!node.isText || !node.text) return;
-                findNormalizedRanges(node.text, query).forEach((range) => {
-                  const isActive = matchIndex === pluginState?.activeIndex;
-                  decorations.push(
-                    Decoration.inline(position + range.start, position + range.end, {
-                      class: isActive
-                        ? "legalise-find-match legalise-find-match-active"
-                        : "legalise-find-match",
-                      "data-find-match": isActive ? "active" : "true",
-                    }),
-                  );
-                  matchIndex += 1;
-                });
-              });
-              return DecorationSet.create(state.doc, decorations);
-            },
-          },
-        }),
-      ];
-    },
-  });
-}
-
-function reviewNoteDecorationsExtension(noteHighlights: DocumentNoteHighlight[]) {
-  return Extension.create({
-    name: "legaliseReviewNotes",
-    addProseMirrorPlugins() {
-      return [
-        new Plugin({
-          key: new PluginKey("legaliseReviewNotes"),
-          props: {
-            decorations(state) {
-              const decorations: Decoration[] = [];
-              state.doc.descendants((node, position) => {
-                if (!node.isText || !node.text) return;
-                noteHighlights.forEach((note) => {
-                  findNormalizedRanges(node.text ?? "", note.quote).forEach((range) => {
-                    decorations.push(
-                      Decoration.inline(position + range.start, position + range.end, {
-                        class:
-                          note.status === "resolved"
-                            ? "legalise-review-note-resolved"
-                            : "legalise-review-note-open",
-                        "data-review-note-id": note.id,
-                        title: note.label,
-                      }),
-                    );
-                  });
-                });
-              });
-              return DecorationSet.create(state.doc, decorations);
-            },
-          },
-        }),
-      ];
-    },
-  });
-}
-
 
 function ToolbarButton({
   active,

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -9,21 +9,6 @@ import {
 import { EditorContent, useEditor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import { type Content } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
-import Placeholder from "@tiptap/extension-placeholder";
-import Typography from "@tiptap/extension-typography";
-import Highlight from "@tiptap/extension-highlight";
-import Color from "@tiptap/extension-color";
-import Image from "@tiptap/extension-image";
-import Link from "@tiptap/extension-link";
-import TaskItem from "@tiptap/extension-task-item";
-import TaskList from "@tiptap/extension-task-list";
-import TextAlign from "@tiptap/extension-text-align";
-import { TextStyle } from "@tiptap/extension-text-style";
-import { Table } from "@tiptap/extension-table";
-import TableCell from "@tiptap/extension-table-cell";
-import TableHeader from "@tiptap/extension-table-header";
-import TableRow from "@tiptap/extension-table-row";
 
 import {
   commitDocumentWorkingDraft,
@@ -93,145 +78,16 @@ import {
 
 export type { DocumentNoteHighlight } from "./reviewNotes";
 
+import { documentEditorExtensions } from "./editorExtensions";
+import {
+  FormatToolbar,
+  renderWorkingDiffParts,
+  ViewModeButton,
+} from "./editorChrome";
+
 type DocumentCanvasMode = "page" | "wide";
 type OriginalImportState = "idle" | "loading" | "ready" | "error";
-type WorkingDiffPart = ReturnType<typeof buildVersionDiff>[number];
-const EDITOR_TEXT_COLORS = [
-  { label: "Ink text", value: "#181818" },
-  { label: "Red text", value: "#8C1D18" },
-  { label: "Amber text", value: "#8A5A00" },
-  { label: "Green text", value: "#236A44" },
-  { label: "Blue text", value: "#245B8A" },
-] as const;
 const SHARED_DRAFT_POLL_MS = 15_000;
-
-function ToolbarButton({
-  active,
-  children,
-  onClick,
-  label,
-  disabled,
-}: {
-  active?: boolean;
-  children: string;
-  onClick: () => void;
-  label: string;
-  disabled?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      onClick={onClick}
-      disabled={disabled}
-      className={`inline-flex h-8 min-w-8 items-center justify-center rounded-item border px-2 text-sm disabled:cursor-not-allowed disabled:opacity-35 ${
-        active
-          ? "border-ink bg-ink text-paper"
-          : "border-rule bg-paper text-ink hover:border-ink"
-      }`}
-    >
-      {children}
-    </button>
-  );
-}
-
-function ToolbarGroup({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-1 border-r border-rule pr-2 last:border-r-0 last:pr-0">
-      <span className="mr-1 hidden text-[10px] font-semibold uppercase tracking-track2 text-muted xl:inline">
-        {label}
-      </span>
-      {children}
-    </div>
-  );
-}
-
-function ColorButton({
-  active,
-  color,
-  label,
-  onClick,
-}: {
-  active?: boolean;
-  color: string;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      onClick={onClick}
-      className={`inline-flex h-8 min-w-8 items-center justify-center rounded-item border bg-paper px-2 ${
-        active ? "border-ink" : "border-rule hover:border-ink"
-      }`}
-    >
-      <span
-        className="block h-4 w-4 rounded-sm border border-rule"
-        style={{ backgroundColor: color }}
-        aria-hidden="true"
-      />
-    </button>
-  );
-}
-
-function ViewModeButton({
-  active,
-  children,
-  onClick,
-}: {
-  active: boolean;
-  children: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`inline-flex h-8 items-center rounded-item border px-3 text-xs ${
-        active
-          ? "border-ink bg-ink text-paper"
-          : "border-rule bg-paper text-muted hover:border-ink hover:text-ink"
-      }`}
-    >
-      {children}
-    </button>
-  );
-}
-
-function renderWorkingDiffParts(parts: WorkingDiffPart[]) {
-  return parts.map((part, index) => {
-    if (part.type === "insert") {
-      return (
-        <ins
-          key={`${part.type}-${index}`}
-          className="bg-green-100 px-0.5 text-green-950 no-underline"
-        >
-          {part.text}
-        </ins>
-      );
-    }
-    if (part.type === "delete") {
-      return (
-        <del
-          key={`${part.type}-${index}`}
-          className="bg-red-100 px-0.5 text-red-950"
-        >
-          {part.text}
-        </del>
-      );
-    }
-    return <span key={`${part.type}-${index}`}>{part.text}</span>;
-  });
-}
 
 export function DocumentRichEditor({
   documentId,
@@ -406,48 +262,11 @@ export function DocumentRichEditor({
 
   const editor = useEditor(
     {
-      extensions: [
-        StarterKit.configure({
-          heading: {
-            levels: [2, 3],
-          },
-          codeBlock: false,
-          horizontalRule: false,
-        }),
-        Placeholder.configure({
-          placeholder: "Start editing this document...",
-        }),
-        Typography,
-        Highlight.configure({ multicolor: false }),
-        TextStyle,
-        Color,
-        Image.configure({
-          allowBase64: false,
-          inline: false,
-        }),
-        Link.configure({
-          autolink: true,
-          defaultProtocol: "https",
-          openOnClick: false,
-          HTMLAttributes: {
-            class: "text-ink underline underline-offset-4",
-          },
-        }),
-        TextAlign.configure({
-          types: ["heading", "paragraph"],
-        }),
-        TaskList,
-        TaskItem.configure({
-          nested: true,
-        }),
+      extensions: documentEditorExtensions({
         findExtension,
         reviewNoteExtension,
         trackChangesExtension,
-        Table.configure({ resizable: true }),
-        TableRow,
-        TableHeader,
-        TableCell,
-      ],
+      }),
       content,
       editorProps: {
         attributes: {
@@ -1176,220 +995,14 @@ export function DocumentRichEditor({
           </div>
         </div>
         {formatOpen && (
-        <div className="flex flex-wrap items-center gap-2 border-t border-rule px-4 py-2">
-          {editor && (
-            <>
-              <ToolbarGroup label="Style">
-                <ToolbarButton
-                  label="Heading 2"
-                  active={editor.isActive("heading", { level: 2 })}
-                  onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-                >
-                  H2
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Heading 3"
-                  active={editor.isActive("heading", { level: 3 })}
-                  onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-                >
-                  H3
-                </ToolbarButton>
-              </ToolbarGroup>
-              <ToolbarGroup label="Text">
-                <ToolbarButton
-                  label="Bold"
-                  active={editor.isActive("bold")}
-                  onClick={() => editor.chain().focus().toggleBold().run()}
-                >
-                  B
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Italic"
-                  active={editor.isActive("italic")}
-                  onClick={() => editor.chain().focus().toggleItalic().run()}
-                >
-                  I
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Underline"
-                  active={editor.isActive("underline")}
-                  onClick={() => editor.chain().focus().toggleUnderline().run()}
-                >
-                  U
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Highlight"
-                  active={editor.isActive("highlight")}
-                  onClick={() => editor.chain().focus().toggleHighlight().run()}
-                >
-                  H
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Link"
-                  active={editor.isActive("link")}
-                  onClick={setEditorLink}
-                >
-                  Link
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Remove link"
-                  disabled={!editor.isActive("link")}
-                  onClick={() =>
-                    editor.chain().focus().extendMarkRange("link").unsetLink().run()
-                  }
-                >
-                  Unlink
-                </ToolbarButton>
-              </ToolbarGroup>
-              <ToolbarGroup label="Colour">
-                {EDITOR_TEXT_COLORS.map((color) => (
-                  <ColorButton
-                    key={color.value}
-                    label={color.label}
-                    color={color.value}
-                    active={editor.isActive("textStyle", { color: color.value })}
-                    onClick={() => editor.chain().focus().setColor(color.value).run()}
-                  />
-                ))}
-                <ToolbarButton
-                  label="Remove text colour"
-                  disabled={!editor.isActive("textStyle")}
-                  onClick={() => editor.chain().focus().unsetColor().run()}
-                >
-                  Clear
-                </ToolbarButton>
-              </ToolbarGroup>
-              <ToolbarGroup label="Align">
-                <ToolbarButton
-                  label="Align left"
-                  active={editor.isActive({ textAlign: "left" })}
-                  onClick={() => editor.chain().focus().setTextAlign("left").run()}
-                >
-                  L
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Align centre"
-                  active={editor.isActive({ textAlign: "center" })}
-                  onClick={() => editor.chain().focus().setTextAlign("center").run()}
-                >
-                  C
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Align right"
-                  active={editor.isActive({ textAlign: "right" })}
-                  onClick={() => editor.chain().focus().setTextAlign("right").run()}
-                >
-                  R
-                </ToolbarButton>
-              </ToolbarGroup>
-              <ToolbarGroup label="Lists">
-                <ToolbarButton
-                  label="Bullet list"
-                  active={editor.isActive("bulletList")}
-                  onClick={() => editor.chain().focus().toggleBulletList().run()}
-                >
-                  •
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Numbered list"
-                  active={editor.isActive("orderedList")}
-                  onClick={() => editor.chain().focus().toggleOrderedList().run()}
-                >
-                  1.
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Checklist"
-                  active={editor.isActive("taskList")}
-                  onClick={() => editor.chain().focus().toggleTaskList().run()}
-                >
-                  ☑
-                </ToolbarButton>
-              </ToolbarGroup>
-              <ToolbarGroup label="Media">
-                <input
-                  ref={imageInputRef}
-                  data-testid="document-image-upload-input"
-                  type="file"
-                  accept="image/png,image/jpeg,image/webp,image/gif"
-                  className="hidden"
-                  onChange={(event) => void handleEditorImageUpload(event)}
-                />
-                <ToolbarButton
-                  label={uploadingImage ? "Uploading image" : "Upload image"}
-                  disabled={uploadingImage}
-                  onClick={() => imageInputRef.current?.click()}
-                >
-                  Up
-                </ToolbarButton>
-                <ToolbarButton
-                  label="Insert image URL"
-                  onClick={insertEditorImageUrl}
-                >
-                  Img
-                </ToolbarButton>
-              </ToolbarGroup>
-              <ToolbarGroup label="Table">
-                <ToolbarButton
-                  label="Insert table"
-                  active={editor.isActive("table")}
-                  onClick={() =>
-                    editor
-                      .chain()
-                      .focus()
-                      .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-                      .run()
-                  }
-                >
-                  Tbl
-                </ToolbarButton>
-                {editor.isActive("table") && (
-                  <>
-                    <ToolbarButton
-                      label="Add row"
-                      onClick={() => editor.chain().focus().addRowAfter().run()}
-                    >
-                      +R
-                    </ToolbarButton>
-                    <ToolbarButton
-                      label="Add column"
-                      onClick={() => editor.chain().focus().addColumnAfter().run()}
-                    >
-                      +C
-                    </ToolbarButton>
-                    <ToolbarButton
-                      label="Delete row"
-                      onClick={() => editor.chain().focus().deleteRow().run()}
-                    >
-                      -R
-                    </ToolbarButton>
-                    <ToolbarButton
-                      label="Delete column"
-                      onClick={() => editor.chain().focus().deleteColumn().run()}
-                    >
-                      -C
-                    </ToolbarButton>
-                    <ToolbarButton
-                      label="Delete table"
-                      onClick={() => editor.chain().focus().deleteTable().run()}
-                    >
-                      X
-                    </ToolbarButton>
-                  </>
-                )}
-                {!editor.isActive("table") && (
-                  <ToolbarButton
-                    label="Add row"
-                    disabled
-                    onClick={() => editor.chain().focus().addRowAfter().run()}
-                  >
-                    +R
-                  </ToolbarButton>
-                )}
-              </ToolbarGroup>
-            </>
-          )}
-          <span className="ml-auto text-xs text-muted">Formatting tools</span>
-        </div>
+          <FormatToolbar
+            editor={editor}
+            imageInputRef={imageInputRef}
+            uploadingImage={uploadingImage}
+            onImageUpload={handleEditorImageUpload}
+            onSetLink={setEditorLink}
+            onInsertImageUrl={insertEditorImageUrl}
+          />
         )}
         {(findOpen || findQuery.trim()) && (
         <div

--- a/frontend/src/modules/document_edit/DocumentRichEditor.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.tsx
@@ -6,7 +6,7 @@ import {
   type ChangeEvent,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
-import { EditorContent, useEditor, type Editor } from "@tiptap/react";
+import { EditorContent, useEditor } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import { Extension, type Content } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
@@ -26,7 +26,6 @@ import TableHeader from "@tiptap/extension-table-header";
 import TableRow from "@tiptap/extension-table-row";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import type { Node as ProseMirrorNode } from "prosemirror-model";
 
 import {
   commitDocumentWorkingDraft,
@@ -70,6 +69,19 @@ export {
   writeDocumentLocalDraft,
 } from "./editorText";
 export type { TiptapNode } from "./editorText";
+
+import {
+  applyProposedEditToEditor,
+  locateProposedEditInDoc,
+  TRACK_CHANGES_PLUGIN_KEY,
+  trackChangesDecorationsExtension,
+  type DocumentProposedEdit,
+  type TrackChangeHandlers,
+  type TrackChangesPluginState,
+} from "./trackedChanges";
+
+export { locateProposedEditInDoc } from "./trackedChanges";
+export type { DocumentProposedEdit, ProposedEditLocation } from "./trackedChanges";
 
 type DocumentCanvasMode = "page" | "wide";
 type OriginalImportState = "idle" | "loading" | "ready" | "error";
@@ -177,231 +189,6 @@ function reviewNoteDecorationsExtension(noteHighlights: DocumentNoteHighlight[])
   });
 }
 
-// ----- Inline tracked changes (proposed document_edits rows) --------------
-//
-// AI/skill-proposed edits arrive as (deleted_text, inserted_text,
-// context_before, context_after) rows. We anchor each one in the live
-// document with the same whitespace-normalised search the review notes
-// use, then decorate: deletion struck through in seal, insertion as an
-// underlined inline widget, with compact accept/reject controls. Edits
-// that cannot be anchored stay in the rail listing — never dropped.
-
-export type DocumentProposedEdit = {
-  id: string;
-  deletedText: string;
-  insertedText: string;
-  contextBefore: string;
-  contextAfter: string;
-  rationale?: string | null;
-};
-
-export type ProposedEditLocation =
-  | { kind: "replace"; from: number; to: number }
-  | { kind: "insert"; pos: number };
-
-type TrackChangesPluginState = {
-  edits: DocumentProposedEdit[];
-  visible: boolean;
-};
-
-type TrackChangeHandlers = {
-  resolve: (edit: DocumentProposedEdit, action: "accept" | "reject") => void;
-};
-
-const TRACK_CHANGES_PLUGIN_KEY = new PluginKey<TrackChangesPluginState>(
-  "legaliseTrackChanges",
-);
-
-export function locateProposedEditInDoc(
-  doc: ProseMirrorNode,
-  edit: DocumentProposedEdit,
-  options?: { strict?: boolean },
-): ProposedEditLocation | null {
-  const deleted = edit.deletedText ?? "";
-  const deletedNeedle = deleted.trim().replace(/\s+/g, " ");
-  let located: ProposedEditLocation | null = null;
-
-  if (deletedNeedle.length >= 3) {
-    // Most specific anchor first; bare deleted text last. First match
-    // wins — the same policy the backend resolver applies. Strict mode
-    // (used when APPLYING text, not just decorating) requires the full
-    // context anchor: a bare-needle match after a neighbouring accept
-    // could land on the wrong occurrence while the server, applying to
-    // untouched base_text, lands on the right one.
-    const anchors = options?.strict
-      ? [`${edit.contextBefore ?? ""}${deleted}${edit.contextAfter ?? ""}`]
-      : [
-          `${edit.contextBefore ?? ""}${deleted}${edit.contextAfter ?? ""}`,
-          `${edit.contextBefore ?? ""}${deleted}`,
-          deleted,
-        ];
-    for (const anchor of anchors) {
-      if (located) break;
-      doc.descendants((node, position) => {
-        if (located) return false;
-        if (!node.isText || !node.text) return true;
-        const anchorRange = findNormalizedRanges(node.text, anchor)[0];
-        if (!anchorRange) return true;
-        const slice = node.text.slice(anchorRange.start, anchorRange.end);
-        const inner = findNormalizedRanges(slice, deleted)[0];
-        if (!inner) return true;
-        located = {
-          kind: "replace",
-          from: position + anchorRange.start + inner.start,
-          to: position + anchorRange.start + inner.end,
-        };
-        return false;
-      });
-    }
-    return located;
-  }
-
-  // Deletions under three characters cannot be anchored safely; they
-  // fall back to the rail listing.
-  if (deletedNeedle.length > 0) return null;
-
-  // Pure insertion: anchor on the surrounding context.
-  doc.descendants((node, position) => {
-    if (located) return false;
-    if (!node.isText || !node.text) return true;
-    const beforeRange = findNormalizedRanges(node.text, edit.contextBefore)[0];
-    if (beforeRange) {
-      located = { kind: "insert", pos: position + beforeRange.end };
-      return false;
-    }
-    const afterRange = findNormalizedRanges(node.text, edit.contextAfter)[0];
-    if (afterRange) {
-      located = { kind: "insert", pos: position + afterRange.start };
-      return false;
-    }
-    return true;
-  });
-  return located;
-}
-
-function applyProposedEditToEditor(
-  activeEditor: Editor,
-  edit: DocumentProposedEdit,
-): boolean {
-  const located = locateProposedEditInDoc(activeEditor.state.doc, edit, {
-    strict: true,
-  });
-  if (!located) return false;
-  const inserted = (edit.insertedText ?? "").replace(/\s+/g, " ");
-  return activeEditor
-    .chain()
-    .command(({ tr, state }) => {
-      if (located.kind === "replace") {
-        if (inserted.trim()) {
-          tr.replaceWith(located.from, located.to, state.schema.text(inserted));
-        } else {
-          tr.delete(located.from, located.to);
-        }
-        return true;
-      }
-      if (!inserted.trim()) return false;
-      tr.insert(located.pos, state.schema.text(inserted));
-      return true;
-    })
-    .run();
-}
-
-function trackChangeWidget(
-  edit: DocumentProposedEdit,
-  handlersRef: { current: TrackChangeHandlers | null },
-): HTMLElement {
-  const wrap = window.document.createElement("span");
-  wrap.className = "legalise-track-change";
-  wrap.dataset.trackEditId = edit.id;
-  if (edit.rationale) wrap.title = edit.rationale;
-  const inserted = (edit.insertedText ?? "").replace(/\s+/g, " ").trim();
-  if (inserted) {
-    const ins = window.document.createElement("span");
-    ins.className = "legalise-track-insert";
-    ins.textContent = inserted;
-    wrap.append(ins);
-  }
-  const controls = window.document.createElement("span");
-  controls.className = "legalise-track-controls";
-  const makeButton = (
-    label: string,
-    glyph: string,
-    action: "accept" | "reject",
-  ) => {
-    const button = window.document.createElement("button");
-    button.type = "button";
-    button.className =
-      action === "accept" ? "legalise-track-accept" : "legalise-track-reject";
-    button.setAttribute("aria-label", label);
-    button.title = label;
-    button.textContent = glyph;
-    // mousedown (not click) so the editor selection is not stolen first.
-    button.addEventListener("mousedown", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      handlersRef.current?.resolve(edit, action);
-    });
-    return button;
-  };
-  controls.append(
-    makeButton("Accept change", "✓", "accept"),
-    makeButton("Reject change", "✕", "reject"),
-  );
-  wrap.append(controls);
-  return wrap;
-}
-
-function trackChangesDecorationsExtension(handlersRef: {
-  current: TrackChangeHandlers | null;
-}) {
-  return Extension.create({
-    name: "legaliseTrackChanges",
-    addProseMirrorPlugins() {
-      return [
-        new Plugin<TrackChangesPluginState>({
-          key: TRACK_CHANGES_PLUGIN_KEY,
-          state: {
-            init: () => ({ edits: [], visible: true }),
-            apply(transaction, previous) {
-              return transaction.getMeta(TRACK_CHANGES_PLUGIN_KEY) ?? previous;
-            },
-          },
-          props: {
-            decorations(state) {
-              const pluginState = TRACK_CHANGES_PLUGIN_KEY.getState(state);
-              if (!pluginState?.visible || pluginState.edits.length === 0) {
-                return DecorationSet.empty;
-              }
-              const decorations: Decoration[] = [];
-              pluginState.edits.forEach((edit) => {
-                const located = locateProposedEditInDoc(state.doc, edit);
-                if (!located) return;
-                if (located.kind === "replace") {
-                  decorations.push(
-                    Decoration.inline(located.from, located.to, {
-                      class: "legalise-track-delete",
-                      "data-track-edit-id": edit.id,
-                    }),
-                  );
-                }
-                const widgetPos =
-                  located.kind === "replace" ? located.to : located.pos;
-                decorations.push(
-                  Decoration.widget(
-                    widgetPos,
-                    () => trackChangeWidget(edit, handlersRef),
-                    { side: 1, key: `legalise-track-${edit.id}` },
-                  ),
-                );
-              });
-              return DecorationSet.create(state.doc, decorations);
-            },
-          },
-        }),
-      ];
-    },
-  });
-}
 
 function ToolbarButton({
   active,

--- a/frontend/src/modules/document_edit/EditorPanels.tsx
+++ b/frontend/src/modules/document_edit/EditorPanels.tsx
@@ -1,0 +1,625 @@
+// Presentational panels for the document editor: find bar, redlines bar,
+// selection ribbon, draft notices, working-diff preview, review map, side
+// rail and the selection bubble menu. All markup, class strings and
+// test ids are verbatim from the pre-split DocumentRichEditor.tsx
+// (Fluff C3); every callback and value arrives via props so state and
+// behaviour stay in the parent.
+import type { KeyboardEvent as ReactKeyboardEvent, RefObject } from "react";
+import type { Editor } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react/menus";
+
+import {
+  selectedEditorText,
+  type DocumentLocalDraft,
+} from "./editorText";
+import type { DocumentNoteHighlight } from "./reviewNotes";
+import { renderWorkingDiffParts, type WorkingDiffPart } from "./editorChrome";
+
+export function FindPanel({
+  documentId,
+  findInputRef,
+  findQuery,
+  setFindQuery,
+  onFindKeyDown,
+  matchCount,
+  moveFind,
+  findPositionLabel,
+  findPreview,
+}: {
+  documentId: string;
+  findInputRef: RefObject<HTMLInputElement | null>;
+  findQuery: string;
+  setFindQuery: (value: string) => void;
+  onFindKeyDown: (event: ReactKeyboardEvent<HTMLInputElement>) => void;
+  matchCount: number;
+  moveFind: (direction: 1 | -1) => void;
+  findPositionLabel: string | null;
+  findPreview: string | null;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-3 border-t border-rule bg-paper px-4 py-2.5"
+      data-testid="document-editor-find-panel"
+    >
+      <label
+        htmlFor={`find-${documentId}`}
+        className="text-xs font-semibold uppercase tracking-track2 text-muted"
+      >
+        Find
+      </label>
+      <input
+        ref={findInputRef}
+        id={`find-${documentId}`}
+        type="search"
+        value={findQuery}
+        onChange={(event) => setFindQuery(event.target.value)}
+        onKeyDown={onFindKeyDown}
+        placeholder="Search this document"
+        className="min-h-[34px] min-w-[220px] flex-1 border border-rule bg-paper-sunken px-3 text-sm outline-none focus:border-ink"
+      />
+      <span className="text-xs text-muted" data-testid="document-editor-find-count">
+        {findQuery.trim().length >= 3
+          ? `${matchCount} match${matchCount === 1 ? "" : "es"}`
+          : "Type 3+ characters"}
+      </span>
+      <button
+        type="button"
+        onClick={() => moveFind(-1)}
+        disabled={matchCount === 0}
+        className="border border-rule px-2 py-1 text-xs text-muted hover:border-ink hover:text-ink disabled:opacity-40"
+      >
+        Previous
+      </button>
+      <button
+        type="button"
+        onClick={() => moveFind(1)}
+        disabled={matchCount === 0}
+        className="border border-rule px-2 py-1 text-xs text-muted hover:border-ink hover:text-ink disabled:opacity-40"
+      >
+        Next
+      </button>
+      {matchCount > 0 && (
+        <span className="text-xs text-muted" data-testid="document-editor-find-position">
+          {findPositionLabel}
+        </span>
+      )}
+      {findQuery && (
+        <button
+          type="button"
+          onClick={() => setFindQuery("")}
+          className="text-xs text-muted underline underline-offset-4 hover:text-ink"
+        >
+          Clear
+        </button>
+      )}
+      {findPreview && (
+        <p
+          className="basis-full text-xs leading-5 text-muted"
+          data-testid="document-editor-find-preview"
+        >
+          Match {findPositionLabel}: {findPreview}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function RedlinesPanel({
+  proposedEditCount,
+  anchoredProposedEditCount,
+  trackNotice,
+  trackBusy,
+  canResolve,
+  onResolveAll,
+}: {
+  proposedEditCount: number;
+  anchoredProposedEditCount: number;
+  trackNotice: string | null;
+  trackBusy: boolean;
+  canResolve: boolean;
+  onResolveAll: (action: "accept" | "reject") => Promise<void>;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-3 border-t border-rule bg-paper px-4 py-2 text-xs text-muted"
+      data-testid="document-editor-redlines-panel"
+    >
+      <span>
+        {proposedEditCount} proposed change
+        {proposedEditCount === 1 ? "" : "s"}
+        {anchoredProposedEditCount < proposedEditCount
+          ? ` · ${proposedEditCount - anchoredProposedEditCount} not anchored in this text — review in the suggested-edits list`
+          : ""}
+        {trackNotice ? ` · ${trackNotice}` : ""}
+      </span>
+      <span className="ml-auto flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() => void onResolveAll("accept")}
+          disabled={trackBusy || !canResolve}
+          className="inline-flex h-7 items-center rounded-item border border-ink bg-ink px-2.5 text-xs text-paper hover:bg-seal disabled:border-rule disabled:bg-paper-sunken disabled:text-muted"
+        >
+          {trackBusy ? "Working…" : "Accept all"}
+        </button>
+        <button
+          type="button"
+          onClick={() => void onResolveAll("reject")}
+          disabled={trackBusy || !canResolve}
+          className="inline-flex h-7 items-center rounded-item border border-rule bg-paper px-2.5 text-xs text-muted hover:border-seal hover:text-seal disabled:opacity-40"
+        >
+          Reject all
+        </button>
+      </span>
+    </div>
+  );
+}
+
+export function SelectionRibbon({
+  selectedQuote,
+  onCopySelectedQuote,
+  onFindInDocument,
+  onCreateNoteFromSelection,
+  onRunSkillFromSelection,
+}: {
+  selectedQuote: string;
+  onCopySelectedQuote: () => Promise<void>;
+  onFindInDocument: () => void;
+  onCreateNoteFromSelection?: () => void;
+  onRunSkillFromSelection?: () => void;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center justify-between gap-3 border-b border-ink bg-paper px-5 py-3"
+      data-testid="document-editor-selection-ribbon"
+    >
+      <div className="min-w-0">
+        <p className="text-[11px] font-semibold uppercase tracking-track2 text-ink">
+          Selected passage
+        </p>
+        <p className="mt-1 max-w-3xl truncate text-sm text-muted">{selectedQuote}</p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void onCopySelectedQuote()}
+          className="border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
+        >
+          Copy
+        </button>
+        <button
+          type="button"
+          onClick={onFindInDocument}
+          className="border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
+        >
+          Find in document
+        </button>
+        {onCreateNoteFromSelection && (
+          <button
+            type="button"
+            onClick={onCreateNoteFromSelection}
+            className="border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-seal"
+          >
+            Add review note
+          </button>
+        )}
+        {onRunSkillFromSelection && (
+          <button
+            type="button"
+            onClick={onRunSkillFromSelection}
+            className="border border-ink bg-paper px-3 py-2 text-xs font-semibold text-ink hover:bg-paper-sunken"
+          >
+            Run skill
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function DraftNotices({
+  draftSaveError,
+  draftConflict,
+  onReloadAfterError,
+  remoteDraftNotice,
+  onReloadAfterNotice,
+  originalImportState,
+  localDraft,
+  onRestoreLocalDraft,
+  onDiscardLocalDraft,
+}: {
+  draftSaveError: boolean;
+  draftConflict: string | null;
+  onReloadAfterError: () => void;
+  remoteDraftNotice: string | null;
+  onReloadAfterNotice: () => void;
+  originalImportState: "idle" | "loading" | "ready" | "error";
+  localDraft: DocumentLocalDraft | null;
+  onRestoreLocalDraft: () => void;
+  onDiscardLocalDraft: () => void;
+}) {
+  return (
+    <>
+      {draftSaveError && (
+        <div
+          className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-300 bg-amber-50 px-5 py-2 text-xs leading-5 text-amber-900"
+          data-testid="document-server-draft-error"
+        >
+          <span>
+            {draftConflict ??
+              "Shared draft could not be saved. The browser copy is preserved locally; try saving again before leaving this file."}
+          </span>
+          <button
+            type="button"
+            onClick={onReloadAfterError}
+            className="border border-amber-900 bg-paper px-3 py-1.5 text-xs font-semibold text-amber-950 hover:bg-amber-100"
+          >
+            Reload shared draft
+          </button>
+        </div>
+      )}
+      {remoteDraftNotice && (
+        <div
+          className="flex flex-wrap items-center justify-between gap-3 border-b border-rule bg-paper-sunken px-5 py-2 text-xs leading-5 text-muted"
+          data-testid="document-remote-draft-notice"
+        >
+          <span>{remoteDraftNotice}</span>
+          <button
+            type="button"
+            onClick={onReloadAfterNotice}
+            className="border border-rule bg-paper px-3 py-1.5 text-xs font-semibold text-ink hover:border-ink"
+          >
+            Reload shared draft
+          </button>
+        </div>
+      )}
+      {originalImportState === "loading" && (
+        <p className="border-b border-rule bg-paper-sunken px-5 py-2 text-xs text-muted">
+          Importing Word structure into the editable working copy...
+        </p>
+      )}
+      {originalImportState === "ready" && (
+        <p
+          className="border-b border-rule bg-paper-sunken px-5 py-2 text-xs text-muted"
+          data-testid="document-word-import-ready"
+        >
+          Word structure imported into the shared draft. Save a version when the edit is ready.
+        </p>
+      )}
+      {originalImportState === "error" && (
+        <p
+          className="border-b border-amber-300 bg-amber-50 px-5 py-2 text-xs leading-5 text-amber-900"
+          data-testid="document-word-import-fallback"
+        >
+          Word structure could not be imported here, so the editor is using extracted text.
+        </p>
+      )}
+      {localDraft && (
+        <div
+          className="flex flex-wrap items-center justify-between gap-3 border-b border-rule bg-amber-50 px-5 py-3 text-sm text-ink"
+          data-testid="document-local-draft-banner"
+        >
+          <span>
+            Unsaved local draft from{" "}
+            {new Date(localDraft.savedAt).toLocaleString()}. Restore it or discard it.
+          </span>
+          <span className="flex gap-2">
+            <button
+              type="button"
+              onClick={onRestoreLocalDraft}
+              className="border border-ink bg-paper px-3 py-1.5 text-xs font-semibold text-ink hover:bg-ink hover:text-paper"
+            >
+              Restore draft
+            </button>
+            <button
+              type="button"
+              onClick={onDiscardLocalDraft}
+              className="border border-rule bg-paper px-3 py-1.5 text-xs font-semibold text-muted hover:border-ink hover:text-ink"
+            >
+              Discard
+            </button>
+          </span>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function WorkingDiffPanel({
+  workingDiffParts,
+  insertedChars,
+  deletedChars,
+}: {
+  workingDiffParts: WorkingDiffPart[];
+  insertedChars: number;
+  deletedChars: number;
+}) {
+  return (
+    <div
+      className="border-b border-rule bg-paper px-5 py-3"
+      data-testid="document-working-diff"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+            Unsaved changes
+          </p>
+          <p className="mt-1 text-sm text-ink">
+            Review the working copy before saving it as a new document version.
+          </p>
+        </div>
+        <dl className="flex flex-wrap gap-2 text-xs">
+          <div className="border border-rule bg-paper-sunken px-3 py-2">
+            <dt className="tech-token uppercase tracking-track2 text-muted">Added</dt>
+            <dd className="mt-1 font-semibold text-green-900">
+              {insertedChars.toLocaleString()} chars
+            </dd>
+          </div>
+          <div className="border border-rule bg-paper-sunken px-3 py-2">
+            <dt className="tech-token uppercase tracking-track2 text-muted">Removed</dt>
+            <dd className="mt-1 font-semibold text-red-900">
+              {deletedChars.toLocaleString()} chars
+            </dd>
+          </div>
+        </dl>
+      </div>
+      <details className="mt-3 border border-rule bg-paper-sunken">
+        <summary className="cursor-pointer px-3 py-2 text-xs font-semibold text-ink">
+          Preview redline before saving
+        </summary>
+        <div className="max-h-[260px] overflow-auto border-t border-rule bg-paper p-4 text-sm leading-7">
+          {renderWorkingDiffParts(workingDiffParts)}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+export type NoteAnchorSummary = DocumentNoteHighlight & { located: boolean };
+
+export function ReviewMapPanel({
+  noteAnchorSummaries,
+  locatedNoteCount,
+  onJumpToNote,
+}: {
+  noteAnchorSummaries: NoteAnchorSummary[];
+  locatedNoteCount: number;
+  onJumpToNote: (quote: string) => void;
+}) {
+  return (
+    <div
+      className="border-b border-rule bg-paper px-5 py-3"
+      data-testid="document-editor-review-map"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+            Review map
+          </p>
+          <p className="mt-1 text-sm text-ink">
+            {locatedNoteCount} of {noteAnchorSummaries.length} note anchor
+            {noteAnchorSummaries.length === 1 ? "" : "s"} located in this working copy.
+          </p>
+        </div>
+        <span className="border border-rule bg-paper-sunken px-2 py-1 text-[11px] font-semibold uppercase tracking-track2 text-muted">
+          Anchored notes
+        </span>
+      </div>
+      <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+        {noteAnchorSummaries.map((note) => (
+          <button
+            key={note.id}
+            type="button"
+            onClick={() => onJumpToNote(note.quote)}
+            className={`min-w-[220px] max-w-[280px] border px-3 py-2 text-left text-xs leading-5 ${
+              note.located
+                ? "border-ink bg-paper text-ink"
+                : "border-amber-300 bg-amber-50 text-amber-950"
+            }`}
+          >
+            <span className="block font-semibold">{note.label}</span>
+            <span className="mt-1 block max-h-10 overflow-hidden text-muted">
+              {note.quote}
+            </span>
+            <span className="mt-2 block tech-token uppercase tracking-track2">
+              {note.located ? "Located" : "Not located"}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function EditorSideRail({
+  sourceHighlight,
+  sourceLocated,
+  selectedQuote,
+  selectedQuoteAnchored,
+  onCopySelectedQuote,
+  onCreateNoteFromSelection,
+  noteHighlights,
+  outlineItems,
+  onFind,
+}: {
+  sourceHighlight?: string | null;
+  sourceLocated: boolean;
+  selectedQuote?: string;
+  selectedQuoteAnchored?: boolean;
+  onCopySelectedQuote: () => Promise<void>;
+  onCreateNoteFromSelection?: () => void;
+  noteHighlights: DocumentNoteHighlight[];
+  outlineItems: { id: string; label: string; query: string }[];
+  onFind: (query: string) => void;
+}) {
+  return (
+    <aside className="border-b border-rule bg-paper px-5 py-5 lg:border-b-0 lg:border-r">
+      <div className="space-y-5">
+        {sourceHighlight && (
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+              Source passage
+            </p>
+            <p className="mt-2 text-sm leading-6 text-muted">
+              {sourceLocated ? "Located in this version." : "Not located in this version."}
+            </p>
+            <button
+              type="button"
+              onClick={() => onFind(sourceHighlight)}
+              className="mt-2 text-xs font-medium text-ink underline underline-offset-4 hover:text-muted"
+            >
+              Search cited text
+            </button>
+          </div>
+        )}
+        {selectedQuote && (
+          <div
+            className="border border-ink bg-paper p-3"
+            data-testid="document-editor-selected-passage"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-[11px] font-semibold uppercase tracking-track2 text-ink">
+                Selected passage
+              </p>
+              <span className="border border-rule bg-paper-sunken px-2 py-1 text-[10px] font-semibold uppercase tracking-track2 text-muted">
+                {selectedQuoteAnchored ? "Anchored" : "Unanchored"}
+              </span>
+            </div>
+            <p className="mt-2 max-h-28 overflow-hidden text-xs leading-5 text-muted">
+              {selectedQuote}
+            </p>
+            <button
+              type="button"
+              onClick={() => void onCopySelectedQuote()}
+              className="mt-3 w-full border border-rule px-3 py-2 text-xs font-semibold text-ink hover:border-ink"
+            >
+              Copy passage
+            </button>
+            {onCreateNoteFromSelection && (
+              <button
+                type="button"
+                onClick={onCreateNoteFromSelection}
+                className="mt-2 w-full border border-ink bg-ink px-3 py-2 text-xs font-semibold text-paper hover:bg-seal"
+              >
+                Add review note
+              </button>
+            )}
+          </div>
+        )}
+        {noteHighlights.length > 0 && (
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+            Review notes
+          </p>
+          {noteHighlights.length > 0 ? (
+            <div className="mt-2 space-y-2" data-testid="document-editor-note-rail">
+              {noteHighlights.map((note) => (
+                <button
+                  key={note.id}
+                  type="button"
+                  onClick={() => onFind(note.quote)}
+                  className="block w-full border border-rule bg-paper px-3 py-2 text-left text-xs leading-5 text-muted hover:border-ink hover:text-ink"
+                >
+                  <span className="block font-medium text-ink">{note.label}</span>
+                  <span className="mt-1 block max-h-10 overflow-hidden">{note.quote}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        )}
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-track2 text-muted">
+            Outline
+          </p>
+          {outlineItems.length > 0 ? (
+            <nav className="mt-2 space-y-1" aria-label="Document outline">
+              {outlineItems.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => onFind(item.query)}
+                  className="block w-full border-l border-transparent py-1 pl-2 text-left text-xs leading-5 text-muted hover:border-ink hover:text-ink"
+                >
+                  {item.label}
+                </button>
+              ))}
+            </nav>
+          ) : (
+            <p className="mt-2 text-sm text-muted">No outline yet.</p>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export function SelectionBubbleMenu({
+  editor,
+  onCopyEditorSelection,
+  onHighlightSelection,
+  onSetLink,
+  onCreateNoteFromSelection,
+  onRunSkillFromSelection,
+}: {
+  editor: Editor;
+  onCopyEditorSelection: () => Promise<void>;
+  onHighlightSelection: () => void;
+  onSetLink: () => void;
+  onCreateNoteFromSelection?: () => void;
+  onRunSkillFromSelection?: () => void;
+}) {
+  return (
+    <BubbleMenu
+      editor={editor}
+      shouldShow={({ editor: bubbleEditor }) =>
+        selectedEditorText(bubbleEditor).length >= 3
+      }
+      options={{ placement: "top", offset: 8 }}
+    >
+      <div
+        className="flex items-center gap-1 border border-ink bg-paper px-1.5 py-1 shadow-[0_10px_30px_rgba(0,0,0,0.12)]"
+        data-testid="document-editor-selection-menu"
+      >
+        <button
+          type="button"
+          onClick={() => void onCopyEditorSelection()}
+          className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
+        >
+          Copy
+        </button>
+        <button
+          type="button"
+          onClick={onHighlightSelection}
+          className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
+        >
+          Highlight
+        </button>
+        <button
+          type="button"
+          onClick={onSetLink}
+          className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
+        >
+          Link
+        </button>
+        {onCreateNoteFromSelection && (
+          <button
+            type="button"
+            onClick={onCreateNoteFromSelection}
+            className="bg-ink px-2 py-1 text-xs font-semibold text-paper hover:bg-seal"
+          >
+            Add note
+          </button>
+        )}
+        {onRunSkillFromSelection && (
+          <button
+            type="button"
+            onClick={onRunSkillFromSelection}
+            className="px-2 py-1 text-xs font-semibold text-ink hover:bg-paper-sunken"
+          >
+            Run skill
+          </button>
+        )}
+      </div>
+    </BubbleMenu>
+  );
+}

--- a/frontend/src/modules/document_edit/editorChrome.tsx
+++ b/frontend/src/modules/document_edit/editorChrome.tsx
@@ -1,0 +1,379 @@
+// Presentational chrome for the document editor: toolbar button
+// primitives, the formatting toolbar, and the working-diff redline
+// renderer. All markup and class strings are verbatim from the pre-split
+// DocumentRichEditor.tsx (Fluff C3); state stays in the parent.
+import type { ChangeEvent, RefObject } from "react";
+import type { Editor } from "@tiptap/react";
+
+import { buildVersionDiff } from "./VersionDiff";
+
+export type WorkingDiffPart = ReturnType<typeof buildVersionDiff>[number];
+
+export const EDITOR_TEXT_COLORS = [
+  { label: "Ink text", value: "#181818" },
+  { label: "Red text", value: "#8C1D18" },
+  { label: "Amber text", value: "#8A5A00" },
+  { label: "Green text", value: "#236A44" },
+  { label: "Blue text", value: "#245B8A" },
+] as const;
+
+export function ToolbarButton({
+  active,
+  children,
+  onClick,
+  label,
+  disabled,
+}: {
+  active?: boolean;
+  children: string;
+  onClick: () => void;
+  label: string;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex h-8 min-w-8 items-center justify-center rounded-item border px-2 text-sm disabled:cursor-not-allowed disabled:opacity-35 ${
+        active
+          ? "border-ink bg-ink text-paper"
+          : "border-rule bg-paper text-ink hover:border-ink"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ToolbarGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-1 border-r border-rule pr-2 last:border-r-0 last:pr-0">
+      <span className="mr-1 hidden text-[10px] font-semibold uppercase tracking-track2 text-muted xl:inline">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+export function ColorButton({
+  active,
+  color,
+  label,
+  onClick,
+}: {
+  active?: boolean;
+  color: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className={`inline-flex h-8 min-w-8 items-center justify-center rounded-item border bg-paper px-2 ${
+        active ? "border-ink" : "border-rule hover:border-ink"
+      }`}
+    >
+      <span
+        className="block h-4 w-4 rounded-sm border border-rule"
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}
+
+export function ViewModeButton({
+  active,
+  children,
+  onClick,
+}: {
+  active: boolean;
+  children: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex h-8 items-center rounded-item border px-3 text-xs ${
+        active
+          ? "border-ink bg-ink text-paper"
+          : "border-rule bg-paper text-muted hover:border-ink hover:text-ink"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function renderWorkingDiffParts(parts: WorkingDiffPart[]) {
+  return parts.map((part, index) => {
+    if (part.type === "insert") {
+      return (
+        <ins
+          key={`${part.type}-${index}`}
+          className="bg-green-100 px-0.5 text-green-950 no-underline"
+        >
+          {part.text}
+        </ins>
+      );
+    }
+    if (part.type === "delete") {
+      return (
+        <del
+          key={`${part.type}-${index}`}
+          className="bg-red-100 px-0.5 text-red-950"
+        >
+          {part.text}
+        </del>
+      );
+    }
+    return <span key={`${part.type}-${index}`}>{part.text}</span>;
+  });
+}
+
+export function FormatToolbar({
+  editor,
+  imageInputRef,
+  uploadingImage,
+  onImageUpload,
+  onSetLink,
+  onInsertImageUrl,
+}: {
+  editor: Editor | null;
+  imageInputRef: RefObject<HTMLInputElement | null>;
+  uploadingImage: boolean;
+  onImageUpload: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
+  onSetLink: () => void;
+  onInsertImageUrl: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-t border-rule px-4 py-2">
+      {editor && (
+        <>
+          <ToolbarGroup label="Style">
+            <ToolbarButton
+              label="Heading 2"
+              active={editor.isActive("heading", { level: 2 })}
+              onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+            >
+              H2
+            </ToolbarButton>
+            <ToolbarButton
+              label="Heading 3"
+              active={editor.isActive("heading", { level: 3 })}
+              onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+            >
+              H3
+            </ToolbarButton>
+          </ToolbarGroup>
+          <ToolbarGroup label="Text">
+            <ToolbarButton
+              label="Bold"
+              active={editor.isActive("bold")}
+              onClick={() => editor.chain().focus().toggleBold().run()}
+            >
+              B
+            </ToolbarButton>
+            <ToolbarButton
+              label="Italic"
+              active={editor.isActive("italic")}
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+            >
+              I
+            </ToolbarButton>
+            <ToolbarButton
+              label="Underline"
+              active={editor.isActive("underline")}
+              onClick={() => editor.chain().focus().toggleUnderline().run()}
+            >
+              U
+            </ToolbarButton>
+            <ToolbarButton
+              label="Highlight"
+              active={editor.isActive("highlight")}
+              onClick={() => editor.chain().focus().toggleHighlight().run()}
+            >
+              H
+            </ToolbarButton>
+            <ToolbarButton
+              label="Link"
+              active={editor.isActive("link")}
+              onClick={onSetLink}
+            >
+              Link
+            </ToolbarButton>
+            <ToolbarButton
+              label="Remove link"
+              disabled={!editor.isActive("link")}
+              onClick={() =>
+                editor.chain().focus().extendMarkRange("link").unsetLink().run()
+              }
+            >
+              Unlink
+            </ToolbarButton>
+          </ToolbarGroup>
+          <ToolbarGroup label="Colour">
+            {EDITOR_TEXT_COLORS.map((color) => (
+              <ColorButton
+                key={color.value}
+                label={color.label}
+                color={color.value}
+                active={editor.isActive("textStyle", { color: color.value })}
+                onClick={() => editor.chain().focus().setColor(color.value).run()}
+              />
+            ))}
+            <ToolbarButton
+              label="Remove text colour"
+              disabled={!editor.isActive("textStyle")}
+              onClick={() => editor.chain().focus().unsetColor().run()}
+            >
+              Clear
+            </ToolbarButton>
+          </ToolbarGroup>
+          <ToolbarGroup label="Align">
+            <ToolbarButton
+              label="Align left"
+              active={editor.isActive({ textAlign: "left" })}
+              onClick={() => editor.chain().focus().setTextAlign("left").run()}
+            >
+              L
+            </ToolbarButton>
+            <ToolbarButton
+              label="Align centre"
+              active={editor.isActive({ textAlign: "center" })}
+              onClick={() => editor.chain().focus().setTextAlign("center").run()}
+            >
+              C
+            </ToolbarButton>
+            <ToolbarButton
+              label="Align right"
+              active={editor.isActive({ textAlign: "right" })}
+              onClick={() => editor.chain().focus().setTextAlign("right").run()}
+            >
+              R
+            </ToolbarButton>
+          </ToolbarGroup>
+          <ToolbarGroup label="Lists">
+            <ToolbarButton
+              label="Bullet list"
+              active={editor.isActive("bulletList")}
+              onClick={() => editor.chain().focus().toggleBulletList().run()}
+            >
+              •
+            </ToolbarButton>
+            <ToolbarButton
+              label="Numbered list"
+              active={editor.isActive("orderedList")}
+              onClick={() => editor.chain().focus().toggleOrderedList().run()}
+            >
+              1.
+            </ToolbarButton>
+            <ToolbarButton
+              label="Checklist"
+              active={editor.isActive("taskList")}
+              onClick={() => editor.chain().focus().toggleTaskList().run()}
+            >
+              ☑
+            </ToolbarButton>
+          </ToolbarGroup>
+          <ToolbarGroup label="Media">
+            <input
+              ref={imageInputRef}
+              data-testid="document-image-upload-input"
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif"
+              className="hidden"
+              onChange={(event) => void onImageUpload(event)}
+            />
+            <ToolbarButton
+              label={uploadingImage ? "Uploading image" : "Upload image"}
+              disabled={uploadingImage}
+              onClick={() => imageInputRef.current?.click()}
+            >
+              Up
+            </ToolbarButton>
+            <ToolbarButton
+              label="Insert image URL"
+              onClick={onInsertImageUrl}
+            >
+              Img
+            </ToolbarButton>
+          </ToolbarGroup>
+          <ToolbarGroup label="Table">
+            <ToolbarButton
+              label="Insert table"
+              active={editor.isActive("table")}
+              onClick={() =>
+                editor
+                  .chain()
+                  .focus()
+                  .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+                  .run()
+              }
+            >
+              Tbl
+            </ToolbarButton>
+            {editor.isActive("table") && (
+              <>
+                <ToolbarButton
+                  label="Add row"
+                  onClick={() => editor.chain().focus().addRowAfter().run()}
+                >
+                  +R
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Add column"
+                  onClick={() => editor.chain().focus().addColumnAfter().run()}
+                >
+                  +C
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Delete row"
+                  onClick={() => editor.chain().focus().deleteRow().run()}
+                >
+                  -R
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Delete column"
+                  onClick={() => editor.chain().focus().deleteColumn().run()}
+                >
+                  -C
+                </ToolbarButton>
+                <ToolbarButton
+                  label="Delete table"
+                  onClick={() => editor.chain().focus().deleteTable().run()}
+                >
+                  X
+                </ToolbarButton>
+              </>
+            )}
+            {!editor.isActive("table") && (
+              <ToolbarButton
+                label="Add row"
+                disabled
+                onClick={() => editor.chain().focus().addRowAfter().run()}
+              >
+                +R
+              </ToolbarButton>
+            )}
+          </ToolbarGroup>
+        </>
+      )}
+      <span className="ml-auto text-xs text-muted">Formatting tools</span>
+    </div>
+  );
+}

--- a/frontend/src/modules/document_edit/editorChrome.tsx
+++ b/frontend/src/modules/document_edit/editorChrome.tsx
@@ -6,6 +6,7 @@ import type { ChangeEvent, RefObject } from "react";
 import type { Editor } from "@tiptap/react";
 
 import { buildVersionDiff } from "./VersionDiff";
+import { documentStatsFromText } from "./editorText";
 
 export type WorkingDiffPart = ReturnType<typeof buildVersionDiff>[number];
 
@@ -376,4 +377,217 @@ export function FormatToolbar({
       <span className="ml-auto text-xs text-muted">Formatting tools</span>
     </div>
   );
+}
+
+export function CommandBarRow({
+  canvasMode,
+  onSetCanvasMode,
+  formatOpen,
+  onToggleFormat,
+  findOpen,
+  onToggleFind,
+  proposedEditCount,
+  redlinesVisible,
+  onToggleRedlines,
+  draftSaveError,
+  dirty,
+  editorStatusLabel,
+  sourceLabel,
+  onSave,
+  canSave,
+  saving,
+  onSaveAndDownloadDocx,
+  canDownloadDocx,
+  downloadingDocx,
+  onCopyWorkingText,
+  onDownloadWorkingText,
+  plainText,
+  onReset,
+}: {
+  canvasMode: "page" | "wide";
+  onSetCanvasMode: (mode: "page" | "wide") => void;
+  formatOpen: boolean;
+  onToggleFormat: () => void;
+  findOpen: boolean;
+  onToggleFind: () => void;
+  proposedEditCount: number;
+  redlinesVisible: boolean;
+  onToggleRedlines: () => void;
+  draftSaveError: boolean;
+  dirty: boolean;
+  editorStatusLabel: string;
+  sourceLabel: string;
+  onSave: () => Promise<unknown>;
+  canSave: boolean;
+  saving: boolean;
+  onSaveAndDownloadDocx: () => Promise<void>;
+  canDownloadDocx: boolean;
+  downloadingDocx: boolean;
+  onCopyWorkingText: () => Promise<void>;
+  onDownloadWorkingText: () => void;
+  plainText: string;
+  onReset: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 px-4 py-2.5 text-[13px]">
+      <div
+        className="flex items-center gap-1 border-r border-rule pr-2"
+        aria-label="Document view"
+        data-testid="document-editor-view-mode"
+      >
+        <ViewModeButton active={canvasMode === "page"} onClick={() => onSetCanvasMode("page")}>
+          Page
+        </ViewModeButton>
+        <ViewModeButton active={canvasMode === "wide"} onClick={() => onSetCanvasMode("wide")}>
+          Wide
+        </ViewModeButton>
+      </div>
+      <button
+        type="button"
+        onClick={onToggleFormat}
+        aria-expanded={formatOpen}
+        className="inline-flex h-8 items-center rounded-item border border-rule px-3 text-xs text-muted hover:border-ink hover:text-ink"
+      >
+        Format
+      </button>
+      <button
+        type="button"
+        onClick={onToggleFind}
+        aria-expanded={findOpen}
+        className="inline-flex h-8 items-center rounded-item border border-rule px-3 text-xs text-muted hover:border-ink hover:text-ink"
+      >
+        Find
+      </button>
+      {proposedEditCount > 0 && (
+        <button
+          type="button"
+          onClick={onToggleRedlines}
+          aria-pressed={redlinesVisible}
+          data-testid="document-editor-redlines-toggle"
+          className={`inline-flex h-8 items-center rounded-item border px-3 text-xs ${
+            redlinesVisible
+              ? "border-ink bg-paper text-ink"
+              : "border-rule bg-paper text-muted hover:border-ink hover:text-ink"
+          }`}
+        >
+          Redlines ({proposedEditCount})
+        </button>
+      )}
+      <span className="ml-2 inline-flex items-center gap-2 text-xs text-muted">
+        <span
+          className={`h-2 w-2 rounded-full ${
+            draftSaveError
+              ? "bg-red-700"
+              : dirty
+                ? "bg-amber-500"
+                : "bg-emerald-700"
+          }`}
+          aria-hidden="true"
+        />
+        {editorStatusLabel}
+      </span>
+      {sourceLabel?.startsWith("Viewing saved version") && (
+        <span className="text-xs text-muted">{sourceLabel}</span>
+      )}
+      <div className="ml-auto flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canSave}
+          className="inline-flex h-8 items-center rounded-item border border-ink bg-ink px-3 text-xs text-paper disabled:border-rule disabled:bg-paper-sunken disabled:text-muted"
+        >
+          {saving ? "Saving…" : "Save version"}
+        </button>
+        <details className="relative" data-testid="document-editor-more">
+          <summary className="inline-flex h-8 cursor-pointer list-none items-center rounded-item border border-rule px-3 text-xs text-muted hover:border-ink hover:text-ink">
+            More
+          </summary>
+          <div className="absolute right-0 z-20 mt-1 grid min-w-44 gap-1 rounded-card border border-rule bg-paper p-1.5 shadow-panel">
+            <button
+              type="button"
+              onClick={() => void onSaveAndDownloadDocx()}
+              disabled={!canDownloadDocx}
+              className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
+            >
+              {downloadingDocx ? "Preparing…" : dirty ? "Save & download DOCX" : "Download DOCX"}
+            </button>
+            <button
+              type="button"
+              onClick={() => void onCopyWorkingText()}
+              disabled={!plainText.trim()}
+              className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
+            >
+              Copy text
+            </button>
+            <button
+              type="button"
+              onClick={onDownloadWorkingText}
+              disabled={!plainText.trim()}
+              className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
+            >
+              Download text
+            </button>
+            <span
+              className="inline-flex h-8 items-center px-2 text-xs text-muted"
+              data-testid="document-editor-word-count"
+            >
+              {documentStatsFromText(plainText).words.toLocaleString()} words
+            </span>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              disabled={!plainText.trim()}
+              className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
+            >
+              Print / PDF
+            </button>
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={!dirty || saving}
+              className="inline-flex h-8 items-center rounded-item px-2 text-xs text-ink hover:bg-paper-sunken disabled:text-muted"
+            >
+              Reset
+            </button>
+          </div>
+        </details>
+      </div>
+    </div>
+  );
+}
+
+// Status line for the command bar. Verbatim ternaries from the pre-split
+// DocumentRichEditor.tsx (Fluff C3).
+export function editorStatusLabelFor({
+  dirty,
+  draftLoadState,
+  draftSaveState,
+  serverDraftCounter,
+  savedMessage,
+  latestVersionNumber,
+}: {
+  dirty: boolean;
+  draftLoadState: "loading" | "ready" | "error";
+  draftSaveState: "idle" | "saving" | "saved" | "error";
+  serverDraftCounter: number | null;
+  savedMessage: string | null;
+  latestVersionNumber?: number;
+}) {
+  const sharedDraftLabel =
+    draftLoadState === "loading"
+      ? "Loading shared draft"
+      : draftSaveState === "saving"
+        ? "Saving shared draft"
+        : draftSaveState === "saved"
+          ? `Shared draft saved${serverDraftCounter !== null ? ` · r${serverDraftCounter}` : ""}`
+          : draftSaveState === "error"
+            ? "Local fallback active"
+            : "Shared draft ready";
+  return dirty
+    ? sharedDraftLabel
+    : savedMessage
+      ? savedMessage
+      : latestVersionNumber
+        ? `Saved v${latestVersionNumber}`
+        : "Extracted text";
 }

--- a/frontend/src/modules/document_edit/editorExtensions.ts
+++ b/frontend/src/modules/document_edit/editorExtensions.ts
@@ -1,0 +1,74 @@
+// Tiptap extension stack for the document editor. The three decoration
+// extensions (find, review notes, tracked changes) are built per-mount in
+// DocumentRichEditor and passed in so their memoisation stays where the
+// React state lives. Order is load-bearing and preserved exactly from the
+// pre-split DocumentRichEditor.tsx (Fluff C3).
+import type { AnyExtension } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import Typography from "@tiptap/extension-typography";
+import Highlight from "@tiptap/extension-highlight";
+import Color from "@tiptap/extension-color";
+import Image from "@tiptap/extension-image";
+import Link from "@tiptap/extension-link";
+import TaskItem from "@tiptap/extension-task-item";
+import TaskList from "@tiptap/extension-task-list";
+import TextAlign from "@tiptap/extension-text-align";
+import { TextStyle } from "@tiptap/extension-text-style";
+import { Table } from "@tiptap/extension-table";
+import TableCell from "@tiptap/extension-table-cell";
+import TableHeader from "@tiptap/extension-table-header";
+import TableRow from "@tiptap/extension-table-row";
+
+export function documentEditorExtensions({
+  findExtension,
+  reviewNoteExtension,
+  trackChangesExtension,
+}: {
+  findExtension: AnyExtension;
+  reviewNoteExtension: AnyExtension;
+  trackChangesExtension: AnyExtension;
+}): AnyExtension[] {
+  return [
+    StarterKit.configure({
+      heading: {
+        levels: [2, 3],
+      },
+      codeBlock: false,
+      horizontalRule: false,
+    }),
+    Placeholder.configure({
+      placeholder: "Start editing this document...",
+    }),
+    Typography,
+    Highlight.configure({ multicolor: false }),
+    TextStyle,
+    Color,
+    Image.configure({
+      allowBase64: false,
+      inline: false,
+    }),
+    Link.configure({
+      autolink: true,
+      defaultProtocol: "https",
+      openOnClick: false,
+      HTMLAttributes: {
+        class: "text-ink underline underline-offset-4",
+      },
+    }),
+    TextAlign.configure({
+      types: ["heading", "paragraph"],
+    }),
+    TaskList,
+    TaskItem.configure({
+      nested: true,
+    }),
+    findExtension,
+    reviewNoteExtension,
+    trackChangesExtension,
+    Table.configure({ resizable: true }),
+    TableRow,
+    TableHeader,
+    TableCell,
+  ];
+}

--- a/frontend/src/modules/document_edit/editorExtensions.ts
+++ b/frontend/src/modules/document_edit/editorExtensions.ts
@@ -4,6 +4,8 @@
 // React state lives. Order is load-bearing and preserved exactly from the
 // pre-split DocumentRichEditor.tsx (Fluff C3).
 import type { AnyExtension } from "@tiptap/core";
+
+import { firstImageFile } from "./editorText";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Typography from "@tiptap/extension-typography";
@@ -71,4 +73,28 @@ export function documentEditorExtensions({
     TableHeader,
     TableCell,
   ];
+}
+
+// Editor view props: canvas styling plus paste/drop image interception.
+// Verbatim from the pre-split DocumentRichEditor.tsx (Fluff C3).
+export function documentEditorProps(onImageFile: (file: File) => void) {
+  return {
+    attributes: {
+      class:
+        "legalise-document-editor min-h-[760px] border border-rule bg-paper px-9 py-12 text-[16px] leading-8 outline-none shadow-[0_18px_50px_rgba(0,0,0,0.08)] sm:px-14",
+    },
+    handlePaste: (_view: unknown, event: ClipboardEvent) => {
+      const file = firstImageFile(event.clipboardData?.files);
+      if (!file) return false;
+      onImageFile(file);
+      return true;
+    },
+    handleDrop: (_view: unknown, event: DragEvent) => {
+      const file = firstImageFile(event.dataTransfer?.files);
+      if (!file) return false;
+      event.preventDefault();
+      onImageFile(file);
+      return true;
+    },
+  };
 }

--- a/frontend/src/modules/document_edit/editorHooks.ts
+++ b/frontend/src/modules/document_edit/editorHooks.ts
@@ -1,0 +1,354 @@
+// Behaviour hooks for the document editor, extracted verbatim from
+// DocumentRichEditor.tsx (Fluff C3):
+// - useFindInDocument: find query/index state, match decorations dispatch,
+//   active-match scrolling, and the Cmd/Ctrl+F / Cmd/Ctrl+S shortcuts.
+// - useTrackedChangeResolution: redlines visibility, per-edit and
+//   accept/reject-all resolution against the real endpoints, and the
+//   tracked-changes plugin state dispatch.
+// - useClipboardActions: copy/download/link/image-URL actions.
+// State lives inside the hooks exactly as it did inline; everything the
+// hooks need from the component arrives as arguments.
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import type { Editor } from "@tiptap/react";
+
+import { findNormalizedRanges, selectedEditorText } from "./editorText";
+import {
+  FIND_DECORATIONS_PLUGIN_KEY,
+  type FindDecorationState,
+} from "./findDecorations";
+import {
+  applyProposedEditToEditor,
+  locateProposedEditInDoc,
+  TRACK_CHANGES_PLUGIN_KEY,
+  type DocumentProposedEdit,
+  type TrackChangeHandlers,
+  type TrackChangesPluginState,
+} from "./trackedChanges";
+
+export function useFindInDocument({
+  editor,
+  plainText,
+  canSave,
+  save,
+}: {
+  editor: Editor | null;
+  plainText: string;
+  canSave: boolean;
+  save: () => Promise<unknown>;
+}) {
+  const [findQuery, setFindQuery] = useState("");
+  const [findOpen, setFindOpen] = useState(false);
+  const [activeFindIndex, setActiveFindIndex] = useState(0);
+  const findInputRef = useRef<HTMLInputElement | null>(null);
+
+  const findMatches = useMemo(
+    () => findNormalizedRanges(plainText, findQuery),
+    [plainText, findQuery],
+  );
+  const activeFindMatch = findMatches[activeFindIndex] ?? findMatches[0] ?? null;
+  const findPreview =
+    activeFindMatch && plainText
+      ? plainText
+          .slice(
+            Math.max(0, activeFindMatch.start - 70),
+            Math.min(plainText.length, activeFindMatch.end + 90),
+          )
+          .replace(/\s+/g, " ")
+          .trim()
+      : null;
+  const findPositionLabel =
+    findMatches.length > 0
+      ? `${activeFindIndex + 1} / ${findMatches.length}`
+      : null;
+
+  useEffect(() => {
+    setActiveFindIndex(0);
+  }, [findQuery]);
+
+  useEffect(() => {
+    if (activeFindIndex >= findMatches.length) setActiveFindIndex(0);
+  }, [activeFindIndex, findMatches.length]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const activeIndex =
+      findMatches.length === 0
+        ? 0
+        : Math.min(activeFindIndex, Math.max(0, findMatches.length - 1));
+    editor.view.dispatch(
+      editor.state.tr.setMeta(FIND_DECORATIONS_PLUGIN_KEY, {
+        query: findQuery,
+        activeIndex,
+      } satisfies FindDecorationState),
+    );
+    if (findQuery.trim().length >= 3 && findMatches.length > 0) {
+      window.requestAnimationFrame(() => {
+        if (editor.isDestroyed) return;
+        editor.view.dom
+          .querySelector('[data-find-match="active"]')
+          ?.scrollIntoView({ block: "center", inline: "nearest" });
+      });
+    }
+  }, [activeFindIndex, editor, findMatches.length, findQuery]);
+
+  const moveFind = (direction: 1 | -1) => {
+    if (findMatches.length === 0) return;
+    setActiveFindIndex((current) =>
+      (current + direction + findMatches.length) % findMatches.length,
+    );
+  };
+  const handleFindKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    moveFind(event.shiftKey ? -1 : 1);
+  };
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!event.metaKey && !event.ctrlKey) return;
+      const key = event.key.toLowerCase();
+      if (key === "f") {
+        event.preventDefault();
+        setFindOpen(true);
+        requestAnimationFrame(() => {
+          findInputRef.current?.focus();
+          findInputRef.current?.select();
+        });
+      }
+      if (key === "s") {
+        event.preventDefault();
+        if (canSave) void save();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
+  return {
+    findQuery,
+    setFindQuery,
+    findOpen,
+    setFindOpen,
+    findInputRef,
+    findMatches,
+    findPreview,
+    findPositionLabel,
+    moveFind,
+    handleFindKeyDown,
+  };
+}
+
+export function useTrackedChangeResolution({
+  editor,
+  proposedEdits,
+  proposedEditsKey,
+  plainText,
+  onResolveProposedEdit,
+  setError,
+  trackHandlersRef,
+}: {
+  editor: Editor | null;
+  proposedEdits: DocumentProposedEdit[];
+  proposedEditsKey: string;
+  plainText: string;
+  onResolveProposedEdit?: (
+    editId: string,
+    action: "accept" | "reject",
+  ) => Promise<void>;
+  setError: (message: string | null) => void;
+  trackHandlersRef: { current: TrackChangeHandlers | null };
+}) {
+  const [redlinesVisible, setRedlinesVisible] = useState(true);
+  const [trackBusy, setTrackBusy] = useState(false);
+  const [trackNotice, setTrackNotice] = useState<string | null>(null);
+
+  // A fresh batch of proposed edits always starts visible.
+  useEffect(() => {
+    setRedlinesVisible(true);
+  }, [proposedEditsKey]);
+
+  useEffect(() => {
+    if (!editor) return;
+    editor.view.dispatch(
+      editor.state.tr.setMeta(TRACK_CHANGES_PLUGIN_KEY, {
+        edits: proposedEdits,
+        visible: redlinesVisible,
+      } satisfies TrackChangesPluginState),
+    );
+    // proposedEditsKey stands in for the array identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, proposedEditsKey, redlinesVisible]);
+
+  const anchoredProposedEditCount = useMemo(() => {
+    if (!editor || proposedEdits.length === 0) return 0;
+    return proposedEdits.filter((edit) =>
+      locateProposedEditInDoc(editor.state.doc, edit),
+    ).length;
+    // plainText tracks document changes; proposedEditsKey tracks the list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor, proposedEditsKey, plainText]);
+
+  async function resolveProposedEditInline(
+    edit: DocumentProposedEdit,
+    action: "accept" | "reject",
+  ) {
+    if (!editor || !onResolveProposedEdit || trackBusy) return;
+    setTrackBusy(true);
+    setError(null);
+    try {
+      await onResolveProposedEdit(edit.id, action);
+      if (action === "accept") {
+        const applied = applyProposedEditToEditor(editor, edit);
+        if (!applied) {
+          setTrackNotice(
+            "Accepted on the record. The text could not be applied in place " +
+              "here — it lands when the final redline is decided.",
+          );
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTrackBusy(false);
+    }
+  }
+
+  // "Accept all" / "Reject all" still resolve one edit at a time so each
+  // decision lands as its own audit row — and they only touch edits the
+  // user can SEE inline (anchored). Unanchored edits stay pending in the
+  // suggested-edits rail; one click never decides an unseen change. The
+  // anchor is re-checked per iteration because applying one edit can
+  // unanchor the next.
+  async function resolveAllProposedEdits(action: "accept" | "reject") {
+    if (!editor || !onResolveProposedEdit || trackBusy) return;
+    setTrackBusy(true);
+    setError(null);
+    try {
+      for (const edit of [...proposedEdits]) {
+        if (!locateProposedEditInDoc(editor.state.doc, edit)) continue;
+        await onResolveProposedEdit(edit.id, action);
+        if (action === "accept") {
+          const applied = applyProposedEditToEditor(editor, edit);
+          if (!applied) {
+            setTrackNotice(
+              "Some accepted changes could not be applied in place — they " +
+                "land when the final redline is decided.",
+            );
+          }
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTrackBusy(false);
+    }
+  }
+
+  trackHandlersRef.current = {
+    resolve: (edit, action) => void resolveProposedEditInline(edit, action),
+  };
+
+  return {
+    redlinesVisible,
+    setRedlinesVisible,
+    trackBusy,
+    trackNotice,
+    anchoredProposedEditCount,
+    resolveAllProposedEdits,
+  };
+}
+
+export function useClipboardActions({
+  editor,
+  plainText,
+  selectedQuote,
+  filename,
+}: {
+  editor: Editor | null;
+  plainText: string;
+  selectedQuote?: string;
+  filename: string;
+}) {
+  const [copiedMessage, setCopiedMessage] = useState<string | null>(null);
+
+  async function copyWorkingText() {
+    if (!plainText.trim()) return;
+    await window.navigator.clipboard.writeText(plainText);
+    setCopiedMessage("Copied working text");
+    window.setTimeout(() => setCopiedMessage(null), 2000);
+  }
+
+  async function copySelectedQuote() {
+    if (!selectedQuote?.trim()) return;
+    await window.navigator.clipboard.writeText(selectedQuote.trim());
+    setCopiedMessage("Copied selected passage");
+    window.setTimeout(() => setCopiedMessage(null), 2000);
+  }
+
+  async function copyEditorSelection() {
+    const selection = selectedEditorText(editor);
+    if (!selection) return;
+    await window.navigator.clipboard.writeText(selection);
+    setCopiedMessage("Copied selected passage");
+    window.setTimeout(() => setCopiedMessage(null), 2000);
+  }
+
+  function highlightEditorSelection() {
+    if (!editor || !selectedEditorText(editor)) return;
+    editor.chain().focus().toggleHighlight().run();
+  }
+
+  function setEditorLink() {
+    if (!editor) return;
+    const currentHref = typeof editor.getAttributes("link").href === "string"
+      ? editor.getAttributes("link").href
+      : "";
+    const nextHref = window.prompt("Paste link URL. Leave blank to remove the link.", currentHref);
+    if (nextHref === null) return;
+    const trimmed = nextHref.trim();
+    if (!trimmed) {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      return;
+    }
+    editor.chain().focus().extendMarkRange("link").setLink({ href: trimmed }).run();
+  }
+
+  function insertEditorImageUrl() {
+    if (!editor) return;
+    const src = window.prompt("Paste image URL");
+    if (src === null) return;
+    const trimmed = src.trim();
+    if (!trimmed) return;
+    const alt = window.prompt("Image description", "")?.trim() ?? "";
+    editor.chain().focus().setImage({ src: trimmed, alt }).run();
+  }
+
+  function downloadWorkingText() {
+    const blob = new Blob([plainText], { type: "text/plain;charset=utf-8" });
+    const url = window.URL.createObjectURL(blob);
+    const anchor = window.document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${filename.replace(/\.[^.]+$/, "") || "document"}-working-copy.txt`;
+    window.document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    window.URL.revokeObjectURL(url);
+  }
+
+  return {
+    copiedMessage,
+    copyWorkingText,
+    copySelectedQuote,
+    copyEditorSelection,
+    highlightEditorSelection,
+    setEditorLink,
+    insertEditorImageUrl,
+    downloadWorkingText,
+  };
+}

--- a/frontend/src/modules/document_edit/editorText.ts
+++ b/frontend/src/modules/document_edit/editorText.ts
@@ -1,0 +1,229 @@
+// Text utilities for the document editor: whitespace-normalised search,
+// plain-text serialisation, outline/stats derivation, and the per-document
+// local draft stored in localStorage. Extracted verbatim from
+// DocumentRichEditor.tsx (Fluff C3); DocumentRichEditor re-exports the
+// public pieces so consumers keep a single import path.
+import type { Editor } from "@tiptap/react";
+import type { JSONContent } from "@tiptap/core";
+
+export type TiptapNode = JSONContent;
+
+export type TextRange = { start: number; end: number };
+export type OutlineItem = { id: string; label: string; query: string };
+export type DocumentStats = { words: number; chars: number; blocks: number };
+export type DocumentLocalDraft = {
+  documentId: string;
+  filename: string;
+  savedAt: string;
+  plainText: string;
+  json: TiptapNode;
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function firstImageFile(files: FileList | File[] | null | undefined): File | null {
+  for (const file of Array.from(files ?? [])) {
+    if (file.type.startsWith("image/")) return file;
+  }
+  return null;
+}
+
+export function selectedEditorText(editor: Editor | null): string {
+  if (!editor) return "";
+  const { from, to } = editor.state.selection;
+  if (from === to) return "";
+  return editor.state.doc.textBetween(from, to, " ").replace(/\s+/g, " ").trim();
+}
+
+export function findNormalizedRanges(
+  text: string,
+  needle: string | null | undefined,
+): TextRange[] {
+  const target = needle?.trim().replace(/\s+/g, " ").toLowerCase();
+  if (!target || target.length < 3) return [];
+
+  let normalised = "";
+  const starts: number[] = [];
+  const ends: number[] = [];
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (/\s/.test(ch)) {
+      if (normalised.length === 0) continue;
+      if (normalised.endsWith(" ")) {
+        ends[ends.length - 1] = i + 1;
+      } else {
+        normalised += " ";
+        starts.push(i);
+        ends.push(i + 1);
+      }
+      continue;
+    }
+    normalised += ch.toLowerCase();
+    starts.push(i);
+    ends.push(i + 1);
+  }
+
+  const searchable = normalised.trimEnd();
+  const ranges: TextRange[] = [];
+  let from = 0;
+  while (from < searchable.length) {
+    const index = searchable.indexOf(target, from);
+    if (index === -1) break;
+    const endIndex = index + target.length - 1;
+    ranges.push({ start: starts[index], end: ends[endIndex] });
+    from = index + Math.max(target.length, 1);
+  }
+  return ranges;
+}
+
+export function findNormalizedRange(
+  text: string,
+  needle: string | null | undefined,
+): TextRange | null {
+  return findNormalizedRanges(text, needle)[0] ?? null;
+}
+
+function escapeWithOptionalMark(text: string, range: TextRange | null): string {
+  if (!range || range.end <= range.start) return escapeHtml(text);
+  const matched = text.slice(range.start, range.end);
+  if (/\n{2,}/.test(matched)) return escapeHtml(text);
+  return [
+    escapeHtml(text.slice(0, range.start)),
+    '<mark data-source-anchor="true">',
+    escapeHtml(matched),
+    "</mark>",
+    escapeHtml(text.slice(range.end)),
+  ].join("");
+}
+
+export function textToEditorHtml(
+  text: string,
+  sourceHighlight?: string | null,
+): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "<p></p>";
+  const range = findNormalizedRange(trimmed, sourceHighlight);
+  const html = escapeWithOptionalMark(trimmed, range)
+    .replace(/\n{2,}/g, "</p><p>")
+    .replace(/\n/g, "<br />");
+  return `<p>${html}</p>`;
+}
+
+function plainTextFromNode(node: TiptapNode): string {
+  if (node.type === "text") return node.text ?? "";
+  if (node.type === "hardBreak") return "\n";
+  if (node.type === "image") return node.attrs?.alt ? `[image: ${node.attrs.alt}]\n\n` : "[image]\n\n";
+  const children = node.content?.map(plainTextFromNode).join("") ?? "";
+  if (node.type === "paragraph" || node.type === "heading") return `${children}\n\n`;
+  if (node.type === "taskItem") {
+    return `${node.attrs?.checked ? "[x]" : "[ ]"} ${children.trimEnd()}\n`;
+  }
+  if (node.type === "listItem") return `${children.trimEnd()}\n`;
+  if (node.type === "tableCell" || node.type === "tableHeader") return children.trim();
+  if (node.type === "tableRow") {
+    return `${node.content?.map(plainTextFromNode).join("\t") ?? ""}\n`;
+  }
+  if (node.type === "table") return `${children}\n`;
+  return children;
+}
+
+export function editorJsonToPlainText(json: TiptapNode): string {
+  return plainTextFromNode(json).replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export function isEditableWordDocument(filename: string, mimeType?: string | null): boolean {
+  return (
+    /\.docx$/i.test(filename) ||
+    mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  );
+}
+
+function firstTextFromNode(node: TiptapNode): string {
+  if (node.type === "text") return node.text ?? "";
+  return node.content?.map(firstTextFromNode).join("") ?? "";
+}
+
+function documentOutlineFromText(text: string): OutlineItem[] {
+  const blocks = text
+    .split(/\n{2,}/)
+    .map((block) => block.replace(/\s+/g, " ").trim())
+    .filter((block) => block.length >= 12);
+  return blocks.slice(0, 12).map((block, index) => {
+    const compact = block.length > 76 ? `${block.slice(0, 73).trimEnd()}...` : block;
+    return {
+      id: `${index}-${compact}`,
+      label: compact,
+      query: block.slice(0, 96),
+    };
+  });
+}
+
+export function documentOutlineFromJson(
+  json: TiptapNode | null | undefined,
+  fallbackText: string,
+): OutlineItem[] {
+  const headingItems =
+    json?.content?.flatMap((node, index): OutlineItem[] => {
+      if (node.type !== "heading") return [];
+      const text = firstTextFromNode(node).replace(/\s+/g, " ").trim();
+      if (!text) return [];
+      return [{
+        id: `heading-${index}-${text}`,
+        label: text.length > 76 ? `${text.slice(0, 73).trimEnd()}...` : text,
+        query: text,
+      }];
+    }) ?? [];
+  return headingItems.length > 0 ? headingItems.slice(0, 12) : documentOutlineFromText(fallbackText);
+}
+
+export function documentStatsFromText(text: string): DocumentStats {
+  const trimmed = text.trim();
+  return {
+    words: trimmed ? trimmed.split(/\s+/).length : 0,
+    chars: text.length,
+    blocks: trimmed ? trimmed.split(/\n{2,}/).filter(Boolean).length : 0,
+  };
+}
+
+function draftStorageKey(documentId: string): string {
+  return `legalise.documentDraft.${documentId}`;
+}
+
+export function readDocumentLocalDraft(documentId: string): DocumentLocalDraft | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(draftStorageKey(documentId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<DocumentLocalDraft>;
+    if (
+      parsed.documentId !== documentId ||
+      !parsed.json ||
+      typeof parsed.plainText !== "string" ||
+      typeof parsed.savedAt !== "string"
+    ) {
+      window.localStorage.removeItem(draftStorageKey(documentId));
+      return null;
+    }
+    return parsed as DocumentLocalDraft;
+  } catch {
+    window.localStorage.removeItem(draftStorageKey(documentId));
+    return null;
+  }
+}
+
+export function writeDocumentLocalDraft(draft: DocumentLocalDraft): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(draftStorageKey(draft.documentId), JSON.stringify(draft));
+}
+
+export function clearDocumentLocalDraft(documentId: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(draftStorageKey(documentId));
+}

--- a/frontend/src/modules/document_edit/findDecorations.ts
+++ b/frontend/src/modules/document_edit/findDecorations.ts
@@ -1,0 +1,61 @@
+// Find-in-document decorations: a ProseMirror plugin that highlights every
+// whitespace-normalised match of the current query and marks the active
+// one. Extracted verbatim from DocumentRichEditor.tsx (Fluff C3).
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+import { findNormalizedRanges } from "./editorText";
+
+export type FindDecorationState = {
+  activeIndex: number;
+  query: string;
+};
+
+export const FIND_DECORATIONS_PLUGIN_KEY = new PluginKey<FindDecorationState>(
+  "legaliseDocumentFind",
+);
+
+export function findDecorationsExtension() {
+  return Extension.create({
+    name: "legaliseDocumentFind",
+    addProseMirrorPlugins() {
+      return [
+        new Plugin<FindDecorationState>({
+          key: FIND_DECORATIONS_PLUGIN_KEY,
+          state: {
+            init: () => ({ query: "", activeIndex: 0 }),
+            apply(transaction, previous) {
+              return transaction.getMeta(FIND_DECORATIONS_PLUGIN_KEY) ?? previous;
+            },
+          },
+          props: {
+            decorations(state) {
+              const pluginState = FIND_DECORATIONS_PLUGIN_KEY.getState(state);
+              const query = pluginState?.query?.trim() ?? "";
+              if (query.length < 3) return DecorationSet.empty;
+              const decorations: Decoration[] = [];
+              let matchIndex = 0;
+              state.doc.descendants((node, position) => {
+                if (!node.isText || !node.text) return;
+                findNormalizedRanges(node.text, query).forEach((range) => {
+                  const isActive = matchIndex === pluginState?.activeIndex;
+                  decorations.push(
+                    Decoration.inline(position + range.start, position + range.end, {
+                      class: isActive
+                        ? "legalise-find-match legalise-find-match-active"
+                        : "legalise-find-match",
+                      "data-find-match": isActive ? "active" : "true",
+                    }),
+                  );
+                  matchIndex += 1;
+                });
+              });
+              return DecorationSet.create(state.doc, decorations);
+            },
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/frontend/src/modules/document_edit/reviewNotes.ts
+++ b/frontend/src/modules/document_edit/reviewNotes.ts
@@ -1,0 +1,52 @@
+// Review-note (comment) decorations: anchors each note's quoted passage in
+// the live document with the shared whitespace-normalised search and marks
+// it open/resolved. Extracted verbatim from DocumentRichEditor.tsx
+// (Fluff C3).
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+
+import { findNormalizedRanges } from "./editorText";
+
+export type DocumentNoteHighlight = {
+  id: string;
+  label: string;
+  quote: string;
+  status: "open" | "resolved";
+};
+
+export function reviewNoteDecorationsExtension(noteHighlights: DocumentNoteHighlight[]) {
+  return Extension.create({
+    name: "legaliseReviewNotes",
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey("legaliseReviewNotes"),
+          props: {
+            decorations(state) {
+              const decorations: Decoration[] = [];
+              state.doc.descendants((node, position) => {
+                if (!node.isText || !node.text) return;
+                noteHighlights.forEach((note) => {
+                  findNormalizedRanges(node.text ?? "", note.quote).forEach((range) => {
+                    decorations.push(
+                      Decoration.inline(position + range.start, position + range.end, {
+                        class:
+                          note.status === "resolved"
+                            ? "legalise-review-note-resolved"
+                            : "legalise-review-note-open",
+                        "data-review-note-id": note.id,
+                        title: note.label,
+                      }),
+                    );
+                  });
+                });
+              });
+              return DecorationSet.create(state.doc, decorations);
+            },
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/frontend/src/modules/document_edit/trackedChanges.ts
+++ b/frontend/src/modules/document_edit/trackedChanges.ts
@@ -1,0 +1,234 @@
+// ----- Inline tracked changes (proposed document_edits rows) --------------
+//
+// AI/skill-proposed edits arrive as (deleted_text, inserted_text,
+// context_before, context_after) rows. We anchor each one in the live
+// document with the same whitespace-normalised search the review notes
+// use, then decorate: deletion struck through in seal, insertion as an
+// underlined inline widget, with compact accept/reject controls. Edits
+// that cannot be anchored stay in the rail listing — never dropped.
+//
+// Extracted verbatim from DocumentRichEditor.tsx (Fluff C3).
+import type { Editor } from "@tiptap/react";
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
+import type { Node as ProseMirrorNode } from "prosemirror-model";
+
+import { findNormalizedRanges } from "./editorText";
+
+export type DocumentProposedEdit = {
+  id: string;
+  deletedText: string;
+  insertedText: string;
+  contextBefore: string;
+  contextAfter: string;
+  rationale?: string | null;
+};
+
+export type ProposedEditLocation =
+  | { kind: "replace"; from: number; to: number }
+  | { kind: "insert"; pos: number };
+
+export type TrackChangesPluginState = {
+  edits: DocumentProposedEdit[];
+  visible: boolean;
+};
+
+export type TrackChangeHandlers = {
+  resolve: (edit: DocumentProposedEdit, action: "accept" | "reject") => void;
+};
+
+export const TRACK_CHANGES_PLUGIN_KEY = new PluginKey<TrackChangesPluginState>(
+  "legaliseTrackChanges",
+);
+
+export function locateProposedEditInDoc(
+  doc: ProseMirrorNode,
+  edit: DocumentProposedEdit,
+  options?: { strict?: boolean },
+): ProposedEditLocation | null {
+  const deleted = edit.deletedText ?? "";
+  const deletedNeedle = deleted.trim().replace(/\s+/g, " ");
+  let located: ProposedEditLocation | null = null;
+
+  if (deletedNeedle.length >= 3) {
+    // Most specific anchor first; bare deleted text last. First match
+    // wins — the same policy the backend resolver applies. Strict mode
+    // (used when APPLYING text, not just decorating) requires the full
+    // context anchor: a bare-needle match after a neighbouring accept
+    // could land on the wrong occurrence while the server, applying to
+    // untouched base_text, lands on the right one.
+    const anchors = options?.strict
+      ? [`${edit.contextBefore ?? ""}${deleted}${edit.contextAfter ?? ""}`]
+      : [
+          `${edit.contextBefore ?? ""}${deleted}${edit.contextAfter ?? ""}`,
+          `${edit.contextBefore ?? ""}${deleted}`,
+          deleted,
+        ];
+    for (const anchor of anchors) {
+      if (located) break;
+      doc.descendants((node, position) => {
+        if (located) return false;
+        if (!node.isText || !node.text) return true;
+        const anchorRange = findNormalizedRanges(node.text, anchor)[0];
+        if (!anchorRange) return true;
+        const slice = node.text.slice(anchorRange.start, anchorRange.end);
+        const inner = findNormalizedRanges(slice, deleted)[0];
+        if (!inner) return true;
+        located = {
+          kind: "replace",
+          from: position + anchorRange.start + inner.start,
+          to: position + anchorRange.start + inner.end,
+        };
+        return false;
+      });
+    }
+    return located;
+  }
+
+  // Deletions under three characters cannot be anchored safely; they
+  // fall back to the rail listing.
+  if (deletedNeedle.length > 0) return null;
+
+  // Pure insertion: anchor on the surrounding context.
+  doc.descendants((node, position) => {
+    if (located) return false;
+    if (!node.isText || !node.text) return true;
+    const beforeRange = findNormalizedRanges(node.text, edit.contextBefore)[0];
+    if (beforeRange) {
+      located = { kind: "insert", pos: position + beforeRange.end };
+      return false;
+    }
+    const afterRange = findNormalizedRanges(node.text, edit.contextAfter)[0];
+    if (afterRange) {
+      located = { kind: "insert", pos: position + afterRange.start };
+      return false;
+    }
+    return true;
+  });
+  return located;
+}
+
+export function applyProposedEditToEditor(
+  activeEditor: Editor,
+  edit: DocumentProposedEdit,
+): boolean {
+  const located = locateProposedEditInDoc(activeEditor.state.doc, edit, {
+    strict: true,
+  });
+  if (!located) return false;
+  const inserted = (edit.insertedText ?? "").replace(/\s+/g, " ");
+  return activeEditor
+    .chain()
+    .command(({ tr, state }) => {
+      if (located.kind === "replace") {
+        if (inserted.trim()) {
+          tr.replaceWith(located.from, located.to, state.schema.text(inserted));
+        } else {
+          tr.delete(located.from, located.to);
+        }
+        return true;
+      }
+      if (!inserted.trim()) return false;
+      tr.insert(located.pos, state.schema.text(inserted));
+      return true;
+    })
+    .run();
+}
+
+function trackChangeWidget(
+  edit: DocumentProposedEdit,
+  handlersRef: { current: TrackChangeHandlers | null },
+): HTMLElement {
+  const wrap = window.document.createElement("span");
+  wrap.className = "legalise-track-change";
+  wrap.dataset.trackEditId = edit.id;
+  if (edit.rationale) wrap.title = edit.rationale;
+  const inserted = (edit.insertedText ?? "").replace(/\s+/g, " ").trim();
+  if (inserted) {
+    const ins = window.document.createElement("span");
+    ins.className = "legalise-track-insert";
+    ins.textContent = inserted;
+    wrap.append(ins);
+  }
+  const controls = window.document.createElement("span");
+  controls.className = "legalise-track-controls";
+  const makeButton = (
+    label: string,
+    glyph: string,
+    action: "accept" | "reject",
+  ) => {
+    const button = window.document.createElement("button");
+    button.type = "button";
+    button.className =
+      action === "accept" ? "legalise-track-accept" : "legalise-track-reject";
+    button.setAttribute("aria-label", label);
+    button.title = label;
+    button.textContent = glyph;
+    // mousedown (not click) so the editor selection is not stolen first.
+    button.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      handlersRef.current?.resolve(edit, action);
+    });
+    return button;
+  };
+  controls.append(
+    makeButton("Accept change", "✓", "accept"),
+    makeButton("Reject change", "✕", "reject"),
+  );
+  wrap.append(controls);
+  return wrap;
+}
+
+export function trackChangesDecorationsExtension(handlersRef: {
+  current: TrackChangeHandlers | null;
+}) {
+  return Extension.create({
+    name: "legaliseTrackChanges",
+    addProseMirrorPlugins() {
+      return [
+        new Plugin<TrackChangesPluginState>({
+          key: TRACK_CHANGES_PLUGIN_KEY,
+          state: {
+            init: () => ({ edits: [], visible: true }),
+            apply(transaction, previous) {
+              return transaction.getMeta(TRACK_CHANGES_PLUGIN_KEY) ?? previous;
+            },
+          },
+          props: {
+            decorations(state) {
+              const pluginState = TRACK_CHANGES_PLUGIN_KEY.getState(state);
+              if (!pluginState?.visible || pluginState.edits.length === 0) {
+                return DecorationSet.empty;
+              }
+              const decorations: Decoration[] = [];
+              pluginState.edits.forEach((edit) => {
+                const located = locateProposedEditInDoc(state.doc, edit);
+                if (!located) return;
+                if (located.kind === "replace") {
+                  decorations.push(
+                    Decoration.inline(located.from, located.to, {
+                      class: "legalise-track-delete",
+                      "data-track-edit-id": edit.id,
+                    }),
+                  );
+                }
+                const widgetPos =
+                  located.kind === "replace" ? located.to : located.pos;
+                decorations.push(
+                  Decoration.widget(
+                    widgetPos,
+                    () => trackChangeWidget(edit, handlersRef),
+                    { side: 1, key: `legalise-track-${edit.id}` },
+                  ),
+                );
+              });
+              return DecorationSet.create(state.doc, decorations);
+            },
+          },
+        }),
+      ];
+    },
+  });
+}


### PR DESCRIPTION
Executes Phase C3 of `docs/handovers/FLUFF_CUT_ORDER_2026-06-12.md` under the recorded Phase A decision: **(a) editor is core**. The 2,387-line `DocumentRichEditor.tsx` — largest file in the repo — splits along its natural seams. Extract, not rewrite: every moved block is verbatim (markup, class strings, test ids, effect bodies, dep arrays, anchor-resolution policy); `DocumentRichEditor.tsx` re-exports every previously public name, so `DocumentDetail` and all other consumers keep a single unchanged import path. The MikeOSS-parity tracked-changes behaviour (PR #185) — strict full-context anchors, per-edit accept/reject against real endpoints, anchored-only accept/reject-all — is untouched.

## Before / after

| File | Lines | Carries |
|---|---|---|
| **Before:** `DocumentRichEditor.tsx` | **2,387** | everything |
| **After:** `DocumentRichEditor.tsx` | **800** | component state, shared-draft sync/poll/conflict, Word import, save/commit, local-draft restore, layout |
| `editorText.ts` | 229 | normalised search, plain-text serialisation, outline/stats, localStorage drafts |
| `trackedChanges.ts` | 234 | proposed-edit types, strict/loose anchor resolver, apply path, accept/reject widget, decorations |
| `findDecorations.ts` | 61 | find-in-document plugin (match + active highlighting) |
| `reviewNotes.ts` | 52 | comment-anchor decorations, `DocumentNoteHighlight` |
| `editorExtensions.ts` | 100 | Tiptap extension stack (order preserved), editor view props (paste/drop image interception) |
| `editorChrome.tsx` | 593 | toolbar primitives, formatting toolbar, command bar row, working-diff renderer, status label |
| `editorHooks.ts` | 354 | `useFindInDocument`, `useTrackedChangeResolution`, `useClipboardActions` |
| `EditorPanels.tsx` | 625 | find/redlines panels, selection ribbon, draft notices, working-diff preview, review map, side rail, bubble menu |

No source file in the touched area exceeds 800 lines. One commit per seam (7), each verified with `tsc --noEmit` + the editor/DocumentDetail vitest files.

## Deliberately left in the core file

The shared-draft persistence layer (`persistWorkingDraft`, `scheduleWorkingDraftSave`, `loadSharedDraftFromServer`, the reset/load/poll effects) stays in `DocumentRichEditor.tsx`. `scheduleWorkingDraftSave` is captured by `useEditor`'s `onUpdate` before the editor instance exists, while the load/poll paths need the live editor — pulling that into a hook would require ref indirection, i.e. a rewrite of the reference pattern rather than an extraction. Same call for `uploadAndInsertEditorImage` (captured by paste/drop handlers). That is the honest core.

## Verification

- `npx tsc --noEmit` green after every seam
- Full `npx vitest run`: **37 files, 301 tests passed** (incl. the P25 editor tests in `DocumentDetail.test.tsx` and `DocumentRichEditor.test.tsx`)
- `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)