### PR TITLE
Demo on-ramp: lead to the live governed loop, not the static snapshot

### DIFF
--- a/frontend/src/landing/About.tsx
+++ b/frontend/src/landing/About.tsx
@@ -96,10 +96,10 @@ export function About() {
               <SectionRule label="Start here" />
               <div className="mt-6 flex flex-wrap gap-4">
                 <a
-                  href="/demo"
+                  href="/demo-loop"
                   className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px] inline-flex items-center"
                 >
-                  Open the demo
+                  Walk the demo
                 </a>
                 <a
                   href="/architecture"

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -6,19 +6,20 @@ import { LedgerLine, SectionRule } from "../ui/certificate";
 
 const DEMO_SLUG = "khan-v-acme-trading-2026";
 
-// The demo, framed before the click: the three moves a visitor watches.
+// The demo, framed before the click: the governed loop a visitor runs,
+// live, on real endpoints, with no provider key.
 const DEMO_MOVES: { title: string; body: string }[] = [
   {
-    title: "Raw",
-    body: "Ask an ordinary model about the matter. It answers in confident prose, and gets a load-bearing fact wrong.",
+    title: "Run",
+    body: "Run a skill against the matter's documents — keyless, on a stub model. It executes under the same privilege control, per-matter permissions, and audit as a real run.",
   },
   {
-    title: "Caught",
-    body: "Ask again through a skill. It tests the claim against the documents, finds no support, and refuses. The refusal is struck onto the record.",
+    title: "Review",
+    body: "The output lands as a first-class artifact and goes for review. The author can't approve their own work; a separate reviewer decides. That separation is the guarantee.",
   },
   {
-    title: "Signed",
-    body: "A named human reviews the output, amends it, and signs. The record now shows who stood behind it.",
+    title: "Record",
+    body: "Open the Record. The whole chain is reconstructed — skill run, model called, artifact written, review requested. Every step real, nothing faked.",
   },
 ];
 
@@ -157,7 +158,7 @@ export function Landing() {
           ) : (
             <div className="flex flex-wrap items-center gap-4 mt-10">
               <a
-                href="/demo"
+                href="/demo-loop"
                 className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px] inline-flex items-center"
               >
                 Walk the demo
@@ -175,8 +176,10 @@ export function Landing() {
           )}
 
           <p className="mt-5 max-w-xl text-sm leading-relaxed text-prose">
-            A real unfair-dismissal matter. Watch the AI get a fact wrong, watch
-            the guardrail catch it, and watch a human sign it off.
+            A keyless run on a matter modelled on a real unfair-dismissal
+            dispute. Run a skill, send it for independent review, and open the
+            Record to see the whole chain &mdash; every step real, no provider
+            key needed.
           </p>
 
           <QuickstartCommand />
