### PR TITLE
Fix forward: e2e disables the auth throttle; empty env means default

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,12 @@ jobs:
       # exercises the documented bootstrap_admin operator path, so keep
       # auto-admin disabled here.
       LEGALISE_DEV_AUTO_ADMIN_FIRST_USER: "false"
+      # The e2e suite registers many users from one runner IP per hour;
+      # the auth abuse throttle (gate 1, PR #219) would 429 it. 0
+      # disables per-route, exactly as production operators can.
+      LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR: "0"
+      LEGALISE_RATE_LIMIT_REQUEST_VERIFY_TOKEN_PER_HOUR: "0"
+      LEGALISE_RATE_LIMIT_FORGOT_PASSWORD_PER_HOUR: "0"
     defaults:
       run:
         working-directory: frontend

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -62,7 +62,10 @@ def route_limit(route: str) -> int:
     """Resolved per-hour limit for a route (env override read per call —
     cheap, and keeps tests free of process-lifetime singletons)."""
     suffix, default = RATE_LIMITED_ROUTES[route]
-    return int(os.environ.get(f"LEGALISE_RATE_LIMIT_{suffix}_PER_HOUR", str(default)))
+    # Compose passthrough sets the var to "" when the host leaves it
+    # unset (${VAR:-}); empty means "use the in-code default".
+    value = os.environ.get(f"LEGALISE_RATE_LIMIT_{suffix}_PER_HOUR")
+    return int(value) if value else default
 
 
 def client_ip(request: Request) -> str:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -81,6 +81,11 @@ services:
       # dev/eval; the e2e workflow exports true so its posture suite can
       # assert firm-mode enforcement. Same ${VAR:-default} pattern.
       LEGALISE_FIRM_ROLE_GATES_ENABLED: ${LEGALISE_FIRM_ROLE_GATES_ENABLED:-false}
+      # Auth abuse throttle overrides (gate 1). Empty default = the
+      # in-code limits; e2e exports 0 to disable for its register storm.
+      LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR: ${LEGALISE_RATE_LIMIT_REGISTER_PER_HOUR:-}
+      LEGALISE_RATE_LIMIT_REQUEST_VERIFY_TOKEN_PER_HOUR: ${LEGALISE_RATE_LIMIT_REQUEST_VERIFY_TOKEN_PER_HOUR:-}
+      LEGALISE_RATE_LIMIT_FORGOT_PASSWORD_PER_HOUR: ${LEGALISE_RATE_LIMIT_FORGOT_PASSWORD_PER_HOUR:-}
       # Local/eval only: first registered user becomes workspace admin
       # automatically, removing the bootstrap_admin copy-paste from the
       # two-minute demo path. The e2e workflow exports false so it can


### PR DESCRIPTION
PR #219's limiter correctly throttled the e2e suite's register storm
(one runner IP, many users). The e2e workflow now exports the 0
overrides; compose passes them through; the env reader treats empty
as unset so the passthrough's ${VAR:-} default cannot crash int().

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
