### PR TITLE
Manual BYO-key gate: PASSED 2026-06-24 + friendly signup email error

### DIFF
--- a/backend/app/api/auth_schemas.py
+++ b/backend/app/api/auth_schemas.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 
+from email_validator import EmailNotValidError, validate_email
 from fastapi_users import schemas
 from pydantic import AliasChoices, Field, field_validator
 
@@ -32,6 +33,24 @@ class UserCreate(schemas.BaseUserCreate):
         default=None,
         validation_alias=AliasChoices("channel", "signup_channel"),
     )
+
+    # The raw email-validator message ("The part after the @-sign is a
+    # special-use or reserved name...") leaks library internals on signup.
+    # Catch it before EmailStr runs and return one human line instead.
+    # Same validator (check_deliverability=False) as EmailStr, so which
+    # addresses pass is unchanged — only the failure message is friendlier.
+    @field_validator("email", mode="before")
+    @classmethod
+    def _friendly_email(cls, v: object) -> object:
+        if isinstance(v, str):
+            try:
+                validate_email(v, check_deliverability=False)
+            except EmailNotValidError as exc:
+                raise ValueError(
+                    "Enter a valid email address. Test or reserved domains "
+                    "(such as .test or .local) are not accepted."
+                ) from exc
+        return v
 
     @field_validator("persona", mode="before")
     @classmethod

--- a/docs/PRE_EVALUATION_GATE.md
+++ b/docs/PRE_EVALUATION_GATE.md
@@ -79,3 +79,67 @@ If both gates pass but the operational gate has open residual risks,
 invite only friendly evaluators with written caveats.
 
 Live-client matters need a separate approval decision.
