### PR TITLE
Demand instrumentation: waitlist capture and the launch funnel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,8 @@ For:
 - Coverage gaps — modules you'd want to see in v0.2+.
 - Corrections — links to authority that says the plan is wrong.
 
+Entirely optional: add one of the `provenance:practitioner` / `provenance:builder` / `provenance:firm` labels to say where you're coming from — it helps us see whose problems we're actually solving.
+
 ## Code of conduct
 
 Be civil. Disagree with reasoning, not people.

--- a/backend/alembic/versions/0034_demand_capture.py
+++ b/backend/alembic/versions/0034_demand_capture.py
@@ -1,0 +1,36 @@
+"""Gate 4 demand capture columns on users.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-06-12
+
+Launch instrumentation: optional self-reported persona + signup channel
+tag, and the server-derived email domain + class (firm-like vs generic
+mail provider). All nullable — pre-instrumentation rows read as
+"unknown" in the launch funnel. See app/core/demand_capture.py.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0034"
+down_revision = "0033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("persona", sa.String(32), nullable=True))
+    op.add_column("users", sa.Column("signup_channel", sa.String(16), nullable=True))
+    op.add_column("users", sa.Column("email_domain", sa.String(255), nullable=True))
+    op.add_column("users", sa.Column("domain_class", sa.String(16), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "domain_class")
+    op.drop_column("users", "email_domain")
+    op.drop_column("users", "signup_channel")
+    op.drop_column("users", "persona")

--- a/backend/app/api/admin_launch_funnel.py
+++ b/backend/app/api/admin_launch_funnel.py
@@ -1,0 +1,155 @@
+"""Launch funnel — the 90-day falsifier dashboard (Gate 4).
+
+Single operator-facing endpoint:
+
+  GET /api/admin/launch-funnel
+
+Superuser-only, JSON-only by design — this is an operator tool, not a
+product surface. It answers, day-1 queryable, the questions the launch
+must produce evidence for:
+
+1. Who signed up — counts by persona, email-domain class, and channel
+   tag. The locked-out ``demo@legalise.dev`` seed row is excluded.
+2. Did anyone complete the golden loop — matters created and outputs
+   signed by real (non-seed) users. The auto-seeded Khan sample copy
+   every new user receives is excluded from "matters created" (it says
+   nothing about demand); sign-offs ON the Khan copy ARE counted — a
+   real person signing the sample is exactly the loop we want evidence
+   of, and the split is reported separately.
+3. Practitioner-labelled GitHub issues — NOT queryable from here (the
+   server holds no GitHub token; adding one for a vanity count would be
+   the wrong trade). The payload says so and names the manual command.
+
+Buckets are exhaustive: rows with NULL capture fields land in
+``unspecified`` / ``unknown`` / ``untagged`` rather than vanishing, so
+the by-* maps always sum to the total. No vanity normalisation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_user
+from app.core.db import get_session
+from app.core.seed import DEMO_USER_EMAIL, KHAN_SLUG
+from app.models import Matter, User
+from app.models.matter_signoff import SIGNOFF_AFFIRMATIVE, MatterSignoff
+
+
+router = APIRouter()
+
+
+def _require_superuser(caller: User) -> None:
+    if not caller.is_superuser:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "admin_required"},
+        )
+
+
+def _bucket(rows: list[tuple[str | None, int]], null_label: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for value, count in rows:
+        out[value if value else null_label] = count
+    return out
+
+
+@router.get("/launch-funnel")
+async def launch_funnel_endpoint(
+    session: AsyncSession = Depends(get_session),
+    caller: User = Depends(current_user),
+) -> dict:
+    _require_superuser(caller)
+
+    # --- Signups (seed demo row excluded) --------------------------------
+    not_seed = User.email != DEMO_USER_EMAIL
+
+    total = await session.scalar(select(func.count(User.id)).where(not_seed)) or 0
+
+    async def grouped(column) -> list[tuple[str | None, int]]:
+        rows = await session.execute(
+            select(column, func.count(User.id)).where(not_seed).group_by(column)
+        )
+        return [(value, count) for value, count in rows.all()]
+
+    by_persona = _bucket(await grouped(User.persona), "unspecified")
+    by_domain_class = _bucket(await grouped(User.domain_class), "unknown")
+    by_channel = _bucket(await grouped(User.signup_channel), "untagged")
+
+    # --- Golden loop (non-seed users) -------------------------------------
+    seed_user_id = await session.scalar(
+        select(User.id).where(User.email == DEMO_USER_EMAIL)
+    )
+
+    def exclude_seed_creator(stmt):
+        if seed_user_id is not None:
+            stmt = stmt.where(Matter.created_by_id != seed_user_id)
+        return stmt
+
+    # Matters a real user created themselves — the auto-seeded Khan copy
+    # (slug pinned by the seeder) is excluded.
+    own_matters_where = exclude_seed_creator(
+        select(func.count(Matter.id)).where(Matter.slug != KHAN_SLUG)
+    )
+    matters_created = await session.scalar(own_matters_where) or 0
+
+    matter_creators = await session.scalar(
+        exclude_seed_creator(
+            select(func.count(func.distinct(Matter.created_by_id))).where(
+                Matter.slug != KHAN_SLUG
+            )
+        )
+    ) or 0
+
+    affirmative = MatterSignoff.decision.in_(sorted(SIGNOFF_AFFIRMATIVE))
+    not_seed_signer = (
+        MatterSignoff.signer_id != seed_user_id
+        if seed_user_id is not None
+        else True
+    )
+
+    outputs_signed = await session.scalar(
+        select(func.count(MatterSignoff.id)).where(affirmative, not_seed_signer)
+    ) or 0
+    signers = await session.scalar(
+        select(func.count(func.distinct(MatterSignoff.signer_id))).where(
+            affirmative, not_seed_signer
+        )
+    ) or 0
+    # Of those, sign-offs on the seeded Khan sample (still real users
+    # completing the loop — reported as its own honest slice).
+    outputs_signed_on_sample = await session.scalar(
+        select(func.count(MatterSignoff.id))
+        .join(Matter, Matter.id == MatterSignoff.matter_id)
+        .where(affirmative, not_seed_signer, Matter.slug == KHAN_SLUG)
+    ) or 0
+
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "signups": {
+            "total": total,
+            "by_persona": by_persona,
+            "by_domain_class": by_domain_class,
+            "by_channel": by_channel,
+        },
+        "golden_loop": {
+            "matters_created": matters_created,
+            "users_who_created_a_matter": matter_creators,
+            "outputs_signed": outputs_signed,
+            "outputs_signed_on_seeded_sample": outputs_signed_on_sample,
+            "users_who_signed_an_output": signers,
+        },
+        "provenance_issues": {
+            "source": "manual",
+            "note": (
+                "Practitioner-labelled GitHub issues are counted manually — "
+                "the server holds no GitHub token. Run: gh issue list "
+                "--label provenance:practitioner (also provenance:builder, "
+                "provenance:firm)."
+            ),
+        },
+    }

