### PR TITLE
Docs: align tidy references with public doc set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Two house rules enforced before commit:
 
 ```bash
 # No em or en dashes in chrome strings or public docs.
-rg -n "—|–" frontend/src/ README.md EXECUTIVE_SUMMARY.md ARCHITECTURE.md docs/MANIFESTO.md docs/ROADMAP.md
+rg -n "—|–" frontend/src/ README.md docs/*.md
 
 # No __pycache__ or .pyc tracked.
 git ls-files | rg "__pycache__|\.pyc$"
@@ -103,11 +103,10 @@ by intent — solicitor voice, not chrome.
 If you're skimming the repo to evaluate, in this order:
 
 1. [`README.md`](./README.md) — what it is, what it does
-2. [`docs/ENGINEERING.md`](./docs/ENGINEERING.md) — bespoke vs boring
-3. [`docs/DESIGN.md`](./docs/DESIGN.md) — visual contract (v0.4 FROZEN)
-4. [`docs/JOY.md`](./docs/JOY.md) — product-feel doctrine
-5. [`ARCHITECTURE.md`](./ARCHITECTURE.md) — stack rationale
-6. [`docs/TRUST.md`](./docs/TRUST.md) — privilege, audit, sub-processors
+2. [`docs/TRUST.md`](./docs/TRUST.md) — privilege, audit, sub-processors, open gaps
+3. [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — stack rationale and current substrate
+4. [`docs/EVALUATING.md`](./docs/EVALUATING.md) — walkthrough and gate records
+5. [`docs/ROADMAP.md`](./docs/ROADMAP.md) — shipped, deferred, parked
 
 ## Pull requests
 

--- a/REGULATORY_PLUMBING.md
+++ b/REGULATORY_PLUMBING.md
@@ -37,7 +37,7 @@ The posture flows through the chronology and contract review modules and influen
 
 **Why it matters.** Legal advice privilege, litigation privilege, common-interest privilege, and joint-defence privilege are real and waivable. Extracting privileged content into AI-assisted outputs that get shared can risk waiver depending on what's distributed and to whom. A workspace that treats privilege as a property rather than an afterthought makes the waiver analysis tractable.
 
-**v1 implementation.** Matter form has the posture selector. Each module's behaviour is documented in `ARCHITECTURE.md` § "Privilege posture enforcement". Posture changes create audit entries.
+**v1 implementation.** Matter form has the posture selector. Each module's behaviour is documented in `docs/ARCHITECTURE.md` §4. Posture changes create audit entries.
 
 **Not in v1.** Refusal to start an LLM call where posture/data combination is invalid (currently a soft warning). Hardened in v0.2.
 

--- a/backend/app/core/demand_capture.py
+++ b/backend/app/core/demand_capture.py
@@ -28,7 +28,7 @@ PERSONAS: frozenset[str] = frozenset(
     }
 )
 
-# Launch channel tags (?c=...). Documented in docs/OPERATIONS.md §Launch.
+# Launch channel tags (?c=...). Summarised in docs/EVALUATING.md.
 CHANNELS: frozenset[str] = frozenset({"hn", "li", "x", "conf"})
 
 DOMAIN_CLASS_FIRM = "firm-like"

--- a/backend/app/core/external_pack.py
+++ b/backend/app/core/external_pack.py
@@ -5,7 +5,7 @@ working-pack-shaped record this workspace can supervise: one read-only
 matter per pack, one WORM artifact per document, sign-off through the
 existing ``core/signoff.py`` path.
 
-The honesty boundary (docs/REGISTER_SIDECAR.md): this workspace did not
+The honesty boundary: this workspace did not
 watch the external work happen. There are exactly two grades of hash
 claim, and each document records which one it carries:
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -9,7 +9,7 @@
 #
 #   Production environments (everything else):
 #     Boot does NOT run migrations. Migrations are a deploy-time release
-#     step (see fly.toml [deploy] release_command and docs/RUNBOOK.md).
+#     step (see fly.toml [deploy] release_command and docs/ARCHITECTURE.md).
 #     To override for a one-off run, set MIGRATIONS_ON_BOOT=true.
 #
 # `exec` matters: it lets uvicorn replace this shell as PID 1 so SIGTERM

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -40,7 +40,7 @@ primary_region = "lhr"
   # single machine before any new app instances start serving traffic.
   # This prevents the boot-time migration race that occurs when multiple
   # Fly machines start concurrently. The app itself does NOT run
-  # migrations at boot (see backend/entrypoint.sh and docs/RUNBOOK.md).
+  # migrations at boot (see backend/entrypoint.sh and docs/ARCHITECTURE.md).
   release_command = "alembic upgrade head"
 
 # Process groups. `app` serves HTTP. `worker` runs the arq queue that

--- a/evals/smoke_cross_user.py
+++ b/evals/smoke_cross_user.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Cross-user access-control eval.
 
-Asserts the §7 invariant from HANDOVER_AUTH.md: a matter slug owned by
+Asserts the auth invariant documented in docs/TRUST.md: a matter slug owned by
 User A returns 404 (not 403) when accessed via User B's session. The
 eval covers load-bearing endpoints that resolve a matter by slug:
 matter detail, audit, audit chain, chronology, documents GET,
 documents POST (multipart), privilege PATCH, export POST.
 
-The slug invariant is per-owner unique (HANDOVER_AUTH.md §3e Option A),
+The slug invariant is per-owner unique,
 so both users can hold a matter named `eval-cross-user-{n}` without
 collision. We confirm that here too: User B creates a matter with
 User A's slug and receives 201, not 409.

--- a/examples/modules/example-tab/README.md
+++ b/examples/modules/example-tab/README.md
@@ -21,4 +21,4 @@ Reads the current matter, calls the model gateway with a fixed prompt, logs an a
 - `frontend/index.tsx` — TanStack Router page component
 - `frontend/components/Hello.tsx` — one component
 
-See `/docs/MODULE_DEVELOPMENT.md` for the full guide.
+See `docs/ARCHITECTURE.md` for the current module/runtime shape.

--- a/frontend/src/landing/Architecture.tsx
+++ b/frontend/src/landing/Architecture.tsx
@@ -106,7 +106,7 @@ const MAPPING: { primitive: string; counterpart: string }[] = [
 const DOC_MAP: { section: string; docs: { label: string; file: string }[] }[] = [
   {
     section: "Identity & access",
-    docs: [{ label: "AUTH.md", file: `${BLOB}/docs/AUTH.md` }],
+    docs: [{ label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` }],
   },
   {
     section: "Inference gateway / keys",
@@ -115,41 +115,38 @@ const DOC_MAP: { section: string; docs: { label: string; file: string }[] }[] = 
   {
     section: "Privilege gate",
     docs: [
-      { label: "POSTURE_GATE_UX.md", file: `${BLOB}/docs/spec/POSTURE_GATE_UX.md` },
-      { label: "ADVICE_BOUNDARY.md", file: `${BLOB}/docs/architecture/ADVICE_BOUNDARY.md` },
+      { label: "ARCHITECTURE.md", file: `${BLOB}/docs/ARCHITECTURE.md` },
+      { label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` },
     ],
   },
   {
     section: "Anonymisation",
-    docs: [{ label: "SANDBOX_STRATEGY.md", file: `${BLOB}/docs/architecture/SANDBOX_STRATEGY.md` }],
+    docs: [{ label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` }],
   },
   {
     section: "Admission / signing",
     docs: [
-      { label: "SIGNING.md", file: `${BLOB}/docs/architecture/SIGNING.md` },
-      { label: "TRUST_CEREMONY.md", file: `${BLOB}/docs/architecture/TRUST_CEREMONY.md` },
-      { label: "MANIFEST_V2_SCHEMA.md", file: `${BLOB}/docs/architecture/MANIFEST_V2_SCHEMA.md` },
+      { label: "ARCHITECTURE.md", file: `${BLOB}/docs/ARCHITECTURE.md` },
+      { label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` },
     ],
   },
   {
     section: "The record",
     docs: [
-      { label: "AUDIT_COVERAGE_MATRIX.md", file: `${BLOB}/docs/spec/AUDIT_COVERAGE_MATRIX.md` },
-      { label: "AUDIT_RECONSTRUCTION.md", file: `${BLOB}/docs/architecture/AUDIT_RECONSTRUCTION.md` },
-      { label: "AUDIT_EMISSION_MAP.md", file: `${BLOB}/docs/spec/AUDIT_EMISSION_MAP.md` },
+      { label: "ARCHITECTURE.md", file: `${BLOB}/docs/ARCHITECTURE.md` },
+      { label: "EVALUATING.md", file: `${BLOB}/docs/EVALUATING.md` },
     ],
   },
   {
     section: "Sign-off / output",
     docs: [
-      { label: "OUTPUT_LIFECYCLE.md", file: `${BLOB}/docs/architecture/OUTPUT_LIFECYCLE.md` },
-      { label: "REVIEW_PANELS.md", file: `${BLOB}/docs/architecture/REVIEW_PANELS.md` },
-      { label: "SUPERVISION_LEGIBILITY_M13.md", file: `${BLOB}/docs/spec/SUPERVISION_LEGIBILITY_M13.md` },
+      { label: "ARCHITECTURE.md", file: `${BLOB}/docs/ARCHITECTURE.md` },
+      { label: "EVALUATING.md", file: `${BLOB}/docs/EVALUATING.md` },
     ],
   },
   {
     section: "Supervised autonomy",
-    docs: [{ label: "SUPERVISED_AUTONOMY.md", file: `${BLOB}/docs/SUPERVISED_AUTONOMY.md` }],
+    docs: [{ label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` }],
   },
   {
     section: "Compliance / regulatory",
@@ -157,7 +154,7 @@ const DOC_MAP: { section: string; docs: { label: string; file: string }[] }[] = 
   },
   {
     section: "Claim boundary",
-    docs: [{ label: "CLAIM_BOUNDARY.md", file: `${BLOB}/docs/CLAIM_BOUNDARY.md` }],
+    docs: [{ label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` }],
   },
   {
     section: "Threat model",
@@ -166,8 +163,8 @@ const DOC_MAP: { section: string; docs: { label: string; file: string }[] }[] = 
   {
     section: "Top-level",
     docs: [
-      { label: "ARCHITECTURE.md", file: `${BLOB}/ARCHITECTURE.md` },
-      { label: "ENGINEERING.md", file: `${BLOB}/docs/ENGINEERING.md` },
+      { label: "ARCHITECTURE.md", file: `${BLOB}/docs/ARCHITECTURE.md` },
+      { label: "EVALUATING.md", file: `${BLOB}/docs/EVALUATING.md` },
       { label: "ROADMAP.md", file: `${BLOB}/docs/ROADMAP.md` },
     ],
   },
@@ -188,23 +185,23 @@ const STATUS_MATRIX: {
   { capability: "Hash-chained audit, dual-implementation verify", status: "shipped", verification: "audit_chain.py · GET /audit/chain" },
   { capability: "Named sign-off over artifact SHA-256", status: "shipped", verification: "signoff.py" },
   { capability: "Skill admission ceremony, two signature grades", status: "shipped", verification: "signing.py · trust_ceremony.py" },
-  { capability: "Per-user matter isolation, session revocation", status: "shipped", verification: "matter_access.py · AUTH.md" },
+  { capability: "Per-user matter isolation, session revocation", status: "shipped", verification: "matter_access.py · TRUST.md" },
   { capability: "Audit-role split asserted in CI", status: "shipped", verification: "SECURITY.md (build gate)" },
-  { capability: "WORM role flipped on hosted deployment", status: "deferred", verification: "OPERATIONS.md" },
-  { capability: "Organisation / team / SSO / MFA", status: "deferred", verification: "AUTH.md · ROADMAP.md" },
+  { capability: "WORM role flipped on hosted deployment", status: "deferred", verification: "TRUST.md · ROADMAP.md" },
+  { capability: "Organisation / team / SSO / MFA", status: "deferred", verification: "TRUST.md · ROADMAP.md" },
   { capability: "Multi-tenancy (one deploy = one workspace today)", status: "deferred", verification: "ROADMAP.md" },
   { capability: "Manifest web-of-trust / publisher registry at scale", status: "deferred", verification: "TRUST.md" },
   { capability: "Durable job recovery, regulator reconstruction", status: "deferred", verification: "ROADMAP.md" },
   { capability: "SBOM / SLSA / signed images / SOC 2 / ISO", status: "deferred", verification: "not present — roadmap only" },
   { capability: "Hosted demo touches Anthropic commercial API", status: "accepted", verification: "TRUST.md (no-training terms)" },
-  { capability: "R2 storage EU-placed, not UK-specific", status: "accepted", verification: "OPERATIONS.md" },
+  { capability: "R2 storage EU-placed, not UK-specific", status: "accepted", verification: "TRUST.md" },
 ];
 
 const CITATIONS: { label: string; href: string }[] = [
   { label: "Trust", href: `${REPO}/blob/master/docs/TRUST.md` },
   { label: "Security", href: `${REPO}/blob/master/SECURITY.md` },
-  { label: "Manifesto", href: `${REPO}/blob/master/docs/MANIFESTO.md` },
-  { label: "Operations", href: `${REPO}/blob/master/docs/OPERATIONS.md` },
+  { label: "Architecture", href: `${REPO}/blob/master/docs/ARCHITECTURE.md` },
+  { label: "Evaluating", href: `${REPO}/blob/master/docs/EVALUATING.md` },
   { label: "Roadmap", href: `${REPO}/blob/master/docs/ROADMAP.md` },
   { label: "Apache 2.0", href: `${REPO}/blob/master/LICENSE` },
 ];
@@ -862,7 +859,7 @@ export function Architecture() {
             items={[
               { label: "matter_access.py", file: SRC.matterAccess },
               { label: "config.py", file: SRC.config },
-              { label: "AUTH.md", file: `${BLOB}/docs/AUTH.md` },
+              { label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` },
             ]}
           />
         </Section>
@@ -1155,7 +1152,7 @@ export function Architecture() {
               { label: "audit_chain.py", file: SRC.auditChain },
               { label: "GET /audit/chain", file: SRC.auditChainEndpoint },
               { label: "SECURITY.md", file: `${BLOB}/SECURITY.md` },
-              { label: "OPERATIONS.md", file: `${BLOB}/docs/OPERATIONS.md` },
+              { label: "TRUST.md", file: `${BLOB}/docs/TRUST.md` },
             ]}
           />
           <Figure

