### PR TITLE
Landing lead-in rework + honesty pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A regulator, insurer, supervisor, or partner will eventually ask four questions 
 3. What did it produce?
 4. Who remained accountable?
 
-Every matter has a spine: documents, chronology, parties, retention clock, privilege posture. The AI only sees what lives inside the matter. Cross-matter leakage is structurally impossible.
+Every matter has a spine: documents, chronology, parties, retention clock, privilege posture. The AI only sees what lives inside the matter. Cross-matter access is scoped by access control at the application layer, and every access is audited. This is enforced in the application, not a structural guarantee. See [`docs/TRUST.md`](./docs/TRUST.md).
 
 Disclosure-tainted chronology entries carry a CPR 31.22 implied-undertaking flag. The chronology gate withholds detail until acknowledgement. The acknowledgement is audited.
 

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -776,7 +776,7 @@ function demoDocumentExtract(doc: MatterDocument): string {
       "RE: TERMINATION OF EMPLOYMENT",
       "I am writing to confirm the outcome of the disciplinary hearing held on 10 March 2026. The panel found that your conduct in publishing material on social media on 5 March 2026 amounted to a serious breach of the Company's Social Media and Communications Policy (section 4.2).",
       "The Company has decided that your employment will terminate with effect from 12 March 2026. You will be paid in lieu of your notice period.",
-      "The disciplinary meeting was chaired by Mr D. Howarth, Warehouse Operations Manager. The panel considered your written representations and the investigation report dated 6 March 2026.",
+      "The disciplinary meeting was chaired by Mr D. Caldwell, Warehouse Operations Manager. The panel considered your written representations and the investigation report dated 6 March 2026.",
       "You have the right to appeal this decision in writing within five working days.",
       "Yours sincerely,\nHR Department\nAcme Trading Ltd",
     ].join("\n\n");
@@ -787,9 +787,9 @@ function demoDocumentExtract(doc: MatterDocument): string {
       "WITNESS STATEMENT OF JASMINE KHAN",
       "1. I make this statement from my own knowledge save where otherwise stated.",
       "2. I was employed by the Respondent from 8 November 2022 until my dismissal on 12 March 2026, most recently as a warehouse team coordinator. My disciplinary record was clean throughout.",
-      "3. On 29 January 2026 I raised a written grievance concerning the conduct of my line manager, Mr Howarth, toward female members of the warehouse team. HR acknowledged the grievance on 18 February 2026 and appointed Mr Howarth's own department to investigate it.",
+      "3. On 29 January 2026 I raised a written grievance concerning the conduct of my line manager, Mr Caldwell, toward female members of the warehouse team. HR acknowledged the grievance on 18 February 2026 and appointed Mr Caldwell's own department to investigate it.",
       "4. The Instagram post relied on by the Respondent was made on 5 March 2026 from my personal account, outside working hours. The account is private, with an audience of 47 approved followers. None of them are customers, suppliers, or people named in the post. The post did not identify the Respondent.",
-      "5. The disciplinary meeting on 10 March 2026 was chaired by Mr Howarth — the manager who was the subject of my grievance six weeks earlier.",
+      "5. The disciplinary meeting on 10 March 2026 was chaired by Mr Caldwell — the manager who was the subject of my grievance six weeks earlier.",
       "I believe the facts stated in this witness statement are true.",
     ].join("\n\n");
   }

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -6,6 +6,38 @@ import { LedgerLine, SectionRule } from "../ui/certificate";
 
 const DEMO_SLUG = "khan-v-acme-trading-2026";
 
