### PR TITLE
The register sidecar: supervise an external workspace's export

### DIFF
--- a/backend/alembic/versions/0035_external_packs.py
+++ b/backend/alembic/versions/0035_external_packs.py
@@ -1,0 +1,59 @@
+"""External workspace packs — matter source marker + non-human artifact authors.
+
+Revision ID: 0035
+Revises: 0034
+Create Date: 2026-06-12
+
+Two small schema changes for the register sidecar (docs/REGISTER_SIDECAR.md):
+
+- ``matters.external_source``: nullable adapter name (``"mike"``) marking a
+  matter as an ingested external-workspace pack. NULL = native matter.
+  External matters are created with ``privilege_posture='C_paused'`` so the
+  posture gate keeps them read-only (no capability runs, no model calls).
+
+- ``matter_artifacts.created_by_id`` becomes nullable. NULL means "no
+  workspace user authored this artifact" — the case for documents ingested
+  from an external workspace, where the author was the external assistant
+  or an external human. ``signer_is_author`` is computed as
+  ``created_by_id == signer.id``, so a NULL author always reads as
+  ``signer_is_author=false`` — a sign-off over external material can never
+  present as self-authorship. DDL only: the WORM trigger on
+  ``matter_artifacts`` blocks row UPDATE/DELETE, not ALTER TABLE.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0035"
+down_revision = "0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "matters",
+        sa.Column("external_source", sa.String(length=64), nullable=True),
+    )
+    op.alter_column(
+        "matter_artifacts",
+        "created_by_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # Reinstating NOT NULL fails if NULL-author artifacts exist — that is
+    # correct: those rows are WORM and cannot be backfilled to a fake author.
+    op.alter_column(
+        "matter_artifacts",
+        "created_by_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+    op.drop_column("matters", "external_source")

--- a/backend/app/api/artifacts.py
+++ b/backend/app/api/artifacts.py
@@ -51,7 +51,8 @@ class ArtifactSummary(BaseModel):
     capability_id: str
     invocation_id: str
     kind: str
-    created_by_id: str
+    # None for external-pack documents: no workspace user authored them.
+    created_by_id: str | None
     created_at: str
     size_bytes: int
 
@@ -92,7 +93,7 @@ def _row_to_summary(row: MatterArtifact) -> ArtifactSummary:
         capability_id=row.capability_id,
         invocation_id=str(row.invocation_id),
         kind=row.kind,
-        created_by_id=str(row.created_by_id),
+        created_by_id=str(row.created_by_id) if row.created_by_id else None,
         created_at=row.created_at.isoformat(),
         size_bytes=row.size_bytes,
     )

--- a/backend/app/api/external_packs.py
+++ b/backend/app/api/external_packs.py
@@ -1,0 +1,242 @@
+"""External pack endpoints — the register sidecar's front door.
+
+Two endpoints under ``/api/external``:
+
+- ``POST /packs`` — authed multipart ingest: ``adapter`` (form field,
+  e.g. ``mike``), ``export`` (the export JSON — project manifest
+  preferred, account export accepted), optional ``documents`` (the
+  documents ZIP), optional ``title``. Creates one read-only external
+  matter (``external_source`` set, ``C_paused`` posture — no model
+  calls, no skills), one WORM artifact per document, a pack manifest
+  artifact, and the ``external.pack.ingested`` audit row carrying the
+  hash manifest.
+- ``GET /packs`` — list this user's external packs with their manifest
+  summary (source, counts: verified-at-source vs attested-at-ingest)
+  and sign-off tallies. Feeds the register face.
+
+Sign-off over pack documents goes through the existing
+``/api/matters/{slug}/signoffs`` surface — external artifacts carry
+``created_by_id=NULL``, so ``signer_is_author`` is always false there.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+import zipfile
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_user
+from app.core.db import get_session
+from app.core.external_pack import (
+    ExternalPackError,
+    KIND_MANIFEST,
+    MalformedExport,
+    UnknownAdapter,
+    ingest_external_pack,
+)
+from app.core.matter_artifacts import (
+    ArtifactBytesUnavailable,
+    load_artifact_payload,
+)
+from app.core.signoff import current_signoff_ids
+from app.models import MatterArtifact, MatterSignoff, User
+from app.models.matter import STATUS_ARCHIVED, Matter
+
+router = APIRouter()
+
+# 25 MB ceiling per upload part — packs are records, not data lakes.
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+
+
+class PackSignoffSummary(BaseModel):
+    total: int
+    signed: int
+    signed_with_observations: int
+    rejected: int
+
+
+class PackRead(BaseModel):
+    matter_id: str
+    matter_slug: str
+    title: str
+    adapter: str
+    source: str
+    exported_at: str | None
+    ingested_at: str | None
+    counts: dict[str, int]
+    manifest_artifact_id: str
+    document_artifact_ids: list[str]
+    signoffs: PackSignoffSummary
+
+
+class PackListResponse(BaseModel):
+    packs: list[PackRead]
+
+
+async def _signoff_summary(
+    session: AsyncSession, matter: Matter
+) -> PackSignoffSummary:
+    """Tally the *current* sign-off per artifact on this matter."""
+    signoffs = await session.scalars(
+        select(MatterSignoff)
+        .where(MatterSignoff.matter_id == matter.id)
+        .order_by(MatterSignoff.signed_at.desc(), MatterSignoff.id.desc())
+    )
+    rows = list(signoffs.all())
+    current = current_signoff_ids(rows)
+    tally = {"signed": 0, "signed_with_observations": 0, "rejected": 0}
+    for s in rows:
+        if s.id in current and s.decision in tally:
+            tally[s.decision] += 1
+    return PackSignoffSummary(total=len(current), **tally)
+
+
+def _pack_read(
+    matter: Matter,
+    manifest: MatterArtifact,
+    payload: dict,
+    signoffs: PackSignoffSummary,
+) -> PackRead:
+    counts = payload.get("counts")
+    doc_ids = payload.get("document_artifact_ids")
+    return PackRead(
+        matter_id=str(matter.id),
+        matter_slug=matter.slug,
+        title=matter.title,
+        adapter=str(payload.get("adapter") or matter.external_source or ""),
+        source=str(payload.get("source") or matter.external_source or ""),
+        exported_at=payload.get("exported_at"),
+        ingested_at=payload.get("ingested_at"),
+        counts={
+            k: v for k, v in (counts or {}).items() if isinstance(v, int)
+        },
+        manifest_artifact_id=str(manifest.id),
+        document_artifact_ids=[
+            str(d) for d in (doc_ids or []) if isinstance(d, str)
+        ],
+        signoffs=signoffs,
+    )
+
+
+async def _read_upload(part: UploadFile, label: str) -> bytes:
+    data = await part.read()
+    if len(data) > MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=413, detail=f"{label} exceeds {MAX_UPLOAD_BYTES} bytes"
+        )
+    return data
+
+
+def _zip_entries(data: bytes) -> dict[str, bytes]:
+    """Flatten a documents ZIP to ``basename -> bytes``. Directories and
+    duplicate basenames resolve last-wins; the adapter matches by the
+    export's own filename convention."""
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile:
+        raise HTTPException(status_code=422, detail="documents is not a valid ZIP")
+    out: dict[str, bytes] = {}
+    for info in archive.infolist():
+        if info.is_dir():
+            continue
+        name = info.filename.rsplit("/", 1)[-1]
+        if not name or name.startswith("."):
+            continue
+        out[name] = archive.read(info)
+    return out
+
+
+@router.post("/packs", response_model=PackRead, status_code=201)
+async def ingest_pack_endpoint(
+    adapter: str = Form(...),
+    export: UploadFile = File(...),
+    documents: UploadFile | None = File(None),
+    title: str | None = Form(None),
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> PackRead:
+    export_bytes = await _read_upload(export, "export")
+    try:
+        export_json = json.loads(export_bytes)
+    except (ValueError, UnicodeDecodeError):
+        raise HTTPException(status_code=422, detail="export is not valid JSON")
+
+    files: dict[str, bytes] = {}
+    if documents is not None:
+        files = _zip_entries(await _read_upload(documents, "documents"))
+
+    try:
+        result = await ingest_external_pack(
+            session,
+            user=user,
+            adapter_name=adapter,
+            export=export_json,
+            files=files,
+            title=(title or "").strip() or None,
+        )
+    except UnknownAdapter as exc:
+        raise HTTPException(
+            status_code=422, detail={"error": "unknown_adapter", "message": str(exc)}
+        )
+    except MalformedExport as exc:
+        raise HTTPException(
+            status_code=422, detail={"error": "malformed_export", "message": str(exc)}
+        )
+    except ExternalPackError as exc:
+        raise HTTPException(
+            status_code=422, detail={"error": "external_pack", "message": str(exc)}
+        )
+
+    await session.commit()
+    payload = load_artifact_payload(result.manifest.storage_path)
+    return _pack_read(
+        result.matter,
+        result.manifest,
+        payload,
+        PackSignoffSummary(total=0, signed=0, signed_with_observations=0, rejected=0),
+    )
+
+
+@router.get("/packs", response_model=PackListResponse)
+async def list_packs_endpoint(
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> PackListResponse:
+    matters = await session.scalars(
+        select(Matter)
+        .where(
+            Matter.created_by_id == user.id,
+            Matter.external_source.is_not(None),
+            Matter.status != STATUS_ARCHIVED,
+        )
+        .order_by(Matter.opened_at.desc())
+    )
+    packs: list[PackRead] = []
+    for matter in matters.all():
+        manifest = await session.scalar(
+            select(MatterArtifact)
+            .where(
+                MatterArtifact.matter_id == matter.id,
+                MatterArtifact.kind == KIND_MANIFEST,
+            )
+            .order_by(MatterArtifact.created_at.desc())
+            .limit(1)
+        )
+        if manifest is None:
+            continue
+        try:
+            payload = load_artifact_payload(manifest.storage_path)
+        except (ArtifactBytesUnavailable, ValueError):
+            payload = {}
+        summary = await _signoff_summary(session, matter)
+        packs.append(_pack_read(matter, manifest, payload, summary))
+    return PackListResponse(packs=packs)
+
+
+__all__ = ["router"]

--- a/backend/app/core/exports.py
+++ b/backend/app/core/exports.py
@@ -531,7 +531,9 @@ async def build_matter_export(
                 "kind": art.kind,
                 "size_bytes": art.size_bytes,
                 "created_at": art.created_at,
-                "created_by_id": str(art.created_by_id),
+                "created_by_id": (
+                    str(art.created_by_id) if art.created_by_id else None
+                ),
                 # Sign-off status: signed | signed_with_observations |
                 # rejected | unsigned.
                 "signoff_status": cur.decision if cur else "unsigned",

--- a/backend/app/core/external_pack.py
+++ b/backend/app/core/external_pack.py
@@ -1,0 +1,680 @@
+"""External workspace pack ingestion — the register sidecar.
+
+Normalises an export from an external AI legal workspace into a
+working-pack-shaped record this workspace can supervise: one read-only
+matter per pack, one WORM artifact per document, sign-off through the
+existing ``core/signoff.py`` path.
+
+The honesty boundary (docs/REGISTER_SIDECAR.md): this workspace did not
+watch the external work happen. There are exactly two grades of hash
+claim, and each document records which one it carries:
+
+- ``verified_at_source`` — the export is a *manifest* whose versions
+  carry ``content_sha256`` computed by the source workspace at write
+  time. The hash predates the export; where the document bytes also
+  travelled, they are re-hashed at ingest and any mismatch is recorded
+  (``hash_mismatch``), never papered over.
+- ``attested_at_ingest`` — the export carried bytes but no source hash,
+  so the sha256 is computed HERE, at ingest. It proves what this
+  workspace received, not what the source workspace held.
+
+The provenance trail is the export's own claim, preserved verbatim and
+mapped, never improved.
+
+Adapter registry: each adapter understands one external workspace's
+export shape. ``mike`` is first — it PREFERS the project export
+manifest (``manifest_version`` / nested ``documents[].versions[]`` with
+``content_sha256`` + ``source`` provenance enum + ``edits``), and falls
+back to the flat account-export JSON (``documents`` /
+``document_versions`` / ``document_edits`` tables). Either may arrive
+with the optional documents ZIP. No external code is vendored; the
+adapter is written against the export *shape* only.
+
+Read-only by construction: external matters are created with
+``privilege_posture=C_paused``, which the posture gate maps to
+"nobody may run a capability" — no model calls, no skills. The matter
+exists to be supervised and signed, not worked.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, UTC
+from typing import Any, Protocol
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.api import audit
+from app.core.matter_artifacts import write_artifact
+from app.models import Matter, MatterArtifact
+from app.models.matter import PRIVILEGE_PAUSED, STATUS_OPEN
+from app.models.user import User
+
+
+PACK_SCHEMA = "legalise.external-pack/v1"
+
+# Module/capability identity the ingested artifacts carry. There is no
+# installed module behind these ids — they name the ingest surface so
+# audit and reconstruction read cleanly.
+PACK_MODULE_ID = "external.pack"
+PACK_INGEST_CAPABILITY = "external.pack.ingest"
+PACK_DOCUMENT_CAPABILITY = "external.pack.document"
+
+KIND_MANIFEST = "external_pack_manifest"
+KIND_DOCUMENT = "external_document"
+
+PACK_INGESTED_ACTION = "external.pack.ingested"
+
+
+class ExternalPackError(Exception):
+    """Base for ingest errors (422 at the API)."""
+
+
+class UnknownAdapter(ExternalPackError):
+    """No adapter registered under that name."""
+
+
+class MalformedExport(ExternalPackError):
+    """The export does not match the adapter's expected shape."""
+
+
+# ---------------------------------------------------------------------------
+# Normalised shapes
+# ---------------------------------------------------------------------------
+
+AUTHOR_HUMAN = "human"
+AUTHOR_ASSISTANT = "assistant"
+AUTHOR_UNKNOWN = "unknown"
+
+# The two grades of hash claim — the honesty boundary, as data.
+HASH_VERIFIED_AT_SOURCE = "verified_at_source"
+HASH_ATTESTED_AT_INGEST = "attested_at_ingest"
+
+
+@dataclass
+class NormalisedVersion:
+    external_id: str | None
+    version_number: int | None
+    source: str | None  # the export's own value, verbatim
+    author: str  # human | assistant | unknown
+    provenance: str  # mapped label (see adapter table)
+    filename: str | None
+    created_at: str | None
+    # The source workspace's own sha256 of this version's bytes, when
+    # the export was a manifest that carried one. Verbatim claim.
+    content_sha256: str | None = None
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "external_id": self.external_id,
+            "version_number": self.version_number,
+            "source": self.source,
+            "author": self.author,
+            "provenance": self.provenance,
+            "filename": self.filename,
+            "created_at": self.created_at,
+            "content_sha256": self.content_sha256,
+        }
+
+
+@dataclass
+class NormalisedEdit:
+    external_id: str | None
+    version_id: str | None
+    change_id: str | None
+    deleted_text: str | None
+    inserted_text: str | None
+    context_before: str | None
+    context_after: str | None
+    status: str | None  # pending | accepted | rejected (export's claim)
+    resolved_at: str | None
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "external_id": self.external_id,
+            "version_id": self.version_id,
+            "change_id": self.change_id,
+            "deleted_text": self.deleted_text,
+            "inserted_text": self.inserted_text,
+            "context_before": self.context_before,
+            "context_after": self.context_after,
+            "status": self.status,
+            "resolved_at": self.resolved_at,
+        }
+
+
+@dataclass
+class NormalisedDocument:
+    external_id: str | None
+    filename: str
+    # Canonical sha256 (hex) for this document's current version. Where
+    # the export manifest carried a source hash, this IS that hash
+    # (``hash_origin=verified_at_source``); otherwise it is computed at
+    # ingest from the bytes the export carried
+    # (``hash_origin=attested_at_ingest``). None when neither existed —
+    # recorded as unhashed, never guessed.
+    sha256: str | None
+    size_bytes: int | None
+    current_version: NormalisedVersion | None
+    # verified_at_source | attested_at_ingest | None — WHICH claim the
+    # sha256 makes. Recorded per document; the register face counts it.
+    hash_origin: str | None = None
+    # sha256 recomputed at ingest from travelled bytes (when present).
+    # Equal to ``sha256`` for attested-at-ingest documents; for
+    # verified-at-source documents it is the cross-check.
+    ingest_sha256: str | None = None
+    # True when a source hash AND travelled bytes both exist and
+    # disagree. Recorded, never repaired.
+    hash_mismatch: bool = False
+    versions: list[NormalisedVersion] = field(default_factory=list)
+    edit_trail: list[NormalisedEdit] = field(default_factory=list)
+
+    @property
+    def author(self) -> str:
+        return self.current_version.author if self.current_version else AUTHOR_UNKNOWN
+
+    @property
+    def provenance(self) -> str:
+        return (
+            self.current_version.provenance
+            if self.current_version
+            else "unknown"
+        )
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "schema": PACK_SCHEMA,
+            "record": "document",
+            "external_id": self.external_id,
+            "filename": self.filename,
+            "sha256": self.sha256,
+            "hash_origin": self.hash_origin,
+            "ingest_sha256": self.ingest_sha256,
+            "hash_mismatch": self.hash_mismatch,
+            "size_bytes": self.size_bytes,
+            "author": self.author,
+            "provenance": self.provenance,
+            "current_version": (
+                self.current_version.as_payload() if self.current_version else None
+            ),
+            "versions": [v.as_payload() for v in self.versions],
+            "edit_trail": [e.as_payload() for e in self.edit_trail],
+        }
+
+
+@dataclass
+class NormalisedPack:
+    adapter: str
+    source: str
+    exported_at: str | None
+    source_user: dict[str, Any] | None
+    documents: list[NormalisedDocument]
+    # Project/matter metadata the export carried about itself (the
+    # manifest's ``project`` block). Verbatim claim, may be None.
+    source_project: dict[str, Any] | None = None
+
+    @property
+    def counts(self) -> dict[str, int]:
+        return {
+            "documents": len(self.documents),
+            "versions": sum(len(d.versions) for d in self.documents),
+            "edits": sum(len(d.edit_trail) for d in self.documents),
+            "verified_at_source": sum(
+                1 for d in self.documents if d.hash_origin == HASH_VERIFIED_AT_SOURCE
+            ),
+            "attested_at_ingest": sum(
+                1 for d in self.documents if d.hash_origin == HASH_ATTESTED_AT_INGEST
+            ),
+            "unhashed": sum(1 for d in self.documents if d.sha256 is None),
+            "hash_mismatches": sum(1 for d in self.documents if d.hash_mismatch),
+        }
+
+    @property
+    def hash_manifest(self) -> list[dict[str, Any]]:
+        """Per-document hash manifest — the audit row's spine."""
+        return [
+            {
+                "external_id": d.external_id,
+                "filename": d.filename,
+                "sha256": d.sha256,
+                "hash_origin": d.hash_origin,
+                "hash_mismatch": d.hash_mismatch,
+                "provenance": d.provenance,
+            }
+            for d in self.documents
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Adapter registry
+# ---------------------------------------------------------------------------
+
+
+class PackAdapter(Protocol):
+    name: str
+    source: str
+
+    def normalise(
+        self, export: dict[str, Any], files: dict[str, bytes]
+    ) -> NormalisedPack: ...
+
+
+# Mike `document_versions.source` → (author, normalised provenance).
+# `user_accept` / `user_reject` are versions created when the human
+# resolved an assistant edit — human decisions, recorded as such.
+MIKE_SOURCE_MAP: dict[str, tuple[str, str]] = {
+    "upload": (AUTHOR_HUMAN, "uploaded"),
+    "user_upload": (AUTHOR_HUMAN, "uploaded"),
+    "assistant_edit": (AUTHOR_ASSISTANT, "assistant_edit"),
+    "user_accept": (AUTHOR_HUMAN, "human_accepted"),
+    "user_reject": (AUTHOR_HUMAN, "human_rejected"),
+    "generated": (AUTHOR_ASSISTANT, "generated"),
+}
+
+
+def _s(row: dict[str, Any], key: str) -> str | None:
+    v = row.get(key)
+    return v if isinstance(v, str) and v else None
+
+
+def _i(row: dict[str, Any], key: str) -> int | None:
+    v = row.get(key)
+    return v if isinstance(v, int) else None
+
+
+class MikeAdapter:
+    """Adapter for Mike's exports — manifest preferred, account fallback.
+
+    Two shapes, tried in order of honesty:
+
+    1. **Project export manifest** (``GET /projects/:id/export``) —
+       detected by ``manifest_version``. Documents nest their
+       ``versions`` (each carrying the source-computed
+       ``content_sha256`` and the ``source`` provenance enum) and
+       ``edits``. Hashes here are *verified at source*: the source
+       workspace hashed the bytes at write time, before any export.
+    2. **Account export** (``GET /user/export``) — flat ``documents`` /
+       ``document_versions`` / ``document_edits`` tables. No source
+       hashes; documents are hashed at ingest from travelled bytes,
+       *attested as received*.
+
+    Optional ``files`` are the entries of the documents ZIP, matched per
+    document by the export's download-filename convention: ``<name>.ext``
+    or ``<stem> [Edited V<n>].ext`` for assistant-edited active versions.
+    """
+
+    name = "mike"
+    source = "mike"
+
+    def normalise(
+        self, export: dict[str, Any], files: dict[str, bytes]
+    ) -> NormalisedPack:
+        if not isinstance(export, dict):
+            raise MalformedExport("export must be a JSON object")
+        if "manifest_version" in export:
+            return self._normalise_manifest(export, files)
+        docs_raw = export.get("documents")
+        if not isinstance(docs_raw, list):
+            raise MalformedExport("mike export: missing 'documents' list")
+        versions_raw = export.get("document_versions")
+        versions_raw = versions_raw if isinstance(versions_raw, list) else []
+        edits_raw = export.get("document_edits")
+        edits_raw = edits_raw if isinstance(edits_raw, list) else []
+
+        versions_by_doc: dict[str, list[dict[str, Any]]] = {}
+        for row in versions_raw:
+            if not isinstance(row, dict):
+                continue
+            doc_id = _s(row, "document_id")
+            if doc_id:
+                versions_by_doc.setdefault(doc_id, []).append(row)
+        edits_by_doc: dict[str, list[dict[str, Any]]] = {}
+        for row in edits_raw:
+            if not isinstance(row, dict):
+                continue
+            doc_id = _s(row, "document_id")
+            if doc_id:
+                edits_by_doc.setdefault(doc_id, []).append(row)
+
+        documents: list[NormalisedDocument] = []
+        for raw in docs_raw:
+            if not isinstance(raw, dict):
+                continue
+            documents.append(
+                self._normalise_document(
+                    raw,
+                    versions_by_doc.get(_s(raw, "id") or "", []),
+                    edits_by_doc.get(_s(raw, "id") or "", []),
+                    files,
+                )
+            )
+
+        user = export.get("user")
+        return NormalisedPack(
+            adapter=self.name,
+            source=self.source,
+            exported_at=_s(export, "exported_at"),
+            source_user=user if isinstance(user, dict) else None,
+            documents=documents,
+        )
+
+    def _normalise_manifest(
+        self, export: dict[str, Any], files: dict[str, bytes]
+    ) -> NormalisedPack:
+        """The preferred shape: per-document versions nested, hashes at
+        source (``content_sha256`` computed by the source workspace at
+        write time)."""
+        docs_raw = export.get("documents")
+        if not isinstance(docs_raw, list):
+            raise MalformedExport("mike manifest: missing 'documents' list")
+
+        documents: list[NormalisedDocument] = []
+        for raw in docs_raw:
+            if not isinstance(raw, dict):
+                continue
+            version_rows = [
+                r for r in (raw.get("versions") or []) if isinstance(r, dict)
+            ]
+            edit_rows = [r for r in (raw.get("edits") or []) if isinstance(r, dict)]
+            documents.append(
+                self._normalise_document(raw, version_rows, edit_rows, files)
+            )
+
+        project = export.get("project")
+        return NormalisedPack(
+            adapter=self.name,
+            source=self.source,
+            exported_at=_s(export, "exported_at"),
+            source_user=None,
+            documents=documents,
+            source_project=project if isinstance(project, dict) else None,
+        )
+
+    def _normalise_version(self, row: dict[str, Any]) -> NormalisedVersion:
+        source = _s(row, "source")
+        author, provenance = MIKE_SOURCE_MAP.get(
+            source or "", (AUTHOR_UNKNOWN, f"unrecognised:{source}")
+        )
+        return NormalisedVersion(
+            external_id=_s(row, "id"),
+            version_number=_i(row, "version_number"),
+            source=source,
+            author=author,
+            provenance=provenance,
+            filename=_s(row, "filename"),
+            created_at=_s(row, "created_at"),
+            content_sha256=_s(row, "content_sha256"),
+        )
+
+    def _normalise_document(
+        self,
+        raw: dict[str, Any],
+        version_rows: list[dict[str, Any]],
+        edit_rows: list[dict[str, Any]],
+        files: dict[str, bytes],
+    ) -> NormalisedDocument:
+        versions = [
+            self._normalise_version(r)
+            for r in sorted(
+                version_rows, key=lambda r: (r.get("version_number") or 0)
+            )
+        ]
+        current_id = _s(raw, "current_version_id")
+        current = next(
+            (v for v in versions if v.external_id == current_id), None
+        ) or (versions[-1] if versions else None)
+
+        filename = (
+            (current.filename if current else None)
+            or _s(raw, "name")
+            or f"document-{_s(raw, 'id') or 'unknown'}"
+        )
+
+        edits = [
+            NormalisedEdit(
+                external_id=_s(r, "id"),
+                version_id=_s(r, "version_id"),
+                change_id=_s(r, "change_id"),
+                deleted_text=_s(r, "deleted_text"),
+                inserted_text=_s(r, "inserted_text"),
+                context_before=_s(r, "context_before"),
+                context_after=_s(r, "context_after"),
+                status=_s(r, "status"),
+                resolved_at=_s(r, "resolved_at"),
+            )
+            for r in edit_rows
+        ]
+
+        data = self._match_bytes(filename, current, files)
+        ingest_sha256 = (
+            hashlib.sha256(data).hexdigest() if data is not None else None
+        )
+        source_sha256 = current.content_sha256 if current else None
+        if source_sha256:
+            # The manifest carried a hash computed at the source — the
+            # stronger claim. Travelled bytes, when present, cross-check
+            # it; a disagreement is recorded, never repaired.
+            sha256 = source_sha256
+            hash_origin = HASH_VERIFIED_AT_SOURCE
+            hash_mismatch = (
+                ingest_sha256 is not None and ingest_sha256 != source_sha256
+            )
+        elif ingest_sha256 is not None:
+            sha256 = ingest_sha256
+            hash_origin = HASH_ATTESTED_AT_INGEST
+            hash_mismatch = False
+        else:
+            sha256 = None
+            hash_origin = None
+            hash_mismatch = False
+
+        return NormalisedDocument(
+            external_id=_s(raw, "id"),
+            filename=filename,
+            sha256=sha256,
+            hash_origin=hash_origin,
+            ingest_sha256=ingest_sha256,
+            hash_mismatch=hash_mismatch,
+            size_bytes=len(data) if data is not None else None,
+            current_version=current,
+            versions=versions,
+            edit_trail=edits,
+        )
+
+    @staticmethod
+    def _match_bytes(
+        filename: str,
+        current: NormalisedVersion | None,
+        files: dict[str, bytes],
+    ) -> bytes | None:
+        """Find this document's bytes among the ZIP entries.
+
+        Mike's ZIP names entries with the active version's filename,
+        decorated as ``<stem> [Edited V<n>]<ext>`` when the active
+        version is an assistant edit. Try the decorated name first
+        (exact intent), then the plain filename.
+        """
+        candidates: list[str] = []
+        if (
+            current is not None
+            and current.source == "assistant_edit"
+            and current.version_number
+        ):
+            m = re.match(r"^(?P<stem>.*?)(?P<ext>\.[^.]+)?$", filename)
+            stem = m.group("stem") if m else filename
+            ext = (m.group("ext") if m else None) or ""
+            candidates.append(f"{stem} [Edited V{current.version_number}]{ext}")
+        candidates.append(filename)
+        for name in candidates:
+            if name in files:
+                return files[name]
+        return None
+
+
+_ADAPTERS: dict[str, PackAdapter] = {MikeAdapter.name: MikeAdapter()}
+
+
+def get_adapter(name: str) -> PackAdapter:
+    adapter = _ADAPTERS.get(name)
+    if adapter is None:
+        raise UnknownAdapter(
+            f"unknown adapter '{name}' (available: {sorted(_ADAPTERS)})"
+        )
+    return adapter
+
+
+def normalise_export(
+    adapter_name: str, export: dict[str, Any], files: dict[str, bytes] | None = None
+) -> NormalisedPack:
+    """Normalise an external export into the working-pack shape."""
+    return get_adapter(adapter_name).normalise(export, files or {})
+
+
+# ---------------------------------------------------------------------------
+# Ingest — pack → read-only matter + WORM artifacts + audit row
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IngestResult:
+    matter: Matter
+    manifest: MatterArtifact
+    documents: list[tuple[MatterArtifact, NormalisedDocument]]
+    pack: NormalisedPack
+
+
+async def _unique_external_slug(
+    session: AsyncSession, source: str, user_id: uuid.UUID
+) -> str:
+    for _ in range(8):
+        candidate = f"external-{source}-{uuid.uuid4().hex[:8]}"
+        exists = await session.scalar(
+            select(Matter.id).where(
+                Matter.slug == candidate, Matter.created_by_id == user_id
+            )
+        )
+        if exists is None:
+            return candidate
+    raise ExternalPackError("could not allocate a unique pack slug")
+
+
+async def ingest_external_pack(
+    session: AsyncSession,
+    *,
+    user: User,
+    adapter_name: str,
+    export: dict[str, Any],
+    files: dict[str, bytes] | None = None,
+    title: str | None = None,
+) -> IngestResult:
+    """Ingest one external pack. Caller commits.
+
+    Creates a C_paused (read-only) matter marked ``external_source``,
+    one WORM document artifact per normalised document, a pack manifest
+    artifact, and the ``external.pack.ingested`` audit row carrying the
+    source, doc counts and hash manifest.
+
+    Document artifacts are written with ``created_by_id=None``: no
+    workspace user authored the external material, so a later sign-off
+    always carries ``signer_is_author=false`` — explicitly so for
+    assistant-authored versions.
+    """
+    pack = normalise_export(adapter_name, export, files)
+    adapter = get_adapter(adapter_name)
+
+    slug = await _unique_external_slug(session, adapter.source, user.id)
+    project_name = (
+        pack.source_project.get("name") if pack.source_project else None
+    )
+    default_title = (
+        f"External pack — {adapter.source}: {project_name}"
+        if isinstance(project_name, str) and project_name
+        else f"External pack — {adapter.source} ({datetime.now(UTC).date().isoformat()})"
+    )
+    matter = Matter(
+        id=uuid.uuid4(),
+        slug=slug,
+        title=title or default_title,
+        matter_type="external_pack",
+        status=STATUS_OPEN,
+        # C_paused → posture gate denies every capability run: the pack
+        # is supervised here, never worked here.
+        privilege_posture=PRIVILEGE_PAUSED,
+        default_model_id="stub-echo",
+        facts={"external_pack": True, "adapter": adapter.name},
+        external_source=adapter.source,
+        created_by_id=user.id,
+    )
+    session.add(matter)
+    await session.flush()
+
+    pack_id = uuid.uuid4()
+    documents: list[tuple[MatterArtifact, NormalisedDocument]] = []
+    for doc in pack.documents:
+        artifact = await write_artifact(
+            session,
+            matter=matter,
+            capability_id=PACK_DOCUMENT_CAPABILITY,
+            module_id=PACK_MODULE_ID,
+            invocation_id=uuid.uuid4(),
+            kind=KIND_DOCUMENT,
+            payload=doc.as_payload(),
+            actor_user_id=None,
+        )
+        documents.append((artifact, doc))
+
+    manifest_payload = {
+        "schema": PACK_SCHEMA,
+        "record": "manifest",
+        "adapter": pack.adapter,
+        "source": pack.source,
+        "exported_at": pack.exported_at,
+        "source_user": pack.source_user,
+        "source_project": pack.source_project,
+        "counts": pack.counts,
+        "hash_manifest": pack.hash_manifest,
+        "document_artifact_ids": [str(a.id) for a, _ in documents],
+        "ingested_at": datetime.now(UTC).isoformat(),
+        # The honesty boundary, stated in the record itself.
+        "attestation": (
+            "Two grades of hash claim, recorded per document: "
+            "verified_at_source (the source workspace hashed the bytes at "
+            "write time; travelled bytes cross-checked where present) and "
+            "attested_at_ingest (hashed here from the bytes the export "
+            "carried). This workspace did not watch the work happen."
+        ),
+    }
+    manifest = await write_artifact(
+        session,
+        matter=matter,
+        capability_id=PACK_INGEST_CAPABILITY,
+        module_id=PACK_MODULE_ID,
+        invocation_id=pack_id,
+        kind=KIND_MANIFEST,
+        payload=manifest_payload,
+        actor_user_id=user.id,
+    )
+
+    await audit.log(
+        session,
+        PACK_INGESTED_ACTION,
+        actor_id=user.id,
+        matter_id=matter.id,
+        module=PACK_MODULE_ID,
+        resource_type="matter_artifact",
+        resource_id=str(manifest.id),
+        payload={
+            "adapter": pack.adapter,
+            "source": pack.source,
+            "counts": pack.counts,
+            "hash_manifest": pack.hash_manifest,
+            "matter_slug": matter.slug,
+        },
+    )
+    return IngestResult(
+        matter=matter, manifest=manifest, documents=documents, pack=pack
+    )

--- a/backend/app/core/matter_artifacts.py
+++ b/backend/app/core/matter_artifacts.py
@@ -92,7 +92,7 @@ async def write_artifact(
     invocation_id: uuid.UUID,
     kind: str,
     payload: dict[str, Any],
-    actor_user_id: uuid.UUID,
+    actor_user_id: uuid.UUID | None,
 ) -> MatterArtifact:
     """Write an artifact to OBJECT STORAGE + insert the DB row.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.api.account import router as account_router
 from app.api.auth import router as auth_router
 from app.api.documents import router as documents_router
 from app.api.exports import router as exports_router
+from app.api.external_packs import router as external_packs_router
 from app.api.jobs import router as jobs_router
 from app.api.admin_launch_funnel import router as admin_launch_funnel_router
 from app.api.admin_users import router as admin_users_router
@@ -340,6 +341,9 @@ app.include_router(
 app.include_router(system_router, prefix="/api/system", tags=["system"])
 app.include_router(jobs_router, prefix="/api/matters", tags=["jobs"])
 app.include_router(exports_router, prefix="/api/matters", tags=["exports"])
+app.include_router(
+    external_packs_router, prefix="/api/external", tags=["external-packs"]
+)
 app.include_router(documents_router, prefix="/api/documents", tags=["documents"])
 app.include_router(modules_router, prefix="/api/modules", tags=["modules"])
 # Lawve Skill Importer v1 — external-source browse/convert (read-only;

--- a/backend/app/models/matter.py
+++ b/backend/app/models/matter.py
@@ -62,6 +62,12 @@ class Matter(Base):
 
     created_by_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
 
+    # Register sidecar: adapter name ("mike") when this matter is an
+    # ingested external-workspace pack; NULL for native matters. External
+    # matters are created C_paused so the posture gate keeps them
+    # read-only — no capability runs, no model calls, no skills.
+    external_source: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
     @property
     def required_provider(self) -> str | None:
         """The keyed provider this matter's default model needs, or None

--- a/backend/app/models/matter_artifact.py
+++ b/backend/app/models/matter_artifact.py
@@ -48,10 +48,14 @@ class MatterArtifact(Base):
     )
     kind: Mapped[str] = mapped_column(String(64), nullable=False)
     storage_path: Mapped[str] = mapped_column(Text, nullable=False)
