### PR TITLE
Guided demo (skill lifecycle) + Almond & Ink site-wide

### DIFF
--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -37,6 +37,7 @@ const CHROMELESS_ROUTES = new Set([
   "verify",
   "verifyPending",
   "demo",
+  "demoGuided",
 ]);
 
 type HealthResponse = {
@@ -167,7 +168,7 @@ function AppShellInner() {
   // The demo workspace (DemoMatter) brings its own full v0.5 panel shell —
   // render it bare, without the marketing TopBar/Drawer, which otherwise
   // stacked a second wordmark above the rail (the v0.5 double-header).
-  if (route.name === "demo" || route.name === "demoDocument") {
+  if (route.name === "demo" || route.name === "demoDocument" || route.name === "demoGuided") {
     return <Outlet />;
   }
 

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -110,7 +110,6 @@ function useTypewriter(text: string, active: boolean) {
 function Coachmark({ children }: { children: React.ReactNode }) {
   return (
     <div className="mt-6 border-l-2 border-seal bg-wash px-4 py-3">
-      <div className="text-[10px] uppercase tracking-[0.22em] text-seal mb-2">What's going on</div>
       <p className="text-sm leading-relaxed text-prose">{children}</p>
     </div>
   );
@@ -177,9 +176,9 @@ export function GuidedDemo() {
   // is granted (mirrors the real InstallCeremony ledger).
   const scanRows = [
     ...chosen.flatMap((s) => [
-      { label: s.id, value: "manifest structure — valid" },
+      { label: s.id, value: "manifest structure valid" },
       { label: s.id, value: `reads ${s.reads} · writes ${s.writes}` },
-      { label: s.id, value: "gate privilege_posture — bound" },
+      { label: s.id, value: "gate privilege_posture bound" },
     ]),
     { label: "source", value: "pinned commit · licence MIT · verified" },
   ];
@@ -271,11 +270,10 @@ export function GuidedDemo() {
 
       <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
         <div className="mx-auto w-full max-w-[860px]">
-          {/* Matter header — the real backend masthead (PageHeader). */}
+          {/* Demo header — framed as a walkthrough, the matter as context. */}
           <PageHeader
-            display
-            title="Khan v Acme Trading Ltd"
-            description="Jasmine Khan · claimant · s.94 ERA 1996 unfair dismissal"
+            title="Demo walkthrough"
+            description="Legalise on a live matter: Khan v Acme, an unfair-dismissal claim. Watch a wrong answer become a signed record."
           />
 
           {/* Stepper — the one piece of guided chrome. */}
@@ -293,7 +291,7 @@ export function GuidedDemo() {
             {act === 0 && (
               <div className="mx-auto max-w-[760px]">
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">The version of AI most lawyers have met.</h2>
-                <p className="mt-3 text-sm leading-relaxed text-prose">One matter, one question. The answer is fluent. Then look at what's wrong with it.</p>
+                <p className="mt-3 text-sm leading-relaxed text-prose">Ask a capable model a real legal question and the answer comes back fluent and sure of itself. Sometimes it is also wrong. The better the lawyer, the faster they see it, distrust the tool, and walk away. The failure is real. It is also catchable.</p>
 
                 <div className="mt-7 space-y-6">
                   {/* user — right-aligned bubble */}
@@ -314,7 +312,7 @@ export function GuidedDemo() {
 
                 {q.done && revealed && (
                   <Coachmark>
-                    Fluent, confident, and wrong. <strong>Henderson v Brent LBC</strong> is invented — no such authority appears anywhere in this matter. The padding and the "very likely to succeed" prediction are bluff too. This is the failure that makes good lawyers quit. It's catchable.
+                    Fluent, confident, and wrong. <strong>Henderson v Brent LBC</strong> is invented. No such authority appears anywhere in this matter. The padding and the "very likely to succeed" line are bluff too. This is the failure that makes good lawyers quit, and every part of it is catchable.
                   </Coachmark>
                 )}
                 <div className="mt-8">
@@ -327,7 +325,7 @@ export function GuidedDemo() {
             {act === 1 && (
               <div>
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">You don't fix this with a better prompt. You install a skill.</h2>
-                <p className="mt-3 text-sm leading-relaxed text-prose">A skill is a small, vetted unit of legal work. Pick the ones that answer the failure you just saw — the bluff and the slop.</p>
+                <p className="mt-3 text-sm leading-relaxed text-prose">A skill is a small, vetted unit of legal work. Pick the ones that answer the failure you just saw: the bluff and the slop.</p>
                 <div className="mt-6 grid gap-4 sm:grid-cols-2">
                   {CATALOGUE.map((s, i) => {
                     const on = selected.has(s.id);
@@ -363,42 +361,32 @@ export function GuidedDemo() {
             {/* ── ACT 3 · INSTALL (the admission ceremony) ── */}
             {act === 2 && (
               <div>
-                <h2 className="text-2xl font-bold tracking-tight2 text-ink">A skill is admitted, not just uploaded.</h2>
-                <p className="mt-3 text-sm leading-relaxed text-prose">The register scans each manifest — what it reads, what it writes, the gate it runs under, the source it came from. Only then do you grant it standing in the matter.</p>
+                <h2 className="text-2xl font-bold tracking-tight2 text-ink">A skill is admitted, not uploaded.</h2>
+                <p className="mt-3 text-sm leading-relaxed text-prose">Each skill declares what it reads, what it writes, and the gate it runs under. The register checks the manifest, then you grant it standing.</p>
 
-                <div className="mt-7">
-                  <SectionRule label="Admission · manifest scan" right={`${Math.min(scanN, scanRows.length)} / ${scanRows.length}`} />
-                  <div className="mt-1">
-                    {scanRows.slice(0, scanN).map((r, i) => (
-                      <LedgerLine
-                        key={i}
-                        index={i + 1}
-                        label={r.label}
-                        right={<span className="tech-token text-[11px] text-ink">✓</span>}
-                      >
-                        {r.value}
-                      </LedgerLine>
-                    ))}
-                    {!scanComplete && (
-                      <div className="flex items-center gap-2 py-2.5 text-[11px] uppercase tracking-[0.18em] text-muted">
-                        <span className="h-2 w-2 animate-pulse rounded-full bg-seal" />
-                        scanning…
-                      </div>
-                    )}
-                  </div>
+                <div className="mt-7 text-[11px] uppercase tracking-[0.18em] text-muted">Manifest scan</div>
+                <div className="mt-1">
+                  {scanRows.slice(0, scanN).map((r, i) => (
+                    <LedgerLine key={i} index={i + 1} label={r.label} right={<span className="tech-token text-[11px] text-ink">✓</span>}>
+                      {r.value}
+                    </LedgerLine>
+                  ))}
+                  {!scanComplete && (
+                    <div className="flex items-center gap-2 py-2.5 text-[11px] uppercase tracking-[0.18em] text-muted">
+                      <span className="h-2 w-2 animate-pulse rounded-full bg-seal" />
+                      scanning
+                    </div>
+                  )}
                 </div>
 
                 {scanComplete && (
-                  <div className="mt-8">
-                    <SectionRule label="Grant of standing" right={installed ? "Granted" : "Your decision"} />
-                    <p className="mt-4 text-sm leading-relaxed text-prose">
-                      The manifests check out. {installed ? "Standing is granted" : "Grant standing"} to{" "}
-                      {chosen.map((s) => s.name).join(" and ")} — and from here, everything {installed ? "they do" : "they will do"} lands on the record.
-                    </p>
-                    {installed && (
-                      <Coachmark>An admitted skill can't reach a document it didn't declare, or run on a matter whose privilege posture forbids it. Standing, not cleverness, is what lets it act.</Coachmark>
-                    )}
-                  </div>
+                  <p className="mt-6 text-sm leading-relaxed text-prose">
+                    The manifests check out. {installed ? "Standing is granted to" : "Grant standing to"}{" "}
+                    {chosen.map((s) => s.name).join(" and ")}. From here, everything {installed ? "they do" : "they will do"} lands on the record.
+                  </p>
+                )}
+                {installed && (
+                  <Coachmark>An admitted skill cannot reach a document it did not declare, or run on a matter whose privilege posture forbids it. Standing, not cleverness, is what lets it act.</Coachmark>
                 )}
 
                 <div className="mt-8 flex items-center gap-4">
@@ -417,7 +405,7 @@ export function GuidedDemo() {
             {act === 3 && (
               <div className="mx-auto max-w-[760px]">
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">Same question. Skills installed.</h2>
-                <p className="mt-3 text-sm leading-relaxed text-prose">The skills run inside the matter — reading the documents in scope, rewriting what the source won't support.</p>
+                <p className="mt-3 text-sm leading-relaxed text-prose">The skills run inside the matter. They read the documents in scope and rewrite what the source will not support.</p>
 
                 {/* the runner */}
                 <div className="mt-6 rounded-card border border-rule bg-paper p-4">
@@ -465,7 +453,7 @@ export function GuidedDemo() {
                 )}
 
                 {ran && (
-                  <Coachmark>The invented citation is gone, struck by the source-anchor check against the matter's documents. The padding is gone, stripped by plain-english. What's left is anchored to the paper — and the refusal itself is about to land on the record.</Coachmark>
+                  <Coachmark>The invented citation is gone, struck by the source-anchor check against the matter's documents. The padding is gone, stripped by plain-english. What is left is anchored to the paper, and the refusal itself is about to land on the record.</Coachmark>
                 )}
                 <div className="mt-8 flex items-center gap-4">
                   <BackLink onClick={() => setAct(2)} />
@@ -484,7 +472,7 @@ export function GuidedDemo() {
                   <div className="mt-7 grid gap-6 lg:grid-cols-[1fr_320px]">
                     {/* the instrument */}
                     <div>
-                      <SectionRule label="The instrument" right="skill_response · draft" />
+                      <SectionRule label="The instrument" />
                       <div className="gd-doc mt-4 text-sm leading-relaxed text-ink" dangerouslySetInnerHTML={{ __html: REDLINE_HTML }} />
                     </div>
                     {/* the decision */}
@@ -517,7 +505,7 @@ export function GuidedDemo() {
                   </div>
                 ) : (
                   <div className="mt-7">
-                    <SectionRule label="The record" right="hash-chained · exportable" />
+                    <SectionRule label="The record" />
                     <div className="mt-2">
                       {AUDIT_ROWS.map((r, i) => (
                         <LedgerLine
@@ -543,7 +531,7 @@ export function GuidedDemo() {
                     </div>
 
                     <Coachmark>
-                      The refusal carries the same weight as an approval — the citation check's refusal of <strong>Henderson v Brent</strong> is struck onto the record, not hidden. The model drafted; you signed. That's the whole product: choose a skill, install it, run it, and stand behind what it produced.
+                      The refusal carries the same weight as an approval. The citation check's refusal of <strong>Henderson v Brent</strong> is struck onto the record, not hidden. The model drafted and you signed. That is the whole product: choose a skill, install it, run it, and stand behind what it produced.
                     </Coachmark>
                   </div>
                 )}

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -14,8 +14,7 @@ import { CertCard, CertEyebrow, InkBands, LedgerLine, LedgerRow, SectionRule } f
 import { PageHeader } from "../ui/primitives";
 import { SidebarView, NavIcon, type RailItem } from "../ui/SidebarView";
 
-const ACTS = ["The failure", "Choose", "Install", "Run", "Govern"] as const;
-// Which rail surface each act lights up — so the guided flow drives the
+// Which rail surface each act lights up: the guided flow drives the
 // real nav, not a parallel stepper alone.
 const ACT_RAIL = ["assistant", "workflows", "workflows", "documents", "audit"] as const;
 
@@ -109,9 +108,7 @@ function useTypewriter(text: string, active: boolean) {
 
 function Coachmark({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mt-6 border-l-2 border-seal bg-wash px-4 py-3">
-      <p className="text-sm leading-relaxed text-prose">{children}</p>
-    </div>
+    <p className="mt-6 text-sm leading-relaxed text-prose">{children}</p>
   );
 }
 
@@ -216,6 +213,34 @@ export function GuidedDemo() {
     { key: "audit", label: "Record", icon: <NavIcon name="audit" />, active: railActive === "audit", onSelect: () => setAct(4) },
   ];
 
+  // The forward action for the pinned footer, by act + state. In-context
+  // actions (Run skill, Sign off) stay in their cards; the footer carries
+  // the reveal and the act-to-act steps so nothing hides below the fold.
+  const resetAll = () => {
+    setAct(0);
+    setRevealed(false);
+    setSelected(new Set());
+    setInstalled(false);
+    setRan(false);
+    setSigned(false);
+  };
+  let primary: { label: string; onClick: () => void } | null = null;
+  if (act === 0 && q.done) {
+    primary = revealed
+      ? { label: "The fix is a skill →", onClick: () => setAct(1) }
+      : { label: "See what went wrong", onClick: () => setRevealed(true) };
+  } else if (act === 1 && selected.size > 0) {
+    primary = { label: `Install ${selected.size} to the matter →`, onClick: () => setAct(2) };
+  } else if (act === 2 && scanComplete) {
+    primary = installed
+      ? { label: "Run it on the matter →", onClick: () => setAct(3) }
+      : { label: "Grant standing & admit", onClick: () => setInstalled(true) };
+  } else if (act === 3 && ran) {
+    primary = { label: "Send it for sign-off →", onClick: () => setAct(4) };
+  } else if (act === 4 && signed) {
+    primary = { label: "Replay from the top", onClick: resetAll };
+  }
+
   return (
     <div className="gd-almond min-h-screen md:h-screen bg-canvas text-ink md:flex md:gap-3 md:p-3 md:overflow-hidden">
       <style>{`
@@ -268,25 +293,17 @@ export function GuidedDemo() {
         </button>
       </div>
 
-      <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
-        <div className="mx-auto w-full max-w-[860px]">
-          {/* Demo header — framed as a walkthrough, the matter as context. */}
-          <PageHeader
-            title="Demo walkthrough"
-            description="Legalise on a live matter: Khan v Acme, an unfair-dismissal claim. Watch a wrong answer become a signed record."
-          />
+      <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel flex flex-col md:overflow-hidden">
+        <div className="flex-1 md:min-h-0 md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
+          <div className="mx-auto w-full max-w-[860px]">
+            {/* Demo header — the backend masthead (display tier). */}
+            <PageHeader
+              display
+              title="Demo walkthrough"
+              description="Legalise on a live matter: Khan v Acme, an unfair-dismissal claim. Watch a wrong answer become a signed record."
+            />
 
-          {/* Stepper — the one piece of guided chrome. */}
-          <nav className="flex flex-wrap gap-x-6 gap-y-2" aria-label="Demo acts">
-            {ACTS.map((label, i) => (
-              <span key={label} aria-current={i === act ? "step" : undefined}
-                className={"text-[11px] uppercase tracking-[0.18em] " + (i === act ? "text-ink font-semibold" : i < act ? "text-seal" : "text-muted/50")}>
-                {String(i + 1).padStart(2, "0")} · {label}
-              </span>
-            ))}
-          </nav>
-
-          <div className="mt-8">
+            <div className="mt-8">
             {/* ── ACT 1 · THE FAILURE (the matter chat) ── */}
             {act === 0 && (
               <div className="mx-auto max-w-[760px]">
@@ -315,9 +332,6 @@ export function GuidedDemo() {
                     Fluent, confident, and wrong. <strong>Henderson v Brent LBC</strong> is invented. No such authority appears anywhere in this matter. The padding and the "very likely to succeed" line are bluff too. This is the failure that makes good lawyers quit, and every part of it is catchable.
                   </Coachmark>
                 )}
-                <div className="mt-8">
-                  {!revealed ? (q.done && <PrimaryBtn onClick={() => setRevealed(true)}>See what went wrong</PrimaryBtn>) : <PrimaryBtn onClick={() => setAct(1)}>The fix is a skill →</PrimaryBtn>}
-                </div>
               </div>
             )}
 
@@ -350,10 +364,6 @@ export function GuidedDemo() {
                       </button>
                     );
                   })}
-                </div>
-                <div className="mt-8 flex items-center gap-4">
-                  <BackLink onClick={() => setAct(0)} />
-                  {selected.size > 0 && <PrimaryBtn onClick={() => setAct(2)}>Install {selected.size} to the matter →</PrimaryBtn>}
                 </div>
               </div>
             )}
@@ -389,15 +399,6 @@ export function GuidedDemo() {
                   <Coachmark>An admitted skill cannot reach a document it did not declare, or run on a matter whose privilege posture forbids it. Standing, not cleverness, is what lets it act.</Coachmark>
                 )}
 
-                <div className="mt-8 flex items-center gap-4">
-                  <BackLink onClick={() => setAct(1)} />
-                  {scanComplete &&
-                    (!installed ? (
-                      <PrimaryBtn onClick={() => setInstalled(true)}>Grant standing &amp; admit</PrimaryBtn>
-                    ) : (
-                      <PrimaryBtn onClick={() => setAct(3)}>Run it on the matter →</PrimaryBtn>
-                    ))}
-                </div>
               </div>
             )}
 
@@ -455,10 +456,6 @@ export function GuidedDemo() {
                 {ran && (
                   <Coachmark>The invented citation is gone, struck by the source-anchor check against the matter's documents. The padding is gone, stripped by plain-english. What is left is anchored to the paper, and the refusal itself is about to land on the record.</Coachmark>
                 )}
-                <div className="mt-8 flex items-center gap-4">
-                  <BackLink onClick={() => setAct(2)} />
-                  {ran && <PrimaryBtn onClick={() => setAct(4)}>Send it for sign-off →</PrimaryBtn>}
-                </div>
               </div>
             )}
 
@@ -536,16 +533,16 @@ export function GuidedDemo() {
                   </div>
                 )}
 
-                <div className="mt-8 flex items-center gap-4">
-                  <BackLink onClick={() => setAct(3)} />
-                  {signed && (
-                    <PrimaryBtn onClick={() => { setAct(0); setRevealed(false); setSelected(new Set()); setInstalled(false); setRan(false); setSigned(false); }}>
-                      Replay from the top
-                    </PrimaryBtn>
-                  )}
-                </div>
               </div>
             )}
+            </div>
+          </div>
+        </div>
+        {/* action bar — pinned, so the buttons never need a scroll */}
+        <div className="shrink-0 border-t border-rule bg-panel px-4 sm:px-6 lg:px-10 py-4">
+          <div className="mx-auto flex w-full max-w-[860px] items-center gap-4">
+            {act > 0 && <BackLink onClick={() => setAct(act - 1)} />}
+            {primary && <PrimaryBtn onClick={primary.onClick}>{primary.label}</PrimaryBtn>}
           </div>
         </div>
       </main>

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -40,6 +40,21 @@ const CATALOGUE: Skill[] = [
   { id: "disclosure-list", name: "disclosure-list", blurb: "Builds a disclosure list from the matter's documents.", fixes: false, reads: "matter.document.read", writes: "matter.artifact.write" },
 ];
 
+// The record the sign-off creates — the chain, refusal struck in seal.
+const AUDIT_ROWS: { label: string; value: string; refused?: boolean }[] = [
+  { label: "skill.invoke", value: "citation-check · plain-english run on the draft" },
+  { label: "model.call", value: "claude · documents read under the privilege gate" },
+  { label: "gate.refuse", value: "authority “Henderson v Brent LBC [2019] EWCA Civ 1021” — not found in source", refused: true },
+  { label: "artifact.write", value: "skill_response · draft written to the matter" },
+  { label: "output.signed", value: "reviewing solicitor (you) · responsibility accepted" },
+];
+
+const DECISIONS: { id: string; title: string; help: string }[] = [
+  { id: "sign", title: "Sign", help: "I accept this draft as reviewed." },
+  { id: "observations", title: "Sign with observations", help: "Accept the refusals; note what still needs checking." },
+  { id: "reject", title: "Reject", help: "Send back for redrafting." },
+];
+
 const DOCS: { key: string; label: string; filename: string; text: string }[] = [
   {
     key: "dismissal",
@@ -117,35 +132,6 @@ function BackLink({ onClick }: { onClick: () => void }) {
   );
 }
 
-// The document reader — the matter's paper, on the page. Tabs across the
-// three documents, the active one rendered as plain extracted text.
-function DocReader({ highlight }: { highlight?: boolean }) {
-  const [key, setKey] = useState("dismissal");
-  const doc = DOCS.find((d) => d.key === key) ?? DOCS[0];
-  return (
-    <div className={"border bg-paper " + (highlight ? "border-seal/50" : "border-rule")}>
-      <div className="flex border-b border-rule">
-        {DOCS.map((d) => (
-          <button
-            key={d.key}
-            type="button"
-            onClick={() => setKey(d.key)}
-            className={
-              "px-3 py-2 text-[11px] uppercase tracking-[0.16em] transition-colors " +
-              (d.key === key ? "text-ink font-semibold border-b-2 border-seal -mb-px" : "text-muted hover:text-seal")
-            }
-          >
-            {d.label}
-          </button>
-        ))}
-      </div>
-      <div className="px-4 py-3">
-        <div className="tech-token text-[11px] text-muted mb-2">{doc.filename}</div>
-        <pre className="whitespace-pre-wrap font-sans text-[13px] leading-relaxed text-prose">{doc.text}</pre>
-      </div>
-    </div>
-  );
-}
 
 export function GuidedDemo() {
   const [act, setAct] = useState(0);
@@ -158,6 +144,8 @@ export function GuidedDemo() {
   const [running, setRunning] = useState(false);
   const [ran, setRan] = useState(false);
   const [showCorrected, setShowCorrected] = useState(true);
+  const [signed, setSigned] = useState(false);
+  const [decision, setDecision] = useState("observations");
   const reduce = usePrefersReducedMotion();
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -301,34 +289,32 @@ export function GuidedDemo() {
           </nav>
 
           <div className="mt-8">
-            {/* ── ACT 1 · THE FAILURE ── */}
+            {/* ── ACT 1 · THE FAILURE (the matter chat) ── */}
             {act === 0 && (
-              <div>
+              <div className="mx-auto max-w-[760px]">
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">The version of AI most lawyers have met.</h2>
-                <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_300px]">
-                  <div>
-                    <div className="border border-rule bg-paper">
-                      <div className="border-b border-rule px-4 py-2 text-[11px] uppercase tracking-[0.18em] text-muted">You ask</div>
-                      <div className="px-4 py-3 text-sm text-ink">
-                        {q.shown}
-                        {!q.done && <span className="ml-0.5 inline-block w-[2px] animate-pulse bg-seal">&nbsp;</span>}
-                      </div>
+                <p className="mt-3 text-sm leading-relaxed text-prose">One matter, one question. The answer is fluent. Then look at what's wrong with it.</p>
+
+                <div className="mt-7 space-y-6">
+                  {/* user — right-aligned bubble */}
+                  <div className="flex justify-end">
+                    <div className="max-w-[560px] rounded-card border border-rule bg-wash px-4 py-3 text-[15px] text-ink whitespace-pre-wrap">
+                      {q.shown}
+                      {!q.done && <span className="ml-0.5 inline-block w-[2px] animate-pulse bg-seal">&nbsp;</span>}
                     </div>
-                    {q.done && (
-                      <div className="mt-4 border border-rule bg-paper">
-                        <div className="border-b border-rule px-4 py-2 text-[11px] uppercase tracking-[0.18em] text-muted">Claude · raw</div>
-                        <div className="gd-doc px-4 py-4 text-sm leading-relaxed text-prose" dangerouslySetInnerHTML={{ __html: RAW_HTML }} />
-                      </div>
-                    )}
                   </div>
-                  <div>
-                    <div className="text-[10px] uppercase tracking-[0.2em] text-muted mb-2">The matter's documents</div>
-                    <DocReader />
-                  </div>
+                  {/* assistant — plain prose, no box */}
+                  {q.done && (
+                    <div>
+                      <div className="tech-token text-[11px] text-muted mb-2">Assistant · raw model · no skills installed</div>
+                      <div className="gd-doc text-[15px] leading-relaxed text-ink" dangerouslySetInnerHTML={{ __html: RAW_HTML }} />
+                    </div>
+                  )}
                 </div>
+
                 {q.done && revealed && (
                   <Coachmark>
-                    Fluent, confident, and wrong. <strong>Henderson v Brent LBC</strong> is invented — there's no such authority anywhere in this matter (check the documents on the right). The padding and the "very likely to succeed" prediction are bluff too. This is the failure that makes good lawyers quit. It's catchable.
+                    Fluent, confident, and wrong. <strong>Henderson v Brent LBC</strong> is invented — no such authority appears anywhere in this matter. The padding and the "very likely to succeed" prediction are bluff too. This is the failure that makes good lawyers quit. It's catchable.
                   </Coachmark>
                 )}
                 <div className="mt-8">
@@ -427,65 +413,148 @@ export function GuidedDemo() {
               </div>
             )}
 
-            {/* ── ACT 4 · RUN → REDLINE (with the document open) ── */}
+            {/* ── ACT 4 · RUN (the skill runner) ── */}
             {act === 3 && (
-              <div>
+              <div className="mx-auto max-w-[760px]">
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">Same question. Skills installed.</h2>
-                <p className="mt-3 text-sm leading-relaxed text-prose">The skills run against the matter's documents — open on the right. Watch the bluff get struck and the padding stripped.</p>
-                <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_300px]">
-                  <div>
-                    {!ran && (
-                      <div>
-                        <PrimaryBtn onClick={runSkills}>{running ? "Running…" : "Run the installed skills"}</PrimaryBtn>
-                        {running && (
-                          <div className="mt-4 space-y-1 text-[11px] uppercase tracking-[0.18em] text-muted">
-                            {chosen.map((s) => (
-                              <div key={s.id} className="flex items-center gap-2">
-                                <span className="h-2 w-2 animate-pulse rounded-full bg-seal" />
-                                {s.name} · reading documents…
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    )}
-                    {ran && (
-                      <>
-                        <div className="inline-flex border border-rule bg-paper text-xs">
-                          <button type="button" onClick={() => setShowCorrected(false)} className={"px-3 py-2 " + (!showCorrected ? "bg-ink text-paper" : "text-muted")}>Raw</button>
-                          <button type="button" onClick={() => setShowCorrected(true)} className={"px-3 py-2 " + (showCorrected ? "bg-ink text-paper" : "text-muted")}>With skills</button>
-                        </div>
-                        <div className="mt-3 border border-rule bg-paper">
-                          <div className="border-b border-rule px-4 py-2 text-[11px] uppercase tracking-[0.18em] text-muted">{showCorrected ? "Claude · citation-check + plain-english" : "Claude · raw"}</div>
-                          <div className="gd-doc px-4 py-4 text-sm leading-relaxed text-prose" dangerouslySetInnerHTML={{ __html: showCorrected ? REDLINE_HTML : RAW_HTML }} />
-                        </div>
-                        <p className="mt-3 text-xs text-muted"><del className="text-muted">struck</del> = removed by a skill · <span className="text-seal">underlined</span> = added · ⚑ = the citation check refused an unsupported claim.</p>
-                      </>
-                    )}
+                <p className="mt-3 text-sm leading-relaxed text-prose">The skills run inside the matter — reading the documents in scope, rewriting what the source won't support.</p>
+
+                {/* the runner */}
+                <div className="mt-6 rounded-card border border-rule bg-paper p-4">
+                  <div className="text-[11px] uppercase tracking-widest text-muted">Request</div>
+                  <div className="mt-1 border border-rule bg-wash px-3 py-2 text-sm text-ink">{QUESTION}</div>
+
+                  <div className="mt-4 text-[11px] uppercase tracking-widest text-muted">Documents in scope</div>
+                  <div className="mt-1 max-h-40 overflow-auto rounded-md border border-rule">
+                    {DOCS.map((d) => (
+                      <label key={d.key} className="flex items-center gap-2 border-b border-rule px-3 py-1.5 last:border-b-0">
+                        <input type="checkbox" checked readOnly className="accent-[#7e2b22]" />
+                        <span className="tech-token text-[12px] text-prose">{d.filename}</span>
+                      </label>
+                    ))}
                   </div>
-                  <div>
-                    <div className="text-[10px] uppercase tracking-[0.2em] text-muted mb-2">Checked against</div>
-                    <DocReader highlight={ran} />
+
+                  <div className="mt-4 text-[11px] uppercase tracking-widest text-muted">Skills</div>
+                  <div className="mt-1 flex flex-wrap gap-2">
+                    {chosen.map((s) => (
+                      <span key={s.id} className="rounded-item border border-rule bg-wash px-2 py-0.5 tech-token text-[11px] text-ink">{s.id}</span>
+                    ))}
                   </div>
+
+                  {!ran && (
+                    <div className="mt-4">
+                      <PrimaryBtn onClick={runSkills}>{running ? "Running skill…" : "Run skill"}</PrimaryBtn>
+                      {running && <p className="mt-3 text-xs text-muted">Running skill… reading {DOCS.length} documents, checking authority against source.</p>}
+                    </div>
+                  )}
                 </div>
+
+                {/* result artifact */}
                 {ran && (
-                  <Coachmark>The invented citation is gone, struck by the source-anchor check against the documents on the right. The padding is gone, stripped by plain-english. What's left is anchored to the paper — and the refusal itself is about to land on the record.</Coachmark>
+                  <div className="mt-5 rounded-md border border-rule bg-paper p-3">
+                    <div className="flex flex-wrap items-baseline justify-between gap-3">
+                      <span className="tech-token text-[11px] text-muted">Artifact · skill_response · draft</span>
+                      <span className="inline-flex border border-rule bg-paper text-xs">
+                        <button type="button" onClick={() => setShowCorrected(false)} className={"px-3 py-1.5 " + (!showCorrected ? "bg-ink text-paper" : "text-muted")}>Raw</button>
+                        <button type="button" onClick={() => setShowCorrected(true)} className={"px-3 py-1.5 " + (showCorrected ? "bg-ink text-paper" : "text-muted")}>With skills</button>
+                      </span>
+                    </div>
+                    <div className="gd-doc mt-3 text-sm leading-relaxed text-ink" dangerouslySetInnerHTML={{ __html: showCorrected ? REDLINE_HTML : RAW_HTML }} />
+                    <p className="mt-3 text-xs text-muted"><del className="text-muted">struck</del> = removed by a skill · <span className="text-seal">underlined</span> = added · ⚑ = the citation check refused an unsupported claim.</p>
+                  </div>
+                )}
+
+                {ran && (
+                  <Coachmark>The invented citation is gone, struck by the source-anchor check against the matter's documents. The padding is gone, stripped by plain-english. What's left is anchored to the paper — and the refusal itself is about to land on the record.</Coachmark>
                 )}
                 <div className="mt-8 flex items-center gap-4">
                   <BackLink onClick={() => setAct(2)} />
-                  {ran && <PrimaryBtn onClick={() => setAct(4)}>Send it to the record →</PrimaryBtn>}
+                  {ran && <PrimaryBtn onClick={() => setAct(4)}>Send it for sign-off →</PrimaryBtn>}
                 </div>
               </div>
             )}
 
-            {/* ── ACT 5 · GOVERN (scaffold) ── */}
+            {/* ── ACT 5 · GOVERN (sign-off → the record) ── */}
             {act === 4 && (
               <div>
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">The model drafted. A human becomes the authority.</h2>
-                <p className="mt-3 text-sm leading-relaxed text-prose">Next: SAW-vs-ASSERTED, the refusal struck on the record, and the sign-off where a named person takes responsibility. (Porting the harness's audit + sign-off card here next.)</p>
+                <p className="mt-3 text-sm leading-relaxed text-prose">Every output is a draft until a named person reviews it and signs what they will stand behind.</p>
+
+                {!signed ? (
+                  <div className="mt-7 grid gap-6 lg:grid-cols-[1fr_320px]">
+                    {/* the instrument */}
+                    <div>
+                      <SectionRule label="The instrument" right="skill_response · draft" />
+                      <div className="gd-doc mt-4 text-sm leading-relaxed text-ink" dangerouslySetInnerHTML={{ __html: REDLINE_HTML }} />
+                    </div>
+                    {/* the decision */}
+                    <div className="self-start border border-rule bg-paper p-4 lg:sticky lg:top-6">
+                      <SectionRule label="The decision" />
+                      <div className="mt-4 space-y-2">
+                        {DECISIONS.map((d) => (
+                          <label key={d.id} className={"block cursor-pointer border p-3 text-sm " + (decision === d.id ? "border-ink bg-wash" : "border-rule")}>
+                            <span className="flex items-center gap-2">
+                              <input type="radio" name="gd-decision" checked={decision === d.id} onChange={() => setDecision(d.id)} className="accent-[#7e2b22]" />
+                              <span className="font-medium text-ink">{d.title}</span>
+                            </span>
+                            <span className="mt-1 block pl-6 text-xs text-muted">{d.help}</span>
+                          </label>
+                        ))}
+                      </div>
+                      <textarea
+                        rows={3}
+                        defaultValue="Accepted the citation refusal. Confirm ACAS position and effective date of termination before relying on any deadline."
+                        className="mt-3 w-full border border-rule bg-wash px-3 py-2 text-sm text-ink"
+                      />
+                      <label className="mt-3 flex items-start gap-2 text-sm text-prose">
+                        <input type="checkbox" defaultChecked className="mt-0.5 accent-[#7e2b22]" />
+                        I am a qualified person and take responsibility for this output.
+                      </label>
+                      <div className="mt-4">
+                        <PrimaryBtn onClick={() => setSigned(true)}>Sign off</PrimaryBtn>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-7">
+                    <SectionRule label="The record" right="hash-chained · exportable" />
+                    <div className="mt-2">
+                      {AUDIT_ROWS.map((r, i) => (
+                        <LedgerLine
+                          key={i}
+                          index={i + 1}
+                          label={r.label}
+                          right={<span className={"tech-token text-[11px] " + (r.refused ? "text-seal" : "text-muted")}>{r.refused ? "refused" : "recorded"}</span>}
+                        >
+                          {r.refused ? <span className="text-seal line-through decoration-1">{r.value}</span> : r.value}
+                        </LedgerLine>
+                      ))}
+                    </div>
+
+                    <div className="relative mt-6 border border-ink/70 bg-paper p-5">
+                      <span className="absolute right-5 top-5 -rotate-6 border-2 border-seal px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-seal">Signed</span>
+                      <CertEyebrow left="Record · created by the sign-off" />
+                      <dl className="mt-4 space-y-1 text-[11px] text-muted">
+                        <LedgerRow label="Matter" tone="ink">Khan v Acme Trading Ltd</LedgerRow>
+                        <LedgerRow label="Decision" tone="ink">{decision === "sign" ? "Signed" : decision === "reject" ? "Rejected" : "Signed with observations"}</LedgerRow>
+                        <LedgerRow label="Signed by" tone="ink">Reviewing solicitor (you)</LedgerRow>
+                        <LedgerRow label="Record hash" tone="ink">a1f9·c3e2·77bd·0e41</LedgerRow>
+                      </dl>
+                    </div>
+
+                    <Coachmark>
+                      The refusal carries the same weight as an approval — the citation check's refusal of <strong>Henderson v Brent</strong> is struck onto the record, not hidden. The model drafted; you signed. That's the whole product: choose a skill, install it, run it, and stand behind what it produced.
+                    </Coachmark>
+                  </div>
+                )}
+
                 <div className="mt-8 flex items-center gap-4">
                   <BackLink onClick={() => setAct(3)} />
-                  <PrimaryBtn onClick={() => { setAct(0); setRevealed(false); setSelected(new Set()); setInstalled(false); setRan(false); }}>Replay from the top</PrimaryBtn>
+                  {signed && (
+                    <PrimaryBtn onClick={() => { setAct(0); setRevealed(false); setSelected(new Set()); setInstalled(false); setRan(false); setSigned(false); }}>
+                      Replay from the top
+                    </PrimaryBtn>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -10,7 +10,7 @@
 // Ink, scoped to this surface (tokens are static, so we override them here).
 
 import { useEffect, useRef, useState } from "react";
-import { CertCard, CertEyebrow, LedgerRow } from "../ui/certificate";
+import { CertCard, CertEyebrow, InkBands, LedgerLine, LedgerRow, SectionRule } from "../ui/certificate";
 import { PageHeader } from "../ui/primitives";
 import { SidebarView, NavIcon, type RailItem } from "../ui/SidebarView";
 
@@ -185,6 +185,39 @@ export function GuidedDemo() {
 
   const chosen = CATALOGUE.filter((s) => selected.has(s.id));
 
+  // Admission scan — the rows that march down with a tick before standing
+  // is granted (mirrors the real InstallCeremony ledger).
+  const scanRows = [
+    ...chosen.flatMap((s) => [
+      { label: s.id, value: "manifest structure — valid" },
+      { label: s.id, value: `reads ${s.reads} · writes ${s.writes}` },
+      { label: s.id, value: "gate privilege_posture — bound" },
+    ]),
+    { label: "source", value: "pinned commit · licence MIT · verified" },
+  ];
+  const [scanN, setScanN] = useState(0);
+  const scanComplete = scanN >= scanRows.length;
+  useEffect(() => {
+    if (act !== 2) return;
+    if (installed || reduce) {
+      setScanN(scanRows.length);
+      return;
+    }
+    setScanN(0);
+    const id = setInterval(() => {
+      setScanN((n) => {
+        if (n >= scanRows.length) {
+          clearInterval(id);
+          return n;
+        }
+        return n + 1;
+      });
+    }, 300);
+    return () => clearInterval(id);
+    // scanRows.length is the only scan input that matters here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [act, installed, reduce, scanRows.length]);
+
   const railActive = ACT_RAIL[act];
   const globalItems: RailItem[] = [
     { key: "matters", label: "Matters", icon: <NavIcon name="matters" />, href: "/" },
@@ -213,8 +246,10 @@ export function GuidedDemo() {
         .gd-almond .text-seal,.gd-almond .hover\\:text-seal:hover{color:#7E2B22!important}
         .gd-almond .text-paper{color:#F6F1E8!important}
         .gd-almond .border-rule{border-color:#E0D8C9!important}
+        .gd-almond .border-rule\\/60{border-color:rgba(224,216,201,.6)!important}
         .gd-almond .border-ink{border-color:#221E17!important}
-        .gd-almond .border-seal,.gd-almond .border-seal\\/50{border-color:#7E2B22!important}
+        .gd-almond .border-ink\\/70{border-color:rgba(34,30,23,.72)!important}
+        .gd-almond .border-seal,.gd-almond .border-seal\\/50,.gd-almond .border-seal\\/40{border-color:rgba(126,43,34,.55)!important}
         .gd-almond .decoration-rule{text-decoration-color:#E0D8C9!important}
         .gd-almond .decoration-seal{text-decoration-color:#7E2B22!important}
         /* Teaching annotations + redline. */
@@ -302,21 +337,32 @@ export function GuidedDemo() {
               </div>
             )}
 
-            {/* ── ACT 2 · CHOOSE ── */}
+            {/* ── ACT 2 · CHOOSE (the skills register) ── */}
             {act === 1 && (
               <div>
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">You don't fix this with a better prompt. You install a skill.</h2>
                 <p className="mt-3 text-sm leading-relaxed text-prose">A skill is a small, vetted unit of legal work. Pick the ones that answer the failure you just saw — the bluff and the slop.</p>
-                <div className="mt-6 space-y-px bg-rule border border-rule">
-                  {CATALOGUE.map((s) => {
+                <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                  {CATALOGUE.map((s, i) => {
                     const on = selected.has(s.id);
                     return (
-                      <button key={s.id} type="button" onClick={() => toggleSkill(s.id)} className={"block w-full text-left px-4 py-4 transition-colors " + (on ? "bg-panel-sel" : "bg-paper hover:bg-wash")}>
-                        <div className="flex items-center justify-between">
-                          <span className="tech-token text-sm text-ink">{s.name}</span>
-                          <span className={"text-[10px] uppercase tracking-[0.18em] " + (on ? "text-seal font-semibold" : "text-muted")}>{on ? "selected" : s.fixes ? "addresses the failure" : "available"}</span>
-                        </div>
-                        <p className="mt-1 text-sm text-prose">{s.blurb}</p>
+                      <button key={s.id} type="button" onClick={() => toggleSkill(s.id)} className="block text-left">
+                        <CertCard tone={on ? "seal" : "ink"}>
+                          <CertEyebrow
+                            left={`Skill ${String(i + 1).padStart(2, "0")}`}
+                            right={on ? "Selected" : s.fixes ? "Fixes the failure" : "Available"}
+                            rightTone={on ? "seal" : "muted"}
+                          />
+                          <div className="mt-3 tech-token text-sm text-ink">{s.name}</div>
+                          <p className="mt-2 text-sm leading-relaxed text-prose">{s.blurb}</p>
+                          <div className="mt-4 space-y-2">
+                            <InkBands label="Reads" values={[s.reads]} />
+                            <InkBands label="Writes" values={[s.writes]} />
+                          </div>
+                          <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
+                            <LedgerRow label="Gate" tone="ink">privilege_posture</LedgerRow>
+                          </dl>
+                        </CertCard>
                       </button>
                     );
                   })}
@@ -328,38 +374,55 @@ export function GuidedDemo() {
               </div>
             )}
 
-            {/* ── ACT 3 · INSTALL (certificate admission) ── */}
+            {/* ── ACT 3 · INSTALL (the admission ceremony) ── */}
             {act === 2 && (
               <div>
                 <h2 className="text-2xl font-bold tracking-tight2 text-ink">A skill is admitted, not just uploaded.</h2>
-                <p className="mt-3 text-sm leading-relaxed text-prose">Each skill declares what it may read, what it may write, and which gate governs it. You approve that contract; then it is admitted to the matter.</p>
-                <div className="mt-6 space-y-5">
-                  {chosen.map((s) => (
-                    <div key={s.id} className="relative">
-                      <CertCard>
-                        <CertEyebrow left="Skill manifest" right={installed ? "Admitted" : "Pending admission"} />
-                        <div className="mt-3 tech-token text-sm text-ink">{s.name}</div>
-                        <dl className="mt-4 space-y-1 text-[11px] text-muted">
-                          <LedgerRow label="Reads" tone="ink">{s.reads}</LedgerRow>
-                          <LedgerRow label="Writes" tone="ink">{s.writes}</LedgerRow>
-                          <LedgerRow label="Gate" tone="ink">privilege_posture</LedgerRow>
-                          <LedgerRow label="External network" tone="ink">none</LedgerRow>
-                        </dl>
-                      </CertCard>
-                      {installed && (
-                        <span className="absolute right-4 top-4 -rotate-6 border-2 border-seal px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-seal">
-                          Admitted
-                        </span>
-                      )}
-                    </div>
-                  ))}
+                <p className="mt-3 text-sm leading-relaxed text-prose">The register scans each manifest — what it reads, what it writes, the gate it runs under, the source it came from. Only then do you grant it standing in the matter.</p>
+
+                <div className="mt-7">
+                  <SectionRule label="Admission · manifest scan" right={`${Math.min(scanN, scanRows.length)} / ${scanRows.length}`} />
+                  <div className="mt-1">
+                    {scanRows.slice(0, scanN).map((r, i) => (
+                      <LedgerLine
+                        key={i}
+                        index={i + 1}
+                        label={r.label}
+                        right={<span className="tech-token text-[11px] text-ink">✓</span>}
+                      >
+                        {r.value}
+                      </LedgerLine>
+                    ))}
+                    {!scanComplete && (
+                      <div className="flex items-center gap-2 py-2.5 text-[11px] uppercase tracking-[0.18em] text-muted">
+                        <span className="h-2 w-2 animate-pulse rounded-full bg-seal" />
+                        scanning…
+                      </div>
+                    )}
+                  </div>
                 </div>
-                {installed && (
-                  <Coachmark>The skill can't reach a document it didn't declare, or run on a matter whose privilege posture forbids it. Everything it does from here lands on the record.</Coachmark>
+
+                {scanComplete && (
+                  <div className="mt-8">
+                    <SectionRule label="Grant of standing" right={installed ? "Granted" : "Your decision"} />
+                    <p className="mt-4 text-sm leading-relaxed text-prose">
+                      The manifests check out. {installed ? "Standing is granted" : "Grant standing"} to{" "}
+                      {chosen.map((s) => s.name).join(" and ")} — and from here, everything {installed ? "they do" : "they will do"} lands on the record.
+                    </p>
+                    {installed && (
+                      <Coachmark>An admitted skill can't reach a document it didn't declare, or run on a matter whose privilege posture forbids it. Standing, not cleverness, is what lets it act.</Coachmark>
+                    )}
+                  </div>
                 )}
+
                 <div className="mt-8 flex items-center gap-4">
                   <BackLink onClick={() => setAct(1)} />
-                  {!installed ? <PrimaryBtn onClick={() => setInstalled(true)}>Admit &amp; install</PrimaryBtn> : <PrimaryBtn onClick={() => setAct(3)}>Run it on the matter →</PrimaryBtn>}
+                  {scanComplete &&
+                    (!installed ? (
+                      <PrimaryBtn onClick={() => setInstalled(true)}>Grant standing &amp; admit</PrimaryBtn>
+                    ) : (
+                      <PrimaryBtn onClick={() => setAct(3)}>Run it on the matter →</PrimaryBtn>
+                    ))}
                 </div>
               </div>
             )}

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -242,28 +242,8 @@ export function GuidedDemo() {
   }
 
   return (
-    <div className="gd-almond min-h-screen md:h-screen bg-canvas text-ink md:flex md:gap-3 md:p-3 md:overflow-hidden">
+    <div className="min-h-screen md:h-screen bg-canvas text-ink md:flex md:gap-3 md:p-3 md:overflow-hidden">
       <style>{`
-        /* Almond & Ink — scoped palette override (tokens are static). */
-        .gd-almond.bg-canvas,.gd-almond .bg-canvas{background-color:#E9E2D4!important}
-        .gd-almond .bg-panel,.gd-almond .bg-panel-2{background-color:#F2ECE1!important}
-        .gd-almond .bg-paper{background-color:#F6F1E8!important}
-        .gd-almond .bg-wash{background-color:#EFE9DD!important}
-        .gd-almond .bg-panel-sel{background-color:#E0D7C6!important}
-        .gd-almond .bg-ink{background-color:#221E17!important}
-        .gd-almond .bg-seal,.gd-almond .hover\\:bg-seal:hover{background-color:#7E2B22!important}
-        .gd-almond .text-ink{color:#221E17!important}
-        .gd-almond .text-prose{color:#564E42!important}
-        .gd-almond .text-muted{color:#8B8273!important}
-        .gd-almond .text-seal,.gd-almond .hover\\:text-seal:hover{color:#7E2B22!important}
-        .gd-almond .text-paper{color:#F6F1E8!important}
-        .gd-almond .border-rule{border-color:#E0D8C9!important}
-        .gd-almond .border-rule\\/60{border-color:rgba(224,216,201,.6)!important}
-        .gd-almond .border-ink{border-color:#221E17!important}
-        .gd-almond .border-ink\\/70{border-color:rgba(34,30,23,.72)!important}
-        .gd-almond .border-seal,.gd-almond .border-seal\\/50,.gd-almond .border-seal\\/40{border-color:rgba(126,43,34,.55)!important}
-        .gd-almond .decoration-rule{text-decoration-color:#E0D8C9!important}
-        .gd-almond .decoration-seal{text-decoration-color:#7E2B22!important}
         /* Teaching annotations + redline. */
         .gd-doc p{margin:0 0 .85rem}
         .gd-doc .ann{border-radius:2px;padding:0 2px}
@@ -293,17 +273,26 @@ export function GuidedDemo() {
         </button>
       </div>
 
-      <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel flex flex-col md:overflow-hidden">
-        <div className="flex-1 md:min-h-0 md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
-          <div className="mx-auto w-full max-w-[860px]">
-            {/* Demo header — the backend masthead (display tier). */}
-            <PageHeader
-              display
-              title="Demo walkthrough"
-              description="Legalise on a live matter: Khan v Acme, an unfair-dismissal claim. Watch a wrong answer become a signed record."
-            />
+      <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
+        <div className="mx-auto w-full max-w-[860px]">
+          {/* Demo header — the backend masthead (display tier). */}
+          <PageHeader
+            display
+            title="Demo walkthrough"
+            description="Legalise on a live matter: Khan v Acme, an unfair-dismissal claim. Watch a wrong answer become a signed record."
+          />
 
-            <div className="mt-8">
+          {/* Action nav — sits under the header, always in view. */}
+          <div className="mt-2 flex items-center gap-4 border-b border-rule pb-6">
+            {act > 0 && <BackLink onClick={() => setAct(act - 1)} />}
+            {primary ? (
+              <PrimaryBtn onClick={primary.onClick}>{primary.label}</PrimaryBtn>
+            ) : (
+              <span className="text-xs text-muted">Read the answer below, then continue.</span>
+            )}
+          </div>
+
+          <div className="mt-8">
             {/* ── ACT 1 · THE FAILURE (the matter chat) ── */}
             {act === 0 && (
               <div className="mx-auto max-w-[760px]">
@@ -535,14 +524,6 @@ export function GuidedDemo() {
 
               </div>
             )}
-            </div>
-          </div>
-        </div>
-        {/* action bar — pinned, so the buttons never need a scroll */}
-        <div className="shrink-0 border-t border-rule bg-panel px-4 sm:px-6 lg:px-10 py-4">
-          <div className="mx-auto flex w-full max-w-[860px] items-center gap-4">
-            {act > 0 && <BackLink onClick={() => setAct(act - 1)} />}
-            {primary && <PrimaryBtn onClick={primary.onClick}>{primary.label}</PrimaryBtn>}
           </div>
         </div>
       </main>

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -10,8 +10,8 @@
 // Ink, scoped to this surface (tokens are static, so we override them here).
 
 import { useEffect, useRef, useState } from "react";
-import { Footer } from "../ui/Footer";
-import { CertCard, CertEyebrow, LedgerRow, SectionRule } from "../ui/certificate";
+import { CertCard, CertEyebrow, LedgerRow } from "../ui/certificate";
+import { PageHeader } from "../ui/primitives";
 import { SidebarView, NavIcon, type RailItem } from "../ui/SidebarView";
 
 const ACTS = ["The failure", "Choose", "Install", "Run", "Govern"] as const;
@@ -248,27 +248,15 @@ export function GuidedDemo() {
 
       <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
         <div className="mx-auto w-full max-w-[860px]">
-          {/* Matter header — the real masthead. */}
-          <div className="border-b border-rule pb-5">
-            <div className="flex items-baseline justify-between">
-              <div className="text-[10px] uppercase tracking-[0.25em] text-muted">Guided demo · read-only</div>
-              <span className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-muted">
-                <span className="h-2 w-2 rounded-full bg-seal" aria-hidden="true" />
-                Active
-              </span>
-            </div>
-            <h1 className="mt-2 font-redaction35 text-[34px] leading-none tracking-tight2 text-ink">
-              Khan v Acme Trading Ltd
-            </h1>
-            <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-[12px] text-muted">
-              <span>Jasmine Khan · claimant</span>
-              <span>s.94 ERA 1996 · unfair dismissal</span>
-              <span className="tech-token">employment_tribunal</span>
-            </div>
-          </div>
+          {/* Matter header — the real backend masthead (PageHeader). */}
+          <PageHeader
+            display
+            title="Khan v Acme Trading Ltd"
+            description="Jasmine Khan · claimant · s.94 ERA 1996 unfair dismissal"
+          />
 
-          {/* Stepper. */}
-          <nav className="mt-6 flex flex-wrap gap-x-6 gap-y-2" aria-label="Demo acts">
+          {/* Stepper — the one piece of guided chrome. */}
+          <nav className="flex flex-wrap gap-x-6 gap-y-2" aria-label="Demo acts">
             {ACTS.map((label, i) => (
               <span key={label} aria-current={i === act ? "step" : undefined}
                 className={"text-[11px] uppercase tracking-[0.18em] " + (i === act ? "text-ink font-semibold" : i < act ? "text-seal" : "text-muted/50")}>
@@ -281,8 +269,7 @@ export function GuidedDemo() {
             {/* ── ACT 1 · THE FAILURE ── */}
             {act === 0 && (
               <div>
-                <SectionRule label={<span className="text-seal">Claude, raw</span>} right="the failure" />
-                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">The version of AI most lawyers have met.</h2>
+                <h2 className="text-2xl font-bold tracking-tight2 text-ink">The version of AI most lawyers have met.</h2>
                 <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_300px]">
                   <div>
                     <div className="border border-rule bg-paper">
@@ -318,8 +305,7 @@ export function GuidedDemo() {
             {/* ── ACT 2 · CHOOSE ── */}
             {act === 1 && (
               <div>
-                <SectionRule label={<span className="text-seal">The catalogue</span>} right="choose" />
-                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">You don't fix this with a better prompt. You install a skill.</h2>
+                <h2 className="text-2xl font-bold tracking-tight2 text-ink">You don't fix this with a better prompt. You install a skill.</h2>
                 <p className="mt-3 text-sm leading-relaxed text-prose">A skill is a small, vetted unit of legal work. Pick the ones that answer the failure you just saw — the bluff and the slop.</p>
                 <div className="mt-6 space-y-px bg-rule border border-rule">
                   {CATALOGUE.map((s) => {
@@ -345,8 +331,7 @@ export function GuidedDemo() {
             {/* ── ACT 3 · INSTALL (certificate admission) ── */}
             {act === 2 && (
               <div>
-                <SectionRule label={<span className="text-seal">Admission</span>} right="install" />
-                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">A skill is admitted, not just uploaded.</h2>
+                <h2 className="text-2xl font-bold tracking-tight2 text-ink">A skill is admitted, not just uploaded.</h2>
                 <p className="mt-3 text-sm leading-relaxed text-prose">Each skill declares what it may read, what it may write, and which gate governs it. You approve that contract; then it is admitted to the matter.</p>
                 <div className="mt-6 space-y-5">
                   {chosen.map((s) => (
@@ -382,8 +367,7 @@ export function GuidedDemo() {
             {/* ── ACT 4 · RUN → REDLINE (with the document open) ── */}
             {act === 3 && (
               <div>
-                <SectionRule label={<span className="text-seal">The run</span>} right="redline" />
-                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">Same question. Skills installed.</h2>
+                <h2 className="text-2xl font-bold tracking-tight2 text-ink">Same question. Skills installed.</h2>
                 <p className="mt-3 text-sm leading-relaxed text-prose">The skills run against the matter's documents — open on the right. Watch the bluff get struck and the padding stripped.</p>
                 <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_300px]">
                   <div>
@@ -434,8 +418,7 @@ export function GuidedDemo() {
             {/* ── ACT 5 · GOVERN (scaffold) ── */}
             {act === 4 && (
               <div>
-                <SectionRule label={<span className="text-seal">Audit &amp; sign-off</span>} right="govern" />
-                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">The model drafted. A human becomes the authority.</h2>
+                <h2 className="text-2xl font-bold tracking-tight2 text-ink">The model drafted. A human becomes the authority.</h2>
                 <p className="mt-3 text-sm leading-relaxed text-prose">Next: SAW-vs-ASSERTED, the refusal struck on the record, and the sign-off where a named person takes responsibility. (Porting the harness's audit + sign-off card here next.)</p>
                 <div className="mt-8 flex items-center gap-4">
                   <BackLink onClick={() => setAct(3)} />
@@ -444,11 +427,6 @@ export function GuidedDemo() {
               </div>
             )}
           </div>
-
-          <div className="mt-14">
-            <SectionRule label="Acts 1–4 built · Almond & Ink" right="Vertical slice" />
-          </div>
-          <Footer />
         </div>
       </main>
     </div>

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -1,0 +1,456 @@
+// /guided-demo — the guided, on-rails demo, layered on the real workspace.
+//
+// Centred on the skill lifecycle (choose → install → run → govern) and
+// played out INSIDE the actual backend shell: the SidebarView rail, the
+// matter header, the document reader, the bg-panel surface. The guided
+// narration rides on top; the rail lights up as you move through the acts.
+//
+// Acts: 1 The failure · 2 Choose · 3 Install · 4 Run · 5 Govern.
+// Teaching content ported from the vibeathon "harness". Palette: Almond &
+// Ink, scoped to this surface (tokens are static, so we override them here).
+
+import { useEffect, useRef, useState } from "react";
+import { Footer } from "../ui/Footer";
+import { CertCard, CertEyebrow, LedgerRow, SectionRule } from "../ui/certificate";
+import { SidebarView, NavIcon, type RailItem } from "../ui/SidebarView";
+
+const ACTS = ["The failure", "Choose", "Install", "Run", "Govern"] as const;
+// Which rail surface each act lights up — so the guided flow drives the
+// real nav, not a parallel stepper alone.
+const ACT_RAIL = ["assistant", "workflows", "workflows", "documents", "audit"] as const;
+
+const QUESTION = "What's the deadline to file the ET1 in this matter?";
+
+const RAW_HTML = `
+<p>The deadline to file the ET1 is <span class="ann ann-bluff">12 June 2026</span>.</p>
+<p>Under the Employment Rights Act 1996, an unfair-dismissal claim must be presented within three months of the effective date of termination. <span class="ann ann-bluff">As established in <em>Henderson v Brent London Borough Council</em> [2019] EWCA Civ 1021, the three-month period runs cleanly from the date of the dismissal letter</span>, giving a firm and calculable deadline. Ms Khan was dismissed on 12 March 2026, so <span class="ann ann-bluff">the period expires exactly three months later, on 12 June 2026</span>.</p>
+<p><span class="ann ann-slop">It is important to note that this is a firm deadline and the claim should be filed by that date to preserve Ms Khan's position.</span> <span class="ann ann-bluff">Given the procedural failings, the claim is very likely to succeed at hearing.</span></p>`;
+
+const REDLINE_HTML = `
+<p>The deadline to file the ET1 is <del>12 June 2026</del> <ins>not fixed by the documents alone — see below</ins>.</p>
+<p>Under the Employment Rights Act 1996 (s.111), an unfair-dismissal claim is normally presented within three months <ins>less one day</ins> of the effective date of termination. <del>As established in Henderson v Brent London Borough Council [2019] EWCA Civ 1021, the three-month period runs cleanly from the date of the dismissal letter.</del> <ins>⚑ No authority by that citation appears in the matter, and the matter contains no case law at all. Two things the documents do not settle are also load-bearing: (a) whether ACAS early conciliation has started; and (b) the exact effective date of termination given the payment in lieu of notice.</ins></p>
+<p><del>It is important to note that this</del> <ins>This</ins> is a time-critical deadline. <del>Given the procedural failings, the claim is very likely to succeed at hearing.</del> <ins>Confirm the ACAS position and the effective date of termination before relying on any date.</ins></p>`;
+
+type Skill = { id: string; name: string; blurb: string; fixes: boolean; reads: string; writes: string };
+
+const CATALOGUE: Skill[] = [
+  { id: "citation-check", name: "citation / source-anchor check", blurb: "Refuses to assert authority not found in the matter's documents.", fixes: true, reads: "matter.document.read", writes: "matter.artifact.write" },
+  { id: "plain-english", name: "plain-english", blurb: "Strips slop and jargon. Plain words a client can read.", fixes: true, reads: "matter.document.read", writes: "matter.artifact.write" },
+  { id: "nda-review", name: "nda-review", blurb: "Flags risks in an NDA, clause by clause.", fixes: false, reads: "matter.document.read", writes: "matter.artifact.write" },
+  { id: "disclosure-list", name: "disclosure-list", blurb: "Builds a disclosure list from the matter's documents.", fixes: false, reads: "matter.document.read", writes: "matter.artifact.write" },
+];
+
+const DOCS: { key: string; label: string; filename: string; text: string }[] = [
+  {
+    key: "dismissal",
+    label: "Dismissal letter",
+    filename: "khan-dismissal-letter.pdf",
+    text: "ACME TRADING LTD\n12 March 2026\n\nDear Ms Khan,\n\nFollowing the disciplinary hearing held on 10 March 2026, the company has concluded that your conduct — a post published on social media on 28 February 2026 — constitutes gross misconduct under the Acme Social Media Policy.\n\nYou are summarily dismissed with effect from today, 12 March 2026. You will receive a payment in lieu of your notice period.\n\nThe hearing was chaired by Mr R. Caldwell, Warehouse Operations Manager.\n\nYours sincerely,\nFor and on behalf of Acme Trading Ltd",
+  },
+  {
+    key: "witness",
+    label: "Witness statement",
+    filename: "witness-statement-khan.docx",
+    text: "WITNESS STATEMENT OF JASMINE KHAN\n\n1. The post treated as gross misconduct was made from my personal Instagram account, outside working hours, to a closed audience of 47 followers. None were customers, suppliers, or colleagues.\n\n2. On 29 January 2026 I raised a grievance about Mr Caldwell's conduct toward female members of the warehouse team.\n\n3. The disciplinary hearing on 10 March 2026 was chaired by Mr Caldwell — the same manager who was the subject of my grievance.",
+  },
+  {
+    key: "nda",
+    label: "Mutual NDA",
+    filename: "synthetic-mutual-nda.docx",
+    text: "MUTUAL NON-DISCLOSURE AGREEMENT\nbetween Acme Trading Ltd and North Mill Consulting Limited · 1 May 2026\n\n3.2  Confidentiality obligations shall continue in force without limit of time.\n\n4.1  Each party shall comply with applicable data protection law.\n\n5.1  The receiving party shall indemnify the disclosing party against all losses without limitation.\n\n[No governing-law or jurisdiction clause.]",
+  },
+];
+
+function usePrefersReducedMotion() {
+  const [reduce, setReduce] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduce(mq.matches);
+    const on = () => setReduce(mq.matches);
+    mq.addEventListener("change", on);
+    return () => mq.removeEventListener("change", on);
+  }, []);
+  return reduce;
+}
+
+function useTypewriter(text: string, active: boolean) {
+  const reduce = usePrefersReducedMotion();
+  const [n, setN] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    if (reduce) return setN(text.length);
+    setN(0);
+    const id = setInterval(() => {
+      setN((prev) => {
+        const next = prev + 1;
+        if (next >= text.length) clearInterval(id);
+        return next;
+      });
+    }, 22);
+    return () => clearInterval(id);
+  }, [text, active, reduce]);
+  return { shown: reduce ? text : text.slice(0, n), done: n >= text.length || reduce };
+}
+
+function Coachmark({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-6 border-l-2 border-seal bg-wash px-4 py-3">
+      <div className="text-[10px] uppercase tracking-[0.22em] text-seal mb-2">What's going on</div>
+      <p className="text-sm leading-relaxed text-prose">{children}</p>
+    </div>
+  );
+}
+
+function PrimaryBtn({ onClick, children }: { onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button type="button" onClick={onClick} className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px]">
+      {children}
+    </button>
+  );
+}
+
+function BackLink({ onClick }: { onClick: () => void }) {
+  return (
+    <button type="button" onClick={onClick} className="text-sm text-muted hover:text-seal transition-colors">
+      ← Back
+    </button>
+  );
+}
+
+// The document reader — the matter's paper, on the page. Tabs across the
+// three documents, the active one rendered as plain extracted text.
+function DocReader({ highlight }: { highlight?: boolean }) {
+  const [key, setKey] = useState("dismissal");
+  const doc = DOCS.find((d) => d.key === key) ?? DOCS[0];
+  return (
+    <div className={"border bg-paper " + (highlight ? "border-seal/50" : "border-rule")}>
+      <div className="flex border-b border-rule">
+        {DOCS.map((d) => (
+          <button
+            key={d.key}
+            type="button"
+            onClick={() => setKey(d.key)}
+            className={
+              "px-3 py-2 text-[11px] uppercase tracking-[0.16em] transition-colors " +
+              (d.key === key ? "text-ink font-semibold border-b-2 border-seal -mb-px" : "text-muted hover:text-seal")
+            }
+          >
+            {d.label}
+          </button>
+        ))}
+      </div>
+      <div className="px-4 py-3">
+        <div className="tech-token text-[11px] text-muted mb-2">{doc.filename}</div>
+        <pre className="whitespace-pre-wrap font-sans text-[13px] leading-relaxed text-prose">{doc.text}</pre>
+      </div>
+    </div>
+  );
+}
+
+export function GuidedDemo() {
+  const [act, setAct] = useState(0);
+  const [navOpen, setNavOpen] = useState(false);
+
+  const q = useTypewriter(QUESTION, act === 0);
+  const [revealed, setRevealed] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [installed, setInstalled] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [ran, setRan] = useState(false);
+  const [showCorrected, setShowCorrected] = useState(true);
+  const reduce = usePrefersReducedMotion();
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const toggleSkill = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+
+  const runSkills = () => {
+    setRunning(true);
+    if (reduce) return (setRunning(false), setRan(true), undefined);
+    timer.current = setTimeout(() => {
+      setRunning(false);
+      setRan(true);
+    }, 1300);
+  };
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const chosen = CATALOGUE.filter((s) => selected.has(s.id));
+
+  const railActive = ACT_RAIL[act];
+  const globalItems: RailItem[] = [
+    { key: "matters", label: "Matters", icon: <NavIcon name="matters" />, href: "/" },
+  ];
+  const matterItems: RailItem[] = [
+    { key: "assistant", label: "Chat", icon: <NavIcon name="assistant" />, active: railActive === "assistant", onSelect: () => setAct(0) },
+    { key: "documents", label: "Files", icon: <NavIcon name="documents" />, active: railActive === "documents", onSelect: () => setAct(3) },
+    { key: "workflows", label: "Skills", icon: <NavIcon name="workflows" />, active: railActive === "workflows", onSelect: () => setAct(1) },
+    { key: "audit", label: "Record", icon: <NavIcon name="audit" />, active: railActive === "audit", onSelect: () => setAct(4) },
+  ];
+
+  return (
+    <div className="gd-almond min-h-screen md:h-screen bg-canvas text-ink md:flex md:gap-3 md:p-3 md:overflow-hidden">
+      <style>{`
+        /* Almond & Ink — scoped palette override (tokens are static). */
+        .gd-almond.bg-canvas,.gd-almond .bg-canvas{background-color:#E9E2D4!important}
+        .gd-almond .bg-panel,.gd-almond .bg-panel-2{background-color:#F2ECE1!important}
+        .gd-almond .bg-paper{background-color:#F6F1E8!important}
+        .gd-almond .bg-wash{background-color:#EFE9DD!important}
+        .gd-almond .bg-panel-sel{background-color:#E0D7C6!important}
+        .gd-almond .bg-ink{background-color:#221E17!important}
+        .gd-almond .bg-seal,.gd-almond .hover\\:bg-seal:hover{background-color:#7E2B22!important}
+        .gd-almond .text-ink{color:#221E17!important}
+        .gd-almond .text-prose{color:#564E42!important}
+        .gd-almond .text-muted{color:#8B8273!important}
+        .gd-almond .text-seal,.gd-almond .hover\\:text-seal:hover{color:#7E2B22!important}
+        .gd-almond .text-paper{color:#F6F1E8!important}
+        .gd-almond .border-rule{border-color:#E0D8C9!important}
+        .gd-almond .border-ink{border-color:#221E17!important}
+        .gd-almond .border-seal,.gd-almond .border-seal\\/50{border-color:#7E2B22!important}
+        .gd-almond .decoration-rule{text-decoration-color:#E0D8C9!important}
+        .gd-almond .decoration-seal{text-decoration-color:#7E2B22!important}
+        /* Teaching annotations + redline. */
+        .gd-doc p{margin:0 0 .85rem}
+        .gd-doc .ann{border-radius:2px;padding:0 2px}
+        .gd-doc .ann-bluff{background:rgba(126,43,34,.16);box-shadow:inset 0 -2px 0 #7e2b22}
+        .gd-doc .ann-slop{background:rgba(120,110,90,.16)}
+        .gd-doc del{color:#9b8f86;text-decoration-color:#7e2b22}
+        .gd-doc ins{background:rgba(126,43,34,.07);text-decoration:none;box-shadow:inset 0 -1px 0 rgba(126,43,34,.4)}
+      `}</style>
+
+      <SidebarView
+        brandHref="/"
+        globalItems={globalItems}
+        matterTitle="Khan v Acme Trading Ltd"
+        matterPosture={{ label: "Active", dot: "bg-seal" }}
+        matterItems={matterItems}
+        utilItems={[]}
+        open={navOpen}
+        onClose={() => setNavOpen(false)}
+      />
+
+      {/* Mobile bar. */}
+      <div className="md:hidden sticky top-0 z-30 flex items-center h-[56px] px-4 bg-canvas border-b border-rule">
+        <button type="button" onClick={() => setNavOpen(true)} aria-label="Open menu" className="min-h-[44px] min-w-[44px] -ml-2 flex items-center justify-center text-ink">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M3 6h14M3 10h14M3 14h14" stroke="currentColor" strokeWidth="1.5" />
+          </svg>
+        </button>
+      </div>
+
+      <main className="min-h-screen bg-panel md:min-h-0 md:flex-1 md:min-w-0 md:h-full md:rounded-panel md:shadow-panel md:overflow-y-auto px-4 sm:px-6 lg:px-10 py-8 lg:py-12">
+        <div className="mx-auto w-full max-w-[860px]">
+          {/* Matter header — the real masthead. */}
+          <div className="border-b border-rule pb-5">
+            <div className="flex items-baseline justify-between">
+              <div className="text-[10px] uppercase tracking-[0.25em] text-muted">Guided demo · read-only</div>
+              <span className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-muted">
+                <span className="h-2 w-2 rounded-full bg-seal" aria-hidden="true" />
+                Active
+              </span>
+            </div>
+            <h1 className="mt-2 font-redaction35 text-[34px] leading-none tracking-tight2 text-ink">
+              Khan v Acme Trading Ltd
+            </h1>
+            <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-[12px] text-muted">
+              <span>Jasmine Khan · claimant</span>
+              <span>s.94 ERA 1996 · unfair dismissal</span>
+              <span className="tech-token">employment_tribunal</span>
+            </div>
+          </div>
+
+          {/* Stepper. */}
+          <nav className="mt-6 flex flex-wrap gap-x-6 gap-y-2" aria-label="Demo acts">
+            {ACTS.map((label, i) => (
+              <span key={label} aria-current={i === act ? "step" : undefined}
+                className={"text-[11px] uppercase tracking-[0.18em] " + (i === act ? "text-ink font-semibold" : i < act ? "text-seal" : "text-muted/50")}>
+                {String(i + 1).padStart(2, "0")} · {label}
+              </span>
+            ))}
+          </nav>
+
+          <div className="mt-8">
+            {/* ── ACT 1 · THE FAILURE ── */}
+            {act === 0 && (
+              <div>
+                <SectionRule label={<span className="text-seal">Claude, raw</span>} right="the failure" />
+                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">The version of AI most lawyers have met.</h2>
+                <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_300px]">
+                  <div>
+                    <div className="border border-rule bg-paper">
+                      <div className="border-b border-rule px-4 py-2 text-[11px] uppercase tracking-[0.18em] text-muted">You ask</div>
+                      <div className="px-4 py-3 text-sm text-ink">
+                        {q.shown}
+                        {!q.done && <span className="ml-0.5 inline-block w-[2px] animate-pulse bg-seal">&nbsp;</span>}
+                      </div>
+                    </div>
+                    {q.done && (
+                      <div className="mt-4 border border-rule bg-paper">
+                        <div className="border-b border-rule px-4 py-2 text-[11px] uppercase tracking-[0.18em] text-muted">Claude · raw</div>
+                        <div className="gd-doc px-4 py-4 text-sm leading-relaxed text-prose" dangerouslySetInnerHTML={{ __html: RAW_HTML }} />
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-[0.2em] text-muted mb-2">The matter's documents</div>
+                    <DocReader />
+                  </div>
+                </div>
+                {q.done && revealed && (
+                  <Coachmark>
+                    Fluent, confident, and wrong. <strong>Henderson v Brent LBC</strong> is invented — there's no such authority anywhere in this matter (check the documents on the right). The padding and the "very likely to succeed" prediction are bluff too. This is the failure that makes good lawyers quit. It's catchable.
+                  </Coachmark>
+                )}
+                <div className="mt-8">
+                  {!revealed ? (q.done && <PrimaryBtn onClick={() => setRevealed(true)}>See what went wrong</PrimaryBtn>) : <PrimaryBtn onClick={() => setAct(1)}>The fix is a skill →</PrimaryBtn>}
+                </div>
+              </div>
+            )}
+
+            {/* ── ACT 2 · CHOOSE ── */}
+            {act === 1 && (
+              <div>
+                <SectionRule label={<span className="text-seal">The catalogue</span>} right="choose" />
+                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">You don't fix this with a better prompt. You install a skill.</h2>
+                <p className="mt-3 text-sm leading-relaxed text-prose">A skill is a small, vetted unit of legal work. Pick the ones that answer the failure you just saw — the bluff and the slop.</p>
+                <div className="mt-6 space-y-px bg-rule border border-rule">
+                  {CATALOGUE.map((s) => {
+                    const on = selected.has(s.id);
+                    return (
+                      <button key={s.id} type="button" onClick={() => toggleSkill(s.id)} className={"block w-full text-left px-4 py-4 transition-colors " + (on ? "bg-panel-sel" : "bg-paper hover:bg-wash")}>
+                        <div className="flex items-center justify-between">
+                          <span className="tech-token text-sm text-ink">{s.name}</span>
+                          <span className={"text-[10px] uppercase tracking-[0.18em] " + (on ? "text-seal font-semibold" : "text-muted")}>{on ? "selected" : s.fixes ? "addresses the failure" : "available"}</span>
+                        </div>
+                        <p className="mt-1 text-sm text-prose">{s.blurb}</p>
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="mt-8 flex items-center gap-4">
+                  <BackLink onClick={() => setAct(0)} />
+                  {selected.size > 0 && <PrimaryBtn onClick={() => setAct(2)}>Install {selected.size} to the matter →</PrimaryBtn>}
+                </div>
+              </div>
+            )}
+
+            {/* ── ACT 3 · INSTALL (certificate admission) ── */}
+            {act === 2 && (
+              <div>
+                <SectionRule label={<span className="text-seal">Admission</span>} right="install" />
+                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">A skill is admitted, not just uploaded.</h2>
+                <p className="mt-3 text-sm leading-relaxed text-prose">Each skill declares what it may read, what it may write, and which gate governs it. You approve that contract; then it is admitted to the matter.</p>
+                <div className="mt-6 space-y-5">
+                  {chosen.map((s) => (
+                    <div key={s.id} className="relative">
+                      <CertCard>
+                        <CertEyebrow left="Skill manifest" right={installed ? "Admitted" : "Pending admission"} />
+                        <div className="mt-3 tech-token text-sm text-ink">{s.name}</div>
+                        <dl className="mt-4 space-y-1 text-[11px] text-muted">
+                          <LedgerRow label="Reads" tone="ink">{s.reads}</LedgerRow>
+                          <LedgerRow label="Writes" tone="ink">{s.writes}</LedgerRow>
+                          <LedgerRow label="Gate" tone="ink">privilege_posture</LedgerRow>
+                          <LedgerRow label="External network" tone="ink">none</LedgerRow>
+                        </dl>
+                      </CertCard>
+                      {installed && (
+                        <span className="absolute right-4 top-4 -rotate-6 border-2 border-seal px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-seal">
+                          Admitted
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                {installed && (
+                  <Coachmark>The skill can't reach a document it didn't declare, or run on a matter whose privilege posture forbids it. Everything it does from here lands on the record.</Coachmark>
+                )}
+                <div className="mt-8 flex items-center gap-4">
+                  <BackLink onClick={() => setAct(1)} />
+                  {!installed ? <PrimaryBtn onClick={() => setInstalled(true)}>Admit &amp; install</PrimaryBtn> : <PrimaryBtn onClick={() => setAct(3)}>Run it on the matter →</PrimaryBtn>}
+                </div>
+              </div>
+            )}
+
+            {/* ── ACT 4 · RUN → REDLINE (with the document open) ── */}
+            {act === 3 && (
+              <div>
+                <SectionRule label={<span className="text-seal">The run</span>} right="redline" />
+                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">Same question. Skills installed.</h2>
+                <p className="mt-3 text-sm leading-relaxed text-prose">The skills run against the matter's documents — open on the right. Watch the bluff get struck and the padding stripped.</p>
+                <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_300px]">
+                  <div>
+                    {!ran && (
+                      <div>
+                        <PrimaryBtn onClick={runSkills}>{running ? "Running…" : "Run the installed skills"}</PrimaryBtn>
+                        {running && (
+                          <div className="mt-4 space-y-1 text-[11px] uppercase tracking-[0.18em] text-muted">
+                            {chosen.map((s) => (
+                              <div key={s.id} className="flex items-center gap-2">
+                                <span className="h-2 w-2 animate-pulse rounded-full bg-seal" />
+                                {s.name} · reading documents…
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                    {ran && (
+                      <>
+                        <div className="inline-flex border border-rule bg-paper text-xs">
+                          <button type="button" onClick={() => setShowCorrected(false)} className={"px-3 py-2 " + (!showCorrected ? "bg-ink text-paper" : "text-muted")}>Raw</button>
+                          <button type="button" onClick={() => setShowCorrected(true)} className={"px-3 py-2 " + (showCorrected ? "bg-ink text-paper" : "text-muted")}>With skills</button>
+                        </div>
+                        <div className="mt-3 border border-rule bg-paper">
+                          <div className="border-b border-rule px-4 py-2 text-[11px] uppercase tracking-[0.18em] text-muted">{showCorrected ? "Claude · citation-check + plain-english" : "Claude · raw"}</div>
+                          <div className="gd-doc px-4 py-4 text-sm leading-relaxed text-prose" dangerouslySetInnerHTML={{ __html: showCorrected ? REDLINE_HTML : RAW_HTML }} />
+                        </div>
+                        <p className="mt-3 text-xs text-muted"><del className="text-muted">struck</del> = removed by a skill · <span className="text-seal">underlined</span> = added · ⚑ = the citation check refused an unsupported claim.</p>
+                      </>
+                    )}
+                  </div>
+                  <div>
+                    <div className="text-[10px] uppercase tracking-[0.2em] text-muted mb-2">Checked against</div>
+                    <DocReader highlight={ran} />
+                  </div>
+                </div>
+                {ran && (
+                  <Coachmark>The invented citation is gone, struck by the source-anchor check against the documents on the right. The padding is gone, stripped by plain-english. What's left is anchored to the paper — and the refusal itself is about to land on the record.</Coachmark>
+                )}
+                <div className="mt-8 flex items-center gap-4">
+                  <BackLink onClick={() => setAct(2)} />
+                  {ran && <PrimaryBtn onClick={() => setAct(4)}>Send it to the record →</PrimaryBtn>}
+                </div>
+              </div>
+            )}
+
+            {/* ── ACT 5 · GOVERN (scaffold) ── */}
+            {act === 4 && (
+              <div>
+                <SectionRule label={<span className="text-seal">Audit &amp; sign-off</span>} right="govern" />
+                <h2 className="mt-5 text-2xl font-bold tracking-tight2 text-ink">The model drafted. A human becomes the authority.</h2>
+                <p className="mt-3 text-sm leading-relaxed text-prose">Next: SAW-vs-ASSERTED, the refusal struck on the record, and the sign-off where a named person takes responsibility. (Porting the harness's audit + sign-off card here next.)</p>
+                <div className="mt-8 flex items-center gap-4">
+                  <BackLink onClick={() => setAct(3)} />
+                  <PrimaryBtn onClick={() => { setAct(0); setRevealed(false); setSelected(new Set()); setInstalled(false); setRan(false); }}>Replay from the top</PrimaryBtn>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-14">
+            <SectionRule label="Acts 1–4 built · Almond & Ink" right="Vertical slice" />
+          </div>
+          <Footer />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/lib/route.ts
+++ b/frontend/src/lib/route.ts
@@ -33,6 +33,7 @@ export type Route =
   | { name: "demoLoop" }
   | { name: "demo"; tab?: string }
   | { name: "demoDocument"; documentId: string }
+  | { name: "demoGuided" }
   | { name: "list" }
   | { name: "new" }
   | { name: "detail"; slug: string; tab?: string }
@@ -90,6 +91,7 @@ export function routeFromPath(pathname: string, search: string): Route {
   if (path === "/skills/lawve" || path === "/modules/lawve") return { name: "lawveImport" };
 
   if (path === "/demo-loop") return { name: "demoLoop" };
+  if (path === "/guided-demo") return { name: "demoGuided" };
   if (path === "/demo") return { name: "demo" };
   const demoDocumentMatch = path.match(/^\/demo\/documents\/([^/]+)$/);
   if (demoDocumentMatch) {
@@ -232,6 +234,7 @@ export const PUBLIC_ROUTE_NAMES = new Set<Route["name"]>([
   "modules",
   "demo",
   "demoDocument",
+  "demoGuided",
   // /app is intentionally public — first-run (user_count=0) and
   // bootstrap-required states must render without a session.
   // AppHome owns its own auth gating once has_superuser=true.

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -28,6 +28,7 @@ import { ModuleDetail } from "../modules-v2/ModuleDetail";
 import { CreateModule } from "../modules-v2/CreateModule";
 import { LawveImport } from "../modules-v2/LawveImport";
 import { DemoLoop } from "../demo/DemoLoop";
+import { GuidedDemo } from "../demo/GuidedDemo";
 import { InstallCeremony } from "../modules-v2/InstallCeremony";
 import { CounselRegister } from "../modules-v2/CounselRegister";
 import { ArtifactsList } from "../matter/ArtifactsList";
@@ -232,6 +233,15 @@ const demoDocumentRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/demo/documents/$documentId",
   component: DemoMatterPage,
+});
+
+// Preview of the rebuilt, guided, skill-lifecycle demo. Public, separate
+// from /demo so the existing static workspace stays untouched while we
+// iterate on the replacement.
+const guidedDemoRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/guided-demo",
+  component: GuidedDemo,
 });
 
 // ---------------------------------------------------------------------------
@@ -570,6 +580,7 @@ const routeTree = rootRoute.addChildren([
   demoIndexRoute,
   demoDocumentRoute,
   demoTabRoute,
+  guidedDemoRoute,
   appHomeRoute,
   authedRoute.addChildren([
     mattersListRoute,

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -20,26 +20,27 @@ export default {
         redaction20: ['"Redaction 20"', 'Georgia', 'serif'],
         redaction35: ['"Redaction 35"', 'Georgia', 'serif'],
       },
-      colors: {
-        ink: '#181818',
-        paper: '#FFFFFF',
-        wash: '#F4F4F4',
-        rule: '#E5E5E5',
-        muted: '#9CA3AF',
-        prose: '#4B5563',
+        // Almond & Ink — warm-neutral register palette, site-wide
+        // (2026-06-16). Replaces the old cool-grey tokens; near-marble
+        // paper, oxblood seal at ~10% chroma.
+        colors: {
+        ink: '#221E17',
+        paper: '#F6F1E8',
+        wash: '#EFE9DD',
+        rule: '#E0D8C9',
+        muted: '#8B8273',
+        prose: '#564E42',
         // Tertiary accent — sealing wax. v0.5: verdicts, the seal/stamp,
         // privilege C_paused, audit blocked rows, CPR 31.22 flag,
         // destructive confirms. NEVER in workspace chrome (no nav accent,
         // no panel border), never a background, never on the brand mark.
-        seal: '#8B0000',
-        // v0.5 workspace register — neutral-grey floating-panel shell.
-        // See docs/DESIGN.md P21. Used by the matter workspace only;
-        // Landing/auth keep paper #FFFFFF.
-        canvas: '#E8E8E8',
-        panel: '#FAFAFA',
-        'panel-hover': '#F3F3F3',
-        'panel-sel': '#E6E6E6',
-        'panel-2': '#F7F7F7',
+        seal: '#7E2B22',
+        // Warm-neutral floating-panel shell (Almond & Ink value ladder).
+        canvas: '#E9E2D4',
+        panel: '#F2ECE1',
+        'panel-hover': '#E9E2D4',
+        'panel-sel': '#E0D7C6',
+        'panel-2': '#F2ECE1',
       },
       maxWidth: {
         page: '1440px',


### PR DESCRIPTION
## What ships

**A new guided demo** at `/guided-demo`, replacing the cold drop into the static workspace. An on-rails walkthrough of the skill lifecycle on Khan v Acme, built on the real backend idioms:

1. **Failure** — raw model, fluent but wrong (the invented *Henderson v Brent* citation), real chat styling
2. **Choose** — the skills register (`CertCard` + InkBands)
3. **Install** — the admission scan ledger (rows march with ✓, then Grant of standing)
4. **Run** — the real skill-runner (Request + documents-in-scope) → `skill_response` artifact with the redline
5. **Govern** — sign-off two-pane → the audit record (gate.refuse struck in seal) + signed record card

Renders bare (no marketing TopBar), nav sits under the header, plain copy (em-dash-free), document reader and certificate ceremony reused from the live components. Old `/demo` left untouched.

**Almond & Ink, site-wide** — the global tokens in `tailwind.config.js` move to the warm register palette (near-marble paper, oxblood seal). Recolours the whole site: landing, architecture, auth, backend.

## Verify
- `tsc --noEmit` + `npm run build` clean
- Walked /, /guided-demo end to end

## Note
The token swap recolours **every** page (white → warm cream, `#8B0000` → `#7E2B22`). Spot-checked landing + demo; worth a glance at architecture / backend screens post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an interactive guided demo that walks users through a hands-on five-step skill lifecycle journey, including skill selection, installation verification, artifact scanning and review, and final governance approval with audit records.

* **Style**
  * Refreshed the interface color palette to a warm "Almond & Ink" theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->