### PR TITLE
Deflake the copy-status assertions (PR #184 class)

### DIFF
--- a/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
+++ b/frontend/src/modules/document_edit/DocumentRichEditor.test.tsx
@@ -726,8 +726,16 @@ describe("DocumentRichEditor surface", () => {
       },
       { timeout: 5000 },
     );
-    expect(screen.getByTestId("document-editor-copy-status")).toHaveTextContent(
-      "Copied working text",
+    // The status line renders from a state update after the clipboard
+    // promise resolves — assert inside a wait or it races under
+    // parallel CI load (the PR #184 deflake class).
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("document-editor-copy-status")).toHaveTextContent(
+          "Copied working text",
+        );
+      },
+      { timeout: 5000 },
     );
   });
 
@@ -894,13 +902,21 @@ describe("DocumentRichEditor surface", () => {
     fireEvent.click(within(ribbon).getByRole("button", { name: "Run skill" }));
     expect(onRunSkillFromSelection).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole("button", { name: "Copy passage" }));
-    await waitFor(() => {
-      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-        "single social-media post",
-      );
-    });
-    expect(screen.getByTestId("document-editor-copy-status")).toHaveTextContent(
-      "Copied selected passage",
+    await waitFor(
+      () => {
+        expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
+          "single social-media post",
+        );
+      },
+      { timeout: 5000 },
+    );
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("document-editor-copy-status")).toHaveTextContent(
+          "Copied selected passage",
+        );
+      },
+      { timeout: 5000 },
     );
     fireEvent.click(within(ribbon).getByRole("button", { name: "Add review note" }));
     expect(onCreateNoteFromSelection).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
The status line renders from a state update after the awaited
clipboard promise — asserting it synchronously races under parallel CI
load. Both call sites now assert inside a waitFor with the standard
generous timeout.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