--- a/backend/app/api/auth_schemas.py
+++ b/backend/app/api/auth_schemas.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import uuid
 
 from fastapi_users import schemas
+from pydantic import AliasChoices, Field, field_validator
+
+from app.core.demand_capture import normalise_channel, normalise_persona
 
 
 class UserRead(schemas.BaseUser[uuid.UUID]):
@@ -18,6 +21,27 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
 
 class UserCreate(schemas.BaseUserCreate):
     name: str = ""
+    # Gate 4 demand capture — both OPTIONAL, both allowlisted. Invalid
+    # values normalise to None rather than failing the signup; demand
+    # analytics never blocks registration. `channel` is the wire name
+    # (the frontend forwards the ?c= launch tag); it lands on the
+    # `signup_channel` column. email_domain/domain_class are deliberately
+    # NOT accepted here — they are derived server-side at registration.
+    persona: str | None = None
+    signup_channel: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("channel", "signup_channel"),
+    )
+
+    @field_validator("persona", mode="before")
+    @classmethod
+    def _persona_allowlist(cls, v: str | None) -> str | None:
+        return normalise_persona(v)
+
+    @field_validator("signup_channel", mode="before")
+    @classmethod
+    def _channel_allowlist(cls, v: str | None) -> str | None:
+        return normalise_channel(v)
 
 
 class UserUpdate(schemas.BaseUserUpdate):

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -61,6 +61,23 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     reset_password_token_secret = settings.session_secret
     verification_token_secret = settings.session_secret
 
+    async def create(self, user_create, safe: bool = False, request: Request | None = None) -> User:
+        """Gate 4 demand capture: derive email_domain + domain_class
+        SERVER-SIDE from the registered address (never client-supplied —
+        UserCreate does not expose these fields), then delegate to the
+        stock fastapi-users create. persona / signup_channel arrive
+        already allowlist-normalised by the UserCreate validators.
+        """
+        from app.core.demand_capture import classify_email_domain
+
+        user = await super().create(user_create, safe=safe, request=request)
+        domain, domain_class = classify_email_domain(user.email)
+        if domain is not None:
+            user = await self.user_db.update(
+                user, {"email_domain": domain, "domain_class": domain_class}
+            )
+        return user
+
     async def on_after_register(self, user: User, request: Request | None = None) -> None:
         # Never log raw email — PII.
         # user_id is the durable handle; admins join via the users table.

