### PR TITLE
Test-slim Phase 4: coverage as a CI artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,19 @@ jobs:
               print(path)
           PY
           mapfile -t pytest_files < /tmp/backend-pytest-files.txt
-          python -m pytest -x -vv --durations=20 --timeout=60 --timeout-method=thread "${pytest_files[@]}"
+          # Coverage published as a CI artifact (test-slim order Phase 4 /
+          # audit item C2) so the suite's reallocation is visible, not
+          # asserted. Per-shard reports; combine offline if needed.
+          python -m pytest -x -vv --durations=20 --timeout=60 --timeout-method=thread \
+            --cov=app --cov-report=xml:coverage-${PYTEST_SHARD}.xml --cov-report=term:skip-covered \
+            "${pytest_files[@]}"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage-${{ matrix.shard }}
+          path: backend/coverage-*.xml
+          retention-days: 30
 
   # ---------------------------------------------------------------------------
   # MinIO smoke — exercises the S3StorageBackend (boto3 path) against a real

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
   "pytest>=8.3.0",
   "pytest-asyncio>=0.24.0",
   "pytest-timeout>=2.3.1",
+  "pytest-cov>=6.0.0",
   "httpx>=0.28.0",
 ]
 


### PR DESCRIPTION
Per-shard pytest --cov reports uploaded (30-day retention) so the
suite's reallocation is visible, not asserted. pytest-cov joins dev
deps.

Order close: 113 files / 28,885 lines at baseline → 91 files / 26,540
lines live, with the golden loop e2e-gated, the assistant pipeline
unit-netted, dormant primitives parked as spec, governance coverage
reorganised and never thinned.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
