### PR TITLE
Funnel on-ramp: first-run note + clearer verify-pending

### DIFF
--- a/frontend/src/auth/VerifyPending.tsx
+++ b/frontend/src/auth/VerifyPending.tsx
@@ -30,10 +30,12 @@ export function VerifyPending() {
   return (
     <AuthCard
       heading="Check your inbox"
-      intro="We sent a verification link to your email. Click it to activate your account."
+      intro="We just sent a verification link to your email. Click it to activate your account. If it does not arrive in a minute, check your spam folder or resend it below."
     >
       {sent ? (
-        <p className="prose-p mb-0">A new link is on its way.</p>
+        <p className="prose-p mb-0">
+          A new link is on its way. Check your spam folder if you do not see it.
+        </p>
       ) : (
         <form className="flex flex-col gap-6" onSubmit={resend}>
           <LedgerField label="Email" hint="resend the link if needed">

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { listMatters, type Matter } from "../lib/api";
+import { listApiKeys, listMatters, type Matter } from "../lib/api";
 import { postureLabel } from "../lib/posture";
 import { EmptyState, ErrorCallout, PageHeader } from "../ui/primitives";
 import { LedgerLine, SectionRule } from "../ui/certificate";
@@ -15,11 +15,17 @@ function formatType(raw: string): string {
 export function MatterList() {
   const [matters, setMatters] = useState<Matter[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // A new user has no provider key on file yet. Used to show one quiet
+  // first-run orientation note. On error we stay silent rather than nag.
+  const [noKey, setNoKey] = useState(false);
 
   useEffect(() => {
     listMatters()
       .then((rows) => setMatters(rows))
       .catch((e) => setError(String(e)));
+    listApiKeys()
+      .then((keys) => setNoKey(keys.length === 0))
+      .catch(() => setNoKey(false));
   }, []);
 
   return (
@@ -38,6 +44,33 @@ export function MatterList() {
           </a>
         }
       />
+
+      {noKey && (
+        <div className="mb-8 border border-rule bg-wash px-5 py-4">
+          <div className="text-[10px] uppercase tracking-[0.25em] text-muted mb-2">
+            Start here
+          </div>
+          <p className="max-w-2xl text-sm leading-relaxed text-prose">
+            New to the workspace? Walk the public demo to see the whole loop
+            end to end, with nothing to set up. To run skills on your own
+            matters, add a model key in settings.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-5">
+            <a
+              href="/demo"
+              className="text-sm text-ink underline underline-offset-4 decoration-rule transition-colors hover:decoration-seal hover:text-seal"
+            >
+              Walk the demo
+            </a>
+            <a
+              href="/settings/keys"
+              className="text-sm text-muted underline underline-offset-4 decoration-rule transition-colors hover:decoration-seal hover:text-seal"
+            >
+              Add a model key
+            </a>
+          </div>
+        </div>
+      )}
 
       {error && <ErrorCallout message={error} />}
 


### PR DESCRIPTION
Closes the residue of the spec's three funnel cliffs. The map back showed the spec (written from a black-box walk) overstated two of them:

- **Cliff 1 (email verify):** already solved. `/auth/verify-pending` already carries a resend form front-and-centre. Only residue was copy.
- **Cliff 2 (API key):** already mostly solved. `InvocationRunner`/`GenericSkillRunner` already render an inline "configure a provider key →" banner, one click from settings. Residue: nothing flagged the key requirement *before* a failed run.
- **Cliff 3 (post-verify):** the real gap. A verified user landed on the seeded matter list with zero orientation.

## Changes
- **MatterList** — one quiet, in-idiom "Start here" note, shown only while the user has no provider key on file. Points to the keyless public `/demo` to see the loop end to end, and to `/settings/keys` to add a key. This proactively closes cliff 2's gap too.
  - Honesty note: the seeded Khan matter runs on `claude-opus-4-7`, **not** keyless, so it would hit the key wall. Only `/demo` is truly keyless, so that's where "nothing to set up" points.
- **VerifyPending** — say the link was *just* sent and point at the spam folder, both in the screen and the post-resend confirmation.

Deliberately **not** built: welcome overlay, onboarding checklist, "you're all set" confetti — the spec suggested these; they're the gimmicky pattern the design taste rejects.

Verified: tsc clean; no tests affected. The note is gated on `listApiKeys().length === 0`, so a live view needs an authed no-key session (best seen on the preview deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)