+
+## Manual BYO-key gate — run record
+
+**2026-06-24 · PASSED · provider: Anthropic · model: claude-opus-4-7**
+
+Full path walked end to end on a local stack (env=development, infra
+compose) with a real Anthropic key entered in Settings → Provider keys.
+Non-client synthetic pack (Okafor v Pennine Freight Ltd — invented facts);
+the public demo matter and the seeded Khan shortcuts were not used.
+
+All nine steps passed:
+
+1. account created via the register endpoint;
+2. Anthropic key added in Settings → Provider keys;
+3. fresh matter created (no model picker at creation — see F2);
+4. two synthetic `.txt` documents uploaded to object storage;
+5. governed skill `github.b1rdmania.pre-motion` run from Chat — **real keyed
+   model call** (`model.invoked`: model `claude-opus-4-7`, provider
+   `anthropic`, 5,898 tokens in), not the keyless `stub-echo`;
+6. source anchors present — both documents cited, with the "Legalise does
+   not certify they prove the claim" framing;
+7. signed with observations;
+8. Activity shows advice-boundary, skill-run, `model.call`, completion,
+   output-decision and sign-off rows; **audit chain verified (21 links)**;
+9. worker-backed export produced a working-pack zip containing matter
+   metadata, original document bytes (content-addressed), signed-output
+   bytes, sign-off, audit + reconstruction (29-entry timeline), and a
+   human-verification checklist (`WORKING_PACK.md` / `README.md`).
+
+Positives confirmed beyond the checklist:
+
+- rubber-stamp detector fired ("signed in 32s — faster than a plausible read
+  of this output"); author≠signer self-sign flagged;
+- `model.call` telemetry records metadata only (model, provider, token
+  counts, ids) — no prompt, response, or document text. (Operational-gate
+  positive: observability scrubbing.)
+
+Findings (non-blocking; none stopped the loop):
+
+- **F1 [FIXED]** Registration rejected reserved-TLD emails (`.test`/`.local`)
+  with the raw email-validator message. Friendly validator added in
+  `backend/app/api/auth_schemas.py`.
+- **F2 [UX]** Profile "Default model" applies only to *new* matters; a matter
+  created before it was set silently used the env default (`claude-opus-4-7`).
+  No in-chat model indicator/picker — an evaluator cannot easily see or
+  control which model a matter runs on.
+- **F3 [UX/sec]** Settings → Provider keys renders the key in plain text (no
+  password mask / reveal toggle), despite "never shown after submission".
+- **F4 [observability]** `model.invoked` records `tokens_in` but
+  `tokens_out: 0` and `cost_micros`/`currency` null — output-token and cost
+  accounting not captured.
+- **F5 [UX]** After a successful export, reloading the working-pack page shows
+  "Start export" again rather than a download link; the completed pack is
+  reachable only via the job result / Activity.
+- **F6 [hardening — recommend]** `worker.run_job` returns silently when the
+  job row is not visible to its session ("job <id> not found — skipping"),
+  leaving the export wedged at "queued" with no error and no timeout. In this
+  run that was triggered by the worker pointing at a different database
+  (`legalise_test`) than the app (`legalise`) after a container recreate — an
+  environment artifact, not a product defect — but the silent-drop behaviour
+  means any worker/DB split or enqueue-before-commit race surfaces to the user
+  as an eternal spinner. Recommend `run_job` mark the job failed (or retry) on
+  not-found, and the export UI time out a stuck job. Maps to the
+  operational-gate "worker running wherever the backend is" item.

--- a/docs/PRE_EVALUATION_GATE.md
+++ b/docs/PRE_EVALUATION_GATE.md
@@ -143,3 +143,35 @@ Findings (non-blocking; none stopped the loop):
   as an eternal spinner. Recommend `run_job` mark the job failed (or retry) on
   not-found, and the export UI time out a stuck job. Maps to the
   operational-gate "worker running wherever the backend is" item.
+
+## Restore rehearsal — run record
+
+**2026-06-24 · PASSED · scope: local self-host restore drill**
+
+Rehearsed the self-host Postgres restore path in a disposable scratch database
+using the populated local stack from the manual BYO-key gate.
+
+Steps:
+
+1. dumped the running app database with `pg_dump -U legalise -Fc legalise`;
+2. created scratch database `legalise_restore_drill_20260624`;
+3. restored with `pg_restore -U legalise -d legalise_restore_drill_20260624
+   --clean --if-exists`;
+4. confirmed restored schema head and audit row counts:
+   `alembic_version=0035`, `audit_entries=423`, `audit_chain=423`;
+5. confirmed both WORM triggers survived the restore:
+   `enforce_audit_worm`, `enforce_audit_chain_worm`;
+6. ran the application verifier against the restored database:
+   `ok audit_chain scope=all scopes audit_entries=423 chain_entries=423
+   scopes=20`.
+
+Doctor also passed the restore-critical checks against the scratch database:
+`db.reachable`, `db.migrations_current`, `db.audit_table_present`, and
+`audit.chain_verifies`. It retained the same pre-existing local seed-data
+failure as the source database (`khan.demo_present`: Khan matter present but no
+`seed.matter.created` audit row), so that was not treated as a restore
+regression.
+
+This closes the operational-gate rehearsal item for local/self-host restore
+evidence. Hosted restore still needs a Neon PITR branch rehearsal before
+live-client use.


### PR DESCRIPTION
Records the manual BYO-key pre-evaluation gate run and fixes the one bug it surfaced.

## What this is
The manual BYO-key gate is the step CI can't prove — real provider inference, not `stub-echo`. Walked the full path on a local stack with a real Anthropic key. **9/9 passed.**

1. account (register endpoint) → 2. Anthropic key in Settings → 3. fresh matter (synthetic, non-client) → 4. docs to object storage → 5. governed skill from Chat = **real keyed call** (`claude-opus-4-7`, anthropic, 5,898 tok in) → 6. source anchors → 7. signed with observations → 8. Activity rows + **audit chain verified (21 links)** → 9. worker-backed export zip **verified** (matter meta, original bytes, signed-output bytes, signoffs, 29-entry reconstruction, human-verification checklist).

Bonus: rubber-stamp detector fired (32s fast-sign), author≠signer flagged, and `model.call` telemetry is metadata-only (no prompt/response/document text).

## Changes
- **`backend/app/api/auth_schemas.py`** — friendly email validation message for reserved-TLD addresses (`.test`/`.local`) instead of raw email-validator internals (finding F1).
- **`docs/PRE_EVALUATION_GATE.md`** — run record (date/model/provider), positives, and findings F1–F6.

## Findings (F2–F6 logged, not fixed here)
- F2 model-selection UX (profile default only applies to new matters; no in-chat picker)
- F3 key field not masked
- F4 usage metering gap (`tokens_out: 0`, cost null)
- F5 completed export not surfaced on page reload
- F6 **hardening rec:** `worker.run_job` silently drops a job whose row it can't see → eternal "queued"; recommend fail/retry + UI timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email validation during account creation with clearer, user-friendly error messages for invalid or restricted email addresses.
* **Documentation**
  * Expanded the pre-evaluation guide with a detailed manual test run record, including verified workflows, audit checks, and noted findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->