--- a/frontend/src/lib/api/external.ts
+++ b/frontend/src/lib/api/external.ts
@@ -1,4 +1,4 @@
-// External packs — the register sidecar (docs/REGISTER_SIDECAR.md).
+// External packs — imported read-only matter bundles.
 //
 // An external workspace's export, ingested as a read-only matter and
 // supervised here: per-document hash manifest (verified-at-source vs

--- a/frontend/src/lib/channel.ts
+++ b/frontend/src/lib/channel.ts
@@ -2,7 +2,7 @@
  * Launch channel tag capture (Gate 4).
  *
  * Tagged launch URLs carry `?c=hn|li|x|conf` (documented in
- * docs/OPERATIONS.md §Launch instrumentation). The tag is remembered in
+ * docs/EVALUATING.md launch instrumentation notes). The tag is remembered in
  * sessionStorage so it survives the landing → signup navigation, then
  * sent with the register payload. Allowlisted; anything else is ignored.
  * Session-scoped on purpose — this is a launch-attribution breadcrumb,

--- a/frontend/src/modules-v2/ExternalPacks.tsx
+++ b/frontend/src/modules-v2/ExternalPacks.tsx
@@ -1,6 +1,6 @@
 /**
  * Supervised exports — the register sidecar's face on /register
- * (docs/REGISTER_SIDECAR.md).
+ * Imported read-only matter bundles.
  *
  * Each certificate is an external workspace's export held under
  * supervision here: where it came from, how many documents, how each

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -7,7 +7,7 @@
 # via UI, bootstrap CLI, install Contract Review via the trust
 # ceremony, grant on Khan v Acme, invoke via stub-echo, read the
 # reconstruction. Exit non-zero means something is wrong; `legalise
-# doctor` and docs/TROUBLESHOOTING.md should explain why.
+# doctor` should say which substrate check failed.
 #
 # The spec resets the local database (truncate users/matters/audit/
 # everything) on every run. This is destructive — DO NOT run on a
@@ -52,7 +52,7 @@ echo
 # wipes the DB before running, so a doctor `khan.demo_present` fail
 # is reset-repairable and not a smoke blocker — we tolerate that one
 # specifically and bail on everything else. Any other fail must be
-# fixed by the operator first (see docs/TROUBLESHOOTING.md).
+# fixed by the operator first.
 echo "→ Pre-flight: legalise doctor"
 doctor_out=$(docker compose -f "$COMPOSE_FILE" exec -T backend \
   python -m app.tools.doctor 2>&1) && doctor_status=$? || doctor_status=$?
@@ -78,7 +78,7 @@ if [[ $doctor_status -ne 0 ]]; then
 ✗ doctor failed on checks smoke cannot repair:
 $(printf '  - %s\n' $failing_names)
 
-  Fix these before re-running smoke. See docs/TROUBLESHOOTING.md.
+  Fix these before re-running smoke. Start with the failing doctor row.
 EOF
     exit 1
   fi


### PR DESCRIPTION
## Summary
- updates the public Architecture page links after the docs slim-down
- points contributor/smoke/eval references at the remaining public docs
- removes stale references to deleted runbook/troubleshooting/register-sidecar docs from user-facing text and comments

## Verification
- npm run typecheck
- npm run build
- local markdown-link check across repo Markdown files
