### PR TITLE
F2: choose the matter model at creation (profile default now flows)

### DIFF
--- a/docs/PRE_EVALUATION_GATE.md
+++ b/docs/PRE_EVALUATION_GATE.md
@@ -121,17 +121,30 @@ Findings (non-blocking; none stopped the loop):
 - **F1 [FIXED]** Registration rejected reserved-TLD emails (`.test`/`.local`)
   with the raw email-validator message. Friendly validator added in
   `backend/app/api/auth_schemas.py`.
-- **F2 [UX]** Profile "Default model" applies only to *new* matters; a matter
-  created before it was set silently used the env default (`claude-opus-4-7`).
-  No in-chat model indicator/picker — an evaluator cannot easily see or
-  control which model a matter runs on.
+- **F2 [FIXED — new matters]** Root cause: the new-matter form sent no model,
+  so every matter silently took the backend `MatterCreate` default
+  (`claude-opus-4-7`) and the profile "Default model" never flowed anywhere.
+  The form now exposes a Default model field pre-filled from the account
+  default (`NewMatter.tsx`), so the model is visible, chosen at creation, and
+  the profile setting actually flows. Residual (by design, not addressed): a
+  matter's model is fixed after creation, and there is no in-chat model
+  indicator for an existing matter.
 - **F3 [WITHDRAWN — false positive]** Initially flagged the provider-key
   field as plain text, but the input is already `type="password"` with
   `autoComplete="off"`. The gate walk read the value from the automation
   accessibility tree, not the rendered (masked) screen. No change needed.
-- **F4 [observability]** `model.invoked` records `tokens_in` but
-  `tokens_out: 0` and `cost_micros`/`currency` null — output-token and cost
-  accounting not captured.
+- **F4 [DEFERRED — scoped follow-up]** `model.invoked` records the combined
+  token total as `tokens_in` with `tokens_out: 0` and cost null. This is a
+  *deliberate, documented* simplification (`runtime.py` pins the 0 sentinel
+  and notes a future protocol extension), not a regression. Proper fix is a
+  cross-cutting provider-interface change: return `(text, tokens_in,
+  tokens_out)` from `ModelProvider.call` (anthropic/openai already expose the
+  split via `usage`; ollama/stub estimate), carry both on `ModelResult`, and
+  have `runtime._provider_call` pass `result.tokens_out` instead of the
+  sentinel — touching all four providers, the gateway unpack, and ~10 tests.
+  Cost stays null until a pricing table exists. Deferred: not safely
+  verifiable in one session without the full backend suite, and lower-priority
+  observability rather than a correctness gap.
 - **F5 [FIXED]** After a successful export, reloading the working-pack page
   showed "Start export" again rather than a download link. The succeeded
   export's id is now persisted so a reload rehydrates the download

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
 import { createMatter } from "../lib/api";
+import { useAuth } from "../auth/AuthProvider";
 import { navigate } from "../lib/route";
 import type { ReactNode } from "react";
 import { ErrorCallout, PageHeader } from "../ui/primitives";
@@ -32,13 +33,19 @@ function Field({
 }
 
 export function NewMatter() {
-  const [form, setForm] = useState({
+  const { user } = useAuth();
+  // A matter's model is fixed at creation. Pre-fill from the account's
+  // default so the profile setting actually flows to new matters (it used
+  // to be ignored — every matter silently got the backend default), and so
+  // an evaluator can see and change which model this matter will run on.
+  const [form, setForm] = useState(() => ({
     title: "",
     matter_type: "employment_tribunal",
     cause: "s.94 ERA 1996, unfair dismissal",
     case_theory: "",
     pivot_fact: "",
-  });
+    default_model_id: user?.default_model_id ?? "claude-opus-4-7",
+  }));
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -47,7 +54,12 @@ export function NewMatter() {
     setSubmitting(true);
     setError(null);
     try {
-      const matter = await createMatter(form);
+      // Omit a blank model so the backend applies its own default rather
+      // than receiving an empty id.
+      const matter = await createMatter({
+        ...form,
+        default_model_id: form.default_model_id.trim() || undefined,
+      });
       navigate(`/matters/${matter.slug}`);
     } catch (err) {
       setError(String(err));
@@ -95,6 +107,18 @@ export function NewMatter() {
             value={form.cause}
             onChange={(e) => setForm({ ...form, cause: e.target.value })}
             className={inputCls}
+          />
+        </Field>
+
+        <Field
+          label="Default model"
+          hint="runs this matter's skills; a claude-/gpt- model needs a provider key in Settings"
+        >
+          <input
+            value={form.default_model_id}
+            onChange={(e) => setForm({ ...form, default_model_id: e.target.value })}
+            placeholder="claude-opus-4-7"
+            className={inputCls + " tech-token"}
           />
         </Field>
 


### PR DESCRIPTION
Fixes gate finding **F2** and defers **F4** with a spec.

## F2 — model selection [fixed for new matters]
The new-matter form sent no model, so every matter silently took the backend `MatterCreate` default (`claude-opus-4-7`) — and the account **"Default model"** setting in Settings never reached a matter (dead UI). This is why the BYO-gate matter ran on `claude-opus-4-7` regardless of profile.

The form now has a **Default model** field, pre-filled from the account default, so the model is **visible**, **chosen at creation**, and the profile setting **actually flows**. A blank value is omitted so the backend default still applies.

Residual (by design, noted in the doc): a matter's model is fixed after creation, and there's no in-chat indicator for an existing matter.

## F4 — token split / cost [deferred, scoped]
`model.invoked` records the combined total as `tokens_in` with `tokens_out: 0`. This is a **deliberate, documented** simplification (`runtime.py` pins the sentinel and notes a future protocol extension), not a regression. The proper fix is a cross-cutting provider-interface change (return `(text, tokens_in, tokens_out)` from `ModelProvider.call`, carry both on `ModelResult`, pass through `runtime`) touching all four providers + gateway + ~10 tests — not safely verifiable in one session. Full spec in `docs/PRE_EVALUATION_GATE.md` F4.

Frontend typecheck + matter tests (171) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible “Default model” field when creating a new matter, prefilled from the account default.
  * The selected model is now included when the matter is created, so the chosen default is applied consistently.
* **Bug Fixes**
  * Fixed an issue where new matters could silently fall back to an unexpected model instead of the user’s selected default.
  * Improved handling when the field is left blank so the backend default can still be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->