### PR TITLE
Premortem checklist: capture at the final scene, 48h security promise, dates hedge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,3 +136,7 @@ For:
 ## Code of conduct
 
 Be civil. Disagree with reasoning, not people.
+
+## Maintainer reality
+
+This is an evaluation release with a single maintainer. Issues are triaged weekly; security reports are acknowledged within 48 hours (see SECURITY.md). Expect honest response times, not enterprise ones.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Please include:
 - impact assessment
 - whether any hosted evaluation data may be affected
 
-We aim to acknowledge reports within 72 hours. Please give us 90 days before public disclosure, longer where deployed users may be affected.
+We acknowledge reports within 48 hours. Please give us 90 days before public disclosure, longer where deployed users may be affected.
 
 ## Scope
 

--- a/frontend/src/demo/DemoSignedOutput.tsx
+++ b/frontend/src/demo/DemoSignedOutput.tsx
@@ -79,6 +79,18 @@ export function DemoSignedOutput() {
             See output.signed on the record →
           </a>
         </p>
+        {/* The loop's last line is a way to reach the builder — the demo's
+            one ask (premortem item: capture at the final scene). */}
+        <p className="mt-6 border-t border-rule pt-4 text-sm text-prose" data-testid="demo-capture-line">
+          Supervise work product in a real firm? Tell me where this breaks,
+          twenty minutes:{" "}
+          <a
+            href="mailto:andy@legalise.dev"
+            className="text-ink underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+          >
+            andy@legalise.dev
+          </a>
+        </p>
       </footer>
     </div>
   );

--- a/frontend/src/demo/snapshot.ts
+++ b/frontend/src/demo/snapshot.ts
@@ -696,7 +696,7 @@ const ASSISTANT_MESSAGES: AssistantMessage[] = [
     id: "asst-msg-04",
     role: "assistant",
     content:
-      "12 March 2026. Acme dismissed Ms Khan citing a social-media policy breach [chron:ev-05]. That date is the EDT for limitation purposes; ACAS Day A was filed on 2 May, so the s.207B extended ET1 deadline lands on 3 July 2026.",
+      "12 March 2026. Acme dismissed Ms Khan citing a social-media policy breach [chron:ev-05]. That date is the EDT for limitation purposes; ACAS Day A was filed on 2 May, so the s.207B extended ET1 deadline lands on 3 July 2026. Check the dates against the source documents before relying on them.",
     suggested_actions: [
       {
         type: "view_chronology",


### PR DESCRIPTION
- The demo's signed-output view ends with the one ask: supervise work
  product? twenty minutes, andy@legalise.dev
- SECURITY.md acknowledgment tightened to 48 hours; CONTRIBUTING gains
  the maintainer-reality note (evaluation release, single maintainer,
  weekly triage)
- The s.207B deadline reply in the demo now tells the reader to check
  the dates against the source documents before relying on them

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