-    created_by_id: Mapped[uuid.UUID] = mapped_column(
+    # NULL = no workspace user authored this artifact (external-pack
+    # documents whose author was the external assistant or an external
+    # human). signer_is_author is computed as created_by_id == signer.id,
+    # so a NULL author always reads as signer_is_author=false.
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("users.id"),
-        nullable=False,
+        nullable=True,
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/tests/test_external_packs.py
+++ b/backend/tests/test_external_packs.py
@@ -1,0 +1,447 @@
+"""Register sidecar — external pack ingestion tests.
+
+Covers the honesty boundary end to end with synthetic Mike-shaped
+fixtures (no vendored external code):
+
+- normalisation of the project export *manifest* (hashes at source →
+  ``verified_at_source``, travelled bytes cross-checked, mismatch
+  recorded);
+- normalisation of the flat account export (no source hashes →
+  ``attested_at_ingest`` from travelled bytes, ``unhashed`` otherwise);
+- provenance enum mapping (upload / assistant_edit / user_accept /
+  user_reject / generated);
+- POST /api/external/packs (multipart) → read-only external matter +
+  WORM artifacts + ``external.pack.ingested`` audit row w/ hash
+  manifest; GET list;
+- sign-off against pack outputs through the existing signoffs surface:
+  ``signer_is_author`` is always false (artifacts carry no workspace
+  author) and the M13 review-open row wires the review window.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import uuid
+import zipfile
+
+import pytest
+from sqlalchemy import select
+
+from app.core.external_pack import (
+    AUTHOR_ASSISTANT,
+    AUTHOR_HUMAN,
+    HASH_ATTESTED_AT_INGEST,
+    HASH_VERIFIED_AT_SOURCE,
+    MalformedExport,
+    UnknownAdapter,
+    normalise_export,
+)
+from app.models import AuditEntry, Matter, User
+from app.models.matter import PRIVILEGE_PAUSED
+
+
+@pytest.fixture(autouse=True)
+def _writable_matters_root(tmp_path, monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "matters_root", str(tmp_path), raising=False)
+
+
+DOC_BYTES = b"PK-fake-docx-bytes: settlement agreement draft"
+DOC_SHA = hashlib.sha256(DOC_BYTES).hexdigest()
+
+
+def mike_manifest(*, with_hashes: bool = True) -> dict:
+    """Synthetic project-export manifest in Mike's PR #181 shape."""
+    sha = DOC_SHA if with_hashes else None
+    return {
+        "manifest_version": 1,
+        "exported_at": "2026-06-12T09:00:00.000Z",
+        "project": {
+            "id": "proj-1",
+            "name": "Hart v Mercia Logistics",
+            "cm_number": "CM-0104",
+            "created_at": "2026-05-02T10:00:00.000Z",
+        },
+        "documents": [
+            {
+                "id": "doc-1",
+                "status": "ready",
+                "current_version_id": "v-2",
+                "created_at": "2026-05-02T10:05:00.000Z",
+                "versions": [
+                    {
+                        "id": "v-1",
+                        "version_number": 1,
+                        "source": "upload",
+                        "filename": "settlement.docx",
+                        "file_type": "docx",
+                        "size_bytes": 11,
+                        "content_sha256": (
+                            hashlib.sha256(b"original").hexdigest()
+                            if with_hashes
+                            else None
+                        ),
+                        "deleted_at": None,
+                        "created_at": "2026-05-02T10:05:00.000Z",
+                    },
+                    {
+                        "id": "v-2",
+                        "version_number": 2,
+                        "source": "assistant_edit",
+                        "filename": "settlement.docx",
+                        "file_type": "docx",
+                        "size_bytes": len(DOC_BYTES),
+                        "content_sha256": sha,
+                        "deleted_at": None,
+                        "created_at": "2026-05-03T16:20:00.000Z",
+                    },
+                ],
+                "edits": [
+                    {
+                        "id": "e-1",
+                        "version_id": "v-2",
+                        "change_id": "c-1",
+                        "status": "accepted",
+                        "created_at": "2026-05-03T16:20:00.000Z",
+                        "resolved_at": "2026-05-03T16:25:00.000Z",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def mike_account_export() -> dict:
+    """Synthetic flat account export — no source hashes anywhere."""
+    return {
+        "exported_at": "2026-06-12T09:00:00.000Z",
+        "user": {"id": "u-1", "email": "claimant@example.com"},
+        "documents": [
+            {
+                "id": "doc-1",
+                "project_id": "proj-1",
+                "status": "ready",
+                "current_version_id": "v-2",
+                "created_at": "2026-05-02T10:05:00.000Z",
+            },
+            {
+                "id": "doc-2",
+                "project_id": "proj-1",
+                "status": "ready",
+                "current_version_id": "v-3",
+                "created_at": "2026-05-04T09:00:00.000Z",
+            },
+        ],
+        "document_versions": [
+            {
+                "id": "v-1",
+                "document_id": "doc-1",
+                "version_number": 1,
+                "source": "upload",
+                "filename": "settlement.docx",
+                "created_at": "2026-05-02T10:05:00.000Z",
+            },
+            {
+                "id": "v-2",
+                "document_id": "doc-1",
+                "version_number": 2,
+                "source": "assistant_edit",
+                "filename": "settlement.docx",
+                "created_at": "2026-05-03T16:20:00.000Z",
+            },
+            {
+                "id": "v-3",
+                "document_id": "doc-2",
+                "version_number": 1,
+                "source": "user_accept",
+                "filename": "particulars.docx",
+                "created_at": "2026-05-04T09:00:00.000Z",
+            },
+        ],
+        "document_edits": [
+            {
+                "id": "e-1",
+                "document_id": "doc-1",
+                "version_id": "v-2",
+                "change_id": "c-1",
+                "deleted_text": "without admission",
+                "inserted_text": "without any admission of liability",
+                "context_before": "settled ",
+                "context_after": " by the Respondent",
+                "status": "accepted",
+                "resolved_at": "2026-05-03T16:25:00.000Z",
+            }
+        ],
+    }
+
+
+def docs_zip(entries: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, data in entries.items():
+            z.writestr(name, data)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Normalisation — the honesty boundary
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_with_source_hashes_is_verified_at_source() -> None:
+    # The assistant-edited active version's bytes travel under the
+    # decorated download name; the manifest already carries the hash.
+    pack = normalise_export(
+        "mike",
+        mike_manifest(with_hashes=True),
+        {"settlement [Edited V2].docx": DOC_BYTES},
+    )
+    assert len(pack.documents) == 1
+    doc = pack.documents[0]
+    assert doc.sha256 == DOC_SHA  # the SOURCE's hash is the record
+    assert doc.hash_origin == HASH_VERIFIED_AT_SOURCE
+    assert doc.ingest_sha256 == DOC_SHA  # cross-check agreed
+    assert doc.hash_mismatch is False
+    assert doc.author == AUTHOR_ASSISTANT
+    assert doc.provenance == "assistant_edit"
+    assert pack.counts["verified_at_source"] == 1
+    assert pack.counts["attested_at_ingest"] == 0
+    assert pack.counts["unhashed"] == 0
+    assert pack.source_project and pack.source_project["name"] == (
+        "Hart v Mercia Logistics"
+    )
+
+
+def test_manifest_source_hash_stands_without_travelled_bytes() -> None:
+    # Manifest-only ingest: no ZIP. The source hash still carries the
+    # claim; there is simply no ingest cross-check.
+    pack = normalise_export("mike", mike_manifest(with_hashes=True), {})
+    doc = pack.documents[0]
+    assert doc.sha256 == DOC_SHA
+    assert doc.hash_origin == HASH_VERIFIED_AT_SOURCE
+    assert doc.ingest_sha256 is None
+    assert doc.hash_mismatch is False
+
+
+def test_manifest_hash_mismatch_is_recorded_not_repaired() -> None:
+    pack = normalise_export(
+        "mike",
+        mike_manifest(with_hashes=True),
+        {"settlement [Edited V2].docx": b"tampered bytes"},
+    )
+    doc = pack.documents[0]
+    assert doc.sha256 == DOC_SHA  # the source claim stays the record
+    assert doc.hash_origin == HASH_VERIFIED_AT_SOURCE
+    assert doc.ingest_sha256 == hashlib.sha256(b"tampered bytes").hexdigest()
+    assert doc.hash_mismatch is True
+    assert pack.counts["hash_mismatches"] == 1
+
+
+def test_manifest_without_source_hashes_falls_back_to_ingest() -> None:
+    # A manifest whose versions predate content hashing: null hashes.
+    # The fallback is honest — hashed here, attested as received.
+    pack = normalise_export(
+        "mike",
+        mike_manifest(with_hashes=False),
+        {"settlement [Edited V2].docx": DOC_BYTES},
+    )
+    doc = pack.documents[0]
+    assert doc.sha256 == DOC_SHA
+    assert doc.hash_origin == HASH_ATTESTED_AT_INGEST
+    assert doc.hash_mismatch is False
+    assert pack.counts["verified_at_source"] == 0
+    assert pack.counts["attested_at_ingest"] == 1
+
+
+def test_account_export_normalises_with_ingest_hashes_and_unhashed() -> None:
+    # Flat account export: doc-1's bytes travelled, doc-2's did not.
+    pack = normalise_export(
+        "mike",
+        mike_account_export(),
+        {"settlement [Edited V2].docx": DOC_BYTES},
+    )
+    assert len(pack.documents) == 2
+    by_id = {d.external_id: d for d in pack.documents}
+
+    d1 = by_id["doc-1"]
+    assert d1.sha256 == DOC_SHA
+    assert d1.hash_origin == HASH_ATTESTED_AT_INGEST
+    assert d1.author == AUTHOR_ASSISTANT
+    assert len(d1.versions) == 2
+    assert d1.edit_trail[0].status == "accepted"
+    assert d1.edit_trail[0].inserted_text == (
+        "without any admission of liability"
+    )
+
+    d2 = by_id["doc-2"]
+    assert d2.sha256 is None  # no bytes, no hash — never guessed
+    assert d2.hash_origin is None
+    assert d2.author == AUTHOR_HUMAN  # user_accept is a human decision
+    assert d2.provenance == "human_accepted"
+
+    assert pack.counts == {
+        "documents": 2,
+        "versions": 3,
+        "edits": 1,
+        "verified_at_source": 0,
+        "attested_at_ingest": 1,
+        "unhashed": 1,
+        "hash_mismatches": 0,
+    }
+
+
+def test_unknown_adapter_and_malformed_export_raise() -> None:
+    with pytest.raises(UnknownAdapter):
+        normalise_export("harvey", {}, {})
+    with pytest.raises(MalformedExport):
+        normalise_export("mike", {"not_documents": []}, {})
+
+
+# ---------------------------------------------------------------------------
+# API — ingest, list, sign-off against external outputs
+# ---------------------------------------------------------------------------
+
+
+async def _register_and_login(client) -> str:
+    email = f"pack-{uuid.uuid4().hex[:8]}@example.com"
+    password = "register-sidecar-2026"
+    await client.post("/auth/register", json={"email": email, "password": password})
+    await client.post(
+        "/auth/login",
+        data={"username": email, "password": password},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    return email
+
+
+async def _post_pack(client, export: dict, files: dict[str, bytes] | None = None):
+    parts = {
+        "export": ("export.json", json.dumps(export).encode(), "application/json"),
+    }
+    if files:
+        parts["documents"] = ("documents.zip", docs_zip(files), "application/zip")
+    return await client.post(
+        "/api/external/packs", data={"adapter": "mike"}, files=parts
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_manifest_pack_end_to_end(client) -> None:
+    email = await _register_and_login(client)
+    resp = await _post_pack(
+        client,
+        mike_manifest(with_hashes=True),
+        {"settlement [Edited V2].docx": DOC_BYTES},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["adapter"] == "mike"
+    assert body["source"] == "mike"
+    assert body["counts"]["documents"] == 1
+    assert body["counts"]["verified_at_source"] == 1
+    assert body["title"] == "External pack — mike: Hart v Mercia Logistics"
+    assert len(body["document_artifact_ids"]) == 1
+
+    # The matter is external and read-only by construction.
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        matter = await session.scalar(
+            select(Matter).where(Matter.slug == body["matter_slug"])
+        )
+        assert matter is not None
+        assert matter.external_source == "mike"
+        assert matter.privilege_posture == PRIVILEGE_PAUSED
+
+        owner = await session.scalar(select(User).where(User.email == email))
+        row = await session.scalar(
+            select(AuditEntry).where(
+                AuditEntry.action == "external.pack.ingested",
+                AuditEntry.matter_id == matter.id,
+            )
+        )
+        assert row is not None
+        assert row.actor_id == owner.id
+        manifest = row.payload["hash_manifest"]
+        assert manifest[0]["sha256"] == DOC_SHA
+        assert manifest[0]["hash_origin"] == "verified_at_source"
+
+    # The pack shows on the list with zero sign-offs.
+    listed = await client.get("/api/external/packs")
+    assert listed.status_code == 200
+    packs = listed.json()["packs"]
+    assert len(packs) == 1
+    assert packs[0]["matter_slug"] == body["matter_slug"]
+    assert packs[0]["signoffs"]["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_rejects_unknown_adapter_and_bad_json(client) -> None:
+    await _register_and_login(client)
+    r1 = await client.post(
+        "/api/external/packs",
+        data={"adapter": "harvey"},
+        files={"export": ("export.json", b"{}", "application/json")},
+    )
+    assert r1.status_code == 422
+    assert r1.json()["detail"]["error"] == "unknown_adapter"
+
+    r2 = await client.post(
+        "/api/external/packs",
+        data={"adapter": "mike"},
+        files={"export": ("export.json", b"not-json", "application/json")},
+    )
+    assert r2.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_signoff_against_external_pack_output(client) -> None:
+    """The point of the sidecar: a workspace user signs an external,
+    assistant-authored output. ``signer_is_author`` must be false and
+    the M13 review window must wire through review-open."""
+    await _register_and_login(client)
+    resp = await _post_pack(
+        client,
+        mike_manifest(with_hashes=True),
+        {"settlement [Edited V2].docx": DOC_BYTES},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    slug = body["matter_slug"]
+    artifact_id = body["document_artifact_ids"][0]
+
+    # M13: open the sign surface first — starts the review window.
+    opened = await client.post(
+        f"/api/matters/{slug}/signoffs/review-open",
+        json={"artifact_id": artifact_id},
+    )
+    assert opened.status_code == 200
+    assert opened.json()["recorded"] is True
+
+    signed = await client.post(
+        f"/api/matters/{slug}/signoffs",
+        json={"artifact_id": artifact_id, "decision": "signed"},
+    )
+    assert signed.status_code == 201, signed.text
+    s = signed.json()
+    # No workspace user authored the external material: never self-sign.
+    assert s["signer_is_author"] is False
+    assert s["decision"] == "signed"
+    # Review window derived from the review-open row, not None.
+    assert s["review_seconds"] is not None and s["review_seconds"] >= 0
+
+    # The pack list now tallies the current sign-off.
+    listed = await client.get("/api/external/packs")
+    pack = listed.json()["packs"][0]
+    assert pack["signoffs"]["total"] == 1
+    assert pack["signoffs"]["signed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_packs_require_auth(client) -> None:
+    r = await client.get("/api/external/packs")
+    assert r.status_code == 401

--- a/docs/REGISTER_SIDECAR.md
+++ b/docs/REGISTER_SIDECAR.md
@@ -1,0 +1,50 @@
+# The register sidecar
+
+Legalise supervises work it did not produce. An export from another
+workspace is ingested as an **external pack**: a read-only matter that
+exists to be reviewed and signed, with every step on the same
+hash-chained record as native work. The workspace that did the work
+stays the workspace; Legalise is the register it answers to.
+
+## The honesty boundary
+
+Two grades of provenance, recorded per document and shown on the
+register face:
+
+- **verified_at_source** — the export carried content hashes computed
+  by the source workspace (a tamper-evident manifest). The chain of
+  custody starts where the work happened.
+- **attested_at_ingest** — the export carried bytes but no hashes.
+  Legalise hashes what it received; the attestation starts at ingest,
+  and the register says so. We never claim more than the export proves.
+
+## The Mike adapter
+
+First adapter: [Mike](https://github.com/willchen96/mike), the
+open-source legal AI workspace. Mapping:
+
+| Mike | Legalise |
+|---|---|
+| project | external matter (`external_source: "mike"`, read-only) |
+| document_versions.content_sha256 | verified_at_source hash (where present) |
+| version `source: assistant_edit / generated` | author = assistant (signer is never the author) |
+| version `source: user_accept / user_upload / upload` | author = human |
+| document_edits accept/reject trail | preserved as the review history |
+| export manifest | ingest audit row's hash manifest |
+
+Mike's plain account export works today (attested_at_ingest). With
+content hashes at source (proposed upstream), packs arrive
+verified_at_source end to end.
+
+## What an external pack cannot do
+
+No model calls. No skills. No edits. It is a record under
+supervision: a named person reviews a version and signs, with the
+review window measured, exactly as for native outputs.
+
+## The interchange manifest (proposed)
+
+Any workspace can make its exports register-ready with one JSON shape:
+per document, a version list of `{content_sha256, source, created_at}`
+plus accept/reject references, and an optional `signoff` slot. The
+Mike adapter's input format is the reference implementation.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,6 +12,7 @@ export * from "./api/documents";
 export * from "./api/assistant";
 export * from "./api/modules";
 export * from "./api/signoffs";
+export * from "./api/external";
 export * from "./api/audit";
 export * from "./api/admin";
 export * from "./api/settings";

--- a/frontend/src/lib/api/external.ts
+++ b/frontend/src/lib/api/external.ts
@@ -1,0 +1,51 @@
+// External packs — the register sidecar (docs/REGISTER_SIDECAR.md).
+//
+// An external workspace's export, ingested as a read-only matter and
+// supervised here: per-document hash manifest (verified-at-source vs
+// attested-at-ingest), sign-off through the existing signoffs surface.
+
+import { API, apiFetch, jsonOrThrow } from "./_core";
+
+export interface ExternalPackSignoffSummary {
+  total: number;
+  signed: number;
+  signed_with_observations: number;
+  rejected: number;
+}
+
+export interface ExternalPack {
+  matter_id: string;
+  matter_slug: string;
+  title: string;
+  adapter: string;
+  source: string;
+  exported_at: string | null;
+  ingested_at: string | null;
+  // documents / versions / edits / verified_at_source /
+  // attested_at_ingest / unhashed / hash_mismatches
+  counts: Record<string, number>;
+  manifest_artifact_id: string;
+  document_artifact_ids: string[];
+  signoffs: ExternalPackSignoffSummary;
+}
+
+export const listExternalPacks = () =>
+  apiFetch(`${API}/external/packs`).then((r) =>
+    jsonOrThrow<{ packs: ExternalPack[] }>(r),
+  );
+
+export const ingestExternalPack = (params: {
+  adapter: string;
+  exportJson: File | Blob;
+  documentsZip?: File | Blob | null;
+  title?: string;
+}) => {
+  const fd = new FormData();
+  fd.append("adapter", params.adapter);
+  fd.append("export", params.exportJson, "export.json");
+  if (params.documentsZip) fd.append("documents", params.documentsZip, "documents.zip");
+  if (params.title) fd.append("title", params.title);
+  return apiFetch(`${API}/external/packs`, { method: "POST", body: fd }).then(
+    (r) => jsonOrThrow<ExternalPack>(r),
+  );
+};

--- a/frontend/src/modules-v2/CounselRegister.tsx
+++ b/frontend/src/modules-v2/CounselRegister.tsx
@@ -21,6 +21,7 @@ import {
   type InstalledModule,
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
+import { ExternalPacksSection } from "./ExternalPacks";
 
 const TIERS = [
   "factual_extraction",
@@ -143,6 +144,8 @@ export function CounselRegister() {
           ))}
         </div>
       )}
+
+      <ExternalPacksSection />
 
       <p className="mt-14 border-t border-rule pt-3 text-[10px] uppercase tracking-[0.2em] text-muted">
         Refusals and revocations are recorded with the same fidelity as

--- a/frontend/src/modules-v2/ExternalPacks.test.tsx
+++ b/frontend/src/modules-v2/ExternalPacks.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Supervised exports — the pack certificate states the honesty boundary
+ * as counts: verified-at-source vs attested-at-ingest, mismatches in
+ * seal, sign-offs tallied.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { PackCertificate } from "./ExternalPacks";
+import type { ExternalPack } from "../lib/api";
+
+afterEach(() => cleanup());
+
+function pack(overrides: Partial<ExternalPack> = {}): ExternalPack {
+  return {
+    matter_id: "m-1",
+    matter_slug: "external-mike-abc12345",
+    title: "External pack — mike: Hart v Mercia Logistics",
+    adapter: "mike",
+    source: "mike",
+    exported_at: "2026-06-12T09:00:00.000Z",
+    ingested_at: "2026-06-12T10:00:00.000Z",
+    counts: {
+      documents: 3,
+      versions: 5,
+      edits: 2,
+      verified_at_source: 2,
+      attested_at_ingest: 1,
+      unhashed: 0,
+      hash_mismatches: 0,
+    },
+    manifest_artifact_id: "a-1",
+    document_artifact_ids: ["a-2", "a-3", "a-4"],
+    signoffs: { total: 0, signed: 0, signed_with_observations: 0, rejected: 0 },
+    ...overrides,
+  };
+}
+
+// Router Link needs a router context in real pages; for the unit test we
+// stub it by rendering inside a plain DOM — TanStack's Link throws
+// without a router, so the certificate is tested through its testids
+// with the title link asserted by text only.
+import { vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+describe("PackCertificate", () => {
+  it("grades the hash claims and shows no sign-offs yet", () => {
+    render(<PackCertificate pack={pack()} index={0} />);
+    expect(screen.getByTestId("pack-doc-count")).toHaveTextContent("3");
+    expect(screen.getByTestId("pack-verified-count")).toHaveTextContent("2");
+    expect(screen.getByTestId("pack-attested-count")).toHaveTextContent("1");
+    expect(screen.queryByTestId("pack-mismatch-count")).not.toBeInTheDocument();
+    expect(screen.getByTestId("pack-signoffs")).toHaveTextContent("none yet");
+    expect(
+      screen.getByText("External pack — mike: Hart v Mercia Logistics"),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces hash mismatches in seal and tallies sign-offs", () => {
+    render(
+      <PackCertificate
+        pack={pack({
+          counts: {
+            documents: 2,
+            versions: 2,
+            edits: 0,
+            verified_at_source: 2,
+            attested_at_ingest: 0,
+            unhashed: 0,
+            hash_mismatches: 1,
+          },
+          signoffs: {
+            total: 2,
+            signed: 1,
+            signed_with_observations: 0,
+            rejected: 1,
+          },
+        })}
+        index={1}
+      />,
+    );
+    expect(screen.getByTestId("pack-mismatch-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("pack-signoffs")).toHaveTextContent(
+      "1 signed · 1 refused",
+    );
+  });
+});

--- a/frontend/src/modules-v2/ExternalPacks.tsx
+++ b/frontend/src/modules-v2/ExternalPacks.tsx
@@ -1,0 +1,157 @@
+/**
+ * Supervised exports — the register sidecar's face on /register
+ * (docs/REGISTER_SIDECAR.md).
+ *
+ * Each certificate is an external workspace's export held under
+ * supervision here: where it came from, how many documents, how each
+ * hash claim grades (verified at source vs attested at ingest — the
+ * honesty boundary, counted, never blurred), and what has been signed.
+ * Rendered in the P27 certificate/ledger idiom from ui/certificate.tsx.
+ */
+
+import { useEffect, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { listExternalPacks, type ExternalPack } from "../lib/api";
+import {
+  CertCard,
+  CertEyebrow,
+  LedgerRow,
+  SectionRule,
+} from "../ui/certificate";
+
+type Query =
+  | { status: "loading" }
+  | { status: "ready"; packs: ExternalPack[] }
+  | { status: "error" };
+
+export function ExternalPacksSection() {
+  const [q, setQ] = useState<Query>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    listExternalPacks()
+      .then(({ packs }) => {
+        if (!cancelled) setQ({ status: "ready", packs });
+      })
+      .catch(() => {
+        if (!cancelled) setQ({ status: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // The section earns its place only when a pack exists — the register
+  // page does not advertise an empty drawer.
+  if (q.status !== "ready" || q.packs.length === 0) return null;
+
+  return (
+    <section className="mt-16" data-testid="external-packs">
+      <SectionRule
+        label="Supervised exports"
+        right={String(q.packs.length).padStart(2, "0")}
+      />
+      <p className="mt-4 max-w-xl text-sm leading-relaxed text-prose">
+        Work done in another workspace, held to account in this one. Each
+        pack below is an external export ingested read-only — no model may
+        touch it here — with every document's hash claim graded: verified
+        at the source workspace, or attested at ingest from the bytes the
+        export carried. Sign-off runs through the same register as native
+        work.
+      </p>
+      <div className="mt-8 grid gap-6 sm:grid-cols-2">
+        {q.packs.map((pack, i) => (
+          <PackCertificate key={pack.matter_id} pack={pack} index={i} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function PackCertificate({
+  pack,
+  index,
+}: {
+  pack: ExternalPack;
+  index: number;
+}) {
+  const c = pack.counts;
+  const mismatches = c.hash_mismatches ?? 0;
+  const signedTotal =
+    pack.signoffs.signed + pack.signoffs.signed_with_observations;
+  return (
+    <CertCard
+      tone={mismatches > 0 ? "seal" : "ink"}
+      testid={`external-pack-${pack.matter_slug}`}
+    >
+      <CertEyebrow
+        left={`Pack ${String(index + 1).padStart(2, "0")}`}
+        right={pack.source}
+      />
+      <h2 className="mt-3 text-[22px] leading-tight tracking-tight2 text-ink">
+        <Link
+          to="/matters/$slug"
+          params={{ slug: pack.matter_slug }}
+          className="hover:underline"
+        >
+          {pack.title}
+        </Link>
+      </h2>
+      <p className="mt-1 text-xs text-muted">
+        ingested {formatDate(pack.ingested_at)} · exported{" "}
+        {formatDate(pack.exported_at)}
+      </p>
+
+      <dl className="mt-4 space-y-1 text-[11px] text-muted">
+        <LedgerRow label="Documents">
+          <span data-testid="pack-doc-count">{c.documents ?? 0}</span>
+        </LedgerRow>
+        <LedgerRow label="Verified at source" tone="ink">
+          <span data-testid="pack-verified-count">
+            {c.verified_at_source ?? 0}
+          </span>
+        </LedgerRow>
+        <LedgerRow label="Attested at ingest">
+          <span data-testid="pack-attested-count">
+            {c.attested_at_ingest ?? 0}
+          </span>
+        </LedgerRow>
+        {(c.unhashed ?? 0) > 0 && (
+          <LedgerRow label="Unhashed">{c.unhashed}</LedgerRow>
+        )}
+        {mismatches > 0 && (
+          <LedgerRow label="Hash mismatches" tone="seal">
+            <span data-testid="pack-mismatch-count">{mismatches}</span>
+          </LedgerRow>
+        )}
+        <LedgerRow label="Sign-offs" tone={signedTotal > 0 ? "ink" : "muted"}>
+          <span data-testid="pack-signoffs">
+            {pack.signoffs.total === 0
+              ? "none yet"
+              : [
+                  pack.signoffs.signed > 0 &&
+                    `${pack.signoffs.signed} signed`,
+                  pack.signoffs.signed_with_observations > 0 &&
+                    `${pack.signoffs.signed_with_observations} with observations`,
+                  pack.signoffs.rejected > 0 &&
+                    `${pack.signoffs.rejected} refused`,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
+          </span>
+        </LedgerRow>
+      </dl>
+    </CertCard>
+  );
+}


### PR DESCRIPTION
An export from another workspace ingests as a read-only external
matter: documents hashed (verified_at_source where the export carries
hashes, attested_at_ingest otherwise, recorded per document), the
assistant/human provenance mapped so the signer is never the author,
sign-off and review-latency machinery applying unchanged, everything
on the hash-chained record. Mike adapter first; the register face
lists packs in the certificate idiom; docs/REGISTER_SIDECAR.md states
the honesty boundary and the proposed interchange manifest.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external pack ingestion capability, allowing users to import workspace exports from external sources.
  * Introduced "External Packs" section in the register displaying ingested packs with document counts, hash verification status, and signoff tracking.
  * Support for external workspace export formats with document provenance verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->