### PR TITLE
Gate 3: WORM role split, CI-asserted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
       # the same `legalise_test` database on localhost.
       POSTGRES_DSN: postgresql+psycopg://legalise:legalise@localhost:5432/legalise_test
       TEST_DATABASE_URL: postgresql+asyncpg://legalise:legalise@localhost:5432/legalise_test
+      # WORM role split (CI-only provisioning; local dev stays single-role).
+      # The unprivileged app-role connection used by
+      # tests/test_audit_worm_role_split.py — those tests skip when this is
+      # unset, and run for real here because the steps below create the
+      # legalise_app role before migrations and apply infra/postgres-roles.sql
+      # after them.
+      TEST_APP_ROLE_DATABASE_URL: postgresql+asyncpg://legalise_app:legalise_app_ci@localhost:5432/legalise_test
       # `development` matches the docker-compose dev env. The email
       # module fails closed on `test` (no RESEND_API_KEY) because the
       # DEV_ENVIRONMENTS allowlist is `{development, dev, local}`. The
@@ -110,9 +117,42 @@ jobs:
           assert v >= (44, 0), f'cryptography {cryptography.__version__} below 44.0 floor'
           "
 
+      # ------------------------------------------------------------------
+      # WORM role split (gate 3). Three steps, CI-only — local docker-compose
+      # dev deliberately stays single-role:
+      #   1. Create the legalise_app role BEFORE migrations, so the
+      #      conditional REVOKE inside alembic 0011 fires on the real
+      #      migration path (it is a no-op when the role is absent).
+      #   2. After migrations, apply the canonical grants script
+      #      (infra/postgres-roles.sql) so the app role can read/write the
+      #      full migrated schema — minus UPDATE/DELETE on audit_entries.
+      #   3. Run the verify harness in `existing` mode: the job FAILS here
+      #      if the app role can UPDATE or DELETE audit_entries.
+      # ------------------------------------------------------------------
+      - name: Create app role so the 0011 REVOKE fires during migration
+        env:
+          PGPASSWORD: legalise
+        run: |
+          psql -h localhost -p 5432 -U legalise -d legalise_test -v ON_ERROR_STOP=1 \
+            -c "CREATE ROLE legalise_app WITH LOGIN PASSWORD 'legalise_app_ci';"
+
       - name: Run alembic migrations against the test DB
         working-directory: backend
         run: python -m alembic upgrade head
+
+      - name: Apply WORM role-split grants (infra/postgres-roles.sql)
+        env:
+          PGPASSWORD: legalise
+        run: |
+          psql -h localhost -p 5432 -U legalise -d legalise_test \
+            -v dbname=legalise_test -f infra/postgres-roles.sql
+
+      - name: Verify WORM role split (fails if app role can mutate audit_entries)
+        env:
+          VERIFY_MODE: existing
+          APP_DSN: postgres://legalise_app:legalise_app_ci@localhost:5432/legalise_test
+          ADMIN_DSN: postgres://legalise:legalise@localhost:5432/legalise_test
+        run: infra/verify-worm-role-split.sh
 
       - name: pytest
         working-directory: backend

--- a/backend/tests/test_audit_worm_role_split.py
+++ b/backend/tests/test_audit_worm_role_split.py
@@ -9,14 +9,16 @@ check — SQLSTATE ``42501`` (insufficient_privilege) — *before* the trigger
 even fires. That guarantee survives a future migration accidentally dropping
 the trigger.
 
-This suite is OPT-IN. It runs only when ``TEST_APP_ROLE_DATABASE_URL`` points
-at a Postgres connection authenticated as the unprivileged ``legalise_app``
-role against a database where 0011 + the role split have been applied. The
-single-role CI used by the rest of the suite cannot exercise this path (one
-role = no privilege boundary), so absent the env var the tests skip cleanly.
+This suite runs only when ``TEST_APP_ROLE_DATABASE_URL`` points at a Postgres
+connection authenticated as the unprivileged ``legalise_app`` role against a
+database where 0011 + the role split have been applied. CI provisions exactly
+that (the backend job creates ``legalise_app`` before migrations and applies
+``infra/postgres-roles.sql`` after them), so these tests run for real on every
+CI build. Local single-role dev leaves the var unset and the tests skip
+cleanly — the local posture is unchanged.
 