--- a/backend/app/core/demand_capture.py
+++ b/backend/app/core/demand_capture.py
@@ -1,0 +1,114 @@
+"""Demand-capture vocabulary + email-domain classification (Gate 4).
+
+Launch-day instrumentation: who is signing up, and through which
+channel. Three rules keep this honest:
+
+1. Everything self-reported is **optional** — persona and channel are
+   nullable; an invalid value is silently dropped, never a signup
+   blocker. No dark patterns, no required marketing fields.
+2. The only derived field is the email domain, computed **server-side**
+   from the address the user already gave us. We store the raw domain
+   plus a coarse class (firm-like vs generic mail provider). The class
+   is a heuristic allowlist of consumer providers, nothing cleverer —
+   "firm-like" means "not a known generic mailbox", not "verified firm".
+3. Channel tags are a tiny locked vocabulary (`?c=hn|li|x|conf`), so the
+   funnel query is a GROUP BY, not a parsing exercise.
+"""
+
+from __future__ import annotations
+
+# Self-reported persona vocabulary. Mirrors the signup <select>.
+PERSONAS: frozenset[str] = frozenset(
+    {
+        "practising_solicitor",
+        "in_house",
+        "legal_ops",
+        "engineer",
+        "other",
+    }
+)
+
+# Launch channel tags (?c=...). Documented in docs/OPERATIONS.md §Launch.
+CHANNELS: frozenset[str] = frozenset({"hn", "li", "x", "conf"})
+
+DOMAIN_CLASS_FIRM = "firm-like"
+DOMAIN_CLASS_GENERIC = "generic"
+
+# Consumer / generic mail providers. Deliberately a short, obvious list —
+# the point is to separate "someone at a firm/org" from "personal inbox",
+# not to fingerprint employers.
+GENERIC_EMAIL_DOMAINS: frozenset[str] = frozenset(
+    {
+        "gmail.com",
+        "googlemail.com",
+        "outlook.com",
+        "outlook.co.uk",
+        "hotmail.com",
+        "hotmail.co.uk",
+        "live.com",
+        "live.co.uk",
+        "msn.com",
+        "yahoo.com",
+        "yahoo.co.uk",
+        "ymail.com",
+        "icloud.com",
+        "me.com",
+        "mac.com",
+        "proton.me",
+        "protonmail.com",
+        "pm.me",
+        "aol.com",
+        "gmx.com",
+        "gmx.net",
+        "mail.com",
+        "fastmail.com",
+        "fastmail.fm",
+        "hey.com",
+        "zoho.com",
+        "yandex.com",
+        "yandex.ru",
+        "tutanota.com",
+        "tuta.com",
+        "tuta.io",
+        "duck.com",
+        "qq.com",
+        "163.com",
+        "126.com",
+    }
+)
+
+
+def normalise_persona(value: str | None) -> str | None:
+    """Allowlisted persona or None. Never raises — analytics must not
+    break signup."""
+    if not value:
+        return None
+    token = value.strip().lower()
+    return token if token in PERSONAS else None
+
+
+def normalise_channel(value: str | None) -> str | None:
+    """Allowlisted channel tag or None. Never raises."""
+    if not value:
+        return None
+    token = value.strip().lower()
+    return token if token in CHANNELS else None
+
+
+def classify_email_domain(email: str) -> tuple[str | None, str | None]:
+    """Return ``(raw_domain, domain_class)`` for an email address.
+
+    domain_class is ``generic`` when the domain is a known consumer
+    provider, else ``firm-like``. Malformed input → ``(None, None)``.
+    """
+    if not email or "@" not in email:
+        return None, None
+    domain = email.rsplit("@", 1)[1].strip().lower().rstrip(".")
+    if not domain:
+        return None, None
+    klass = (
+        DOMAIN_CLASS_GENERIC
+        if domain in GENERIC_EMAIL_DOMAINS
+        else DOMAIN_CLASS_FIRM
+    )
+    return domain, klass

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.api.auth import router as auth_router
 from app.api.documents import router as documents_router
 from app.api.exports import router as exports_router
 from app.api.jobs import router as jobs_router
+from app.api.admin_launch_funnel import router as admin_launch_funnel_router
 from app.api.admin_users import router as admin_users_router
 from app.api.artifacts import router as artifacts_router
 from app.api.audit import router as audit_router, admin_router as audit_admin_router
@@ -331,6 +332,10 @@ app.include_router(signoffs_router, prefix="/api/matters", tags=["signoffs"])
 # Admin role endpoint. Future admin endpoints land alongside under
 # /api/admin.
 app.include_router(admin_users_router, prefix="/api/admin", tags=["admin"])
+# Gate 4 launch-funnel counts — operator-facing JSON, superuser-only.
+app.include_router(
+    admin_launch_funnel_router, prefix="/api/admin", tags=["admin"]
+)
 # Bootstrap-state endpoint. Open (no auth) — gate to the first-auth flow.
 app.include_router(system_router, prefix="/api/system", tags=["system"])
 app.include_router(jobs_router, prefix="/api/matters", tags=["jobs"])

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -36,6 +36,15 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     default_privilege_posture: Mapped[str | None] = mapped_column(
         String(16), nullable=True, default="B_mixed"
     )
