### PR TITLE
F5: surface a completed export after reload (F3 was a false positive)

### DIFF
--- a/docs/PRE_EVALUATION_GATE.md
+++ b/docs/PRE_EVALUATION_GATE.md
@@ -125,15 +125,18 @@ Findings (non-blocking; none stopped the loop):
   created before it was set silently used the env default (`claude-opus-4-7`).
   No in-chat model indicator/picker — an evaluator cannot easily see or
   control which model a matter runs on.
-- **F3 [UX/sec]** Settings → Provider keys renders the key in plain text (no
-  password mask / reveal toggle), despite "never shown after submission".
+- **F3 [WITHDRAWN — false positive]** Initially flagged the provider-key
+  field as plain text, but the input is already `type="password"` with
+  `autoComplete="off"`. The gate walk read the value from the automation
+  accessibility tree, not the rendered (masked) screen. No change needed.
 - **F4 [observability]** `model.invoked` records `tokens_in` but
   `tokens_out: 0` and `cost_micros`/`currency` null — output-token and cost
   accounting not captured.
-- **F5 [UX]** After a successful export, reloading the working-pack page shows
-  "Start export" again rather than a download link; the completed pack is
-  reachable only via the job result / Activity.
-- **F6 [hardening — recommend]** `worker.run_job` returns silently when the
+- **F5 [FIXED]** After a successful export, reloading the working-pack page
+  showed "Start export" again rather than a download link. The succeeded
+  export's id is now persisted so a reload rehydrates the download
+  (`MatterLifecycle` ExportPanel); only failed/cancelled jobs are cleared.
+- **F6 [FIXED #237]** `worker.run_job` returns silently when the
   job row is not visible to its session ("job <id> not found — skipping"),
   leaving the export wedged at "queued" with no error and no timeout. In this
   run that was triggered by the worker pointing at a different database

--- a/frontend/src/matter/MatterLifecycle.tsx
+++ b/frontend/src/matter/MatterLifecycle.tsx
@@ -96,10 +96,16 @@ function ExportPanel({ slug }: { slug: string }) {
         .then((j) => {
           setJob(j);
           if (TERMINAL.has(j.status)) {
-            try {
-              window.localStorage.removeItem(EXPORT_LS_KEY(slug));
-            } catch {
-              /* ignore */
+            // Keep a succeeded export's id so a later reload rehydrates the
+            // download link (the resume effect re-fetches it); only a
+            // failed/cancelled job is cleared. A new Start export overwrites
+            // the key. (Gate finding F5: completed export not surfaced on reload.)
+            if (j.status !== "succeeded") {
+              try {
+                window.localStorage.removeItem(EXPORT_LS_KEY(slug));
+              } catch {
+                /* ignore */
+              }
             }
             return;
           }


### PR DESCRIPTION
Closes the step-3 UX items from the manual BYO-key gate.

## F5 — completed export not surfaced on reload [fixed]
`MatterLifecycle` ExportPanel discarded the export job id once the job reached `succeeded`, so reloading the working-pack page showed **"Start export"** with no download link — the finished pack was only reachable via Activity. Now a succeeded export's id is **persisted**, so the resume effect re-fetches it on mount and shows **Download export**. Failed/cancelled jobs are still cleared; a new Start export overwrites the key.

## F3 — provider-key field masking [withdrawn, false positive]
Originally flagged the key field as plain text. It's already `type="password"` with `autoComplete="off"` — the gate walk read the value from the automation accessibility tree, not the rendered (masked) screen. **No code change**; gate doc corrected.

## Doc
`docs/PRE_EVALUATION_GATE.md` updated: F3 withdrawn, F5 fixed, F6 marked fixed (#237).

Frontend typecheck + `MatterLifecycle` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)