-Stand the harness up with ``infra/verify-worm-role-split.sh`` (which exports
-the var and invokes pytest), or point the var at any role-split DB.
+Stand a local harness up with ``infra/verify-worm-role-split.sh`` (disposable
+mode), or point the var at any role-split DB.
 """
 
 from __future__ import annotations
@@ -80,6 +82,20 @@ async def test_app_role_can_insert_audit_row() -> None:
                 ),
                 _probe_row(),
             )
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_app_role_can_select_audit_rows() -> None:
+    """The app role must still be able to READ the audit trail."""
+    engine = await _app_engine()
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                sa.text("SELECT count(*) FROM audit_entries")
+            )
+            assert result.scalar_one() >= 0
     finally:
         await engine.dispose()
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -259,3 +259,58 @@ Honest gaps, so nobody assumes them:
   involved — restart the add flow from the beginning.
 
 - No multi-tenancy: one deployment is one workspace (deliberate beta scope; see README Status). Teams needing separation run one deployment each.
+
+---
+
+## 6. Enabling the WORM role split in production
+
+The audit trail's second enforcement layer — the application database
+role losing UPDATE/DELETE on `audit_entries` by grant — is provisioned
+and asserted on every CI build (the backend job fails if the app role
+can mutate an audit row). Local dev stays single-role on purpose.
+Enabling it on a deployment is a connection-string switch:
+
+1. **Create the roles** in the Postgres cluster (Neon: connect as the
+   project owner) and apply the canonical grants:
+
+   ```sh
+   psql "$OWNER_DSN" \
+     -v app_pw="'<app password>'" -v migrate_pw="'<migrate password>'" \
+     -f infra/postgres-roles.sql
+   ```
+
+   The script is idempotent: it creates `legalise_app` and
+   `legalise_migrate` if absent, grants the app role full read/write on
+   the schema, and revokes UPDATE/DELETE on `audit_entries`. For a
+   database not named `legalise`, add `-v dbname=<name>`.
+
+2. **Point the app at the app role.** On Fly, swap the runtime secret to
+   the `legalise_app` DSN:
+
+   ```sh
+   fly secrets set --app legalise-backend \
+     POSTGRES_DSN="postgresql+asyncpg://legalise_app:<app password>@<host>/legalise"
+   ```
+
+   Migrations (`alembic upgrade head` in the deploy path) keep using the
+   privileged `legalise_migrate` DSN — migrations do DDL, the app does
+   not.
+
+3. **Verify before trusting it.** Run the same assertion CI runs, against
+   the live cluster:
+
+   ```sh
+   VERIFY_MODE=existing \
+     APP_DSN="postgres://legalise_app:<app password>@<host>/legalise" \
+     ADMIN_DSN="$OWNER_DSN" \
+     infra/verify-worm-role-split.sh
+   ```
+
+   It appends one probe audit row, then confirms the app role can
+   INSERT and SELECT but gets `42501 insufficient_privilege` on UPDATE
+   and DELETE, and that the 0011 trigger still catches a privileged
+   role.
+
+Rollback is the same secret swap in reverse: point `POSTGRES_DSN` back
+at the original role. The trigger layer holds either way; the role
+split is the belt on top of the braces.

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -63,11 +63,14 @@ reading the architecture.
 - **Retention is recorded, not enforced.** Every matter has a
   `retention_until` field; nothing actively sweeps and deletes when that
   date passes.
-- **Audit WORM is trigger-enforced, not yet role-enforced.** A Postgres
-  trigger rejects UPDATE and DELETE on `audit_entries`, and every row is
-  hash-chained so any out-of-band rewrite is detectable. The remaining
-  work is operational: split the migration and application database
-  roles so the REVOKE on the app role takes effect.
+- **Audit WORM role split is exercised in CI, not yet enabled on the
+  hosted deployment.** A Postgres trigger rejects UPDATE and DELETE on
+  `audit_entries`, and every row is hash-chained so any out-of-band
+  rewrite is detectable. The second layer — a database role split where
+  the application role loses UPDATE/DELETE on `audit_entries` by
+  grant — is provisioned and asserted on every CI build (a build fails
+  if the app role can mutate audit rows). Turning it on for the hosted
+  stack is an operational switch; the runbook is in `OPERATIONS.md`.
 - **Application-layer encryption of stored prompts/responses is not yet
   implemented.** We rely on Neon/Fly/R2 at-rest encryption defaults.
 - **One deployment is one workspace.** There is no organisation or
@@ -230,10 +233,19 @@ work or was refused at the door:
   The trade-off is transactional integrity: semantic rows commit
   only when the semantic operation commits.
 
-The `audit_entries` table is append-only by enforcement: a Postgres
-trigger rejects UPDATE and DELETE on every row. The remaining hardening
-is operational, not code: split the migration and application database
-roles so the app role also loses UPDATE/DELETE by grant.
+The `audit_entries` table is append-only by enforcement, in two
+independent layers. First, a Postgres trigger rejects UPDATE and DELETE
+on every row, whatever role issues them. Second, a database role split
+(`infra/postgres-roles.sql`) removes UPDATE/DELETE on `audit_entries`
+from the application role by grant, so a mutation is refused at the
+privilege check before the trigger even runs. The role split is
+exercised in CI on every build: the backend job provisions the
+`legalise_app` role, runs the migrations and grants, and fails the
+build if that role can update or delete an audit row
+(`infra/verify-worm-role-split.sh` plus
+`backend/tests/test_audit_worm_role_split.py`). Operational adoption on
+a production deployment is a connection-string switch, documented in
+`OPERATIONS.md`.
 
 **Third-party verification.** Every audit row is hash-chained: an
 append-only `audit_chain` table links each entry to the previous one
@@ -367,6 +379,7 @@ unless they prefer anonymity.
 | 2026-05-14 | Added §9 skill provenance and approval: Git review as approval trail, `PLUGINS_REPO_REF` pinning, and `plugin.invoked` audit provenance |
 | 2026-06-11 | Filesystem plugin path removed; §1/§9 reframed around the import path (Lawve + GitHub) — pinned-SHA provenance, trust ceremony as the only install route |
 | 2026-06-12 | Currency pass: audit WORM recorded as trigger-enforced with hash chain (role split remains); object storage and durable jobs removed from §3 gaps (shipped); single-workspace scope added to §3; Pre-Motion audit-row count corrected; R2 v0.2 marker dropped |
+| 2026-06-12 | §3/§8: WORM role split now exercised in CI on every build (provisioned role, REVOKE asserted, build fails if the app role can mutate audit rows); production adoption runbook added to `OPERATIONS.md` |
 
 This file changes when the architecture changes. `git log docs/TRUST.md`
 is the canonical history.

--- a/infra/postgres-roles.sql
+++ b/infra/postgres-roles.sql
@@ -22,6 +22,14 @@
 
 \set ON_ERROR_STOP on
 
+-- Target database name. Defaults to the production name (`legalise`); CI
+-- points it at its own service DB:
+--   psql -v dbname=legalise_test -f infra/postgres-roles.sql
+\if :{?dbname}
+\else
+    \set dbname legalise
+\endif
+
 -- ---------------------------------------------------------------------------
 -- 1. Roles (created LOGIN-less if they don't exist; password set separately).
 -- ---------------------------------------------------------------------------
@@ -47,7 +55,7 @@ $$;
 -- ---------------------------------------------------------------------------
 -- 2. Migration role — full DDL/DML authority (used only by `alembic upgrade`).
 -- ---------------------------------------------------------------------------
-GRANT CONNECT ON DATABASE legalise TO legalise_migrate;
+GRANT CONNECT ON DATABASE :"dbname" TO legalise_migrate;
 GRANT ALL ON SCHEMA public TO legalise_migrate;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO legalise_migrate;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO legalise_migrate;
@@ -59,7 +67,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 -- ---------------------------------------------------------------------------
 -- 3. App role — read/write everywhere EXCEPT mutation of audit_entries.
 -- ---------------------------------------------------------------------------
-GRANT CONNECT ON DATABASE legalise TO legalise_app;
+GRANT CONNECT ON DATABASE :"dbname" TO legalise_app;
 GRANT USAGE ON SCHEMA public TO legalise_app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO legalise_app;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO legalise_app;

--- a/infra/verify-worm-role-split.sh
+++ b/infra/verify-worm-role-split.sh
@@ -2,23 +2,94 @@
 # Verify the WORM audit role-split property (R2 hardening #7) end to end.
 #
 # Proves two independent guarantees on a production-shaped two-role Postgres:
-#   1. legalise_app may INSERT audit rows but is REFUSED UPDATE/DELETE at the
-#      privilege layer (SQLSTATE 42501) — before the trigger runs.
+#   1. legalise_app may INSERT and SELECT audit rows but is REFUSED
+#      UPDATE/DELETE at the privilege layer (SQLSTATE 42501) — before the
+#      trigger runs.
 #   2. A privileged role that bypasses the REVOKE still hits the 0011 trigger
 #      ("append-only").
 #
-# This is the verification the v0.6 role-split deploy needs green BEFORE the
-# Fly secret swap, so the maintenance window carries zero engineering risk.
+# Two modes:
 #
-# Usage:
-#   infra/verify-worm-role-split.sh                 # native, uses local superuser
-#   ADMIN_DSN=postgres://user@host/db infra/verify-worm-role-split.sh
+#   disposable (default) — self-contained harness. Creates a throwaway DB
+#     named legalise_worm_verify with the exact 0011 trigger + role split,
+#     runs the checks, drops everything on exit. No app schema or running
+#     stack needed. Usage:
+#       infra/verify-worm-role-split.sh        # native, local superuser
+#       ADMIN_USER=postgres infra/verify-worm-role-split.sh
 #
-# Requires: psql on PATH, and a Postgres reachable as a superuser (to create
-# the throwaway DB + roles). Runs entirely against a disposable database named
-# legalise_worm_verify; drops it on exit. No production data is touched.
+#   existing — verify an ALREADY-PROVISIONED role-split database (the real
+#     migrated schema: alembic 0011 trigger + infra/postgres-roles.sql
+#     grants). This is what CI runs against its service Postgres. Nothing is
+#     created or dropped; one probe audit row is appended (audit_entries is
+#     append-only by design, so the probe row stays). Usage:
+#       VERIFY_MODE=existing \
+#         APP_DSN='postgres://legalise_app:pw@localhost:5432/legalise_test' \
+#         ADMIN_DSN='postgres://legalise:pw@localhost:5432/legalise_test' \
+#         infra/verify-worm-role-split.sh
+#
+# Exit code is non-zero if ANY layer fails — in particular, if the app role
+# CAN update or delete audit_entries, this script fails.
+#
+# Requires: psql on PATH.
 set -euo pipefail
 
+VERIFY_MODE="${VERIFY_MODE:-disposable}"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# The four checks. Callers must set:
+#   PSQL_APP      — psql invocation array connected as legalise_app
+#   PSQL_ADMIN_DB — psql invocation array connected as a privileged role,
+#                   to the SAME database (ON_ERROR_STOP=1)
+# ---------------------------------------------------------------------------
+run_checks() {
+    echo "==> [1/5] app role INSERT must succeed"
+    "${PSQL_APP[@]}" -v ON_ERROR_STOP=1 \
+      -c "INSERT INTO audit_entries (id, action, module, payload) VALUES (gen_random_uuid(), 'worm.rolesplit.probe', 'verify', '{}'::jsonb);" \
+      >/dev/null 2>&1 || fail "app role could not INSERT (append broken)"
+    echo "    ok — append works"
+
+    echo "==> [2/5] app role SELECT must succeed"
+    "${PSQL_APP[@]}" -v ON_ERROR_STOP=1 \
+      -c "SELECT count(*) FROM audit_entries;" \
+      >/dev/null 2>&1 || fail "app role could not SELECT (read broken)"
+    echo "    ok — read works"
+
+    echo "==> [3/5] app role UPDATE must be denied with SQLSTATE 42501"
+    out=$("${PSQL_APP[@]}" -v ON_ERROR_STOP=0 -c "\set VERBOSITY verbose" -c "UPDATE audit_entries SET action='x';" 2>&1 || true)
+    echo "$out" | grep -q "42501" || fail "app UPDATE not blocked by privilege (got: $out)"
+    echo "    ok — permission denied (REVOKE layer)"
+
+    echo "==> [4/5] app role DELETE must be denied with SQLSTATE 42501"
+    out=$("${PSQL_APP[@]}" -v ON_ERROR_STOP=0 -c "\set VERBOSITY verbose" -c "DELETE FROM audit_entries;" 2>&1 || true)
+    echo "$out" | grep -q "42501" || fail "app DELETE not blocked by privilege (got: $out)"
+    echo "    ok — permission denied (REVOKE layer)"
+
+    echo "==> [5/5] privileged role (bypasses REVOKE) must still hit the trigger"
+    out=$("${PSQL_ADMIN_DB[@]}" -c "UPDATE audit_entries SET action='x';" 2>&1 || true)
+    echo "$out" | grep -q "append-only" || fail "trigger did not fire for privileged UPDATE (got: $out)"
+    echo "    ok — append-only trigger (belt-and-braces layer)"
+}
+
+# ---------------------------------------------------------------------------
+# existing mode — verify a provisioned DB (CI path), then exit.
+# ---------------------------------------------------------------------------
+if [[ "$VERIFY_MODE" == "existing" ]]; then
+    : "${APP_DSN:?existing mode needs APP_DSN (legalise_app connection string)}"
+    : "${ADMIN_DSN:?existing mode needs ADMIN_DSN (privileged connection string, same DB)}"
+    PSQL_APP=(psql "$APP_DSN" -X -q -t -A)
+    PSQL_ADMIN_DB=(psql "$ADMIN_DSN" -v ON_ERROR_STOP=1 -X -q)
+    echo "==> [setup] existing mode — verifying provisioned role split (no DDL)"
+    run_checks
+    echo
+    echo "PASS: WORM role split verified — both layers independently enforced."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# disposable mode — self-contained throwaway harness.
+# ---------------------------------------------------------------------------
 ADMIN_USER="${ADMIN_USER:-$(whoami)}"
 ADMIN_HOST="${ADMIN_HOST:-localhost}"
 ADMIN_PORT="${ADMIN_PORT:-5432}"
@@ -68,28 +139,9 @@ REVOKE UPDATE, DELETE ON audit_entries FROM legalise_app;
 SQL
 
 PSQL_APP=(psql -h "$ADMIN_HOST" -p "$ADMIN_PORT" -U legalise_app -d "${VERIFY_DB}" -X -q -t -A)
-fail() { echo "FAIL: $1" >&2; exit 1; }
+PSQL_ADMIN_DB=("${PSQL_ADMIN[@]}" -d "${VERIFY_DB}")
 
-echo "==> [1/4] app role INSERT must succeed"
-"${PSQL_APP[@]}" -v ON_ERROR_STOP=1 \
-  -c "INSERT INTO audit_entries (id, action, module, payload) VALUES (gen_random_uuid(), 'probe', 'verify', '{}'::jsonb);" \
-  >/dev/null 2>&1 || fail "app role could not INSERT (append broken)"
-echo "    ok — append works"
-
-echo "==> [2/4] app role UPDATE must be denied with SQLSTATE 42501"
-out=$("${PSQL_APP[@]}" -v ON_ERROR_STOP=0 -c "\set VERBOSITY verbose" -c "UPDATE audit_entries SET action='x';" 2>&1 || true)
-echo "$out" | grep -q "42501" || fail "app UPDATE not blocked by privilege (got: $out)"
-echo "    ok — permission denied (REVOKE layer)"
-
-echo "==> [3/4] app role DELETE must be denied with SQLSTATE 42501"
-out=$("${PSQL_APP[@]}" -v ON_ERROR_STOP=0 -c "\set VERBOSITY verbose" -c "DELETE FROM audit_entries;" 2>&1 || true)
-echo "$out" | grep -q "42501" || fail "app DELETE not blocked by privilege (got: $out)"
-echo "    ok — permission denied (REVOKE layer)"
-
-echo "==> [4/4] privileged role (bypasses REVOKE) must still hit the trigger"
-out=$("${PSQL_ADMIN[@]}" -d "${VERIFY_DB}" -c "UPDATE audit_entries SET action='x';" 2>&1 || true)
-echo "$out" | grep -q "append-only" || fail "trigger did not fire for privileged UPDATE (got: $out)"
-echo "    ok — append-only trigger (belt-and-braces layer)"
+run_checks
 
 echo
 echo "PASS: WORM role split verified — both layers independently enforced."


### PR DESCRIPTION
## What

VC diligence gate 3: the Postgres WORM role split is now LIVE in CI, not just documented. Every backend CI build provisions the two-role posture and **fails if the application role can UPDATE or DELETE `audit_entries`**.

## How CI asserts it

The backend job (both shards) now runs, in order:

1. **Create `legalise_app` before migrations** — so the conditional REVOKE inside alembic 0011 fires on the genuine migration path (previously a no-op because the role never existed in CI).
2. **`alembic upgrade head`** — 0011's DO block revokes UPDATE/DELETE from the now-present role.
3. **Apply `infra/postgres-roles.sql`** (now parameterised with `-v dbname=legalise_test`) — canonical grants: full read/write on the schema, minus mutation of `audit_entries`.
4. **`infra/verify-worm-role-split.sh` in new `existing` mode** — connects as both roles and asserts: app INSERT ok, app SELECT ok, app UPDATE → SQLSTATE 42501, app DELETE → 42501, privileged UPDATE still caught by the 0011 trigger. Non-zero exit on any miss, so the build goes red if the REVOKE is absent.
5. **pytest** — `TEST_APP_ROLE_DATABASE_URL` is now set in the job env, so `tests/test_audit_worm_role_split.py` (INSERT+SELECT work; UPDATE+DELETE raise insufficient_privilege) runs for real instead of skipping. It still skips cleanly when the var is unset — **local single-role dev posture is unchanged**.

Negative path proven locally: with `GRANT UPDATE, DELETE` restored to the app role, the verify script fails (exit 1) — it distinguishes the trigger block from the privilege block, so a dropped REVOKE cannot hide behind the trigger.

## Docs

- `TRUST.md` §3/§8: "role split remains" → role split exercised in CI on every build; operational adoption documented in OPERATIONS.md.
- `OPERATIONS.md` §6: production enablement runbook — create roles on Neon via `infra/postgres-roles.sql`, swap the Fly `POSTGRES_DSN` secret to the `legalise_app` DSN (migrations keep the privileged DSN), verify live with the same script CI runs, rollback = reverse secret swap.

## Verification

- Fresh pgvector DB: role created → migrations → grants → verify script PASS (both `existing` and disposable modes).
- Role-split pytest: 4 passed provisioned, 4 skipped unprovisioned.
- Full backend suite locally: **804 passed, 3 failed (known macOS sandbox baseline: `test_sandbox.py` preexec_fn/rlimits), 8 skipped, 1 xfailed.**

Do not merge — diligence review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)