+    # Gate 4 demand capture (see app/core/demand_capture.py). persona and
+    # signup_channel are optional self-reported signup fields; email_domain
+    # + domain_class are derived server-side from the email address at
+    # registration. All nullable — rows created before instrumentation (or
+    # via scripts/seed) simply read as "unknown" in the funnel.
+    persona: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    signup_channel: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    email_domain: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    domain_class: Mapped[str | None] = mapped_column(String(16), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
     )

--- a/backend/tests/test_demand_capture.py
+++ b/backend/tests/test_demand_capture.py
@@ -1,0 +1,167 @@
+"""Gate 4 — demand capture at signup.
+
+Two layers:
+
+1. Unit — domain classifier + allowlist normalisers (no DB).
+2. HTTP E2E — /auth/register stores persona / channel / derived domain
+   fields, drops invalid values without failing the signup, and ignores
+   client attempts to set the server-derived fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from app.core.demand_capture import (
+    DOMAIN_CLASS_FIRM,
+    DOMAIN_CLASS_GENERIC,
+    classify_email_domain,
+    normalise_channel,
+    normalise_persona,
+)
+from app.models import User
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — unit (no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_generic_provider_classified_generic() -> None:
+    assert classify_email_domain("jane@gmail.com") == ("gmail.com", DOMAIN_CLASS_GENERIC)
+    assert classify_email_domain("J@Outlook.com") == ("outlook.com", DOMAIN_CLASS_GENERIC)
+
+
+def test_firm_domain_classified_firm_like() -> None:
+    assert classify_email_domain("partner@smithlaw.co.uk") == (
+        "smithlaw.co.uk",
+        DOMAIN_CLASS_FIRM,
+    )
+
+
+def test_malformed_email_classifies_to_none() -> None:
+    assert classify_email_domain("not-an-email") == (None, None)
+    assert classify_email_domain("") == (None, None)
+    assert classify_email_domain("trailing@") == (None, None)
+
+
+def test_persona_allowlist() -> None:
+    assert normalise_persona("practising_solicitor") == "practising_solicitor"
+    assert normalise_persona(" Engineer ") == "engineer"
+    assert normalise_persona("growth_hacker") is None
+    assert normalise_persona(None) is None
+    assert normalise_persona("") is None
+
+
+def test_channel_allowlist() -> None:
+    assert normalise_channel("hn") == "hn"
+    assert normalise_channel("LI") == "li"
+    assert normalise_channel("tiktok") is None
+    assert normalise_channel(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — HTTP E2E (DB-backed; see conftest.py)
+# ---------------------------------------------------------------------------
+
+PASSWORD = "demand-capture-2026"
+
+
+async def _user_row(db_session, email: str) -> User:
+    user = await db_session.scalar(select(User).where(User.email == email))
+    assert user is not None
+    return user
+
+
+@pytest.mark.asyncio
+async def test_register_stores_persona_channel_and_derived_domain(
+    client, db_session
+) -> None:
+    email = "capture-full@chancerylane-llp.co.uk"
+    resp = await client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": PASSWORD,
+            "persona": "practising_solicitor",
+            "channel": "hn",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+    user = await _user_row(db_session, email)
+    assert user.persona == "practising_solicitor"
+    assert user.signup_channel == "hn"
+    assert user.email_domain == "chancerylane-llp.co.uk"
+    assert user.domain_class == DOMAIN_CLASS_FIRM
+
+
+@pytest.mark.asyncio
+async def test_register_generic_mailbox_classified_generic(client, db_session) -> None:
+    email = "capture-generic@gmail.com"
+    resp = await client.post(
+        "/auth/register", json={"email": email, "password": PASSWORD}
+    )
+    assert resp.status_code == 201, resp.text
+
+    user = await _user_row(db_session, email)
+    assert user.email_domain == "gmail.com"
+    assert user.domain_class == DOMAIN_CLASS_GENERIC
+
+
+@pytest.mark.asyncio
+async def test_register_without_capture_fields_stores_nulls(client, db_session) -> None:
+    """The fields are optional — a bare register stays exactly as before."""
+    email = "capture-bare@example.com"
+    resp = await client.post(
+        "/auth/register", json={"email": email, "password": PASSWORD}
+    )
+    assert resp.status_code == 201, resp.text
+
+    user = await _user_row(db_session, email)
+    assert user.persona is None
+    assert user.signup_channel is None
+
+
+@pytest.mark.asyncio
+async def test_register_invalid_capture_values_dropped_not_fatal(
+    client, db_session
+) -> None:
+    """Junk persona/channel must not block the signup — normalised to None."""
+    email = "capture-junk@example.com"
+    resp = await client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": PASSWORD,
+            "persona": "definitely-not-a-persona",
+            "channel": "carrier-pigeon",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+    user = await _user_row(db_session, email)
+    assert user.persona is None
+    assert user.signup_channel is None
+
+
+@pytest.mark.asyncio
+async def test_register_cannot_spoof_derived_domain_fields(client, db_session) -> None:
+    """email_domain / domain_class are server-derived; payload values are
+    ignored by the schema."""
+    email = "capture-spoof@gmail.com"
+    resp = await client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": PASSWORD,
+            "email_domain": "magic-circle-llp.com",
+            "domain_class": DOMAIN_CLASS_FIRM,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+
+    user = await _user_row(db_session, email)
+    assert user.email_domain == "gmail.com"
+    assert user.domain_class == DOMAIN_CLASS_GENERIC

--- a/backend/tests/test_launch_funnel.py
+++ b/backend/tests/test_launch_funnel.py
@@ -1,0 +1,168 @@
+"""Gate 4 — GET /api/admin/launch-funnel (the 90-day falsifier counts).
+
+Coverage:
+- non-superuser → 403
+- signup buckets (persona / domain-class / channel) are exhaustive and
+  sum to the total
+- golden-loop counts: the auto-seeded Khan copy is excluded from
+  "matters created"; affirmative sign-offs count; rejected ones do not
+- the provenance-issues slice is explicitly manual (no GitHub token)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.core.seed import KHAN_SLUG
+from app.models import Matter, User
+from app.models.matter_artifact import MatterArtifact
+from app.models.matter_signoff import (
+    SIGNOFF_REJECTED,
+    SIGNOFF_SIGNED,
+    MatterSignoff,
+)
+
+
+PASSWORD = "launch-funnel-2026"
+
+
+async def _register(client, email: str, **extra) -> None:
+    resp = await client.post(
+        "/auth/register", json={"email": email, "password": PASSWORD, **extra}
+    )
+    assert resp.status_code == 201, resp.text
+
+
+async def _login(client, email: str) -> None:
+    resp = await client.post(
+        "/auth/login",
+        data={"username": email, "password": PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 204, resp.text
+
+
+async def _promote(db_session, email: str) -> None:
+    user = await db_session.scalar(select(User).where(User.email == email))
+    assert user is not None
+    user.is_superuser = True
+    await db_session.flush()
+
+
+async def _insert_signoff(db_session, matter: Matter, signer: User, decision: str) -> None:
+    invocation_id = uuid.uuid4()
+    artifact = MatterArtifact(
+        matter_id=matter.id,
+        module_id="examples.test",
+        capability_id="examples.test.capability",
+        invocation_id=invocation_id,
+        kind="letter",
+        storage_path=f"artifacts/{invocation_id}.json",
+        created_by_id=signer.id,
+        size_bytes=128,
+    )
+    db_session.add(artifact)
+    await db_session.flush()
+    db_session.add(
+        MatterSignoff(
+            matter_id=matter.id,
+            artifact_id=artifact.id,
+            invocation_id=invocation_id,
+            module_id="examples.test",
+            capability_id="examples.test.capability",
+            kind="letter",
+            artifact_hash="0" * 64,
+            decision=decision,
+            reasoning="test reasoning" if decision == SIGNOFF_REJECTED else None,
+            signer_id=signer.id,
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_launch_funnel_requires_superuser(client) -> None:
+    email = "funnel-non-admin@example.com"
+    await _register(client, email)
+    await _login(client, email)
+    resp = await client.get("/api/admin/launch-funnel")
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_launch_funnel_requires_auth(client) -> None:
+    resp = await client.get("/api/admin/launch-funnel")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_launch_funnel_counts(client, db_session) -> None:
+    # Three real signups with mixed capture fields.
+    await _register(
+        client,
+        "funnel-a@smithlaw.co.uk",
+        persona="practising_solicitor",
+        channel="hn",
+    )
+    await _register(client, "funnel-b@gmail.com", persona="engineer", channel="hn")
+    await _register(client, "funnel-c@example.com")  # untagged / unspecified
+
+    # User A creates their own matter and signs one output; also a
+    # rejected sign-off that must NOT count.
+    await _login(client, "funnel-a@smithlaw.co.uk")
+    create = await client.post("/api/matters", json={"title": "Funnel Test Matter"})
+    assert create.status_code == 201, create.text
+
+    user_a = await db_session.scalar(
+        select(User).where(User.email == "funnel-a@smithlaw.co.uk")
+    )
+    matter = await db_session.scalar(
+        select(Matter).where(
+            Matter.created_by_id == user_a.id, Matter.slug != KHAN_SLUG
+        )
+    )
+    assert matter is not None
+    await _insert_signoff(db_session, matter, user_a, SIGNOFF_SIGNED)
+    await _insert_signoff(db_session, matter, user_a, SIGNOFF_REJECTED)
+
+    # Promote an operator and read the funnel.
+    await client.post("/auth/logout")
+    await _register(client, "funnel-operator@example.com")
+    await _promote(db_session, "funnel-operator@example.com")
+    await _login(client, "funnel-operator@example.com")
+
+    resp = await client.get("/api/admin/launch-funnel")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    signups = body["signups"]
+    assert signups["total"] == 4  # a, b, c, operator
+    assert signups["by_persona"]["practising_solicitor"] == 1
+    assert signups["by_persona"]["engineer"] == 1
+    assert signups["by_persona"]["unspecified"] == 2
+    assert sum(signups["by_persona"].values()) == signups["total"]
+
+    assert signups["by_channel"]["hn"] == 2
+    assert signups["by_channel"]["untagged"] == 2
+    assert sum(signups["by_channel"].values()) == signups["total"]
+
+    # smithlaw + example.com (funnel-c, operator) — heuristic says
+    # "not a known generic mailbox", which is all firm-like claims.
+    assert signups["by_domain_class"]["firm-like"] == 3
+    assert signups["by_domain_class"]["generic"] == 1  # gmail
+    assert sum(signups["by_domain_class"].values()) == signups["total"]
+
+    loop = body["golden_loop"]
+    # Each register auto-seeds a Khan copy in dev — must be excluded.
+    assert loop["matters_created"] == 1
+    assert loop["users_who_created_a_matter"] == 1
+    # One affirmative sign-off; the rejected one does not count.
+    assert loop["outputs_signed"] == 1
+    assert loop["users_who_signed_an_output"] == 1
+    assert loop["outputs_signed_on_seeded_sample"] == 0
+
+    assert body["provenance_issues"]["source"] == "manual"
+    assert "gh issue list" in body["provenance_issues"]["note"]

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -241,7 +241,61 @@ top of the store-level backups.
 
 ---
 
-## 5. What is not covered yet
+## 5. Launch instrumentation
+
+Demand evidence for launch day (Gate 4), so the 90-day questions get
+answered with counts, not anecdotes.
+
+### 5.1 Tagged launch URLs
+
+Every link we post carries a channel tag. Locked vocabulary — these
+four, nothing else (the backend allowlists and drops anything unknown):
+
+| Channel | URL to post |
+|---|---|
+| Hacker News | `https://legalise.dev/?c=hn` |
+| LinkedIn | `https://legalise.dev/?c=li` |
+| X | `https://legalise.dev/?c=x` |
+| Conferences / talks | `https://legalise.dev/?c=conf` |
+
+The tag is remembered client-side for the session
+(`frontend/src/lib/channel.ts`) and stored on the user row at signup
+(`users.signup_channel`). Untagged signups read as `untagged` — that is
+the honest bucket, don't backfill it.
+
+Signup also captures an **optional** self-reported persona (practising
+solicitor / in-house / legal ops / engineer / other) and derives the
+email domain server-side, classed `firm-like` vs `generic` (heuristic
+consumer-provider list in `backend/app/core/demand_capture.py`). All
+optional, no dark patterns.
+
+### 5.2 The launch-funnel endpoint
+
+Operator-facing, superuser-only, JSON by design:
+
+```bash
+curl -s --cookie "$SESSION_COOKIE" \
+  https://api.legalise.dev/api/admin/launch-funnel | jq
+```
+
+Returns signup counts by persona / domain-class / channel, plus
+golden-loop counts (matters created and outputs signed by non-seed
+users; the auto-seeded Khan copy is excluded from "matters created").
+
+### 5.3 Issue provenance
+
+GitHub issues self-identify via optional labels
+`provenance:practitioner` / `provenance:builder` / `provenance:firm`
+(see CONTRIBUTING). Counted manually — the server holds no GitHub
+token:
+
+```bash
+gh issue list --label provenance:practitioner
+```
+
+---
+
+## 6. What is not covered yet
 
 Honest gaps, so nobody assumes them:
 
@@ -262,7 +316,7 @@ Honest gaps, so nobody assumes them:
 
 ---
 
-## 6. Enabling the WORM role split in production
+## 7. Enabling the WORM role split in production
 
 The audit trail's second enforcement layer — the application database
 role losing UPDATE/DELETE on `audit_entries` by grant — is provisioned

--- a/frontend/src/auth/AuthProvider.tsx
+++ b/frontend/src/auth/AuthProvider.tsx
@@ -6,6 +6,7 @@ import {
   signout,
   signup,
   type CurrentUser,
+  type SignupCapture,
 } from "../lib/api";
 import { setAuthSnapshot } from "./AuthSnapshot";
 
@@ -16,7 +17,12 @@ export type AuthState = {
   refresh: () => Promise<void>;
   signIn: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
-  signUp: (email: string, password: string, name?: string) => Promise<void>;
+  signUp: (
+    email: string,
+    password: string,
+    name?: string,
+    capture?: SignupCapture,
+  ) => Promise<void>;
 };
 
 const AuthContext = createContext<AuthState | null>(null);
@@ -74,8 +80,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const doSignUp = useCallback(
-    async (email: string, password: string, name = "") => {
-      await signup(email, password, name);
+    async (email: string, password: string, name = "", capture: SignupCapture = {}) => {
+      await signup(email, password, name, capture);
       // Backend may auto-login on register (cookie set). Either way refresh.
       await refresh();
     },

--- a/frontend/src/auth/SignUp.tsx
+++ b/frontend/src/auth/SignUp.tsx
@@ -1,15 +1,28 @@
 import { useEffect, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { navigate } from "../lib/route";
+import { getSignupChannel } from "../lib/channel";
 import { useAuth } from "./AuthProvider";
 import { AuthCard, LedgerField } from "./AuthCard";
 import { ErrorCallout, inputCls, primaryBtn } from "../ui/primitives";
+
+// Gate 4 demand capture — optional, self-reported. Mirrors the backend
+// allowlist in app/core/demand_capture.py.
+const PERSONA_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "", label: "Prefer not to say" },
+  { value: "practising_solicitor", label: "Practising solicitor" },
+  { value: "in_house", label: "In-house counsel" },
+  { value: "legal_ops", label: "Legal ops" },
+  { value: "engineer", label: "Engineer" },
+  { value: "other", label: "Other" },
+];
 
 export function SignUp() {
   const auth = useAuth();
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
+  const [persona, setPersona] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -22,7 +35,10 @@ export function SignUp() {
     setBusy(true);
     setError(null);
     try {
-      await auth.signUp(email, password, name);
+      await auth.signUp(email, password, name, {
+        persona: persona || null,
+        channel: getSignupChannel(),
+      });
       // After register, backend may require verification - route to pending.
       navigate("/auth/verify-pending");
     } catch (err) {
@@ -67,6 +83,19 @@ export function SignUp() {
             onChange={(e: ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
             className={inputCls}
           />
+        </LedgerField>
+        <LedgerField label="I am a" hint="optional - helps us understand who is evaluating">
+          <select
+            value={persona}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setPersona(e.target.value)}
+            className={inputCls}
+          >
+            {PERSONA_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
         </LedgerField>
         {error && <ErrorCallout message={error} />}
         <button type="submit" disabled={busy} className={primaryBtn}>

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -74,11 +74,31 @@ export const signin = (email: string, password: string) =>
 export const signout = () =>
   apiFetch(`${AUTH}/logout`, { method: "POST" }).then((r) => authJsonOrThrow<unknown>(r));
 
-export const signup = (email: string, password: string, name: string = "") =>
+// Optional demand-capture fields (Gate 4). Both honest and optional:
+// persona is self-reported; channel is the ?c= launch tag (see
+// src/lib/channel.ts). Backend allowlists both — invalid values are
+// dropped server-side, never a signup failure.
+export interface SignupCapture {
+  persona?: string | null;
+  channel?: string | null;
+}
+
+export const signup = (
+  email: string,
+  password: string,
+  name: string = "",
+  capture: SignupCapture = {},
+) =>
   apiFetch(`${AUTH}/register`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, password, name }),
+    body: JSON.stringify({
+      email,
+      password,
+      name,
+      ...(capture.persona ? { persona: capture.persona } : {}),
+      ...(capture.channel ? { channel: capture.channel } : {}),
+    }),
   }).then((r) => authJsonOrThrow<CurrentUser>(r));
 
 export const forgotPassword = (email: string) =>

--- a/frontend/src/lib/channel.test.ts
+++ b/frontend/src/lib/channel.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { captureChannelFromUrl, getSignupChannel } from "./channel";
+
+const setSearch = (search: string) => {
+  window.history.replaceState({}, "", `/${search}`);
+};
+
+describe("launch channel capture", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    setSearch("");
+  });
+
+  it("remembers an allowlisted ?c= tag", () => {
+    setSearch("?c=hn");
+    captureChannelFromUrl();
+    expect(getSignupChannel()).toBe("hn");
+  });
+
+  it("normalises case", () => {
+    setSearch("?c=LI");
+    captureChannelFromUrl();
+    expect(getSignupChannel()).toBe("li");
+  });
+
+  it("ignores tags outside the allowlist", () => {
+    setSearch("?c=tiktok");
+    captureChannelFromUrl();
+    expect(getSignupChannel()).toBeNull();
+  });
+
+  it("keeps an earlier tag when revisiting without one", () => {
+    setSearch("?c=conf");
+    captureChannelFromUrl();
+    setSearch("");
+    captureChannelFromUrl();
+    expect(getSignupChannel()).toBe("conf");
+  });
+
+  it("returns null when nothing captured", () => {
+    expect(getSignupChannel()).toBeNull();
+  });
+});

--- a/frontend/src/lib/channel.ts
+++ b/frontend/src/lib/channel.ts
@@ -1,0 +1,35 @@
+/**
+ * Launch channel tag capture (Gate 4).
+ *
+ * Tagged launch URLs carry `?c=hn|li|x|conf` (documented in
+ * docs/OPERATIONS.md §Launch instrumentation). The tag is remembered in
+ * sessionStorage so it survives the landing → signup navigation, then
+ * sent with the register payload. Allowlisted; anything else is ignored.
+ * Session-scoped on purpose — this is a launch-attribution breadcrumb,
+ * not a tracking cookie.
+ */
+
+const CHANNELS = new Set(["hn", "li", "x", "conf"]);
+
+const STORAGE_KEY = "legalise.signup_channel";
+
+/** Read ?c= from the current URL and remember a valid tag. Call once at boot. */
+export function captureChannelFromUrl(): void {
+  try {
+    const c = new URLSearchParams(globalThis.location?.search ?? "").get("c");
+    if (c && CHANNELS.has(c.toLowerCase())) {
+      globalThis.sessionStorage?.setItem(STORAGE_KEY, c.toLowerCase());
+    }
+  } catch {
+    // Storage unavailable (private mode etc.) — attribution is best-effort.
+  }
+}
+
+/** The remembered channel tag, or null. */
+export function getSignupChannel(): string | null {
+  try {
+    return globalThis.sessionStorage?.getItem(STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,12 +2,17 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { redirectLegacyHash } from "./router/legacyHashRedirect";
+import { captureChannelFromUrl } from "./lib/channel";
 import "./index.css";
 
 // Rewrite pre-A0 hash URLs (e.g. legalise.dev/#/matters/khan-...) to
 // the canonical path form BEFORE the router mounts. Must come before
 // render so the router never observes the hash form.
 redirectLegacyHash();
+
+// Remember a ?c= launch-channel tag (Gate 4 demand instrumentation)
+// before navigation changes the URL.
+captureChannelFromUrl();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## What

Launch-day demand evidence, so the 90-day questions get answered with counts, not anecdotes.

### Signup capture
- Optional **persona** select at signup (practising solicitor / in-house / legal ops / engineer / other) — self-reported, "prefer not to say" default.
- **Channel tag**: `?c=hn|li|x|conf` on launch URLs is remembered client-side for the session (`frontend/src/lib/channel.ts`) and stored on the user row at register. Allowlisted; unknown values dropped.
- **Email-domain class** derived server-side at registration: raw domain + `firm-like` vs `generic` (heuristic consumer-provider list in `backend/app/core/demand_capture.py`). Not client-settable — spoof attempts are ignored.
- All optional, never a signup blocker; invalid values normalise to `NULL` rather than failing registration.

### Launch funnel (operator tool)
`GET /api/admin/launch-funnel` — superuser-only, JSON-only by design:

```json
{
  "generated_at": "...",
  "signups": { "total": n, "by_persona": {...}, "by_domain_class": {...}, "by_channel": {...} },
  "golden_loop": {
    "matters_created": n,
    "users_who_created_a_matter": n,
    "outputs_signed": n,
    "outputs_signed_on_seeded_sample": n,
    "users_who_signed_an_output": n
  },
  "provenance_issues": { "source": "manual", "note": "gh issue list --label provenance:..." }
}
```

Buckets are exhaustive (NULLs land in `unspecified` / `unknown` / `untagged`) so each map sums to the total. Seed demo user excluded; auto-seeded Khan copies excluded from "matters created"; sign-offs on the Khan sample reported as their own honest slice.

### Docs & provenance
- Tagged launch URLs documented in `docs/OPERATIONS.md` §5 Launch instrumentation.
- `CONTRIBUTING.md` gains one optional self-identify line; `provenance:practitioner` / `provenance:builder` / `provenance:firm` labels exist on the repo.

### Migration
`0034_demand_capture` (renumbered after master gained `0033_auth_throttle_events`): four nullable columns on `users`.

## Tests
- `backend/tests/test_demand_capture.py` — classifier/allowlist units + register E2E (storage, invalid-value drop, spoof rejection).
- `backend/tests/test_launch_funnel.py` — 401/403 gating + full count assertions incl. Khan-copy exclusion and rejected-sign-off exclusion.
- `frontend/src/lib/channel.test.ts` — tag capture/persistence/allowlist.
- Full backend suite: 834 passed, 3 failed (known macOS sandbox baseline), 12 skipped, 1 xfailed.
- Frontend: tsc clean, vitest 320/320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)