### PR TITLE
Gate 2: supervision made legible (M12+M13)

### DIFF
--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -394,3 +394,142 @@ async def get_admin_reconstruction(
         next_cursor=page.next_cursor,
         total_in_window_estimate=page.total_in_window_estimate,
     )
+
+
+# ---------------------------------------------------------------------------
+# E2 — the rubber-stamp detector (docs/spec/SUPERVISION_LEGIBILITY_M13.md)
+# ---------------------------------------------------------------------------
+#
+# Per-signer supervision diagnostic, derived entirely from existing
+# audit rows (the decision rows output.signed / _with_observations /
+# sign_rejected plus the output.review.opened window-start rows). The
+# economics analysis names a healthy scrutiny band of 2–30% — a signer
+# whose rejection+observations rate sits at 0% over a real n is
+# rubber-stamping; one far above is reviewing work that should not have
+# shipped. The endpoint reports; it does not judge.
+
+
+class SupervisionSignerRow(BaseModel):
+    signer_id: str
+    signer_email: str | None
+    signed: int
+    signed_with_observations: int
+    rejected: int
+    total: int
+    # (rejected + with-observations) / total, 0..1.
+    scrutiny_rate: float
+    # Median review latency across this signer's decisions that have a
+    # derivable window (open-event present). None when none do.
+    median_review_seconds: int | None
+    # How many decisions the median is over — honesty about thin data.
+    latency_n: int
+
+
+class SupervisionResponse(BaseModel):
+    signers: list[SupervisionSignerRow]
+    # The economics analysis's healthy scrutiny band, for the UI to
+    # cite rather than restate.
+    healthy_band: tuple[float, float] = (0.02, 0.30)
+
+
+@admin_router.get("/supervision", response_model=SupervisionResponse)
+async def get_supervision_diagnostic(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> SupervisionResponse:
+    import statistics
+
+    from sqlalchemy import func
+
+    from app.core.signoff import (
+        REVIEW_OPENED_ACTION,
+        SIGNOFF_ACTION_BY_DECISION,
+        review_latency_seconds,
+    )
+    from app.models import AuditEntry
+
+    _require_superuser(user)
+
+    action_by_decision = SIGNOFF_ACTION_BY_DECISION
+    decision_by_action = {v: k for k, v in action_by_decision.items()}
+
+    decision_rows = (
+        await session.execute(
+            select(
+                AuditEntry.actor_id,
+                AuditEntry.action,
+                AuditEntry.timestamp,
+                AuditEntry.payload,
+            ).where(AuditEntry.action.in_(decision_by_action.keys()))
+        )
+    ).all()
+
+    open_rows = (
+        await session.execute(
+            select(
+                AuditEntry.actor_id,
+                AuditEntry.resource_id,
+                func.min(AuditEntry.timestamp),
+            )
+            .where(
+                AuditEntry.action == REVIEW_OPENED_ACTION,
+                AuditEntry.resource_type == "matter_artifact",
+            )
+            .group_by(AuditEntry.actor_id, AuditEntry.resource_id)
+        )
+    ).all()
+    opened_at = {
+        (actor_id, resource_id): ts for actor_id, resource_id, ts in open_rows
+    }
+
+    counts: dict[uuid.UUID, dict[str, int]] = {}
+    latencies: dict[uuid.UUID, list[int]] = {}
+    for actor_id, action, ts, payload in decision_rows:
+        if actor_id is None:
+            continue
+        decision = decision_by_action[action]
+        counts.setdefault(actor_id, {})[decision] = (
+            counts.get(actor_id, {}).get(decision, 0) + 1
+        )
+        artifact_id = (
+            payload.get("artifact_id") if isinstance(payload, dict) else None
+        )
+        latency = review_latency_seconds(
+            opened_at.get((actor_id, artifact_id)), ts
+        )
+        if latency is not None:
+            latencies.setdefault(actor_id, []).append(latency)
+
+    emails: dict[uuid.UUID, str] = {}
+    if counts:
+        email_rows = await session.execute(
+            select(User.id, User.email).where(User.id.in_(counts.keys()))
+        )
+        emails = {uid: email for uid, email in email_rows.all()}
+
+    signers: list[SupervisionSignerRow] = []
+    for actor_id, by_decision in counts.items():
+        signed = by_decision.get("signed", 0)
+        observations = by_decision.get("signed_with_observations", 0)
+        rejected = by_decision.get("rejected", 0)
+        total = signed + observations + rejected
+        signer_latencies = latencies.get(actor_id, [])
+        signers.append(
+            SupervisionSignerRow(
+                signer_id=str(actor_id),
+                signer_email=emails.get(actor_id),
+                signed=signed,
+                signed_with_observations=observations,
+                rejected=rejected,
+                total=total,
+                scrutiny_rate=(observations + rejected) / total if total else 0.0,
+                median_review_seconds=(
+                    int(statistics.median(signer_latencies))
+                    if signer_latencies
+                    else None
+                ),
+                latency_n=len(signer_latencies),
+            )
+        )
+    signers.sort(key=lambda r: (-r.total, r.signer_id))
+    return SupervisionResponse(signers=signers)

--- a/backend/app/api/module_routes/common.py
+++ b/backend/app/api/module_routes/common.py
@@ -169,6 +169,13 @@ class InstalledModuleOut(BaseModel):
     # workspace for this module's outputs. Derived from matter_signoffs
     # at read time; the audit chain is the source of truth.
     track_record: dict[str, int] = {}
+    # Median review latency (seconds) across this module's sign-offs
+    # with a derivable review window (M13). None when no decision has
+    # an output.review.opened row — renders "—", never 0.
+    track_median_review_seconds: int | None = None
+    # How many decisions the median is over. Sub-n=30 carries the
+    # honesty label in the UI ("n=4 — too few to mean much").
+    track_review_latency_n: int = 0
 
 
 class StartInstallRequest(BaseModel):

--- a/backend/app/api/module_routes/installed_listing.py
+++ b/backend/app/api/module_routes/installed_listing.py
@@ -80,6 +80,43 @@ async def list_installed_modules(
     for module_id, decision, n in tr_rows:
         track.setdefault(module_id, {})[decision] = n
 
+    # Median review latency per module (M13): the review window is the
+    # signer's first output.review.opened audit row → the sign-off's
+    # signed_at, derived at read time per the spec. Sign-offs without an
+    # open-event (legacy / direct API) simply don't contribute — the
+    # median is over the decisions that have a derivable window.
+    import statistics
+
+    from app.core.signoff import review_latency_seconds, review_opened_at_map
+
+    so_rows = (
+        await session.execute(
+            select(
+                MatterSignoff.module_id,
+                MatterSignoff.signer_id,
+                MatterSignoff.artifact_id,
+                MatterSignoff.signed_at,
+            )
+        )
+    ).all()
+    opened = await review_opened_at_map(
+        session, pairs={(r.signer_id, r.artifact_id) for r in so_rows}
+    )
+    latencies_by_module: dict[str, list[int]] = {}
+    for r in so_rows:
+        latency = review_latency_seconds(
+            opened.get((r.signer_id, r.artifact_id)), r.signed_at
+        )
+        if latency is not None:
+            latencies_by_module.setdefault(r.module_id, []).append(latency)
+    median_by_module = {
+        module_id: int(statistics.median(values))
+        for module_id, values in latencies_by_module.items()
+    }
+    latency_n_by_module = {
+        module_id: len(values) for module_id, values in latencies_by_module.items()
+    }
+
     return [
         InstalledModuleOut(
             module_id=r.module_id,
@@ -104,6 +141,8 @@ async def list_installed_modules(
             ),
             install_path=r.install_path,
             track_record=track.get(r.module_id, {}),
+            track_median_review_seconds=median_by_module.get(r.module_id),
+            track_review_latency_n=latency_n_by_module.get(r.module_id, 0),
         )
         for r in rows
     ]

--- a/backend/app/api/signoffs.py
+++ b/backend/app/api/signoffs.py
@@ -38,6 +38,8 @@ from app.core.signoff import (
     create_signoff,
     current_signoff_ids,
     list_signoffs,
+    record_review_opened,
+    review_annotations,
 )
 from app.models import MatterArtifact, MatterSignoff, User
 from app.models.matter import STATUS_ARCHIVED, Matter
@@ -67,6 +69,14 @@ class SignoffRead(BaseModel):
     signer_is_author: bool
     signed_at: str
     is_current: bool
+    # Review window (M13): seconds between the signer's first open of
+    # the sign surface (output.review.opened audit row) and the
+    # decision. None when no open-event exists (legacy sign-offs) —
+    # surfaces render "—", never 0.
+    review_seconds: int | None = None
+    # Recorded at sign time against the artifact's word count
+    # (docs/spec/SUPERVISION_LEGIBILITY_M13.md). Recorded, not blocked.
+    implausible_speed: bool = False
 
 
 class SignoffListResponse(BaseModel):
@@ -91,6 +101,8 @@ def _to_read(
     is_current: bool,
     signer_email: str | None,
     signer_is_author: bool,
+    review_seconds: int | None = None,
+    implausible_speed: bool = False,
 ) -> SignoffRead:
     return SignoffRead(
         id=str(s.id),
@@ -108,6 +120,8 @@ def _to_read(
         signer_is_author=signer_is_author,
         signed_at=s.signed_at.isoformat() if s.signed_at else "",
         is_current=is_current,
+        review_seconds=review_seconds,
+        implausible_speed=implausible_speed,
     )
 
 
@@ -189,13 +203,66 @@ async def create_signoff_endpoint(
         )
 
     await session.commit()
+    annotations = await review_annotations(session, [signoff])
+    review_seconds, implausible_speed = annotations.get(signoff.id, (None, False))
     # A newly created sign-off is always the current one for its artifact.
     return _to_read(
         signoff,
         is_current=True,
         signer_email=user.email,
         signer_is_author=artifact.created_by_id == user.id,
+        review_seconds=review_seconds,
+        implausible_speed=implausible_speed,
     )
+
+
+class ReviewOpenBody(BaseModel):
+    artifact_id: str
+
+
+class ReviewOpenResponse(BaseModel):
+    artifact_id: str
+    # True when this call recorded the first open; False when an
+    # earlier open already holds the window's start (idempotent).
+    recorded: bool
+
+
+@router.post("/{slug}/signoffs/review-open", response_model=ReviewOpenResponse)
+async def review_open_endpoint(
+    slug: str,
+    body: ReviewOpenBody,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> ReviewOpenResponse:
+    """Record the first open of an artifact's sign surface (M13).
+
+    Called by the sign page when it loads its artifact. Idempotent per
+    signer+artifact: the first open wins and starts the review window;
+    repeat opens write nothing.
+    """
+    matter = await _load_matter_or_404(session, slug=slug, user=user)
+    try:
+        artifact_uuid = uuid.UUID(body.artifact_id)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="artifact_id is not a valid uuid")
+
+    artifact = await session.scalar(
+        select(MatterArtifact).where(
+            MatterArtifact.id == artifact_uuid,
+            MatterArtifact.matter_id == matter.id,
+        )
+    )
+    if artifact is None:
+        raise HTTPException(
+            status_code=404, detail=f"artifact not found on matter: {body.artifact_id}"
+        )
+
+    recorded = await record_review_opened(
+        session, matter=matter, artifact=artifact, user=user
+    )
+    if recorded:
+        await session.commit()
+    return ReviewOpenResponse(artifact_id=str(artifact.id), recorded=recorded)
 
 
 @router.get("/{slug}/signoffs", response_model=SignoffListResponse)
@@ -209,6 +276,7 @@ async def list_signoffs_endpoint(
     current = current_signoff_ids(signoffs)
     emails = await _signer_emails(session, {s.signer_id for s in signoffs})
     authors = await _artifact_authors(session, {s.artifact_id for s in signoffs})
+    annotations = await review_annotations(session, signoffs)
     return SignoffListResponse(
         matter_id=str(matter.id),
         signoffs=[
@@ -217,6 +285,8 @@ async def list_signoffs_endpoint(
                 is_current=s.id in current,
                 signer_email=emails.get(s.signer_id),
                 signer_is_author=authors.get(s.artifact_id) == s.signer_id,
+                review_seconds=annotations.get(s.id, (None, False))[0],
+                implausible_speed=annotations.get(s.id, (None, False))[1],
             )
             for s in signoffs
         ],
@@ -255,9 +325,13 @@ async def get_signoff_endpoint(
     )
     emails = await _signer_emails(session, {signoff.signer_id})
     authors = await _artifact_authors(session, {signoff.artifact_id})
+    annotations = await review_annotations(session, [signoff])
+    review_seconds, implausible_speed = annotations.get(signoff.id, (None, False))
     return _to_read(
         signoff,
         is_current=(latest == signoff.id),
         signer_email=emails.get(signoff.signer_id),
         signer_is_author=authors.get(signoff.artifact_id) == signoff.signer_id,
+        review_seconds=review_seconds,
+        implausible_speed=implausible_speed,
     )

--- a/backend/app/core/signoff.py
+++ b/backend/app/core/signoff.py
@@ -25,13 +25,14 @@ import json
 import uuid
 from datetime import datetime, UTC
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.api import audit
 from app.core.config import settings
 from app.core.matter_artifacts import load_artifact_bytes
 from app.models import (
+    AuditEntry,
     MatterArtifact,
     MatterSignoff,
     SIGNOFF_DECISIONS,
@@ -52,6 +53,143 @@ SIGNOFF_ACTION_BY_DECISION: dict[str, str] = {
     SIGNOFF_SIGNED_WITH_OBSERVATIONS: "output.signed_with_observations",
     SIGNOFF_REJECTED: "output.sign_rejected",
 }
+
+# First open of an artifact's sign surface by a signer. Idempotent per
+# (signer, artifact): first open wins, repeat opens write nothing. The
+# review window = this row's timestamp → the sign-off decision's
+# ``signed_at``; latency is derived from the two at read time
+# (docs/spec/SUPERVISION_LEGIBILITY_M13.md). No new tables.
+REVIEW_OPENED_ACTION = "output.review.opened"
+
+
+# Implausible-speed threshold (docs/spec/SUPERVISION_LEGIBILITY_M13.md,
+# closing diligence gates G-A3/G-A4). The economics analysis baselines
+# real review at ~10 minutes per 1,000 words. A sign-off faster than ONE
+# QUARTER of that baseline is flagged ``implausible_speed`` — generous
+# to skim-and-reject, suspicious of skim-and-sign. The 120s floor stops
+# tiny outputs from making any signature speed "plausible". Recorded,
+# not blocked: the register testifies; it does not nanny.
+IMPLAUSIBLE_SPEED_FLOOR_SECONDS = 120
+IMPLAUSIBLE_SPEED_SECONDS_PER_WORD = (10 * 60 / 1000) * 0.25  # 0.15 s/word
+
+
+def implausible_speed_threshold_seconds(word_count: int) -> float:
+    """Seconds below which a review of ``word_count`` words is implausible."""
+    return max(
+        IMPLAUSIBLE_SPEED_FLOOR_SECONDS,
+        word_count * IMPLAUSIBLE_SPEED_SECONDS_PER_WORD,
+    )
+
+
+def count_payload_words(payload: object) -> int:
+    """Whitespace-delimited word count across every string in ``payload``.
+
+    Walks the artifact payload JSON and counts words in string values
+    only — keys, numbers and structure don't cost review time. This is
+    an estimate feeding a generous threshold, not a billing meter.
+    """
+    if isinstance(payload, str):
+        return len(payload.split())
+    if isinstance(payload, dict):
+        return sum(count_payload_words(v) for v in payload.values())
+    if isinstance(payload, (list, tuple)):
+        return sum(count_payload_words(v) for v in payload)
+    return 0
+
+
+async def record_review_opened(
+    session: AsyncSession,
+    *,
+    matter: Matter,
+    artifact: MatterArtifact,
+    user: User,
+) -> bool:
+    """Record the first open of ``artifact``'s sign surface by ``user``.
+
+    Idempotent per signer+artifact: if an ``output.review.opened`` row
+    already exists for this (actor, artifact), nothing is written and
+    False is returned. Caller commits.
+    """
+    existing = await session.scalar(
+        select(AuditEntry.id)
+        .where(
+            AuditEntry.action == REVIEW_OPENED_ACTION,
+            AuditEntry.actor_id == user.id,
+            AuditEntry.resource_type == "matter_artifact",
+            AuditEntry.resource_id == str(artifact.id),
+        )
+        .limit(1)
+    )
+    if existing is not None:
+        return False
+    await audit.log(
+        session,
+        REVIEW_OPENED_ACTION,
+        actor_id=user.id,
+        matter_id=matter.id,
+        module=artifact.module_id,
+        resource_type="matter_artifact",
+        resource_id=str(artifact.id),
+        payload={
+            "artifact_id": str(artifact.id),
+            "invocation_id": str(artifact.invocation_id),
+            "kind": artifact.kind,
+        },
+    )
+    return True
+
+
+async def review_opened_at_map(
+    session: AsyncSession,
+    *,
+    pairs: set[tuple[uuid.UUID, uuid.UUID]],
+) -> dict[tuple[uuid.UUID, uuid.UUID], datetime]:
+    """Earliest ``output.review.opened`` timestamp per (signer, artifact).
+
+    Takes MIN(timestamp) so a duplicate row (e.g. a lost race on the
+    idempotency check) can never shorten the review window.
+    """
+    if not pairs:
+        return {}
+    artifact_ids = {str(a) for _, a in pairs}
+    rows = await session.execute(
+        select(
+            AuditEntry.actor_id,
+            AuditEntry.resource_id,
+            func.min(AuditEntry.timestamp),
+        )
+        .where(
+            AuditEntry.action == REVIEW_OPENED_ACTION,
+            AuditEntry.resource_type == "matter_artifact",
+            AuditEntry.resource_id.in_(artifact_ids),
+        )
+        .group_by(AuditEntry.actor_id, AuditEntry.resource_id)
+    )
+    out: dict[tuple[uuid.UUID, uuid.UUID], datetime] = {}
+    for actor_id, resource_id, opened_at in rows.all():
+        if actor_id is None:
+            continue
+        key = (actor_id, uuid.UUID(resource_id))
+        if key in pairs:
+            out[key] = opened_at
+    return out
+
+
+def review_latency_seconds(
+    opened_at: datetime | None, signed_at: datetime | None
+) -> int | None:
+    """Review latency in whole seconds, or None when underivable.
+
+    A missing open-event (legacy sign-offs) yields None — the surfaces
+    render "—", never 0. A negative delta (clock skew, backfilled rows)
+    also yields None rather than lying with a 0.
+    """
+    if opened_at is None or signed_at is None:
+        return None
+    delta = (signed_at - opened_at).total_seconds()
+    if delta < 0:
+        return None
+    return int(delta)
 
 
 class SignoffError(Exception):
@@ -80,6 +218,10 @@ def compute_signoff_hash(artifact: MatterArtifact) -> str:
     ``ArtifactBytesUnavailable`` for legacy/missing objects.
     """
     payload = json.loads(load_artifact_bytes(artifact.storage_path))
+    return _canonical_payload_hash(artifact, payload)
+
+
+def _canonical_payload_hash(artifact: MatterArtifact, payload: object) -> str:
     canonical = json.dumps(
         {"artifact_id": str(artifact.id), "kind": artifact.kind, "payload": payload},
         sort_keys=True,
@@ -131,7 +273,27 @@ async def create_signoff(
             "reject your own draft."
         )
 
-    artifact_hash = compute_signoff_hash(artifact)
+    payload = json.loads(load_artifact_bytes(artifact.storage_path))
+    artifact_hash = _canonical_payload_hash(artifact, payload)
+
+    # Review latency (M13): first open of the sign surface → this
+    # decision. Derived from the output.review.opened audit row; a
+    # missing open-event (legacy / direct-API sign-offs) yields None and
+    # never flags. The implausible-speed flag is recorded on the audit
+    # payload, not enforced.
+    signed_at = datetime.now(UTC)
+    opened = await review_opened_at_map(
+        session, pairs={(user.id, artifact.id)}
+    )
+    review_seconds = review_latency_seconds(
+        opened.get((user.id, artifact.id)), signed_at
+    )
+    implausible_speed = (
+        review_seconds is not None
+        and review_seconds
+        < implausible_speed_threshold_seconds(count_payload_words(payload))
+    )
+
     signoff = MatterSignoff(
         matter_id=matter.id,
         artifact_id=artifact.id,
@@ -143,7 +305,7 @@ async def create_signoff(
         decision=decision,
         reasoning=clean_reasoning or None,
         signer_id=user.id,
-        signed_at=datetime.now(UTC),
+        signed_at=signed_at,
     )
     session.add(signoff)
     await session.flush()
@@ -165,6 +327,8 @@ async def create_signoff(
             "decision": decision,
             "reasoning": clean_reasoning or None,
             "signer_is_author": signer_is_author,
+            "review_seconds": review_seconds,
+            "implausible_speed": implausible_speed,
         },
     )
     return signoff
@@ -180,6 +344,47 @@ async def list_signoffs(
         .order_by(MatterSignoff.signed_at.desc(), MatterSignoff.id.desc())
     )
     return list(rows.all())
+
+
+async def review_annotations(
+    session: AsyncSession, signoffs: list[MatterSignoff]
+) -> dict[uuid.UUID, tuple[int | None, bool]]:
+    """Per-signoff ``(review_seconds, implausible_speed)`` for API reads.
+
+    - ``review_seconds`` is derived at read time from the two audit rows
+      (open → decision), per the spec — no stored latency column.
+    - ``implausible_speed`` is read back from the decision's own audit
+      payload, where it was recorded against the word count at sign
+      time. Legacy rows without the key read as False (never accuse
+      without evidence).
+    """
+    if not signoffs:
+        return {}
+    opened = await review_opened_at_map(
+        session, pairs={(s.signer_id, s.artifact_id) for s in signoffs}
+    )
+    flag_rows = await session.execute(
+        select(AuditEntry.resource_id, AuditEntry.payload)
+        .where(
+            AuditEntry.action.in_(SIGNOFF_ACTION_BY_DECISION.values()),
+            AuditEntry.resource_type == "matter_signoff",
+            AuditEntry.resource_id.in_({str(s.id) for s in signoffs}),
+        )
+    )
+    flags = {
+        resource_id: bool(payload.get("implausible_speed"))
+        for resource_id, payload in flag_rows.all()
+        if isinstance(payload, dict)
+    }
+    return {
+        s.id: (
+            review_latency_seconds(
+                opened.get((s.signer_id, s.artifact_id)), s.signed_at
+            ),
+            flags.get(str(s.id), False),
+        )
+        for s in signoffs
+    }
 
 
 def current_signoff_ids(signoffs: list[MatterSignoff]) -> set[uuid.UUID]:

--- a/backend/tests/test_modules_api.py
+++ b/backend/tests/test_modules_api.py
@@ -312,6 +312,10 @@ async def test_response_shape_excludes_secrets_and_internals(client, db_session)
         "installed_by_user_id",
         "install_path",
         "track_record",
+        # M13 supervision legibility: median review latency + its n,
+        # both derived from audit rows at read time - not secrets.
+        "track_median_review_seconds",
+        "track_review_latency_n",
     }
     assert set(matching.keys()) == expected_keys
     # Never leaks the raw snapshots or signer internals.

--- a/backend/tests/test_signoff_api.py
+++ b/backend/tests/test_signoff_api.py
@@ -237,6 +237,16 @@ async def test_signoff_emits_output_signed_audit(client) -> None:
             .scalars()
             .all()
         )
+        # M13: the decision payload always carries the review-window
+        # fields. No open-event here → review_seconds None, no flag.
+        signed_row = await session.scalar(
+            select(AuditEntry).where(
+                AuditEntry.matter_id == matter.id,
+                AuditEntry.action == "output.signed",
+            )
+        )
+        assert signed_row.payload["review_seconds"] is None
+        assert signed_row.payload["implausible_speed"] is False
     assert "output.signed" in actions
 
 

--- a/backend/tests/test_supervision_legibility.py
+++ b/backend/tests/test_supervision_legibility.py
@@ -1,0 +1,376 @@
+"""Supervision made legible (M12+M13) — review latency, the
+implausible-speed flag, and the E2 per-signer diagnostic.
+
+Spec: docs/spec/SUPERVISION_LEGIBILITY_M13.md. The review window is the
+signer's first open of the sign surface (``output.review.opened``,
+idempotent) → the sign-off decision; latency is derived from the two
+audit rows at read time. The implausible-speed threshold lives in one
+constant with its rationale; a missing open-event reads as None ("—"),
+never 0.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, UTC
+
+import pytest
+from sqlalchemy import select
+
+from app.core.matter_artifacts import write_artifact
+from app.core.signoff import (
+    IMPLAUSIBLE_SPEED_FLOOR_SECONDS,
+    REVIEW_OPENED_ACTION,
+    count_payload_words,
+    implausible_speed_threshold_seconds,
+    review_latency_seconds,
+)
+from app.models import (
+    AuditEntry,
+    Matter,
+    PRIVILEGE_CLEARED,
+    STATUS_OPEN,
+    User,
+)
+
+
+@pytest.fixture(autouse=True)
+def _writable_matters_root(tmp_path, monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "matters_root", str(tmp_path), raising=False)
+
+
+# --- Unit: threshold + word count + latency derivation ----------------------
+
+
+def test_threshold_floor_applies_to_small_outputs() -> None:
+    # Below the floor the 0.15 s/word slope is irrelevant: tiny outputs
+    # never make a sub-2-minute signature "plausible".
+    assert implausible_speed_threshold_seconds(0) == IMPLAUSIBLE_SPEED_FLOOR_SECONDS
+    assert implausible_speed_threshold_seconds(100) == IMPLAUSIBLE_SPEED_FLOOR_SECONDS
+
+
+def test_threshold_scales_at_quarter_of_economics_baseline() -> None:
+    # 10 min / 1,000 words × 0.25 = 0.15 s/word. 4,000 words → 600s.
+    assert implausible_speed_threshold_seconds(4000) == pytest.approx(600.0)
+    # 1,000 words → 150s (above the 120s floor).
+    assert implausible_speed_threshold_seconds(1000) == pytest.approx(150.0)
+
+
+def test_count_payload_words_walks_strings_only() -> None:
+    payload = {
+        "output": "one two three",
+        "claims": [{"text": "four five"}, {"text": "six"}],
+        "n_tokens": 12345,  # numbers don't cost review time
+        "nested": {"deep": ["seven eight"]},
+    }
+    assert count_payload_words(payload) == 8
+
+
+def test_latency_none_for_missing_open_or_negative_delta() -> None:
+    now = datetime.now(UTC)
+    # Missing open-event (legacy sign-off): None — renders "—", never 0.
+    assert review_latency_seconds(None, now) is None
+    # Clock skew / backfill: a negative window is not a 0-second review.
+    assert review_latency_seconds(now + timedelta(seconds=5), now) is None
+    # The happy path is whole seconds.
+    assert review_latency_seconds(now - timedelta(seconds=94), now) == 94
+
+
+# --- API helpers -------------------------------------------------------------
+
+
+async def _register_and_login(client) -> str:
+    email = f"m13-{uuid.uuid4().hex[:8]}@example.com"
+    password = "supervision-legibility-2026"
+    await client.post("/auth/register", json={"email": email, "password": password})
+    await client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    return email
+
+
+async def _seed_matter_with_artifact(owner_email: str):
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        owner = await session.scalar(select(User).where(User.email == owner_email))
+        matter = Matter(
+            id=uuid.uuid4(),
+            slug=f"m13-{uuid.uuid4().hex[:8]}",
+            title="M13 Supervision Test",
+            matter_type="employment_tribunal",
+            status=STATUS_OPEN,
+            privilege_posture=PRIVILEGE_CLEARED,
+            default_model_id="stub-echo",
+            created_by_id=owner.id,
+        )
+        session.add(matter)
+        await session.flush()
+        artifact = await write_artifact(
+            session,
+            matter=matter,
+            capability_id="summarise",
+            module_id="demo.guided-skill",
+            invocation_id=uuid.uuid4(),
+            kind="skill_response",
+            payload={"output": "A plain-English summary.", "model_id": "stub-echo"},
+            actor_user_id=owner.id,
+        )
+        await session.commit()
+        return matter.slug, str(artifact.id), owner.id
+
+
+async def _open_row_count(artifact_id: str) -> int:
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        rows = (
+            await session.execute(
+                select(AuditEntry).where(
+                    AuditEntry.action == REVIEW_OPENED_ACTION,
+                    AuditEntry.resource_id == artifact_id,
+                )
+            )
+        ).scalars().all()
+        return len(rows)
+
+
+async def _backdate_open_row(artifact_id: str, owner_id, matter_slug: str, *, seconds_ago: int) -> None:
+    """Insert an open-event ``seconds_ago`` in the past.
+
+    Audit rows are WORM (no UPDATE), so a long review window is staged
+    by inserting the open row with an explicit historical timestamp.
+    """
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        matter = await session.scalar(select(Matter).where(Matter.slug == matter_slug))
+        session.add(
+            AuditEntry(
+                actor_id=owner_id,
+                matter_id=matter.id,
+                action=REVIEW_OPENED_ACTION,
+                module="demo.guided-skill",
+                resource_type="matter_artifact",
+                resource_id=artifact_id,
+                timestamp=datetime.now(UTC) - timedelta(seconds=seconds_ago),
+                payload={"artifact_id": artifact_id},
+            )
+        )
+        await session.commit()
+
+
+# --- The idempotent open row -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_open_idempotent_first_open_wins(client) -> None:
+    email = await _register_and_login(client)
+    slug, artifact_id, _ = await _seed_matter_with_artifact(email)
+
+    r1 = await client.post(
+        f"/api/matters/{slug}/signoffs/review-open",
+        json={"artifact_id": artifact_id},
+    )
+    assert r1.status_code == 200, r1.text
+    assert r1.json() == {"artifact_id": artifact_id, "recorded": True}
+
+    r2 = await client.post(
+        f"/api/matters/{slug}/signoffs/review-open",
+        json={"artifact_id": artifact_id},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["recorded"] is False
+
+    # Exactly one output.review.opened row — first open wins.
+    assert await _open_row_count(artifact_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_review_open_unknown_artifact_404(client) -> None:
+    email = await _register_and_login(client)
+    slug, _, _ = await _seed_matter_with_artifact(email)
+    resp = await client.post(
+        f"/api/matters/{slug}/signoffs/review-open",
+        json={"artifact_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404
+
+
+# --- Latency derivation + implausible flag on sign ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_fast_sign_after_open_is_flagged_implausible(client) -> None:
+    # Open then sign within the same breath: under the 120s floor for a
+    # tiny payload → implausible_speed True, recorded on the audit
+    # payload AND surfaced on the API read. Recorded, not blocked.
+    email = await _register_and_login(client)
+    slug, artifact_id, _ = await _seed_matter_with_artifact(email)
+
+    await client.post(
+        f"/api/matters/{slug}/signoffs/review-open",
+        json={"artifact_id": artifact_id},
+    )
+    resp = await client.post(
+        f"/api/matters/{slug}/signoffs",
+        json={"artifact_id": artifact_id, "decision": "signed"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["review_seconds"] is not None
+    assert 0 <= body["review_seconds"] < IMPLAUSIBLE_SPEED_FLOOR_SECONDS
+    assert body["implausible_speed"] is True
+
+    # The flag + latency live on the output.signed audit payload.
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        row = await session.scalar(
+            select(AuditEntry).where(
+                AuditEntry.action == "output.signed",
+                AuditEntry.resource_id == body["id"],
+            )
+        )
+        assert row is not None
+        assert row.payload["implausible_speed"] is True
+        assert row.payload["review_seconds"] == body["review_seconds"]
+
+    # GET /{id} (the confirmation page's read) carries the same fields.
+    one = await client.get(f"/api/matters/{slug}/signoffs/{body['id']}")
+    assert one.status_code == 200
+    assert one.json()["implausible_speed"] is True
+    assert one.json()["review_seconds"] == body["review_seconds"]
+
+
+@pytest.mark.asyncio
+async def test_unhurried_sign_is_not_flagged(client) -> None:
+    email = await _register_and_login(client)
+    slug, artifact_id, owner_id = await _seed_matter_with_artifact(email)
+    await _backdate_open_row(artifact_id, owner_id, slug, seconds_ago=15 * 60)
+
+    resp = await client.post(
+        f"/api/matters/{slug}/signoffs",
+        json={"artifact_id": artifact_id, "decision": "signed"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    # ~15 minutes of review, derived from the backdated open row.
+    assert body["review_seconds"] >= 14 * 60
+    assert body["implausible_speed"] is False
+
+
+@pytest.mark.asyncio
+async def test_missing_open_event_yields_null_latency_and_no_flag(client) -> None:
+    # Legacy path: sign without ever opening the sign surface. Latency
+    # is None (renders "—", never 0) and nothing is accused.
+    email = await _register_and_login(client)
+    slug, artifact_id, _ = await _seed_matter_with_artifact(email)
+
+    resp = await client.post(
+        f"/api/matters/{slug}/signoffs",
+        json={"artifact_id": artifact_id, "decision": "signed"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["review_seconds"] is None
+    assert resp.json()["implausible_speed"] is False
+
+    listing = await client.get(f"/api/matters/{slug}/signoffs")
+    row = listing.json()["signoffs"][0]
+    assert row["review_seconds"] is None
+    assert row["implausible_speed"] is False
+
+
+@pytest.mark.asyncio
+async def test_listing_derives_latency_from_the_two_audit_rows(client) -> None:
+    email = await _register_and_login(client)
+    slug, artifact_id, owner_id = await _seed_matter_with_artifact(email)
+    await _backdate_open_row(artifact_id, owner_id, slug, seconds_ago=10 * 60)
+
+    await client.post(
+        f"/api/matters/{slug}/signoffs",
+        json={"artifact_id": artifact_id, "decision": "rejected", "reasoning": "No."},
+    )
+    listing = await client.get(f"/api/matters/{slug}/signoffs")
+    row = listing.json()["signoffs"][0]
+    assert row["review_seconds"] is not None
+    assert row["review_seconds"] >= 9 * 60
+
+
+# --- E2: the per-signer supervision diagnostic --------------------------------
+
+
+async def _promote_superuser(email: str) -> None:
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        u = await session.scalar(select(User).where(User.email == email))
+        u.is_superuser = True
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_supervision_diagnostic_requires_superuser(client) -> None:
+    await _register_and_login(client)
+    resp = await client.get("/api/admin/audit/supervision")
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["error"] == "admin_required"
+
+
+@pytest.mark.asyncio
+async def test_supervision_diagnostic_reports_per_signer_rates(client) -> None:
+    email = await _register_and_login(client)
+    slug, a1, owner_id = await _seed_matter_with_artifact(email)
+    _, a2, _ = await _seed_matter_with_artifact(email)  # second matter+artifact
+
+    # One unhurried sign, one quick rejection — both with open rows.
+    await _backdate_open_row(a1, owner_id, slug, seconds_ago=12 * 60)
+    await client.post(
+        f"/api/matters/{slug}/signoffs",
+        json={"artifact_id": a1, "decision": "signed"},
+    )
+    # Find the second matter's slug from the seeded artifact.
+    from app.main import app
+    from app.models import MatterArtifact
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        artifact2 = await session.scalar(
+            select(MatterArtifact).where(MatterArtifact.id == uuid.UUID(a2))
+        )
+        matter2 = await session.scalar(
+            select(Matter).where(Matter.id == artifact2.matter_id)
+        )
+        slug2 = matter2.slug
+    await client.post(
+        f"/api/matters/{slug2}/signoffs/review-open", json={"artifact_id": a2}
+    )
+    await client.post(
+        f"/api/matters/{slug2}/signoffs",
+        json={"artifact_id": a2, "decision": "rejected", "reasoning": "Not sound."},
+    )
+
+    await _promote_superuser(email)
+    resp = await client.get("/api/admin/audit/supervision")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["healthy_band"] == [0.02, 0.30]
+
+    row = next(r for r in body["signers"] if r["signer_email"] == email)
+    assert row["signed"] == 1
+    assert row["rejected"] == 1
+    assert row["total"] == 2
+    assert row["scrutiny_rate"] == pytest.approx(0.5)
+    # Both decisions have derivable windows; the median is real.
+    assert row["latency_n"] == 2
+    assert row["median_review_seconds"] is not None
+    assert row["median_review_seconds"] > 0

--- a/frontend/src/admin/AdminAuditView.test.tsx
+++ b/frontend/src/admin/AdminAuditView.test.tsx
@@ -54,6 +54,12 @@ function spyAdminMe() {
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  // E2 supervision diagnostic loads alongside the record; default to
+  // empty (the section hides itself) unless a test overrides it.
+  vi.spyOn(api, "getAdminSupervision").mockResolvedValue({
+    signers: [],
+    healthy_band: [0.02, 0.3],
+  });
   globalThis.fetch = vi.fn(() =>
     Promise.resolve(
       new Response(
@@ -153,6 +159,41 @@ describe("AdminAuditView — superuser", () => {
     expect(ab.disabled).toBe(true);
     // Tooltip names the substrate constraint.
     expect(sm.getAttribute("title")).toMatch(/matter-bound by substrate/);
+  });
+
+  it("renders the E2 supervision diagnostic table per signer", async () => {
+    spyAdminMe();
+    vi.spyOn(api, "getAdminReconstruction").mockResolvedValue({
+      entries: [],
+      next_cursor: null,
+      total_in_window_estimate: 0,
+    });
+    vi.spyOn(api, "getAdminSupervision").mockResolvedValue({
+      signers: [
+        {
+          signer_id: "u-1",
+          signer_email: "solicitor@example.com",
+          signed: 9,
+          signed_with_observations: 1,
+          rejected: 0,
+          total: 10,
+          scrutiny_rate: 0.1,
+          median_review_seconds: 840,
+          latency_n: 10,
+        },
+      ],
+      healthy_band: [0.02, 0.3],
+    });
+
+    mountAt("/admin/audit");
+    await waitFor(() => {
+      expect(screen.getByTestId("supervision-diagnostic")).toBeInTheDocument();
+    });
+    const row = screen.getByTestId("supervision-row-u-1");
+    expect(row).toHaveTextContent("solicitor@example.com");
+    expect(row).toHaveTextContent("10%"); // scrutiny rate in the healthy band
+    expect(row).toHaveTextContent("14 minutes");
+    expect(row).toHaveTextContent("n=10");
   });
 
   it("substrate 403 → renders Admin required shell", async () => {

--- a/frontend/src/admin/AdminAuditView.tsx
+++ b/frontend/src/admin/AdminAuditView.tsx
@@ -23,8 +23,11 @@ import { useCallback, useEffect, useState } from "react";
 import {
   ALL_RECONSTRUCTION_SOURCES,
   AdminRequiredError,
+  formatReviewDuration,
   getAdminReconstruction,
+  getAdminSupervision,
   type ReconstructionSource,
+  type SupervisionResponse,
   type TimelineEntry,
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
@@ -70,6 +73,7 @@ export function AdminAuditView() {
   // disabled.
   const [sources, setSources] = useState<ReconstructionSource[]>(["audit"]);
   const [fetchState, setFetchState] = useState<FetchState>({ status: "loading" });
+  const [supervision, setSupervision] = useState<SupervisionResponse | null>(null);
 
   const loadPage = useCallback(
     async (cursor: string | null) => {
@@ -123,6 +127,19 @@ export function AdminAuditView() {
     void loadPage(null);
   }, [auth.loading, auth.user, loadPage]);
 
+  // E2 supervision diagnostic — loaded once per visit; quietly absent
+  // on failure (the record below is the primary surface).
+  useEffect(() => {
+    if (auth.loading || !auth.user || !auth.user.is_superuser) return;
+    let cancelled = false;
+    getAdminSupervision()
+      .then((s) => !cancelled && setSupervision(s))
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.loading, auth.user]);
+
   if (!auth.loading && auth.user && !auth.user.is_superuser) {
     return <AdminRequiredShell />;
   }
@@ -138,6 +155,72 @@ export function AdminAuditView() {
         whisper="The workspace record"
         description="What the workspace did when no matter was before it — admission ceremonies, settings key operations, role changes, and the viewing of this very page. Entries bound to a matter live with the matter; nothing renders here that the audit chain does not hold."
       />
+
+      {/* E2 — supervision per signer (M13): rejection + observations
+          rate and median review latency, from existing audit rows.
+          The rubber-stamp detector the economics analysis specifies. */}
+      {supervision !== null &&
+        Array.isArray(supervision.signers) &&
+        supervision.signers.length > 0 && (
+        <section className="mb-10" data-testid="supervision-diagnostic">
+          <SectionRule
+            label="Supervision"
+            right={`${supervision.signers.length} signer${
+              supervision.signers.length === 1 ? "" : "s"
+            }`}
+          />
+          <table className="mt-4 w-full border-collapse text-left text-xs">
+            <thead>
+              <tr className="border-b border-rule text-[10px] uppercase tracking-[0.18em] text-muted">
+                <th className="py-2 pr-3 font-normal">Signer</th>
+                <th className="py-2 pr-3 font-normal">Signed</th>
+                <th className="py-2 pr-3 font-normal">Observations</th>
+                <th className="py-2 pr-3 font-normal">Refused</th>
+                <th className="py-2 pr-3 font-normal">Scrutiny rate</th>
+                <th className="py-2 font-normal">Median review</th>
+              </tr>
+            </thead>
+            <tbody>
+              {supervision.signers.map((s) => {
+                const [lo, hi] = supervision.healthy_band ?? [0.02, 0.3];
+                const outOfBand =
+                  s.total > 0 && (s.scrutiny_rate < lo || s.scrutiny_rate > hi);
+                return (
+                  <tr
+                    key={s.signer_id}
+                    className="border-b border-rule/60"
+                    data-testid={`supervision-row-${s.signer_id}`}
+                  >
+                    <td className="py-2 pr-3 text-ink">
+                      {s.signer_email ?? s.signer_id}
+                    </td>
+                    <td className="py-2 pr-3">{s.signed}</td>
+                    <td className="py-2 pr-3">{s.signed_with_observations}</td>
+                    <td className={"py-2 pr-3" + (s.rejected > 0 ? " text-seal" : "")}>
+                      {s.rejected}
+                    </td>
+                    <td className={"py-2 pr-3" + (outOfBand ? " text-seal" : " text-ink")}>
+                      {Math.round(s.scrutiny_rate * 100)}%
+                    </td>
+                    <td className="py-2">
+                      {s.median_review_seconds === null
+                        ? "—"
+                        : formatReviewDuration(s.median_review_seconds)}{" "}
+                      <span className="text-muted">· n={s.latency_n}</span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <p className="mt-2 text-[11px] text-muted">
+            Scrutiny rate = (refused + with observations) / total. The economics
+            analysis names 2–30% as the healthy band; 0% over a real n reads as
+            rubber-stamping. Latency is evidence of attention, not proof of
+            quality. “—” = no review window on record.
+          </p>
+        </section>
+      )}
 
       <SectionRule
         label="The record"

--- a/frontend/src/lib/api/audit.ts
+++ b/frontend/src/lib/api/audit.ts
@@ -79,6 +79,31 @@ export const getAdminReconstruction = (
   ).then((r) => jsonOrThrow<ReconstructionResponse>(r));
 };
 
+// E2 supervision diagnostic (M13): per-signer decision counts,
+// scrutiny rate and median review latency, derived from audit rows
+// (the rubber-stamp detector). Superuser-only.
+export interface SupervisionSignerRow {
+  signer_id: string;
+  signer_email: string | null;
+  signed: number;
+  signed_with_observations: number;
+  rejected: number;
+  total: number;
+  scrutiny_rate: number;
+  median_review_seconds: number | null;
+  latency_n: number;
+}
+
+export interface SupervisionResponse {
+  signers: SupervisionSignerRow[];
+  healthy_band: [number, number];
+}
+
+export const getAdminSupervision = (): Promise<SupervisionResponse> =>
+  apiFetch(`${API}/admin/audit/supervision`).then((r) =>
+    jsonOrThrow<SupervisionResponse>(r),
+  );
+
 export const getReconstruction = (
   slug: string,
   opts: ReconstructionOptions = {},

--- a/frontend/src/lib/api/modules.ts
+++ b/frontend/src/lib/api/modules.ts
@@ -145,6 +145,11 @@ export interface InstalledModule {
   installed_by_user_id: string | null;
   install_path?: string | null;
   track_record?: Record<string, number>;
+  // Median review latency (seconds) over sign-offs with a derivable
+  // review window (M13); null when none — render "—", never 0.
+  track_median_review_seconds?: number | null;
+  // How many decisions the median is over (sub-n=30 gets the honesty label).
+  track_review_latency_n?: number;
 }
 
 export const listInstalledModules = () =>

--- a/frontend/src/lib/api/signoffs.ts
+++ b/frontend/src/lib/api/signoffs.ts
@@ -76,7 +76,36 @@ export interface Signoff {
   signer_is_author: boolean;
   signed_at: string;
   is_current: boolean;
+  // Review window (M13): seconds between the signer's first open of the
+  // sign surface and the decision. null = no open-event (legacy) —
+  // render "—", never 0.
+  review_seconds: number | null;
+  // Recorded at sign time against the artifact's word count. Recorded,
+  // not blocked — surfaces show a seal-toned "signed in 94s" note.
+  implausible_speed: boolean;
 }
+
+// Plain-English review duration. null/undefined renders "—" (a missing
+// open-event is not a 0-second review).
+export function formatReviewDuration(
+  seconds: number | null | undefined,
+): string {
+  if (seconds === null || seconds === undefined) return "—";
+  if (seconds < 120) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 120) return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  const hours = Math.round((minutes / 60) * 10) / 10;
+  return `${hours} hours`;
+}
+
+// Record the first open of an artifact's sign surface (starts the
+// review window; idempotent server-side — first open wins).
+export const openSignoffReview = (slug: string, artifactId: string) =>
+  apiFetch(`${API}/matters/${encodeURIComponent(slug)}/signoffs/review-open`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ artifact_id: artifactId }),
+  }).then((r) => jsonOrThrow<{ artifact_id: string; recorded: boolean }>(r));
 
 export const createSignoff = (
   slug: string,

--- a/frontend/src/matter/ArtifactDetail.test.tsx
+++ b/frontend/src/matter/ArtifactDetail.test.tsx
@@ -133,6 +133,8 @@ describe("ArtifactDetail", () => {
           signer_is_author: true,
           signed_at: "2026-05-29T13:00:00",
           is_current: true,
+          review_seconds: 600,
+          implausible_speed: false,
         },
       ],
     });

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import {
+  formatReviewDuration,
   listSignoffs,
   readArtifact,
   requestReview,
@@ -199,6 +200,15 @@ export function ArtifactDetail({
             {signoff.signer_is_author && " (author)"} · {signoff.signed_at.slice(0, 10)}
           </p>
         )}
+        {/* M13: the implausible-speed marker rides wherever the
+            signature renders. Recorded, not blocked. */}
+        {signoff != null &&
+          signoff.implausible_speed &&
+          signoff.review_seconds !== null && (
+            <p className="mt-1 text-[11px] text-seal" data-testid="signoff-implausible-speed">
+              signed in {formatReviewDuration(signoff.review_seconds)}
+            </p>
+          )}
         <div className="mt-3 flex flex-wrap items-center gap-4 text-sm">
           <Link
             to="/matters/$slug/artifacts/$artifactId/sign"

--- a/frontend/src/matter/ArtifactsList.test.tsx
+++ b/frontend/src/matter/ArtifactsList.test.tsx
@@ -116,6 +116,8 @@ describe("ArtifactsList", () => {
           signer_is_author: true,
           signed_at: "2026-05-29T13:00:00",
           is_current: true,
+          review_seconds: 600,
+          implausible_speed: false,
         },
       ],
     });

--- a/frontend/src/matter/SignOff.test.tsx
+++ b/frontend/src/matter/SignOff.test.tsx
@@ -60,10 +60,20 @@ const ARTIFACT = {
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.spyOn(api, "readArtifact").mockResolvedValue(ARTIFACT as never);
+  vi.spyOn(api, "openSignoffReview").mockResolvedValue({
+    artifact_id: "art-1",
+    recorded: true,
+  });
 });
 afterEach(() => cleanup());
 
 describe("SignOff", () => {
+  it("records the review-window open when the artifact loads (M13)", async () => {
+    mountSign();
+    await waitFor(() => expect(screen.getByTestId("signoff-artifact")).toBeInTheDocument());
+    expect(api.openSignoffReview).toHaveBeenCalledWith("khan", "art-1");
+  });
+
   it("gates submit on the affirmation, then signs and navigates", async () => {
     const createSignoff = vi
       .spyOn(api, "createSignoff")

--- a/frontend/src/matter/SignOff.tsx
+++ b/frontend/src/matter/SignOff.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import {
   createSignoff,
+  openSignoffReview,
   readArtifact,
   type ArtifactRead,
   type SignoffDecision,
@@ -125,7 +126,14 @@ export function SignOff({ slug, artifactId }: { slug: string; artifactId: string
   useEffect(() => {
     let cancelled = false;
     readArtifact(slug, artifactId)
-      .then((a) => !cancelled && setArtifact(a))
+      .then((a) => {
+        if (cancelled) return;
+        setArtifact(a);
+        // M13: opening the sign surface starts the review window
+        // (output.review.opened, idempotent — first open wins).
+        // Fire-and-forget: a failed open never blocks the review.
+        openSignoffReview(slug, artifactId).catch(() => undefined);
+      })
       .catch((err: unknown) => !cancelled && setLoadErr(String(err)));
     return () => {
       cancelled = true;

--- a/frontend/src/matter/SignOffConfirmation.test.tsx
+++ b/frontend/src/matter/SignOffConfirmation.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Sign-off confirmation — review-window labels (M13).
+ *
+ * The confirmation states the review duration plainly on the happy
+ * path, renders "—" (never 0) when no open-event exists, and carries
+ * the seal-toned implausible-speed note when flagged.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+
+import { SignOffConfirmation } from "./SignOffConfirmation";
+import * as api from "../lib/api";
+
+function mountConfirmation() {
+  const root = createRootRoute({ component: () => <Outlet /> });
+  const confirmRoute = createRoute({
+    getParentRoute: () => root,
+    path: "/matters/$slug/signoffs/$signoffId",
+    component: () => <SignOffConfirmation slug="khan" signoffId="so-1" />,
+  });
+  const detailStub = createRoute({
+    getParentRoute: () => root,
+    path: "/matters/$slug/artifacts/$artifactId",
+    component: () => <div data-testid="detail-stub" />,
+  });
+  const auditStub = createRoute({
+    getParentRoute: () => root,
+    path: "/matters/$slug/audit",
+    component: () => <div data-testid="audit-stub" />,
+  });
+  const router = createRouter({
+    routeTree: root.addChildren([confirmRoute, detailStub, auditStub]),
+    history: createMemoryHistory({
+      initialEntries: ["/matters/khan/signoffs/so-1"],
+    }),
+  });
+  return render(<RouterProvider router={router} />);
+}
+
+const SIGNOFF: api.Signoff = {
+  id: "so-1",
+  matter_id: "m-1",
+  artifact_id: "art-1",
+  invocation_id: "inv-1",
+  module_id: "demo.guided-skill",
+  capability_id: "summarise",
+  kind: "skill_response",
+  artifact_hash: "a".repeat(64),
+  decision: "signed",
+  reasoning: null,
+  signer_id: "u-1",
+  signer_email: "solicitor@example.com",
+  signer_is_author: false,
+  signed_at: "2026-06-12T10:30:00+00:00",
+  is_current: true,
+  review_seconds: 840,
+  implausible_speed: false,
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(() => cleanup());
+
+describe("SignOffConfirmation review labels", () => {
+  it("states the review duration plainly on the happy path", async () => {
+    vi.spyOn(api, "getSignoff").mockResolvedValue(SIGNOFF);
+    mountConfirmation();
+    await waitFor(() =>
+      expect(screen.getByTestId("signoff-record")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("signoff-review-duration")).toHaveTextContent(
+      "14 minutes",
+    );
+    expect(screen.getByTestId("signoff-reviewed-line")).toHaveTextContent(
+      "Reviewed for 14 minutes.",
+    );
+    // No judgement on the happy path.
+    expect(
+      screen.queryByTestId("signoff-implausible-speed"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an em-dash, never 0, when no open-event exists", async () => {
+    vi.spyOn(api, "getSignoff").mockResolvedValue({
+      ...SIGNOFF,
+      review_seconds: null,
+    });
+    mountConfirmation();
+    await waitFor(() =>
+      expect(screen.getByTestId("signoff-record")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("signoff-review-duration")).toHaveTextContent("—");
+    expect(screen.queryByTestId("signoff-reviewed-line")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("signoff-implausible-speed"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("carries the seal-toned note for an implausibly fast signature", async () => {
+    vi.spyOn(api, "getSignoff").mockResolvedValue({
+      ...SIGNOFF,
+      review_seconds: 94,
+      implausible_speed: true,
+    });
+    mountConfirmation();
+    await waitFor(() =>
+      expect(screen.getByTestId("signoff-record")).toBeInTheDocument(),
+    );
+    const note = screen.getByTestId("signoff-implausible-speed");
+    expect(note).toHaveTextContent("Signed in 94s");
+    expect(note.className).toContain("text-seal");
+    expect(screen.queryByTestId("signoff-reviewed-line")).not.toBeInTheDocument();
+  });
+});
+
+describe("formatReviewDuration", () => {
+  it("renders seconds below two minutes, minutes after, dash for missing", () => {
+    expect(api.formatReviewDuration(null)).toBe("—");
+    expect(api.formatReviewDuration(undefined)).toBe("—");
+    expect(api.formatReviewDuration(0)).toBe("0s");
+    expect(api.formatReviewDuration(94)).toBe("94s");
+    expect(api.formatReviewDuration(840)).toBe("14 minutes");
+    expect(api.formatReviewDuration(60 * 60 * 3)).toBe("3 hours");
+  });
+});

--- a/frontend/src/matter/SignOffConfirmation.tsx
+++ b/frontend/src/matter/SignOffConfirmation.tsx
@@ -11,7 +11,7 @@
 
 import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { getSignoff, type Signoff } from "../lib/api";
+import { formatReviewDuration, getSignoff, type Signoff } from "../lib/api";
 import { ErrorCallout, LoadingLine } from "../ui/primitives";
 import { CertCard, CertEyebrow, LedgerRow } from "../ui/certificate";
 
@@ -89,7 +89,26 @@ export function SignOffConfirmation({
               {signoff.kind} · {signoff.module_id} / {signoff.capability_id}
             </span>
           </LedgerRow>
+          {/* The review window, stated plainly (M13). "—" = no
+              open-event on record (legacy sign-off), never 0. */}
+          <LedgerRow label="Reviewed" tone={signoff.implausible_speed ? "seal" : undefined}>
+            <span data-testid="signoff-review-duration">
+              {formatReviewDuration(signoff.review_seconds)}
+            </span>
+          </LedgerRow>
         </dl>
+
+        {signoff.review_seconds !== null && !signoff.implausible_speed && (
+          <p className="mt-2 text-[11px] text-muted" data-testid="signoff-reviewed-line">
+            Reviewed for {formatReviewDuration(signoff.review_seconds)}.
+          </p>
+        )}
+        {signoff.implausible_speed && signoff.review_seconds !== null && (
+          <p className="mt-2 text-[11px] text-seal" data-testid="signoff-implausible-speed">
+            Signed in {formatReviewDuration(signoff.review_seconds)} — faster than a
+            plausible read of this output. Recorded, not blocked.
+          </p>
+        )}
 
         {(signoff.signer_is_author || !signoff.is_current) && (
           <p className="mt-2 text-[11px] text-muted">

--- a/frontend/src/modules-v2/CounselRegister.test.tsx
+++ b/frontend/src/modules-v2/CounselRegister.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Counsel Register — track-record block (M13 extension).
+ *
+ * The per-skill track record adds median review latency and the n,
+ * with the sub-n=30 honesty label. "—" for no derivable window.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { TrackRecord } from "./CounselRegister";
+
+afterEach(() => cleanup());
+
+describe("TrackRecord", () => {
+  it("shows median latency with the honesty label under n=30", () => {
+    render(
+      <TrackRecord
+        record={{ signed: 3, rejected: 1 }}
+        medianReviewSeconds={240}
+        latencyN={4}
+      />,
+    );
+    const latency = screen.getByTestId("track-record-latency");
+    expect(latency).toHaveTextContent("median review 4 minutes");
+    expect(latency).toHaveTextContent("n=4");
+    expect(screen.getByTestId("track-record-low-n")).toHaveTextContent(
+      "too few to mean much",
+    );
+  });
+
+  it("drops the honesty label at n=30 and above", () => {
+    render(
+      <TrackRecord
+        record={{ signed: 28, rejected: 2 }}
+        medianReviewSeconds={600}
+        latencyN={30}
+      />,
+    );
+    expect(screen.getByTestId("track-record-latency")).toHaveTextContent("n=30");
+    expect(screen.queryByTestId("track-record-low-n")).not.toBeInTheDocument();
+  });
+
+  it("renders an em-dash, never 0, when no review window is derivable", () => {
+    render(
+      <TrackRecord record={{ signed: 2 }} medianReviewSeconds={null} latencyN={0} />,
+    );
+    expect(screen.getByTestId("track-record-latency")).toHaveTextContent(
+      "median review —",
+    );
+  });
+
+  it("keeps the empty state when nothing is signed", () => {
+    render(<TrackRecord record={{}} />);
+    expect(screen.queryByTestId("track-record-latency")).not.toBeInTheDocument();
+    expect(screen.getByText(/No supervised work signed yet/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/modules-v2/CounselRegister.tsx
+++ b/frontend/src/modules-v2/CounselRegister.tsx
@@ -15,7 +15,11 @@
 
 import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { listInstalledModules, type InstalledModule } from "../lib/api";
+import {
+  formatReviewDuration,
+  listInstalledModules,
+  type InstalledModule,
+} from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
 
 const TIERS = [
@@ -211,7 +215,11 @@ function Certificate({ row, index }: { row: InstalledModule; index: number }) {
         </span>
       </div>
 
-      <TrackRecord record={row.track_record ?? {}} />
+      <TrackRecord
+        record={row.track_record ?? {}}
+        medianReviewSeconds={row.track_median_review_seconds ?? null}
+        latencyN={row.track_review_latency_n ?? 0}
+      />
 
       <dl className="mt-3 space-y-1 text-[11px] text-muted">
         <div className="flex justify-between gap-3">
@@ -270,7 +278,20 @@ function Certificate({ row, index }: { row: InstalledModule; index: number }) {
 // under supervision, from the sign-off table: approvals and refusals
 // recorded with the same fidelity. The moat is the venue's, not the
 // model's.
-function TrackRecord({ record }: { record: Record<string, number> }) {
+// A track record with fewer than this many decisions carries the
+// honesty label — sub-n=30 medians are anecdotes, not statistics
+// (docs/spec/SUPERVISION_LEGIBILITY_M13.md).
+const TRACK_RECORD_HONEST_N = 30;
+
+export function TrackRecord({
+  record,
+  medianReviewSeconds = null,
+  latencyN = 0,
+}: {
+  record: Record<string, number>;
+  medianReviewSeconds?: number | null;
+  latencyN?: number;
+}) {
   const signed = record.signed ?? 0;
   const observations = record.signed_with_observations ?? 0;
   const refused = record.rejected ?? 0;
@@ -285,16 +306,30 @@ function TrackRecord({ record }: { record: Record<string, number> }) {
           No supervised work signed yet.
         </p>
       ) : (
-        <p className="mt-1 text-[11px] text-ink">
-          {signed} signed
-          {observations > 0 && <> · {observations} with observations</>}
-          {refused > 0 && (
-            <>
-              {" · "}
-              <span className="text-seal">{refused} refused</span>
-            </>
-          )}
-        </p>
+        <>
+          <p className="mt-1 text-[11px] text-ink">
+            {signed} signed
+            {observations > 0 && <> · {observations} with observations</>}
+            {refused > 0 && (
+              <>
+                {" · "}
+                <span className="text-seal">{refused} refused</span>
+              </>
+            )}
+          </p>
+          {/* Median review latency — evidence of attention, not proof
+              of quality. "—" = no derivable review window yet. */}
+          <p className="mt-1 text-[11px] text-muted" data-testid="track-record-latency">
+            median review{" "}
+            {medianReviewSeconds === null
+              ? "—"
+              : formatReviewDuration(medianReviewSeconds)}{" "}
+            · n={latencyN}
+            {latencyN < TRACK_RECORD_HONEST_N && (
+              <span data-testid="track-record-low-n"> — too few to mean much</span>
+            )}
+          </p>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
Builds [docs/spec/SUPERVISION_LEGIBILITY_M13.md](https://github.com/b1rdmania/legalise/blob/master/docs/spec/SUPERVISION_LEGIBILITY_M13.md) exactly as merged in #218. Closes diligence gates G-A3/G-A4 — review effort was recorded but invisible, so shallow signing privately dominated. The fix is legibility, not enforcement.

## Data

- **`output.review.opened`** audit row, idempotent per signer+artifact (first open wins), written via `POST /api/matters/{slug}/signoffs/review-open` when the sign surface loads its artifact. Review latency = that row → the sign-off's `signed_at`, derived from the two audit rows at read time (`review_annotations` in `core/signoff.py`). No new tables.
- **Threshold in one constant with the rationale** (`core/signoff.py`): `max(120s, words × 0.15s)` — one quarter of the economics baseline (~10 min/1,000 words), generous to skim-and-reject, suspicious of skim-and-sign. Word count walks string values of the payload only.

## Surfaces

1. **Sign-off confirmation** states the duration plainly ("Reviewed for 14 minutes."). No judgement on the happy path.
2. **Implausible-speed flag**: under-threshold sign-offs carry `implausible_speed: true` + `review_seconds` in the `output.*` audit payload, and a seal-toned "Signed in 94s" note on the confirmation record and artifact detail. Recorded, not blocked.
3. **Track record** (Counsel Register, extends #182): median review latency + n; sub-n=30 rows carry "— too few to mean much". Demo's seeded records keep their existing label (untouched).
4. **E2 diagnostic** on `/admin/audit` (`GET /api/admin/audit/supervision`, superuser-only): per-signer signed / observations / refused counts, scrutiny rate against the 2–30% healthy band, and median review latency with its n — the rubber-stamp detector, a plain table from existing audit rows.

## Honesty rules

- Missing open-event (legacy sign-offs) renders "—", never 0; negative deltas (clock skew) also refuse to pretend.
- Copy says latency is evidence of attention, not proof of quality.

## Tests

- `backend/tests/test_supervision_legibility.py`: threshold floor + scaling, word count, latency derivation (None/negative/happy), idempotent open-row, fast-sign flagged / unhurried not / legacy null, E2 superuser gate + per-signer rates. `test_signoff_api.py` extended (payload carries the fields); `test_modules_api.py` shape updated.
- Frontend: confirmation label rendering ("Reviewed for…", "—", seal note), track-record median + honesty label, E2 table render, review-open fired on sign-surface load.
- Backend suite: **812 passed**, 3 failed = the known macOS sandbox baseline (`test_sandbox.py` preexec_fn/rlimits). Frontend: tsc clean, **315 vitest passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)