### PR TITLE
F6: surface stuck export jobs instead of an eternal spinner

### DIFF
--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -54,8 +54,25 @@ async def run_job(ctx: dict[str, Any], job_id_str: str) -> None:
     async with session_factory() as session:
         job = await session.scalar(select(Job).where(Job.id == job_id))
         if job is None:
-            logger.error("run_job: job %s not found — skipping", job_id)
-            return
+            # The id was queued but its row isn't visible to this worker's
+            # session. Callers commit the row before enqueuing (see
+            # exports._enqueue_or_mark_failed), so a brief absence can only be
+            # replication/visibility lag — and arq will retry. A *persistent*
+            # absence means the worker is connected to a different database
+            # than the API (the failure mode the pre-eval gate F6 caught).
+            #
+            # Either way, do NOT return silently: a clean return marks the arq
+            # job successful and leaves the DB row wedged at "queued" forever
+            # with no error. Raise so arq retries, then records a hard failure
+            # that surfaces the lag or the misconfiguration instead of hiding
+            # it. (The export UI also times out a stuck job — see
+            # MatterLifecycle — so the user isn't left on an eternal spinner.)
+            logger.error(
+                "run_job: job %s not found in this worker's database — row not "
+                "yet visible, or worker connected to the wrong database",
+                job_id,
+            )
+            raise RuntimeError(f"run_job: job {job_id} not found in worker database")
 
         matter = await session.scalar(
             select(Matter).where(Matter.id == job.matter_id)

--- a/frontend/src/matter/MatterLifecycle.tsx
+++ b/frontend/src/matter/MatterLifecycle.tsx
@@ -24,6 +24,12 @@ import { ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
 
 const EXPORT_LS_KEY = (slug: string) => `legalise.export.${slug}`;
 const POLL_MS = 3000;
+// A healthy worker finishes an export in seconds. If a job is still
+// non-terminal after this long it is wedged — e.g. a worker pointed at the
+// wrong database, the failure mode the pre-eval gate F6 caught — so we stop
+// polling and surface it instead of spinning forever. (The worker side now
+// also fails loud rather than dropping the job silently; see worker.run_job.)
+const EXPORT_TIMEOUT_MS = 120000;
 const TERMINAL: ReadonlySet<string> = new Set(["succeeded", "failed", "cancelled"]);
 
 export function MatterLifecycle({ slug }: { slug: string }) {
@@ -80,22 +86,38 @@ function ExportPanel({ slug }: { slug: string }) {
   const [job, setJob] = useState<JobRead | null>(null);
   const [starting, setStarting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
   const timer = useRef<number | null>(null);
+  const startedAt = useRef<number | null>(null);
 
   const poll = useCallback(
     (jobId: string) => {
       getJob(slug, jobId)
         .then((j) => {
           setJob(j);
-          if (!TERMINAL.has(j.status)) {
-            timer.current = window.setTimeout(() => poll(jobId), POLL_MS);
-          } else {
+          if (TERMINAL.has(j.status)) {
             try {
               window.localStorage.removeItem(EXPORT_LS_KEY(slug));
             } catch {
               /* ignore */
             }
+            return;
           }
+          // Still queued/running. Stop and surface if it has been stuck
+          // past the timeout — a healthy export never takes this long.
+          if (
+            startedAt.current !== null &&
+            Date.now() - startedAt.current > EXPORT_TIMEOUT_MS
+          ) {
+            setTimedOut(true);
+            try {
+              window.localStorage.removeItem(EXPORT_LS_KEY(slug));
+            } catch {
+              /* ignore */
+            }
+            return;
+          }
+          timer.current = window.setTimeout(() => poll(jobId), POLL_MS);
         })
         .catch(() => undefined);
     },
@@ -110,7 +132,10 @@ function ExportPanel({ slug }: { slug: string }) {
     } catch {
       resumeId = null;
     }
-    if (resumeId) poll(resumeId);
+    if (resumeId) {
+      startedAt.current = Date.now();
+      poll(resumeId);
+    }
     return () => {
       if (timer.current) window.clearTimeout(timer.current);
     };
@@ -119,9 +144,11 @@ function ExportPanel({ slug }: { slug: string }) {
   const start = async () => {
     setStarting(true);
     setErr(null);
+    setTimedOut(false);
     try {
       const j = await createMatterExport(slug);
       setJob(j);
+      startedAt.current = Date.now();
       try {
         window.localStorage.setItem(EXPORT_LS_KEY(slug), j.id);
       } catch {
@@ -135,7 +162,7 @@ function ExportPanel({ slug }: { slug: string }) {
     }
   };
 
-  const inProgress = job !== null && !TERMINAL.has(job.status);
+  const inProgress = job !== null && !TERMINAL.has(job.status) && !timedOut;
   const succeeded = job?.status === "succeeded";
   const failed = job?.status === "failed" || job?.status === "cancelled";
 
@@ -205,6 +232,13 @@ function ExportPanel({ slug }: { slug: string }) {
       {failed && (
         <p className="mt-2 text-sm text-seal">
           Export {job?.status}. {job?.error_message ?? ""}
+        </p>
+      )}
+      {timedOut && (
+        <p className="mt-2 text-sm text-seal" data-testid="export-timeout">
+          This export is taking longer than expected and may be stuck. Start it
+          again, or check Activity. If it keeps stalling, the matter's worker may
+          not be running.
         </p>
       )}
 


### PR DESCRIPTION
Fixes finding **F6** from the manual BYO-key gate: a worker that couldn't see a job's row left the export wedged at "queued" with no error and no end (an eternal "Export running…" spinner). Two coordinated halves.

## Backend — `worker.run_job`
When the job row isn't visible to the worker's session, **raise instead of returning**. A clean return marked the arq job *successful* and left the DB row queued forever. Raising lets arq retry (covers a transient visibility lag) and, if it persists — e.g. the worker is pointed at a different database than the API, the exact case the gate caught — records a **hard failure** that surfaces the misconfiguration.

Note: the export path already commits the job row *before* enqueuing (`exports._enqueue_or_mark_failed`), so this is the worker/DB-split case, not an enqueue-before-commit race.

## Frontend — `MatterLifecycle` ExportPanel
The status poll now **times out after 120s** of a non-terminal job and shows a "may be stuck — start again / check Activity" message, re-enabling **Start export**, instead of polling forever behind "Export running…". A healthy worker finishes in seconds.

## Safety
No existing test exercises the job-not-found path, and the happy path is unchanged, so worker-smoke and the e2e export stay green. Frontend typecheck + `MatterLifecycle` tests pass locally.

Surfaced by the 2026-06-24 manual BYO-key gate (see `docs/PRE_EVALUATION_GATE.md` F6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)