### PR TITLE
Gate 1: abuse throttling on the auth surface

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ In scope:
 
 - the open-source Legalise repository
 - the hosted legalise.dev evaluation environment
-- authentication, provider-key storage, matter access control, audit, storage, job execution, upload validation, and module capability enforcement
+- authentication (including per-IP rate limiting on register / verification / password-reset), provider-key storage, matter access control, audit, storage, job execution, upload validation, and module capability enforcement
 
 Out of scope:
 

--- a/backend/alembic/versions/0033_auth_throttle_events.py
+++ b/backend/alembic/versions/0033_auth_throttle_events.py
@@ -1,0 +1,47 @@
+"""Add auth_throttle_events for per-IP auth rate limiting.
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-06-12
+
+Postgres-backed sliding window for the unauthenticated auth surface
+(register / request-verify-token / forgot-password). Counts are recomputed
+from this table on each call — no Redis counter — so the limit holds across
+multiple backend instances. See app/core/rate_limit.py.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0033"
+down_revision = "0032"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_throttle_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("ip", sa.String(length=64), nullable=False),
+        sa.Column("route", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_auth_throttle_events_route_ip_created",
+        "auth_throttle_events",
+        ["route", "ip", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_auth_throttle_events_route_ip_created",
+        table_name="auth_throttle_events",
+    )
+    op.drop_table("auth_throttle_events")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -14,23 +14,65 @@ Routes (mounted at `/auth` in main.py):
 The frontend can call these directly. We keep fastapi-users' standard
 names (login/logout/register) rather than aliasing to signin/signout —
 matching upstream docs reduces surprise for self-hosters.
+
+Abuse throttling: register, request-verify-token and forgot-password are
+per-IP rate limited (Postgres sliding window — see app/core/rate_limit.py).
+The fastapi-users routers are upstream factories, so the throttle rides in
+as router-level dependencies; the verify and reset routers each bundle a
+second route we do NOT throttle (/verify, /reset-password — both already
+gated by a single-use token), so those dependencies match on path.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth_schemas import UserCreate, UserRead, UserUpdate
 from app.core.auth import auth_backend, fastapi_users
+from app.core.db import get_session
+from app.core.rate_limit import enforce_ip_rate_limit
 
 router = APIRouter()
+
+
+async def _throttle_register(
+    request: Request, session: AsyncSession = Depends(get_session)
+) -> None:
+    await enforce_ip_rate_limit(request, session, "auth.register")
+
+
+async def _throttle_request_verify_token(
+    request: Request, session: AsyncSession = Depends(get_session)
+) -> None:
+    # The verify router also serves POST /verify — token-gated, not throttled.
+    if request.url.path.endswith("/request-verify-token"):
+        await enforce_ip_rate_limit(request, session, "auth.request_verify_token")
+
+
+async def _throttle_forgot_password(
+    request: Request, session: AsyncSession = Depends(get_session)
+) -> None:
+    # The reset router also serves POST /reset-password — token-gated.
+    if request.url.path.endswith("/forgot-password"):
+        await enforce_ip_rate_limit(request, session, "auth.forgot_password")
+
 
 router.include_router(
     fastapi_users.get_auth_router(auth_backend, requires_verification=True)
 )
-router.include_router(fastapi_users.get_register_router(UserRead, UserCreate))
-router.include_router(fastapi_users.get_reset_password_router())
-router.include_router(fastapi_users.get_verify_router(UserRead))
+router.include_router(
+    fastapi_users.get_register_router(UserRead, UserCreate),
+    dependencies=[Depends(_throttle_register)],
+)
+router.include_router(
+    fastapi_users.get_reset_password_router(),
+    dependencies=[Depends(_throttle_forgot_password)],
+)
+router.include_router(
+    fastapi_users.get_verify_router(UserRead),
+    dependencies=[Depends(_throttle_request_verify_token)],
+)
 router.include_router(
     fastapi_users.get_users_router(UserRead, UserUpdate),
     prefix="/users",

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -1,0 +1,161 @@
+"""Per-IP rate limiting for the unauthenticated auth surface.
+
+Doctrine (same as ``app/core/limits.py``): counts are recomputed from
+Postgres on each call — no Redis counter, no in-process state — so the
+limit holds across multiple backend instances and survives restarts.
+
+Mechanism: a sliding window over ``auth_throttle_events``. Every attempt
+on a throttled route inserts one row (ip, route, created_at); the check
+counts rows for that (route, ip) inside the window. Blocked attempts are
+recorded too, so an attacker who keeps hammering keeps the window full —
+the limit is on *attempts*, not successes. That is deliberate: this is an
+abuse throttle, not a quota.
+
+Defaults (overridable via ``LEGALISE_RATE_LIMIT_<ROUTE>_PER_HOUR``):
+
+- ``auth.register``               5 / IP / hour
+- ``auth.request_verify_token``  10 / IP / hour
+- ``auth.forgot_password``       10 / IP / hour
+
+Set an override to ``0`` to disable that route's throttle (e.g. local
+load testing).
+
+Client IP resolution: the hosted instance sits behind Cloudflare → Fly,
+so the direct peer (``request.client.host``) is a proxy. We prefer
+``CF-Connecting-IP``, then ``Fly-Client-IP``, then the first hop of
+``X-Forwarded-For``, then the direct peer. Self-hosters terminating TLS
+themselves get the direct peer, which is correct for them. A client that
+can reach the origin directly could spoof these headers; the hosted
+deployment only exposes the origin via the proxy chain, and the
+worst-case failure is a throttle bypass — never an authz bypass.
+
+Throttled responses are 429 with the same ``detail``-envelope shape as
+``limits.py``. The first rejection in a window also writes one
+``auth.rate_limited`` audit row (only the first, so a sustained attack
+cannot flood the WORM audit log at request rate).
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+from fastapi import HTTPException, Request
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Route key -> (env var suffix, default per-hour limit). The window is one
+# hour for every route; per-route windows can be added if ever needed.
+RATE_LIMITED_ROUTES: dict[str, tuple[str, int]] = {
+    "auth.register": ("REGISTER", 5),
+    "auth.request_verify_token": ("REQUEST_VERIFY_TOKEN", 10),
+    "auth.forgot_password": ("FORGOT_PASSWORD", 10),
+}
+
+WINDOW_SECONDS = 3600
+
+# Proxy headers in trust order for the hosted Cloudflare → Fly chain.
+_IP_HEADERS = ("cf-connecting-ip", "fly-client-ip")
+
+
+def route_limit(route: str) -> int:
+    """Resolved per-hour limit for a route (env override read per call —
+    cheap, and keeps tests free of process-lifetime singletons)."""
+    suffix, default = RATE_LIMITED_ROUTES[route]
+    return int(os.environ.get(f"LEGALISE_RATE_LIMIT_{suffix}_PER_HOUR", str(default)))
+
+
+def client_ip(request: Request) -> str:
+    for header in _IP_HEADERS:
+        value = request.headers.get(header)
+        if value:
+            return value.strip()
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first = forwarded.split(",")[0].strip()
+        if first:
+            return first
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _rate_limited(route: str, limit: int) -> HTTPException:
+    return HTTPException(
+        status_code=429,
+        detail={
+            "error": "rate_limited",
+            "route": route,
+            "limit_per_hour": limit,
+            "message": (
+                "Too many requests from this address. "
+                "Try again in an hour."
+            ),
+        },
+        headers={"Retry-After": str(WINDOW_SECONDS)},
+    )
+
+
+async def enforce_ip_rate_limit(
+    request: Request, session: AsyncSession, route: str
+) -> None:
+    """Record this attempt and raise 429 if the IP is over the limit.
+
+    Commits its own writes on the request session before any raise so the
+    attempt row (and the audit row on first rejection) survives the 429.
+    """
+    from app.models.audit import AuditEntry
+    from app.models.auth_throttle import AuthThrottleEvent
+
+    limit = route_limit(route)
+    if limit <= 0:
+        return  # throttle disabled for this route
+
+    ip = client_ip(request)
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(seconds=WINDOW_SECONDS)
+
+    # Opportunistic cleanup: expired rows for this route are dead weight.
+    await session.execute(
+        delete(AuthThrottleEvent).where(
+            AuthThrottleEvent.route == route,
+            AuthThrottleEvent.created_at < window_start,
+        )
+    )
+
+    count = await session.scalar(
+        select(func.count(AuthThrottleEvent.id)).where(
+            AuthThrottleEvent.route == route,
+            AuthThrottleEvent.ip == ip,
+            AuthThrottleEvent.created_at >= window_start,
+        )
+    )
+    current = count or 0
+
+    # Record the attempt — including blocked ones (see module docstring).
+    session.add(AuthThrottleEvent(ip=ip, route=route, created_at=now))
+
+    if current >= limit:
+        # Audit only the first rejection in the window: current == limit
+        # exactly once, then keeps growing as blocked attempts accrue.
+        if current == limit:
+            session.add(
+                AuditEntry(
+                    actor_id=None,
+                    matter_id=None,
+                    action="auth.rate_limited",
+                    resource_type="auth",
+                    resource_id=route,
+                    payload={
+                        "ip": ip,
+                        "route": route,
+                        "limit_per_hour": limit,
+                        "window_seconds": WINDOW_SECONDS,
+                        "path": request.url.path,
+                    },
+                )
+            )
+        await session.commit()
+        raise _rate_limited(route, limit)
+
+    await session.commit()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -38,6 +38,7 @@ from app.models.matter import (
 from app.models.document import Document, TAG_VALUES
 from app.models.event import Event
 from app.models.audit import AuditEntry
+from app.models.auth_throttle import AuthThrottleEvent
 from app.models.audit_chain import (
     AUDIT_CHAIN_SCOPE_MATTER,
     AUDIT_CHAIN_SCOPE_SYSTEM,
@@ -252,4 +253,6 @@ __all__ = [
     "REVIEW_TERMINAL_STATES",
     "REVIEW_STATE_VALUES",
     "REVIEW_ELIGIBLE_KINDS",
+    # Auth rate limiting.
+    "AuthThrottleEvent",
 ]

--- a/backend/app/models/auth_throttle.py
+++ b/backend/app/models/auth_throttle.py
@@ -1,0 +1,50 @@
+"""AuthThrottleEvent — one row per attempt on a throttled auth route.
+
+Postgres-backed sliding-window rate limiting for the unauthenticated auth
+surface (register / request-verify-token / forgot-password). The window is
+recomputed from this table on each call — same doctrine as
+``app/core/limits.py``: no Redis counter, no in-process cache, correct
+across multiple backend instances.
+
+Rows are tiny (ip + route + timestamp) and short-lived in relevance: only
+rows inside the window are ever counted. A sweep job is not required for
+correctness; ``app.core.rate_limit`` opportunistically deletes expired rows
+for the route it is checking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, UTC
+
+from sqlalchemy import DateTime, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AuthThrottleEvent(Base):
+    __tablename__ = "auth_throttle_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    # Textual IP (v4 or v6). String not INET so the model stays portable and
+    # we never do address arithmetic on it — it is an opaque bucket key.
+    ip: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Route key, e.g. "auth.register" — see RATE_LIMITED_ROUTES in
+    # app/core/rate_limit.py for the canonical set.
+    route: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("ix_auth_throttle_events_route_ip_created", "route", "ip", "created_at"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<AuthThrottleEvent {self.route} {self.ip} {self.created_at}>"

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -1,0 +1,235 @@
+"""Per-IP abuse throttling on the unauthenticated auth surface.
+
+Covers app/core/rate_limit.py + the router wiring in app/api/auth.py:
+
+- register / request-verify-token / forgot-password throttle at the
+  configured per-IP-per-hour limit and return the 429 envelope;
+- a different client IP is an independent bucket;
+- the window slides — backdated attempts (inserted directly, no sleeps)
+  do not count and are swept;
+- the first rejection in a window writes exactly one ``auth.rate_limited``
+  audit row, however many blocked attempts follow;
+- routes that share an upstream fastapi-users router with a throttled
+  route (POST /auth/verify, POST /auth/reset-password) are NOT throttled;
+- a 0 override disables the throttle.
+
+All limits are pinned via env overrides so the tests are independent of
+the shipped defaults; one test asserts the defaults themselves.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import func, select
+
+from app.core.rate_limit import RATE_LIMITED_ROUTES, route_limit
+from app.models import AuditEntry, AuthThrottleEvent
+
+
+def _email(i: int) -> str:
+    return f"throttle-{i}@example.com"
+
+
+PASSWORD = "throttle-password-2026"
+
+
+async def _register(client, i: int, headers: dict | None = None):
+    return await client.post(
+        "/auth/register",
+        json={"email": _email(i), "password": PASSWORD},
+        headers=headers or {},
+    )
+
+
+async def _audit_throttle_count(db_session) -> int:
+    return (
+        await db_session.scalar(
+            select(func.count(AuditEntry.id)).where(
+                AuditEntry.action == "auth.rate_limited"
+            )
+        )
+    ) or 0
+
+
+# ---------------------------------------------------------------------------
+# Defaults (no env override in play)
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_defaults(monkeypatch) -> None:
+    for suffix, _ in RATE_LIMITED_ROUTES.values():
+        monkeypatch.delenv(f"LEGALISE_RATE_LIMIT_{suffix}_PER_HOUR", raising=False)
+    assert route_limit("auth.register") == 5
+    assert route_limit("auth.request_verify_token") == 10
+    assert route_limit("auth.forgot_password") == 10
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/register
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_throttles_at_limit(client, db_session, monkeypatch) -> None:
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR", "3")
+
+    for i in range(3):
+        resp = await _register(client, i)
+        assert resp.status_code == 201, resp.text
+
+    resp = await _register(client, 3)
+    assert resp.status_code == 429, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == "rate_limited"
+    assert detail["route"] == "auth.register"
+    assert detail["limit_per_hour"] == 3
+    assert resp.headers.get("retry-after") == "3600"
+
+    # Exactly one audit row for the first rejection.
+    assert await _audit_throttle_count(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_register_repeat_blocks_audit_once(client, db_session, monkeypatch) -> None:
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR", "1")
+
+    assert (await _register(client, 0)).status_code == 201
+    for i in range(1, 4):
+        assert (await _register(client, i)).status_code == 429
+
+    assert await _audit_throttle_count(db_session) == 1
+    row = await db_session.scalar(
+        select(AuditEntry).where(AuditEntry.action == "auth.rate_limited")
+    )
+    assert row.actor_id is None
+    assert row.resource_type == "auth"
+    assert row.resource_id == "auth.register"
+    assert row.payload["limit_per_hour"] == 1
+    assert row.payload["ip"]
+
+
+@pytest.mark.asyncio
+async def test_register_different_ip_is_separate_bucket(client, monkeypatch) -> None:
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR", "1")
+
+    assert (await _register(client, 0)).status_code == 201
+    assert (await _register(client, 1)).status_code == 429
+    # Same socket, different proxy-asserted client IP — fresh bucket.
+    resp = await _register(client, 2, headers={"cf-connecting-ip": "203.0.113.7"})
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_register_window_slides_without_sleeping(
+    client, db_session, monkeypatch
+) -> None:
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR", "2")
+    ip = "203.0.113.9"
+    stale = datetime.now(timezone.utc) - timedelta(hours=2)
+
+    # Two attempts from this IP, both outside the 1h window.
+    for _ in range(2):
+        db_session.add(AuthThrottleEvent(ip=ip, route="auth.register", created_at=stale))
+    await db_session.commit()
+
+    resp = await _register(client, 0, headers={"cf-connecting-ip": ip})
+    assert resp.status_code == 201, resp.text
+
+    # The expired rows were swept by the opportunistic cleanup.
+    stale_left = await db_session.scalar(
+        select(func.count(AuthThrottleEvent.id)).where(
+            AuthThrottleEvent.route == "auth.register",
+            AuthThrottleEvent.created_at < datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+    )
+    assert stale_left == 0
+
+
+@pytest.mark.asyncio
+async def test_register_zero_disables_throttle(client, db_session, monkeypatch) -> None:
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR", "0")
+
+    for i in range(4):
+        assert (await _register(client, i)).status_code == 201
+
+    # Disabled means no attempt rows either.
+    rows = await db_session.scalar(
+        select(func.count(AuthThrottleEvent.id)).where(
+            AuthThrottleEvent.route == "auth.register"
+        )
+    )
+    assert rows == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/request-verify-token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_verify_token_throttles(client, monkeypatch) -> None:
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_REQUEST_VERIFY_TOKEN_PER_HOUR", "2")
+
+    for _ in range(2):
+        resp = await client.post(
+            "/auth/request-verify-token", json={"email": "nobody@example.com"}
+        )
+        # fastapi-users always 202s to avoid email enumeration.
+        assert resp.status_code == 202, resp.text
+
+    resp = await client.post(
+        "/auth/request-verify-token", json={"email": "nobody@example.com"}
+    )
+    assert resp.status_code == 429
+    assert resp.json()["detail"]["route"] == "auth.request_verify_token"
+
+
+@pytest.mark.asyncio
+async def test_verify_route_not_throttled(client, monkeypatch) -> None:
+    """POST /auth/verify shares the upstream verify router but is
+    token-gated — it must keep returning 400 (bad token), never 429."""
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_REQUEST_VERIFY_TOKEN_PER_HOUR", "1")
+
+    resp = await client.post(
+        "/auth/request-verify-token", json={"email": "nobody@example.com"}
+    )
+    assert resp.status_code == 202
+    resp = await client.post(
+        "/auth/request-verify-token", json={"email": "nobody@example.com"}
+    )
+    assert resp.status_code == 429
+
+    # Bucket exhausted — /verify still serves.
+    resp = await client.post("/auth/verify", json={"token": "not-a-real-token"})
+    assert resp.status_code == 400, resp.text
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/forgot-password
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_throttles_but_reset_password_does_not(
+    client, monkeypatch
+) -> None:
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_FORGOT_PASSWORD_PER_HOUR", "1")
+
+    resp = await client.post(
+        "/auth/forgot-password", json={"email": "nobody@example.com"}
+    )
+    assert resp.status_code == 202, resp.text
+    resp = await client.post(
+        "/auth/forgot-password", json={"email": "nobody@example.com"}
+    )
+    assert resp.status_code == 429
+    assert resp.json()["detail"]["route"] == "auth.forgot_password"
+
+    # Same upstream router, token-gated sibling route: not throttled.
+    resp = await client.post(
+        "/auth/reset-password",
+        json={"token": "not-a-real-token", "password": PASSWORD},
+    )
+    assert resp.status_code == 400, resp.text

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -287,6 +287,13 @@ SameSite=Lax), email verification via Resend, and password reset via
 one-time token. Sessions are backed by a server-side `access_token`
 table — revocation is real, not just client-side.
 
+**Abuse throttling.** The unauthenticated auth surface is per-IP rate
+limited at the application layer: 5 registrations and 10
+verification-email / password-reset requests per IP per hour, counted
+via a sliding window recomputed from Postgres (no Redis counter, so the
+limit holds across instances). Throttled requests return 429, and the
+first rejection in a window writes an `auth.rate_limited` audit row.
+
 **Bring-your-own provider keys.** Each user adds their Anthropic or
 OpenAI key under Settings → API keys. The privilege-aware model gateway
 reads the user's key for every call on their matters. Server-side keys


### PR DESCRIPTION
## What

Per-IP rate limiting on the unauthenticated auth surface, app-level (no Cloudflare dashboard dependency):

| Route | Limit |
|---|---|
| `POST /auth/register` | 5 / IP / hour |
| `POST /auth/request-verify-token` | 10 / IP / hour |
| `POST /auth/forgot-password` | 10 / IP / hour |

Overridable via `LEGALISE_RATE_LIMIT_<ROUTE>_PER_HOUR` (0 disables).

## How

- Extends the `limits.py` doctrine: sliding window recomputed from Postgres on each call (new `auth_throttle_events` table, migration 0033) — **no Redis counter**, correct across multiple Fly instances.
- Blocked attempts count toward the window, so sustained hammering stays blocked.
- Client IP: `CF-Connecting-IP` → `Fly-Client-IP` → first `X-Forwarded-For` hop → direct peer (matches the hosted Cloudflare → Fly chain; spoofing worst case is a throttle bypass, never authz).
- 429 with the same `detail`-envelope shape as the hosted evaluation limits + `Retry-After`.
- First rejection in a window writes one `auth.rate_limited` audit row — only the first, so an attack can't flood the WORM audit log at request rate.
- Wired as router-level dependencies on the fastapi-users factory routers; token-gated siblings (`/auth/verify`, `/auth/reset-password`) deliberately not throttled (tested).

## Tests

9 new fixture-level cases in `backend/tests/test_auth_rate_limit.py` — throttle path, per-IP bucketing, window expiry via backdated rows (no real sleeps), audit-once semantics, disable switch, untouched sibling routes.

Full backend suite locally: **809 passed, 11 skipped, 1 xfailed, 3 failed** — the 3 are the known macOS sandbox baseline (`test_sandbox.py` preexec_fn).

## Docs

- `docs/TRUST.md` §10 Authentication: abuse-throttling paragraph.
- `SECURITY.md` scope: rate limiting explicitly in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-IP rate limiting for authentication endpoints (registration, verification requests, password reset).

* **Security**
  * Implements sliding-window abuse throttling with configurable per-hour limits.
  * Rate-limited requests return HTTP 429 responses with retry-after headers.
  * First rejection per window logged to audit trail.

* **Documentation**
  * Updated security and trust documentation to reflect new rate-limiting policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->