@@ -221,7 +224,7 @@ export function Landing() {
         <div className="max-w-page mx-auto">
           <SectionRule label="The demo" right="Three moves" />
           <h2 className="mt-5 text-3xl md:text-4xl font-bold tracking-tight2 text-ink mb-10 leading-tight max-w-2xl">
-            Watch it work, catch it, and sign it.
+            Run it, review it, read the record.
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-px bg-rule border border-rule">
             {DEMO_MOVES.map((m, i) => (
@@ -236,12 +239,18 @@ export function Landing() {
               </div>
             ))}
           </div>
-          <div className="mt-8">
+          <div className="mt-8 flex flex-wrap items-center gap-4">
             <a
-              href="/demo"
+              href="/demo-loop"
               className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px] inline-flex items-center"
             >
               Walk the demo
+            </a>
+            <a
+              href="/demo"
+              className="text-sm text-muted underline underline-offset-4 decoration-rule transition-colors hover:decoration-seal hover:text-seal"
+            >
+              Or explore the full workspace
             </a>
           </div>
         </div>

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -57,7 +57,7 @@ export function MatterList() {
           </p>
           <div className="mt-3 flex flex-wrap items-center gap-5">
             <a
-              href="/demo"
+              href="/demo-loop"
               className="text-sm text-ink underline underline-offset-4 decoration-rule transition-colors hover:decoration-seal hover:text-seal"
             >
               Walk the demo

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -297,7 +297,7 @@ export function ModulesCatalog() {
               </>
             ) : (
               <a
-                href="/demo"
+                href="/demo-loop"
                 className="inline-flex items-center rounded-md bg-ink px-4 py-2 text-sm font-medium text-paper hover:bg-seal"
               >
                 Open demo

--- a/frontend/src/ui/Drawer.tsx
+++ b/frontend/src/ui/Drawer.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { SIDEBAR_NAV, sidebarActiveFor, isTabKey } from "../matter/tabs/types";
 import { postureLabel } from "../lib/posture";
 
-const DEMO_HREF_UNAUTHED = "/demo";
+const DEMO_HREF_UNAUTHED = "/demo-loop";
 const GITHUB_REPO = "https://github.com/b1rdmania/legalise";
 
 type HealthResponse = { status: string; version: string; database: string; environment: string };

--- a/frontend/src/ui/TopBar.tsx
+++ b/frontend/src/ui/TopBar.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../auth/AuthProvider";
 import { ProfileChip } from "./ProfileChip";
 import { MATTER_TAB_LABELS, type TabKey } from "../matter/tabs/types";
 
-const DEMO_HREF_UNAUTHED = "/demo";
+const DEMO_HREF_UNAUTHED = "/demo-loop";
 
 export function TopBar({
   route,
@@ -24,7 +24,7 @@ export function TopBar({
   const isDetail = route.name === "detail";
   const isModules = route.name === "modules";
   const isList = route.name === "list";
-  const isDemo = route.name === "demo";
+  const isDemo = route.name === "demoLoop" || route.name === "demo";
   // Admin nav anchor. Only superusers see it; the substrate
   // enforces independently. Active state covers the admin user
   // surfaces.


### PR DESCRIPTION
## What

Every "Walk the demo" CTA now opens **`/demo-loop`** (the live, keyless supervised-autonomy walk) instead of `/demo` (the static read-only snapshot): hero, demo section, global nav (TopBar + Drawer), About, MatterList, ModulesCatalog. TopBar nav highlight tracks both `demoLoop` and `demo`.

## Why

The landing's three-act copy — "Raw → Caught → Signed", *watch the AI get a fact wrong* — was written for the Khan snapshot (DemoMatter), but the genuinely guided, live-endpoint walk (DemoLoop) was **orphaned** — nothing on the public surface linked to it. So the on-ramp promised a guided walk and delivered a static workspace, while the stronger, more honest proof (real endpoints, nothing faked) was unreachable.

This points the front door at the live loop **and** retargets the framing to what that loop actually delivers — run → independent review → record — so the promise matches the delivery:
- three cards rewritten **Run / Review / Record**
- subhead → "Run it, review it, read the record"
- hero subcopy now describes the keyless live run

DemoMatter stays reachable as the secondary door (new "Or explore the full workspace" link; Waitlist unchanged). Felt-problem hook (lead paragraph + "1,600 / Why this exists") untouched.

## Open call for review

Current state: DemoLoop is the front door. Alternative if you'd rather keep the hallucination-caught beat front-and-centre: snapshot stays the narrative door, DemoLoop becomes a second "see it run live" door. Easy to flip.

## Verification

- All load-bearing claims confirmed against backend (`posture_gate.py` C_paused hard-stop + audit row, `signoff.py`, `signing.py`)
- `tsc --noEmit` clean
- 11/11 focused tests pass (ModulesCatalog, DemoLoop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Navigation demo links across the application have been updated to point to a new, unified demo experience
  * Landing page has been refreshed with messaging highlighting keyless execution and the ability to review recorded chain activity
  * Demo section now offers enhanced navigation options with multiple pathways for users to explore the product

<!-- end of auto-generated comment: release notes by coderabbit.ai -->