### PR TITLE
F2 backend: resolve matter model (body -> account default -> settings)

### DIFF
--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -13,6 +13,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_user
+from app.core.config import settings
 from app.core.db import get_session
 from app.core.limits import check_matter_create, check_document_upload
 from app.core.document_uploads import (
@@ -78,7 +79,10 @@ class MatterCreate(BaseModel):
     case_theory: str | None = None
     pivot_fact: str | None = None
     privilege_posture: str = Field(default=PRIVILEGE_MIXED)
-    default_model_id: str = Field(default="claude-opus-4-7", max_length=64)
+    # None means "not specified" — create_matter resolves the effective model
+    # from body -> the account default -> the settings default, so API callers
+    # that omit it inherit the profile default instead of a hardcoded id.
+    default_model_id: str | None = Field(default=None, max_length=64)
     facts: dict = Field(default_factory=dict)
     retention_until: date | None = None
 
@@ -245,7 +249,14 @@ async def create_matter(
         case_theory=body.case_theory,
         pivot_fact=body.pivot_fact,
         privilege_posture=body.privilege_posture,
-        default_model_id=body.default_model_id,
+        # body -> account default -> settings default. So the profile
+        # "Default model" flows to new matters via the API too, not just the
+        # new-matter form (gate finding F2).
+        default_model_id=(
+            body.default_model_id
+            or user.default_model_id
+            or settings.default_model_id
+        ),
         facts=body.facts,
         retention_until=body.retention_until,
         created_by_id=user.id,

--- a/docs/PRE_EVALUATION_GATE.md
+++ b/docs/PRE_EVALUATION_GATE.md
@@ -126,9 +126,12 @@ Findings (non-blocking; none stopped the loop):
   (`claude-opus-4-7`) and the profile "Default model" never flowed anywhere.
   The form now exposes a Default model field pre-filled from the account
   default (`NewMatter.tsx`), so the model is visible, chosen at creation, and
-  the profile setting actually flows. Residual (by design, not addressed): a
-  matter's model is fixed after creation, and there is no in-chat model
-  indicator for an existing matter.
+  the profile setting actually flows. `create_matter` also resolves the model
+  `body -> account default -> settings default`, so API callers that omit it
+  inherit the profile default too (`MatterCreate.default_model_id` now defaults
+  to `None`). Residual (by design, not addressed): a matter's model is fixed
+  after creation, and there is no in-chat model indicator for an existing
+  matter.
 - **F3 [WITHDRAWN — false positive]** Initially flagged the provider-key
   field as plain text, but the input is already `type="password"` with
   `autoComplete="off"`. The gate walk read the value from the automation
@@ -137,14 +140,17 @@ Findings (non-blocking; none stopped the loop):
   token total as `tokens_in` with `tokens_out: 0` and cost null. This is a
   *deliberate, documented* simplification (`runtime.py` pins the 0 sentinel
   and notes a future protocol extension), not a regression. Proper fix is a
-  cross-cutting provider-interface change: return `(text, tokens_in,
-  tokens_out)` from `ModelProvider.call` (anthropic/openai already expose the
-  split via `usage`; ollama/stub estimate), carry both on `ModelResult`, and
-  have `runtime._provider_call` pass `result.tokens_out` instead of the
+  cross-cutting provider-interface change. Decided shape (reviewer): providers
+  return `ProviderCallResult(text, usage=ModelUsage(...))` rather than widening
+  the tuple — a dataclass so cost, currency, cached tokens, provider request
+  ids and finish reasons can be added without another signature churn.
+  `ModelProvider.call` returns it (anthropic/openai already expose the split
+  via `usage`; ollama/stub estimate), the gateway maps it onto `ModelResult`,
+  and `runtime._provider_call` passes `result.tokens_out` instead of the
   sentinel — touching all four providers, the gateway unpack, and ~10 tests.
-  Cost stays null until a pricing table exists. Deferred: not safely
-  verifiable in one session without the full backend suite, and lower-priority
-  observability rather than a correctness gap.
+  Cost/`cost_micros` stays null until an explicit pricing table exists.
+  Deferred: not safely verifiable in one session without the full backend
+  suite, and lower-priority observability rather than a correctness gap.
 - **F5 [FIXED]** After a successful export, reloading the working-pack page
   showed "Start export" again rather than a download link. The succeeded
   export's id is now persisted so a reload rehydrates the download


### PR DESCRIPTION
Reviewer-requested follow-up to #239.

#239 fixed the user-visible path (the new-matter form now sends a model), but **API callers that omit the model still bypassed the account default** because `MatterCreate` hardcoded `default_model_id="claude-opus-4-7"`. That's substrate-correctness, not just UX.

## Change
- `MatterCreate.default_model_id` now defaults to **`None`** (so "omitted" is distinguishable from an explicit id).
- `create_matter` resolves the effective model: **`body -> user.default_model_id -> settings.default_model_id`**.

Existing callers that pass an explicit model are unchanged (body wins). Callers that omit it inherit the profile default, falling back to the settings default (still `"claude-opus-4-7"`) when neither is set — so behaviour is **preserved** for users without a profile default.

## Also
Updates the deferred **F4** spec in `docs/PRE_EVALUATION_GATE.md` to the reviewer's decided shape: providers return `ProviderCallResult(text, usage=ModelUsage(...))` rather than widening the tuple.

`py_compile` clean; create-matter tests pass an explicit model so are unaffected. Full backend suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)