+// The demo, framed before the click: the three moves a visitor watches.
+const DEMO_MOVES: { title: string; body: string }[] = [
+  {
+    title: "Raw",
+    body: "Ask an ordinary model about the matter. It answers in confident prose, and gets a load-bearing fact wrong.",
+  },
+  {
+    title: "Caught",
+    body: "Ask again through a skill. It tests the claim against the documents, finds no support, and refuses. The refusal is struck onto the record.",
+  },
+  {
+    title: "Signed",
+    body: "A named human reviews the output, amends it, and signs. The record now shows who stood behind it.",
+  },
+];
+
+// The three load-bearing words, defined plainly on first contact.
+const TERMS: { term: string; body: string }[] = [
+  {
+    term: "Register",
+    body: "A running record of a matter: what the AI read, what it produced, what it refused to do. Like a court file, kept automatically.",
+  },
+  {
+    term: "Refusal on record",
+    body: "When a skill will not do something, reach a privileged document, answer beyond its remit, the refusal is logged as faithfully as an answer. The blocked move is evidence too.",
+  },
+  {
+    term: "Sign-off",
+    body: "An output is not finished until a named person reads it and takes responsibility. The signature pins exactly what they signed.",
+  },
+];
+
 const SURFACES: { title: string; body: string }[] = [
   {
     title: "Open project",
@@ -63,6 +95,7 @@ export function Landing() {
 
   return (
     <div className="max-w-page mx-auto">
+      {/* Hero: the felt problem first, the answer second, the demo framed. */}
       <section className="relative overflow-hidden border-b border-rule">
         <div
           className="pointer-events-none absolute inset-0 z-0 hidden md:block"
@@ -82,17 +115,21 @@ export function Landing() {
         </div>
         <div className="relative z-10 px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-24 max-w-3xl">
           <div className="eyebrow text-muted mb-5">
-            Open source · Apache 2.0 · v0.1
+            Open source · England &amp; Wales · v0.1
           </div>
+          <p className="text-lg md:text-xl text-prose leading-relaxed max-w-2xl mb-6">
+            Today&rsquo;s models draft your case fluently, cite authorities that
+            were never decided, and leave no record of how they got there.
+          </p>
           <h1 className="text-4xl md:text-5xl font-bold tracking-tight2 text-ink mb-2 leading-[1.05]">
-            Legal AI that signs its work.
+            Not another AI workspace. The register underneath them.
           </h1>
           <div className="w-16 h-[3px] bg-seal mt-3 mb-6" aria-hidden="true" />
           <p className="text-xl text-muted leading-relaxed max-w-xl">
-            Not another AI workspace. The register underneath them, for
-            England &amp; Wales: skills admitted like counsel, outputs
-            signed by named people, refusals kept on the record. Open
-            source, with a live matter to walk.
+            Legalise runs AI inside a matter file and keeps the kind of record
+            you could hand a regulator: what it read, what it refused to do, and
+            the named person who signed the work off. Open source, built for
+            England &amp; Wales.
           </p>
 
           {/* CTAs */}
@@ -123,7 +160,7 @@ export function Landing() {
                 href="/demo"
                 className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px] inline-flex items-center"
               >
-                Open the demo
+                Walk the demo
               </a>
               <a
                 href="https://github.com/b1rdmania/legalise"
@@ -137,6 +174,11 @@ export function Landing() {
             </div>
           )}
 
+          <p className="mt-5 max-w-xl text-sm leading-relaxed text-prose">
+            A real unfair-dismissal matter. Watch the AI get a fact wrong, watch
+            the guardrail catch it, and watch a human sign it off.
+          </p>
+
           <QuickstartCommand />
 
           <p className="eyebrow mt-8 text-muted">
@@ -145,6 +187,84 @@ export function Landing() {
         </div>
       </section>
 
+      {/* Why this exists: the cost of capability alone, earned early. */}
+      <section className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
+        <SectionRule label="Why this exists" right="The cost of capability alone" />
+        <div className="mt-8 max-w-3xl">
+          <div className="flex flex-col sm:flex-row sm:items-baseline sm:gap-8">
+            <div className="font-redaction35 text-ink text-[64px] sm:text-[88px] leading-none tracking-tight2">
+              1,600
+            </div>
+            <p className="mt-3 sm:mt-0 text-lg text-prose leading-relaxed max-w-xl">
+              court decisions where AI put citations to cases that were never
+              decided in front of a judge. Damien Charlotin has been cataloguing
+              them, and the count keeps climbing.
+            </p>
+          </div>
+          <p className="mt-8 max-w-2xl text-base leading-relaxed text-prose">
+            The models are capable enough to be trusted and confident enough to
+            be wrong. The missing piece is not a better model. It is a record:
+            of what the AI did, what it would not do, and who took
+            responsibility.
+          </p>
+          <a
+            href="/architecture"
+            className="mt-6 inline-flex text-sm text-muted underline underline-offset-4 decoration-rule transition-colors hover:decoration-seal hover:text-seal"
+          >
+            Read the full argument
+          </a>
+        </div>
+      </section>
+
+      {/* The demo, framed: raw -> caught -> signed. */}
+      <section className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
+        <div className="max-w-page mx-auto">
+          <SectionRule label="The demo" right="Three moves" />
+          <h2 className="mt-5 text-3xl md:text-4xl font-bold tracking-tight2 text-ink mb-10 leading-tight max-w-2xl">
+            Watch it work, catch it, and sign it.
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-rule border border-rule">
+            {DEMO_MOVES.map((m, i) => (
+              <div key={m.title} className="bg-paper p-6 md:p-8">
+                <div className="text-[10px] uppercase tracking-[0.25em] text-muted mb-4">
+                  {String(i + 1).padStart(2, "0")} / 03
+                </div>
+                <h3 className="text-lg font-bold text-ink mb-3 tracking-tight2">
+                  {m.title}
+                </h3>
+                <p className="text-sm text-prose leading-relaxed">{m.body}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-8">
+            <a
+              href="/demo"
+              className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px] inline-flex items-center"
+            >
+              Walk the demo
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* The three load-bearing words, in plain English. */}
+      <section className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
+        <div className="max-w-page mx-auto">
+          <SectionRule label="In plain English" />
+          <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-px bg-rule border border-rule">
+            {TERMS.map((t) => (
+              <div key={t.term} className="bg-paper p-6 md:p-8">
+                <h3 className="text-lg font-bold text-ink mb-3 tracking-tight2">
+                  {t.term}
+                </h3>
+                <p className="text-sm text-prose leading-relaxed">{t.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* How it works: the six steps. */}
       <section className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
         <div className="max-w-page mx-auto">
           <SectionRule label="How it works" />
@@ -170,6 +290,7 @@ export function Landing() {
         </div>
       </section>
 
+      {/* The register depth: for the visitor who is now bought in. */}
       <section className="border-b border-rule px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20">
         <SectionRule label="The record" right="In three lines" />
         <div className="max-w-3xl">

--- a/frontend/src/modules-v2/ExternalPacks.tsx
+++ b/frontend/src/modules-v2/ExternalPacks.tsx
@@ -48,7 +48,7 @@ export function ExternalPacksSection() {
   return (
     <section className="mt-16" data-testid="external-packs">
       <SectionRule
-        label="Supervised exports"
+        label="External exports"
         right={String(q.packs.length).padStart(2, "0")}
       />
       <p className="mt-4 max-w-xl text-sm leading-relaxed text-prose">


### PR DESCRIPTION
Integrates the landing review spec (~/Desktop/legalise-landing-review-spec-2026-06-15.md). Presentation only — no backend changes, register depth and substance untouched.

## Landing lead-in (the main thrust)
The hero started at the destination and never said what this is or why you'd care before how it works. Cold visitors bounced before the value landed. Reworked to teach in order:

- **Hero** opens on the felt problem (confident models, fabricated citations, no record) before the answer; the **register reframe is now the H1** ("Not another AI workspace. The register underneath them."), and the demo is framed before the click.
- **"Why this exists"** pulls the Charlotin 1,600-case figure up near the top, so the *why* is earned before the *what*.
- **"The demo"** frames the walk as three moves: Raw → Caught → Signed.
- **"In plain English"** defines the three load-bearing words on first contact: register, refusal on record, sign-off.
- The register depth (three-line ledger + architecture CTA) stays as the closer for the bought-in visitor.

## Honesty pass (the spec's over-claim fixes)
- README: "cross-matter leakage structurally impossible" → scoped by access control at the application layer and audited; not a structural guarantee. Promotes wording TRUST.md already carried.
- Register sidecar section label "Supervised exports" → "External exports" (body copy was already accurate; export carries sign-off status + source anchors, it does not gate).

## Demo correctness
- The disciplinary chair was named two different ways across the termination letter and Khan's witness statement. Renamed consistently to Caldwell — the matter's whole point is that the manager who was subject of her grievance then chaired her disciplinary, so the name has to match.

Verified: tsc clean; landing checked at desktop and mobile widths via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified trust boundary documentation with improved details on application-layer access control scoping and comprehensive audit trail visibility.

* **UI Updates**
  * Landing page redesigned with new "Why this exists" and "In plain English" informational sections for improved clarity.
  * Demo content updated with revised character names for consistency across documents.
  * Updated label terminology from "Supervised exports" to "External exports".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->