### PR TITLE
Launch punch-list: audit-true model routing, chat surface, abuse limits

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -15,12 +15,13 @@ The frontend can call these directly. We keep fastapi-users' standard
 names (login/logout/register) rather than aliasing to signin/signout —
 matching upstream docs reduces surprise for self-hosters.
 
-Abuse throttling: register, request-verify-token and forgot-password are
-per-IP rate limited (Postgres sliding window — see app/core/rate_limit.py).
+Abuse throttling: login, register, request-verify-token and forgot-password
+are per-IP rate limited (Postgres sliding window — see app/core/rate_limit.py).
 The fastapi-users routers are upstream factories, so the throttle rides in
-as router-level dependencies; the verify and reset routers each bundle a
-second route we do NOT throttle (/verify, /reset-password — both already
-gated by a single-use token), so those dependencies match on path.
+as router-level dependencies; the auth, verify and reset routers each bundle
+a second route we do NOT throttle (/logout, /verify, /reset-password — all
+already gated by a cookie or single-use token), so those dependencies match
+on path.
 """
 
 from __future__ import annotations
@@ -42,6 +43,14 @@ async def _throttle_register(
     await enforce_ip_rate_limit(request, session, "auth.register")
 
 
+async def _throttle_login(
+    request: Request, session: AsyncSession = Depends(get_session)
+) -> None:
+    # The auth router also serves POST /logout — cookie-gated, not throttled.
+    if request.url.path.endswith("/login"):
+        await enforce_ip_rate_limit(request, session, "auth.login")
+
+
 async def _throttle_request_verify_token(
     request: Request, session: AsyncSession = Depends(get_session)
 ) -> None:
@@ -59,7 +68,8 @@ async def _throttle_forgot_password(
 
 
 router.include_router(
-    fastapi_users.get_auth_router(auth_backend, requires_verification=True)
+    fastapi_users.get_auth_router(auth_backend, requires_verification=True),
+    dependencies=[Depends(_throttle_login)],
 )
 router.include_router(
     fastapi_users.get_register_router(UserRead, UserCreate),

--- a/backend/app/api/document_routes/body_versions.py
+++ b/backend/app/api/document_routes/body_versions.py
@@ -450,6 +450,9 @@ async def get_document_version_docx(
     user: User = Depends(current_user),
 ) -> StreamingResponse:
     """Download a saved document version as a Word document."""
+    # Evaluation limit: renders are capped per day (counted from the
+    # *.exported audit rows this route writes).
+    await check_generated_artefact(user.id, session)
     doc, matter = await _load_owned_document(document_id, session, user)
     version = await session.scalar(
         select(DocumentVersion).where(
@@ -518,6 +521,9 @@ async def get_document_version_pdf(
     user: User = Depends(current_user),
 ) -> StreamingResponse:
     """Download a saved document version as a print-ready PDF."""
+    # Evaluation limit: Gotenberg renders are capped per day (counted from
+    # the *.exported audit rows this route writes).
+    await check_generated_artefact(user.id, session)
     doc, matter = await _load_owned_document(document_id, session, user)
     version = await session.scalar(
         select(DocumentVersion).where(

--- a/backend/app/api/document_routes/common.py
+++ b/backend/app/api/document_routes/common.py
@@ -45,6 +45,7 @@ from app.core.api import (
 from app.core.auth import current_user
 from app.core.config import settings
 from app.core.db import get_session
+from app.core.limits import check_generated_artefact
 from app.core.document_uploads import (
     validate_upload_magic_bytes,
     validate_upload_mime,

--- a/backend/app/api/invocations.py
+++ b/backend/app/api/invocations.py
@@ -48,6 +48,7 @@ from app.core.auth import current_user
 from app.core.capabilities import CapabilityDenied
 from app.core.db import get_session
 from app.core.grants_lifecycle import CapabilityScopeUnsupported
+from app.core.limits import check_workflow_run
 from app.core.phase1_runtime.exceptions import Phase1Blocked
 from app.core.posture_gate import PostureBlocked
 from app.core.runtime import (
@@ -126,6 +127,10 @@ async def invoke_capability_endpoint(
     user: User = Depends(current_user),
 ) -> InvocationResponse:
     matter = await _load_matter_or_404(session, slug=slug, user=user)
+
+    # 0. Evaluation limit — capability runs are capped per day (counted
+    #    from the module.capability.invoked audit rows dispatch writes).
+    await check_workflow_run(user.id, session)
 
     # 1. Module must be installed AND enabled.
     installed = await session.scalar(

--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -16,6 +16,7 @@ from app.core.auth import current_user
 from app.core.config import settings
 from app.core.db import get_session
 from app.core.limits import check_matter_create, check_document_upload
+from app.core.matter_access import resolve_owned_open_matter
 from app.core.document_uploads import (
     validate_upload_magic_bytes,
     validate_upload_mime,
@@ -388,11 +389,7 @@ async def upload_document(
     session: AsyncSession = Depends(get_session),
     user: User = Depends(current_user),
 ) -> Document:
-    matter = await session.scalar(
-        select(Matter).where(Matter.slug == slug, Matter.created_by_id == user.id)
-    )
-    if matter is None:
-        raise HTTPException(404, f"matter not found: {slug}")
+    matter = await resolve_owned_open_matter(session, slug, user.id)
 
     if tag is not None and tag not in TAG_VALUES:
         raise HTTPException(400, f"tag must be one of {sorted(TAG_VALUES)}")
@@ -680,11 +677,7 @@ async def reindex_documents(
     fork backfill documents uploaded before retrieval existed. Returns the
     per-status count and emits a ``matter.reindexed`` audit row.
     """
-    matter = await session.scalar(
-        select(Matter).where(Matter.slug == slug, Matter.created_by_id == user.id)
-    )
-    if matter is None:
-        raise HTTPException(404, f"matter not found: {slug}")
+    matter = await resolve_owned_open_matter(session, slug, user.id)
 
     summary = await reindex_matter(session, matter.id)
 

--- a/backend/app/api/usage.py
+++ b/backend/app/api/usage.py
@@ -37,7 +37,7 @@ class UsageResponse(BaseModel):
     assistant_messages_today: LimitEntry
     generated_artefacts_today: LimitEntry
     module_submissions_today: LimitEntry
-    workflow_runs_today: LimitEntry  # Pre-Motion + Contract Review jobs
+    workflow_runs_today: LimitEntry  # capability dispatches (skills/tools/workflows)
     active_jobs: LimitEntry  # queued + running, point-in-time
 
 
@@ -45,14 +45,18 @@ async def _get_usage(user: User, session: AsyncSession) -> UsageResponse:
     from app.models.assistant import AssistantMessage, ROLE_USER
     from app.models.audit import AuditEntry
     from app.models.document import Document
-    from app.models.matter import Matter
+    from app.models.matter import STATUS_ARCHIVED, Matter
 
     lim = get_limits()
     today_start = _today_utc_start()
 
-    # --- matter count ---
+    # --- matter count (live only — archived matters free their slot,
+    #     matching check_matter_create) ---
     matter_count = await session.scalar(
-        select(func.count(Matter.id)).where(Matter.created_by_id == user.id)
+        select(func.count(Matter.id)).where(
+            Matter.created_by_id == user.id,
+            Matter.status != STATUS_ARCHIVED,
+        )
     )
 
     # --- documents per matter (max across all matters) ---
@@ -66,11 +70,14 @@ async def _get_usage(user: User, session: AsyncSession) -> UsageResponse:
     )
     doc_max = await session.scalar(select(func.coalesce(func.max(doc_max_subq.c.doc_count), 0)))
 
-    # --- total storage ---
+    # --- total storage (live matters only, matching check_document_upload) ---
     storage_used = await session.scalar(
         select(func.coalesce(func.sum(Document.size_bytes), 0))
         .join(Matter, Document.matter_id == Matter.id)
-        .where(Matter.created_by_id == user.id)
+        .where(
+            Matter.created_by_id == user.id,
+            Matter.status != STATUS_ARCHIVED,
+        )
     )
 
     # --- assistant messages today ---
@@ -82,11 +89,11 @@ async def _get_usage(user: User, session: AsyncSession) -> UsageResponse:
         )
     )
 
-    # --- generated artefacts today ---
+    # --- generated artefacts today (matching check_generated_artefact) ---
     artefacts_today = await session.scalar(
         select(func.count(AuditEntry.id)).where(
             AuditEntry.actor_id == user.id,
-            AuditEntry.action.like("module.%.exported"),
+            AuditEntry.action.like("%.exported"),
             AuditEntry.timestamp >= today_start,
         )
     )
@@ -100,18 +107,15 @@ async def _get_usage(user: User, session: AsyncSession) -> UsageResponse:
         )
     )
 
-    # --- workflow runs today (job kinds other than export) ---
-    from app.models.job import (
-        JOB_ACTIVE_STATUSES,
-        JOB_KIND_EXPORT,
-        Job,
-    )
+    # --- workflow runs today (capability dispatches, matching
+    #     check_workflow_run — no workflow job kinds exist any more) ---
+    from app.models.job import JOB_ACTIVE_STATUSES, Job
 
     workflow_runs_today = await session.scalar(
-        select(func.count(Job.id)).where(
-            Job.created_by_id == user.id,
-            Job.kind != JOB_KIND_EXPORT,
-            Job.created_at >= today_start,
+        select(func.count(AuditEntry.id)).where(
+            AuditEntry.actor_id == user.id,
+            AuditEntry.action == "module.capability.invoked",
+            AuditEntry.timestamp >= today_start,
         )
     )
 

--- a/backend/app/core/limits.py
+++ b/backend/app/core/limits.py
@@ -146,12 +146,17 @@ async def check_matter_create(user_id: uuid.UUID, session: AsyncSession) -> None
 
     Called before the matter row is inserted — the count reflects the
     current committed state, so the imminent insert is not yet counted.
+    Archived (tombstoned) matters are excluded: deleting a matter frees
+    its slot.
     """
-    from app.models.matter import Matter
+    from app.models.matter import STATUS_ARCHIVED, Matter
 
     lim = get_limits()
     count = await session.scalar(
-        select(func.count(Matter.id)).where(Matter.created_by_id == user_id)
+        select(func.count(Matter.id)).where(
+            Matter.created_by_id == user_id,
+            Matter.status != STATUS_ARCHIVED,
+        )
     )
     current = count or 0
     if current >= lim.matters_per_user:
@@ -170,10 +175,12 @@ async def check_document_upload(
     This is called *after* the 413 size-cap check in the upload route so
     that oversized bodies still produce 413 (not 429).  Two checks run:
     1. documents_per_matter for this matter.
-    2. total_storage_bytes_per_user across all matters.
+    2. total_storage_bytes_per_user across all live matters — archived
+       matters' document bytes were purged on tombstone, so counting
+       them would charge the user for storage that no longer exists.
     """
     from app.models.document import Document
-    from app.models.matter import Matter
+    from app.models.matter import STATUS_ARCHIVED, Matter
 
     lim = get_limits()
 
@@ -189,7 +196,10 @@ async def check_document_upload(
     storage_used = await session.scalar(
         select(func.coalesce(func.sum(Document.size_bytes), 0)).join(
             Matter, Document.matter_id == Matter.id
-        ).where(Matter.created_by_id == user_id)
+        ).where(
+            Matter.created_by_id == user_id,
+            Matter.status != STATUS_ARCHIVED,
+        )
     )
     used = int(storage_used or 0)
     if used + content_length > lim.total_storage_bytes_per_user:
@@ -230,9 +240,9 @@ async def check_assistant_message(user_id: uuid.UUID, session: AsyncSession) -> 
 async def check_generated_artefact(user_id: uuid.UUID, session: AsyncSession) -> None:
     """Raise 429 if the user has generated ≥ generated_artefacts_per_day today (UTC).
 
-    Counts ``module.*.docx.exported`` and ``module.*.pdf.exported`` audit rows
-    for the user today.  AuditEntry.action is the discriminator:
-    ``module.<id>.docx.exported`` / ``module.<id>.pdf.exported``.
+    Counts ``*.exported`` audit rows for the user today — the DOCX/PDF
+    export routes write ``document.version.docx.exported`` /
+    ``document.version.pdf.exported`` on every render.
 
     Using the audit log avoids introducing a separate artefacts table before
     Unit 1 storage is fully wired.
@@ -245,7 +255,7 @@ async def check_generated_artefact(user_id: uuid.UUID, session: AsyncSession) ->
     count = await session.scalar(
         select(func.count(AuditEntry.id)).where(
             AuditEntry.actor_id == user_id,
-            AuditEntry.action.like("module.%.exported"),
+            AuditEntry.action.like("%.exported"),
             AuditEntry.timestamp >= today_start,
         )
     )
@@ -253,6 +263,33 @@ async def check_generated_artefact(user_id: uuid.UUID, session: AsyncSession) ->
     if current >= lim.generated_artefacts_per_day:
         raise _limit_exceeded(
             "generated_artefacts_per_day", current, lim.generated_artefacts_per_day
+        )
+
+
+async def check_workflow_run(user_id: uuid.UUID, session: AsyncSession) -> None:
+    """Raise 429 if the user has run ≥ workflow_runs_per_day capabilities today (UTC).
+
+    Counts ``module.capability.invoked`` audit rows — one per skill/tool/
+    workflow dispatch through the prompt runtime. Enforced at the HTTP
+    invoke endpoint (POST /api/matters/{slug}/invocations); assistant
+    tool-loop dispatches ride under assistant_messages_per_day instead.
+    """
+    from app.models.audit import AuditEntry
+
+    lim = get_limits()
+    today_start = _today_utc_start()
+
+    count = await session.scalar(
+        select(func.count(AuditEntry.id)).where(
+            AuditEntry.actor_id == user_id,
+            AuditEntry.action == "module.capability.invoked",
+            AuditEntry.timestamp >= today_start,
+        )
+    )
+    current = count or 0
+    if current >= lim.workflow_runs_per_day:
+        raise _limit_exceeded(
+            "workflow_runs_per_day", current, lim.workflow_runs_per_day
         )
 
 

--- a/backend/app/core/model_gateway.py
+++ b/backend/app/core/model_gateway.py
@@ -113,6 +113,11 @@ class ModelResult:
     response_hash: str
     token_count: int
     latency_ms: int
+    # Provider that served the call ("anthropic", "openai", "ollama",
+    # "stub-echo"). `model_used` carries the model actually run; callers
+    # that need the provider name read this instead. Optional so existing
+    # test fakes constructing ModelResult keep working.
+    provider: str | None = None
 
 
 class ModelProvider(Protocol):
@@ -326,6 +331,7 @@ class ModelGateway:
         model: str | None = None,
         posture: PrivilegePosture | None = None,
         system: str | None = None,
+        max_tokens: int | None = None,
         resource_type: str | None = None,
         resource_id: str | None = None,
         payload: dict | None = None,
@@ -384,6 +390,21 @@ class ModelGateway:
         # dev-only server fallback isn't permitted, raise structured
         # ProviderKeyMissing — routers translate to 422 with a UI nudge.
         provider_kwargs: dict = {}
+        if max_tokens is not None:
+            provider_kwargs["max_tokens"] = max_tokens
+        # Pass the requested model through to keyed providers so the picked
+        # model actually runs (not the provider's construct-time default).
+        # Skipped when `requested` is a bare provider name (test passthrough)
+        # and for keyless providers (ollama serves its own default in
+        # B_mixed; forcing a frontier id onto it would be wrong).
+        if provider.name in _KEYED_PROVIDERS and requested != provider.name:
+            provider_kwargs["model"] = requested
+        # The model that will actually run — what audit rows must record.
+        served_model = (
+            provider_kwargs.get("model")
+            or getattr(provider, "default_model", None)
+            or provider.name
+        )
         if provider.name in _KEYED_PROVIDERS:
             user_key: str | None = None
             if actor_id is not None:
@@ -455,13 +476,14 @@ class ModelGateway:
                 module=caller_module,
                 resource_type=resource_type,
                 resource_id=resource_id,
-                model_used=provider.name,
+                model_used=served_model,
                 prompt_hash=_sha(prompt),
                 response_hash=None,
                 token_count=None,
                 latency_ms=latency_ms,
                 payload={
                     "requested_model": requested,
+                    "provider": provider.name,
                     "posture": effective_posture.value,
                     "error": {
                         "code": exc.code,
@@ -479,11 +501,12 @@ class ModelGateway:
 
         result = ModelResult(
             text=response_text,
-            model_used=provider.name,
+            model_used=served_model,
             prompt_hash=_sha(prompt),
             response_hash=_sha(response_text),
             token_count=tokens,
             latency_ms=latency_ms,
+            provider=provider.name,
         )
 
         # Audit the call. Session lifecycle is the caller's responsibility.
@@ -506,6 +529,7 @@ class ModelGateway:
             latency_ms=result.latency_ms,
             payload={
                 "requested_model": requested,
+                "provider": provider.name,
                 "posture": effective_posture.value,
                 **(payload or {}),
             },

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -16,18 +16,20 @@ Defaults (overridable via ``LEGALISE_RATE_LIMIT_<ROUTE>_PER_HOUR``):
 - ``auth.register``               5 / IP / hour
 - ``auth.request_verify_token``  10 / IP / hour
 - ``auth.forgot_password``       10 / IP / hour
+- ``auth.login``                 10 / IP / hour
 
 Set an override to ``0`` to disable that route's throttle (e.g. local
 load testing).
 
 Client IP resolution: the hosted instance sits behind Cloudflare → Fly,
-so the direct peer (``request.client.host``) is a proxy. We prefer
-``CF-Connecting-IP``, then ``Fly-Client-IP``, then the first hop of
-``X-Forwarded-For``, then the direct peer. Self-hosters terminating TLS
-themselves get the direct peer, which is correct for them. A client that
-can reach the origin directly could spoof these headers; the hosted
-deployment only exposes the origin via the proxy chain, and the
-worst-case failure is a throttle bypass — never an authz bypass.
+so the direct peer (``request.client.host``) is a proxy. ``CF-Connecting-IP``
+is only trusted when the request demonstrably arrived via Cloudflare:
+``Fly-Client-IP`` (set by Fly's proxy, not client-controllable) must fall
+inside Cloudflare's published ranges. A client hitting the .fly.dev origin
+directly gets its ``CF-Connecting-IP`` ignored — otherwise it could mint a
+fresh throttle bucket per request. Fallback order: ``Fly-Client-IP``, then
+the direct peer. Self-hosters without either proxy get the direct peer,
+which is correct for them.
 
 Throttled responses are 429 with the same ``detail``-envelope shape as
 ``limits.py``. The first rejection in a window also writes one
@@ -37,6 +39,7 @@ cannot flood the WORM audit log at request rate).
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from datetime import datetime, timedelta, timezone
 
@@ -50,12 +53,53 @@ RATE_LIMITED_ROUTES: dict[str, tuple[str, int]] = {
     "auth.register": ("REGISTER", 5),
     "auth.request_verify_token": ("REQUEST_VERIFY_TOKEN", 10),
     "auth.forgot_password": ("FORGOT_PASSWORD", 10),
+    "auth.login": ("LOGIN", 10),
 }
 
 WINDOW_SECONDS = 3600
 
-# Proxy headers in trust order for the hosted Cloudflare → Fly chain.
-_IP_HEADERS = ("cf-connecting-ip", "fly-client-ip")
+# Cloudflare's published egress ranges — https://www.cloudflare.com/ips/
+# (static list, embedded to stay dependency-free; refresh on the rare
+# occasions Cloudflare changes it). `CF-Connecting-IP` is only trusted
+# when `Fly-Client-IP` — set by Fly's proxy, not client-controllable —
+# falls inside one of these.
+_CLOUDFLARE_RANGES = tuple(
+    ipaddress.ip_network(cidr)
+    for cidr in (
+        # IPv4
+        "173.245.48.0/20",
+        "103.21.244.0/22",
+        "103.22.200.0/22",
+        "103.31.4.0/22",
+        "141.101.64.0/18",
+        "108.162.192.0/18",
+        "190.93.240.0/20",
+        "188.114.96.0/20",
+        "197.234.240.0/22",
+        "198.41.128.0/17",
+        "162.158.0.0/15",
+        "104.16.0.0/13",
+        "104.24.0.0/14",
+        "172.64.0.0/13",
+        "131.0.72.0/22",
+        # IPv6
+        "2400:cb00::/32",
+        "2606:4700::/32",
+        "2803:f800::/32",
+        "2405:b500::/32",
+        "2405:8100::/32",
+        "2a06:98c0::/29",
+        "2c0f:f248::/32",
+    )
+)
+
+
+def _is_cloudflare_ip(value: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return any(addr in network for network in _CLOUDFLARE_RANGES)
 
 
 def route_limit(route: str) -> int:
@@ -69,15 +113,15 @@ def route_limit(route: str) -> int:
 
 
 def client_ip(request: Request) -> str:
-    for header in _IP_HEADERS:
-        value = request.headers.get(header)
-        if value:
-            return value.strip()
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        first = forwarded.split(",")[0].strip()
-        if first:
-            return first
+    fly_ip = (request.headers.get("fly-client-ip") or "").strip()
+    cf_ip = (request.headers.get("cf-connecting-ip") or "").strip()
+    # CF-Connecting-IP is trustworthy only when the hop that reached Fly
+    # actually was Cloudflare; anyone hitting the .fly.dev origin directly
+    # can set the header to anything (module docstring, spoof scenario).
+    if cf_ip and fly_ip and _is_cloudflare_ip(fly_ip):
+        return cf_ip
+    if fly_ip:
+        return fly_ip
     if request.client and request.client.host:
         return request.client.host
     return "unknown"

--- a/backend/app/core/runtime.py
+++ b/backend/app/core/runtime.py
@@ -135,11 +135,10 @@ def make_provider_call(
         )
         return ProviderResponse(
             text=result.text,
-            # The requested model (what the matter asked for), not the
-            # provider's internal name. result.model_used carries the
-            # provider name; we map it to ProviderResponse.provider.
-            model_id=matter.default_model_id or result.model_used,
-            provider=result.model_used,
+            # result.model_used now carries the model actually run;
+            # result.provider carries the provider name.
+            model_id=result.model_used or matter.default_model_id,
+            provider=result.provider or result.model_used,
             tokens_in=result.token_count,
             # Sentinel — pinned at 0 so the audit row's
             # token_count = tokens_in + tokens_out stays honestly equal

--- a/backend/app/modules/assistant/pipeline.py
+++ b/backend/app/modules/assistant/pipeline.py
@@ -83,6 +83,8 @@ You see two document sections. "Document index" lists every document in the matt
 
 Cite document content with [doc:<document_id>] using the UUID from the document sections. Cite chronology with [chron:<event_id>] using the UUID from the Chronology section. IDs verbatim, never titles. The workspace resolves them to a clickable label.
 
+Do not cite case law, statutes, or authorities from memory as established fact. When you state a legal proposition that no document in the matter supports, flag it as requiring verification. Never invent citations.
+
 England & Wales only. If asked about other jurisdictions, say so and stop.
 
 Return JSON only, matching this shape:
@@ -106,6 +108,10 @@ _CHRONOLOGY_EVENT_LIMIT = 12
 # How many chunks to retrieve per turn when no documents are attached. Hits
 # are grouped by document, so this maps to a smaller number of documents.
 _RETRIEVAL_K = 8
+# Output cap for the assistant turn itself. The provider default (2048) is
+# sized for short module calls; a chat answer that cites documents needs
+# headroom or it truncates mid-envelope and fails the JSON parse.
+_ASSISTANT_MAX_TOKENS = 8192
 # The matter spine: a cheap, always-present orientation layer so the
 # assistant knows the whole matter exists even though it only reads a few
 # document bodies per turn. Metadata only — titles, not contents.
@@ -900,8 +906,8 @@ def _make_assistant_provider_call(
         )
         return ProviderResponse(
             text=result.text,
-            model_id=matter.default_model_id or result.model_used,
-            provider=result.model_used,
+            model_id=result.model_used or matter.default_model_id,
+            provider=result.provider or result.model_used,
             tokens_in=result.token_count,
             tokens_out=0,
             cost_micros=None,
@@ -1300,6 +1306,7 @@ async def run_assistant_turn(
         *,
         sources: list[AssistantSource] | None = None,
         kind: str = "document_summary",
+        model_used: str = "deterministic-summary",
     ) -> AssistantMessage:
         assistant_row = AssistantMessage(
             matter_id=matter.id,
@@ -1309,7 +1316,7 @@ async def run_assistant_turn(
             content=content_out,
             suggested_actions=[a.model_dump(mode="json") for a in actions],
             sources=[s.model_dump(mode="json") for s in (sources or [])],
-            model_used="deterministic-summary",
+            model_used=model_used,
             prompt_hash=None,
             response_hash=None,
             token_count=0,
@@ -1358,6 +1365,7 @@ async def run_assistant_turn(
             model=matter.default_model_id,
             posture=PrivilegePosture(matter.privilege_posture),
             system=SYSTEM_PROMPT,
+            max_tokens=_ASSISTANT_MAX_TOKENS,
             resource_type="assistant_message",
             resource_id=str(user_row.id),
             payload={"stage": "assistant", "module": "assistant"},
@@ -1377,11 +1385,27 @@ async def run_assistant_turn(
             return user_row, assistant_row
         # Second choice: any other question, but retrieval found passages —
         # show them, labelled as retrieval not generation, with sources so
-        # the "what the AI saw" panel still renders. Only a question that
-        # surfaced nothing propagates to the router's key-missing banner.
+        # the "what the AI saw" panel still renders.
         keyless = _keyless_retrieval_answer(message_sources)
         if keyless is None:
-            raise
+            # Nothing to show at all. Raising a 422 here used to roll back
+            # the user's message while leaving the pre-committed thread as
+            # an empty ghost — the typed message was lost. Persist the turn
+            # instead, with an honest "no model" assistant reply, so the
+            # thread stays coherent and nothing is lost.
+            content_out = (
+                "No model key is configured, so I can't write an answer, "
+                "and this matter has no indexed passages relevant to your "
+                "question to show instead. Your message is saved. Add a "
+                "model key in Settings → API Keys to get a written answer."
+            )
+            assistant_row = await _persist_deterministic_summary(
+                content_out,
+                [],
+                kind="no_model",
+                model_used="no-model",
+            )
+            return user_row, assistant_row
         content_out, actions = keyless
         assistant_row = await _persist_deterministic_summary(
             content_out,
@@ -1392,23 +1416,36 @@ async def run_assistant_turn(
         return user_row, assistant_row
 
     parse_failed = False
-    try:
-        envelope = parse_model_json(result.text, AssistantResponseEnvelope)
-        content_out = envelope.content
-        actions: list[SuggestedAction] = list(envelope.suggested_actions)
-        tool_calls = list(envelope.tool_calls)
-    except StructuredOutputError:
-        # Show a controlled message in the chat thread. Raw provenance
-        # (response hash + token count) lives on the gateway's audit row.
-        # The module audit row gains `parse_failed: true` so this case is
-        # filterable.
-        parse_failed = True
+    if matter.default_model_id == "stub-echo":
+        # The demo provider echoes the prompt — it can never produce the
+        # JSON envelope, so demanding one fails every turn. Wrap the raw
+        # echo as the reply, clearly labelled as the keyless demo path.
         content_out = (
-            "I couldn't structure that response. Try rephrasing your "
-            "message, or check the model settings on this matter."
+            f"{result.text}\n\n"
+            "Demo model (stub-echo) — this is a deterministic echo, not a "
+            "reasoned answer. Pick a real model in the matter's settings "
+            "to chat about the matter."
         )
         actions = []
         tool_calls = []
+    else:
+        try:
+            envelope = parse_model_json(result.text, AssistantResponseEnvelope)
+            content_out = envelope.content
+            actions = list(envelope.suggested_actions)
+            tool_calls = list(envelope.tool_calls)
+        except StructuredOutputError:
+            # Show a controlled message in the chat thread. Raw provenance
+            # (response hash + token count) lives on the gateway's audit row.
+            # The module audit row gains `parse_failed: true` so this case is
+            # filterable.
+            parse_failed = True
+            content_out = (
+                "I couldn't structure that response. Try rephrasing your "
+                "message, or check the model settings on this matter."
+            )
+            actions = []
+            tool_calls = []
 
     tool_invocation_id: uuid.UUID | None = None
     tool_result: dict[str, Any] | None = None
@@ -1457,6 +1494,7 @@ async def run_assistant_turn(
                 model=matter.default_model_id,
                 posture=PrivilegePosture(matter.privilege_posture),
                 system=SYSTEM_PROMPT,
+                max_tokens=_ASSISTANT_MAX_TOKENS,
                 resource_type="assistant_message",
                 resource_id=str(user_row.id),
                 payload={

--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -58,10 +58,12 @@ class AnthropicProvider:
         # is true in a dev environment. Production gateway refuses to fall
         # back even if this is set.
         self._fallback_key = api_key
-        self._default_model = default_model or settings.default_model_id
+        # Public: the gateway reads this to record the model actually run
+        # when the caller didn't pass one.
+        self.default_model = default_model or settings.default_model_id
 
     async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
-        model = kwargs.get("model") or self._default_model
+        model = kwargs.get("model") or self.default_model
         max_tokens = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
         api_key = kwargs.get("api_key") or self._fallback_key
         if not api_key:
@@ -99,6 +101,25 @@ class AnthropicProvider:
                 message=f"anthropic: {type(exc).__name__}: {exc}",
             ) from exc
 
+        # A hard stop at the output cap means the response is incomplete —
+        # surfacing the truncation honestly beats handing the caller a
+        # half-written body that fails its JSON-envelope parse downstream.
+        if getattr(message, "stop_reason", None) == "max_tokens":
+            logger.warning(
+                "legalise.provider.anthropic.truncated",
+                model=model,
+                max_tokens=max_tokens,
+            )
+            raise ProviderUpstreamError(
+                provider="anthropic",
+                code="provider_truncated",
+                upstream_status=None,
+                message=(
+                    "anthropic: response truncated at the output limit — "
+                    "try a narrower question"
+                ),
+            )
+
         # Concatenate text blocks; v0.1 ignores tool_use blocks.
         text_parts: list[str] = []
         for block in message.content:
@@ -107,6 +128,10 @@ class AnthropicProvider:
         text = "".join(text_parts)
 
         usage = message.usage
+        # Summed: the ModelProvider protocol returns one count and the
+        # audit plumbing carries one token_count column. Splitting
+        # input/output ripples through ModelResult, AssistantMessage and
+        # AuditEntry — not worth it for v0.1.
         tokens = (usage.input_tokens or 0) + (usage.output_tokens or 0)
 
         return text, tokens

--- a/backend/app/providers/ollama_provider.py
+++ b/backend/app/providers/ollama_provider.py
@@ -51,11 +51,13 @@ class OllamaProvider:
 
     def __init__(self, base_url: str, default_model: str = DEFAULT_MODEL):
         self._base_url = base_url.rstrip("/")
-        self._default_model = default_model
+        # Public: the gateway reads this to record the model actually run
+        # when the caller didn't pass one.
+        self.default_model = default_model
         self._client = httpx.AsyncClient(timeout=DEFAULT_TIMEOUT_SECONDS)
 
     async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
-        model = kwargs.get("model") or self._default_model
+        model = kwargs.get("model") or self.default_model
         # Strip an `ollama/` prefix if the caller passed a fully-qualified id.
         if model.startswith("ollama/"):
             model = model[len("ollama/") :]

--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -47,10 +47,12 @@ class OpenAIProvider:
 
     def __init__(self, api_key: str | None, default_model: str = DEFAULT_MODEL):
         self._fallback_key = api_key
-        self._default_model = default_model
+        # Public: the gateway reads this to record the model actually run
+        # when the caller didn't pass one.
+        self.default_model = default_model
 
     async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
-        model = kwargs.get("model") or self._default_model
+        model = kwargs.get("model") or self.default_model
         max_tokens = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
         api_key = kwargs.get("api_key") or self._fallback_key
         if not api_key:

--- a/backend/tests/test_archived_matter_access.py
+++ b/backend/tests/test_archived_matter_access.py
@@ -109,6 +109,28 @@ async def test_assistant_messages_returns_404_when_archived(client) -> None:
     assert resp.status_code == 404, resp.text
 
 
+@pytest.mark.asyncio
+async def test_upload_returns_404_when_matter_archived(client) -> None:
+    """POST /api/matters/{slug}/documents must 404 once the matter is
+    archived — no new content lands on a tombstoned matter."""
+    await _signup_and_login(client)
+    slug = await _create_and_archive(client)
+    resp = await client.post(
+        f"/api/matters/{slug}/documents",
+        files={"file": ("note.txt", b"hello archived world", "text/plain")},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_reindex_returns_404_when_matter_archived(client) -> None:
+    """POST /api/matters/{slug}/reindex must 404 on archived matter."""
+    await _signup_and_login(client)
+    slug = await _create_and_archive(client)
+    resp = await client.post(f"/api/matters/{slug}/reindex")
+    assert resp.status_code == 404, resp.text
+
+
 # ---------------------------------------------------------------------------
 # Sanity: live matters still work
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_assistant_pipeline.py
+++ b/backend/tests/test_assistant_pipeline.py
@@ -77,6 +77,7 @@ class _AssistantFakeGateway:
         model=None,
         posture=None,
         system=None,
+        max_tokens=None,
         resource_type=None,
         resource_id=None,
         payload=None,
@@ -88,6 +89,7 @@ class _AssistantFakeGateway:
                 "system": system,
                 "model": model,
                 "posture": posture,
+                "max_tokens": max_tokens,
                 "payload": payload or {},
             }
         )
@@ -596,12 +598,11 @@ class TestAssistantPipeline:
         assert audit_rows[0].payload["deterministic"] == "keyless_retrieval"
 
     @pytest.mark.asyncio
-    async def test_keyless_question_with_no_retrieval_raises(self) -> None:
-        """No key AND retrieval found nothing to show: there is no honest
-        extract to offer, so the turn propagates ProviderKeyMissing for the
-        router's 'add a key' banner rather than inventing an answer."""
-        from app.core.model_gateway import ProviderKeyMissing
-
+    async def test_keyless_question_with_no_retrieval_persists_no_model_reply(self) -> None:
+        """No key AND retrieval found nothing to show: the turn must NOT
+        raise (a 422 used to roll back the user's message and leave the
+        pre-committed thread as an empty ghost). Both rows persist, with
+        an honest 'no model' assistant reply."""
         matter = _make_matter()
         session = _AssistantSession(matter, documents=[], bodies={})
         gateway = _KeylessFakeGateway()
@@ -612,15 +613,95 @@ class TestAssistantPipeline:
         with patch.object(
             assistant_pipeline.retrieval, "search_documents", _no_hits
         ):
-            with pytest.raises(ProviderKeyMissing):
-                await run_assistant_turn(
-                    session=session,
-                    matter=matter,
-                    actor_id=uuid.uuid4(),
-                    thread_id=uuid.uuid4(),
-                    request=AssistantPostRequest(content="Draft a wholly new letter"),
-                    gateway=gateway,
-                )
+            user_row, assistant_row = await run_assistant_turn(
+                session=session,
+                matter=matter,
+                actor_id=uuid.uuid4(),
+                thread_id=uuid.uuid4(),
+                request=AssistantPostRequest(content="Draft a wholly new letter"),
+                gateway=gateway,
+            )
+
+        assert user_row.content == "Draft a wholly new letter"
+        assert "No model key is configured" in assistant_row.content
+        assert "Settings" in assistant_row.content
+        assert assistant_row.model_used == "no-model"
+        audit_rows = [
+            o
+            for o in session.added
+            if isinstance(o, AuditEntry) and o.module == "assistant"
+        ]
+        assert audit_rows[0].payload["deterministic"] == "no_model"
+
+    @pytest.mark.asyncio
+    async def test_stub_echo_matter_wraps_raw_text_without_envelope(self) -> None:
+        """A matter pinned to the demo model never gets a JSON envelope
+        back, so the pipeline must wrap the raw echo as the reply (clearly
+        labelled) instead of failing the parse every turn."""
+        matter = _make_matter()
+        matter.default_model_id = "stub-echo"
+        session = _AssistantSession(matter)
+        gateway = _AssistantFakeGateway()
+
+        async def _raw_text_call(**kwargs):
+            gateway.calls.append(kwargs)
+            return ModelResult(
+                text="[stub-echo] What does the NDA say?",
+                model_used="stub-echo",
+                prompt_hash="ph",
+                response_hash="rh",
+                token_count=7,
+                latency_ms=1,
+            )
+
+        gateway.call = _raw_text_call
+
+        _, assistant_row = await run_assistant_turn(
+            session=session,
+            matter=matter,
+            actor_id=uuid.uuid4(),
+            thread_id=uuid.uuid4(),
+            request=AssistantPostRequest(content="What does the NDA say?"),
+            gateway=gateway,
+        )
+
+        assert assistant_row.content.startswith("[stub-echo]")
+        assert "Demo model" in assistant_row.content
+        audit_rows = [
+            o
+            for o in session.added
+            if isinstance(o, AuditEntry) and o.module == "assistant"
+        ]
+        assert audit_rows[-1].payload["parse_failed"] is False
+
+    @pytest.mark.asyncio
+    async def test_assistant_turn_passes_max_tokens(self) -> None:
+        """The assistant turn raises the output cap above the provider
+        default so long cited answers don't truncate mid-envelope."""
+        matter = _make_matter()
+        session = _AssistantSession(matter)
+        gateway = _AssistantFakeGateway()
+
+        await run_assistant_turn(
+            session=session,
+            matter=matter,
+            actor_id=uuid.uuid4(),
+            thread_id=uuid.uuid4(),
+            request=AssistantPostRequest(content="Summarise the matter."),
+            gateway=gateway,
+        )
+
+        assert gateway.calls[0]["max_tokens"] == assistant_pipeline._ASSISTANT_MAX_TOKENS
+
+    def test_system_prompt_forbids_uncited_law(self) -> None:
+        """The uncited-law rule ships in the system prompt."""
+        from app.modules.assistant.pipeline import SYSTEM_PROMPT
+
+        assert "Never invent citations" in SYSTEM_PROMPT
+        assert (
+            "Do not cite case law, statutes, or authorities from memory"
+            in SYSTEM_PROMPT
+        )
 
     @pytest.mark.asyncio
     async def test_prompt_includes_matter_and_chronology(self) -> None:

--- a/backend/tests/test_auth_rate_limit.py
+++ b/backend/tests/test_auth_rate_limit.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import func, select
 
-from app.core.rate_limit import RATE_LIMITED_ROUTES, route_limit
+from app.core.rate_limit import RATE_LIMITED_ROUTES, client_ip, route_limit
 from app.models import AuditEntry, AuthThrottleEvent
 
 
@@ -116,8 +116,9 @@ async def test_register_different_ip_is_separate_bucket(client, monkeypatch) -> 
 
     assert (await _register(client, 0)).status_code == 201
     assert (await _register(client, 1)).status_code == 429
-    # Same socket, different proxy-asserted client IP — fresh bucket.
-    resp = await _register(client, 2, headers={"cf-connecting-ip": "203.0.113.7"})
+    # Same socket, different Fly-asserted client IP — fresh bucket.
+    # (Fly-Client-IP is set by Fly's proxy, not client-controllable.)
+    resp = await _register(client, 2, headers={"fly-client-ip": "203.0.113.7"})
     assert resp.status_code == 201, resp.text
 
 
@@ -134,7 +135,7 @@ async def test_register_window_slides_without_sleeping(
         db_session.add(AuthThrottleEvent(ip=ip, route="auth.register", created_at=stale))
     await db_session.commit()
 
-    resp = await _register(client, 0, headers={"cf-connecting-ip": ip})
+    resp = await _register(client, 0, headers={"fly-client-ip": ip})
     assert resp.status_code == 201, resp.text
 
     # The expired rows were swept by the opportunistic cleanup.
@@ -233,3 +234,133 @@ async def test_forgot_password_throttles_but_reset_password_does_not(
         json={"token": "not-a-real-token", "password": PASSWORD},
     )
     assert resp.status_code == 400, resp.text
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/login
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_throttles_at_limit(client, db_session, monkeypatch) -> None:
+    """Login attempts (valid or not) throttle at the per-IP limit —
+    mirrors the register throttle wiring."""
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_LOGIN_PER_HOUR", "3")
+
+    for _ in range(3):
+        resp = await client.post(
+            "/auth/login",
+            data={"username": "nobody@example.com", "password": "wrong-password"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert resp.status_code == 400, resp.text  # bad credentials, not throttled
+
+    resp = await client.post(
+        "/auth/login",
+        data={"username": "nobody@example.com", "password": "wrong-password"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 429, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == "rate_limited"
+    assert detail["route"] == "auth.login"
+    assert detail["limit_per_hour"] == 3
+    assert resp.headers.get("retry-after") == "3600"
+
+    # Exactly one audit row for the first rejection.
+    assert await _audit_throttle_count(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_logout_not_throttled_by_login_bucket(client, monkeypatch) -> None:
+    """POST /auth/logout shares the upstream auth router but is
+    cookie-gated — exhausting the login bucket must not 429 it."""
+    monkeypatch.setenv("LEGALISE_RATE_LIMIT_LOGIN_PER_HOUR", "1")
+
+    resp = await client.post(
+        "/auth/login",
+        data={"username": "nobody@example.com", "password": "wrong-password"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 400
+    resp = await client.post(
+        "/auth/login",
+        data={"username": "nobody@example.com", "password": "wrong-password"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 429
+
+    # Bucket exhausted — /logout still serves (401: no cookie).
+    resp = await client.post("/auth/logout")
+    assert resp.status_code == 401, resp.text
+
+
+def test_login_shipped_default(monkeypatch) -> None:
+    monkeypatch.delenv("LEGALISE_RATE_LIMIT_LOGIN_PER_HOUR", raising=False)
+    assert route_limit("auth.login") == 10
+
+
+# ---------------------------------------------------------------------------
+# client_ip — header-trust hardening (spoof scenarios)
+# ---------------------------------------------------------------------------
+
+
+class _StubClient:
+    def __init__(self, host: str | None) -> None:
+        self.host = host
+
+
+class _StubRequest:
+    """Duck-typed Request: client_ip only reads .headers.get and .client."""
+
+    def __init__(self, headers: dict[str, str], peer: str | None = "10.0.0.1") -> None:
+        self.headers = {k.lower(): v for k, v in headers.items()}
+        self.client = _StubClient(peer) if peer else None
+
+
+class TestClientIpHeaderTrust:
+    def test_cf_header_trusted_when_hop_is_cloudflare(self) -> None:
+        # Fly-Client-IP inside Cloudflare's published ranges → the request
+        # really came via Cloudflare, so CF-Connecting-IP is authoritative.
+        request = _StubRequest(
+            {"cf-connecting-ip": "198.51.100.9", "fly-client-ip": "172.68.1.2"}
+        )
+        assert client_ip(request) == "198.51.100.9"
+
+    def test_cf_header_ignored_when_origin_hit_directly(self) -> None:
+        # Attacker hits the .fly.dev origin directly and forges the CF
+        # header: Fly saw the attacker's real IP, not Cloudflare, so the
+        # forged header must not mint a fresh throttle bucket.
+        request = _StubRequest(
+            {"cf-connecting-ip": "203.0.113.99", "fly-client-ip": "198.51.100.7"}
+        )
+        assert client_ip(request) == "198.51.100.7"
+
+    def test_cf_header_alone_ignored(self) -> None:
+        # No Fly hop at all (e.g. local/self-hosted): a bare CF header is
+        # client-controlled — fall through to the peer address.
+        request = _StubRequest({"cf-connecting-ip": "203.0.113.99"})
+        assert client_ip(request) == "10.0.0.1"
+
+    def test_cf_header_trusted_for_ipv6_cloudflare_hop(self) -> None:
+        request = _StubRequest(
+            {"cf-connecting-ip": "2001:db8::7", "fly-client-ip": "2606:4700::1234"}
+        )
+        assert client_ip(request) == "2001:db8::7"
+
+    def test_x_forwarded_for_never_trusted(self) -> None:
+        # XFF is trivially spoofable and no longer part of the chain.
+        request = _StubRequest({"x-forwarded-for": "203.0.113.5, 10.0.0.9"})
+        assert client_ip(request) == "10.0.0.1"
+
+    def test_garbage_fly_header_falls_back_to_itself(self) -> None:
+        # A malformed Fly-Client-IP can't be a Cloudflare hop; the CF
+        # header is ignored and the Fly value (still proxy-set) is used.
+        request = _StubRequest(
+            {"cf-connecting-ip": "203.0.113.99", "fly-client-ip": "not-an-ip"}
+        )
+        assert client_ip(request) == "not-an-ip"
+
+    def test_no_headers_no_peer_is_unknown(self) -> None:
+        request = _StubRequest({}, peer=None)
+        assert client_ip(request) == "unknown"

--- a/backend/tests/test_gateway_fallback.py
+++ b/backend/tests/test_gateway_fallback.py
@@ -28,15 +28,18 @@ from app.core.user_keys import ProviderKeyMissing
 
 class _AnthropicStub:
     """Stand-in with name='anthropic' so the gateway's KEYED_PROVIDERS
-    check fires. Records the api_key it was called with."""
+    check fires. Records the kwargs it was called with."""
 
     name = "anthropic"
+    default_model = "claude-default-model"
 
     def __init__(self) -> None:
         self.last_api_key: str | None = None
+        self.last_kwargs: dict = {}
 
     async def call(self, prompt: str, *, system=None, **kwargs):
         self.last_api_key = kwargs.get("api_key")
+        self.last_kwargs = dict(kwargs)
         return ("ok", 1)
 
 
@@ -172,3 +175,84 @@ async def test_user_key_passed_through_when_present(
             posture=PrivilegePosture.B_MIXED,
         )
     assert stub.last_api_key == "sk-user-key"
+
+
+# ---------------------------------------------------------------------------
+# Model passthrough + max_tokens — the picked model must actually run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch.object(gw_module, "mark_user_key_used")
+@patch.object(gw_module, "get_user_provider_key", return_value="sk-user-key")
+async def test_requested_model_is_forwarded_to_keyed_provider(
+    _mock_lookup, _mock_mark, gateway, actor_id
+):
+    """The user-picked model id reaches the provider AND is what the
+    result records — not the provider's construct-time default."""
+    g, stub = gateway
+
+    result = await g.call(
+        session=_StubSession(),
+        matter_id=None,
+        actor_id=actor_id,
+        prompt="hi",
+        model="claude-haiku-4-5",
+        posture=PrivilegePosture.A_CLEARED,
+    )
+    assert stub.last_kwargs.get("model") == "claude-haiku-4-5"
+    assert result.model_used == "claude-haiku-4-5"
+    assert result.provider == "anthropic"
+
+
+@pytest.mark.asyncio
+@patch.object(gw_module, "mark_user_key_used")
+@patch.object(gw_module, "get_user_provider_key", return_value="sk-user-key")
+async def test_bare_provider_name_falls_back_to_provider_default(
+    _mock_lookup, _mock_mark, gateway, actor_id
+):
+    """`model="anthropic"` (test passthrough) sends no model kwarg; the
+    result records the provider's default model as the one actually run."""
+    g, stub = gateway
+
+    result = await g.call(
+        session=_StubSession(),
+        matter_id=None,
+        actor_id=actor_id,
+        prompt="hi",
+        model="anthropic",
+        posture=PrivilegePosture.A_CLEARED,
+    )
+    assert "model" not in stub.last_kwargs
+    assert result.model_used == "claude-default-model"
+    assert result.provider == "anthropic"
+
+
+@pytest.mark.asyncio
+@patch.object(gw_module, "mark_user_key_used")
+@patch.object(gw_module, "get_user_provider_key", return_value="sk-user-key")
+async def test_max_tokens_forwarded_when_set(
+    _mock_lookup, _mock_mark, gateway, actor_id
+):
+    g, stub = gateway
+
+    await g.call(
+        session=_StubSession(),
+        matter_id=None,
+        actor_id=actor_id,
+        prompt="hi",
+        model="claude-haiku-4-5",
+        posture=PrivilegePosture.A_CLEARED,
+        max_tokens=8192,
+    )
+    assert stub.last_kwargs.get("max_tokens") == 8192
+
+    await g.call(
+        session=_StubSession(),
+        matter_id=None,
+        actor_id=actor_id,
+        prompt="hi",
+        model="claude-haiku-4-5",
+        posture=PrivilegePosture.A_CLEARED,
+    )
+    assert "max_tokens" not in stub.last_kwargs  # provider default applies

--- a/backend/tests/test_invocations_api.py
+++ b/backend/tests/test_invocations_api.py
@@ -131,11 +131,12 @@ def stub_gateway(monkeypatch):
     async def _stub_call(**kwargs):
         return ModelResult(
             text=canned,
-            model_used="anthropic",
+            model_used="claude-sonnet-4-6",
             prompt_hash="x" * 64,
             response_hash="x" * 64,
             token_count=42,
             latency_ms=10,
+            provider="anthropic",
         )
 
     monkeypatch.setattr(gateway_singleton, "call", _stub_call)
@@ -172,11 +173,12 @@ def stub_gateway_two_findings(monkeypatch):
     async def _stub_call(**kwargs):
         return ModelResult(
             text=_stub_findings_json(),
-            model_used="anthropic",
+            model_used="claude-sonnet-4-6",
             prompt_hash="x" * 64,
             response_hash="x" * 64,
             token_count=1850,
             latency_ms=120,
+            provider="anthropic",
         )
 
     monkeypatch.setattr(gateway_singleton, "call", _stub_call)

--- a/backend/tests/test_limits.py
+++ b/backend/tests/test_limits.py
@@ -200,3 +200,127 @@ async def test_matter_create_limit_blocks_at_max(
     detail = r2.json()["detail"]
     assert detail["error"] == "evaluation_limit_reached"
     assert detail["limit"] == "matters_per_user"
+
+
+@pytest.mark.asyncio
+async def test_archived_matter_frees_matter_cap(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tombstoning a matter frees its slot under matters_per_user."""
+    monkeypatch.setattr(
+        limits_module, "_limits", Limits(matters_per_user=2)
+    )
+    await _signup_and_login(client)
+
+    # Khan (auto-seeded) + Matter A = at the cap.
+    r1 = await client.post("/api/matters", json={"title": "Matter A"})
+    assert r1.status_code == 201, r1.text
+    slug_a = r1.json()["slug"]
+
+    r2 = await client.post("/api/matters", json={"title": "Matter B"})
+    assert r2.status_code == 429, r2.text
+
+    # Archive A — the slot comes back.
+    resp = await client.delete(f"/api/matters/{slug_a}")
+    assert resp.status_code == 204, resp.text
+    r3 = await client.post("/api/matters", json={"title": "Matter B"})
+    assert r3.status_code == 201, r3.text
+
+
+@pytest.mark.asyncio
+async def test_archived_matter_bytes_excluded_from_storage_cap(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Archived matters' purged document bytes stop counting against
+    total_storage_bytes_per_user."""
+    monkeypatch.setattr(
+        limits_module,
+        "_limits",
+        Limits(total_storage_bytes_per_user=100, matters_per_user=10),
+    )
+    await _signup_and_login(client)
+
+    # Archive the auto-seeded Khan matter so its seeded document bytes
+    # cannot skew the arithmetic below.
+    resp = await client.delete(f"/api/matters/{KHAN_SLUG}")
+    assert resp.status_code == 204, resp.text
+
+    body = b"x" * 80
+    r_a = await client.post("/api/matters", json={"title": "Storage A"})
+    assert r_a.status_code == 201
+    slug_a = r_a.json()["slug"]
+    up_a = await client.post(
+        f"/api/matters/{slug_a}/documents",
+        files={"file": ("a.txt", body, "text/plain")},
+    )
+    assert up_a.status_code == 201, up_a.text
+
+    r_b = await client.post("/api/matters", json={"title": "Storage B"})
+    assert r_b.status_code == 201
+    slug_b = r_b.json()["slug"]
+
+    # 80 (live A) + 80 (incoming) > 100 → blocked.
+    up_b = await client.post(
+        f"/api/matters/{slug_b}/documents",
+        files={"file": ("b.txt", body, "text/plain")},
+    )
+    assert up_b.status_code == 429, up_b.text
+    assert up_b.json()["detail"]["limit"] == "total_storage_bytes_per_user"
+
+    # Archive A — its bytes stop counting; the same upload now fits.
+    resp = await client.delete(f"/api/matters/{slug_a}")
+    assert resp.status_code == 204, resp.text
+    up_b2 = await client.post(
+        f"/api/matters/{slug_b}/documents",
+        files={"file": ("b.txt", body, "text/plain")},
+    )
+    assert up_b2.status_code == 201, up_b2.text
+
+
+@pytest.mark.asyncio
+async def test_docx_export_capped_by_generated_artefacts_limit(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The DOCX/PDF export routes enforce generated_artefacts_per_day."""
+    import uuid as uuid_module
+
+    monkeypatch.setattr(
+        limits_module, "_limits", Limits(generated_artefacts_per_day=0)
+    )
+    await _signup_and_login(client)
+
+    fake_doc = uuid_module.uuid4()
+    fake_version = uuid_module.uuid4()
+    resp = await client.get(
+        f"/api/documents/{fake_doc}/versions/{fake_version}/docx"
+    )
+    assert resp.status_code == 429, resp.text
+    assert resp.json()["detail"]["limit"] == "generated_artefacts_per_day"
+
+    resp = await client.get(
+        f"/api/documents/{fake_doc}/versions/{fake_version}/pdf"
+    )
+    assert resp.status_code == 429, resp.text
+    assert resp.json()["detail"]["limit"] == "generated_artefacts_per_day"
+
+
+@pytest.mark.asyncio
+async def test_invocations_capped_by_workflow_runs_limit(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /api/matters/{slug}/invocations enforces workflow_runs_per_day."""
+    monkeypatch.setattr(
+        limits_module, "_limits", Limits(workflow_runs_per_day=0)
+    )
+    await _signup_and_login(client)
+
+    resp = await client.post(
+        f"/api/matters/{KHAN_SLUG}/invocations",
+        json={
+            "module_id": "legalise.anything",
+            "capability_id": "run",
+            "args": {},
+        },
+    )
+    assert resp.status_code == 429, resp.text
+    assert resp.json()["detail"]["limit"] == "workflow_runs_per_day"

--- a/backend/tests/test_provider_audit_completeness.py
+++ b/backend/tests/test_provider_audit_completeness.py
@@ -291,7 +291,10 @@ async def test_upstream_error_all_subcodes_audited(
     rows = fake_audit.rows_with_action("model.call.error")
     assert len(rows) == 1, f"expected one audit_failure call for {code}"
     row = rows[0]
-    assert row["model_used"] == "anthropic"
+    # model_used records the model actually attempted; the provider name
+    # lives in the payload.
+    assert row["model_used"] == "claude-opus-4-7"
+    assert row["payload"]["provider"] == "anthropic"
     assert row["module"] == "assistant"
     assert row["prompt_hash"] is not None
     err = row["payload"].get("error")

--- a/backend/tests/test_provider_upstream_errors.py
+++ b/backend/tests/test_provider_upstream_errors.py
@@ -160,7 +160,10 @@ async def test_gateway_translates_status_to_structured_error(
     rows = [c for c in fake_audit.calls if c["action"] == "model.call.error"]
     assert len(rows) == 1, "expected one audit_failure call on failure"
     row = rows[0]
-    assert row["model_used"] == "anthropic"
+    # model_used records the model actually attempted; the provider name
+    # lives in the payload.
+    assert row["model_used"] == "claude-opus-4-7"
+    assert row["payload"]["provider"] == "anthropic"
     assert row["prompt_hash"] is not None
     err = row["payload"].get("error")
     assert isinstance(err, dict)
@@ -263,3 +266,63 @@ async def test_assistant_route_translates_provider_upstream_to_502(client, monke
     assert detail["provider"] == "anthropic"
     assert detail["upstream_status"] == 429
     assert "anthropic" in detail["message"]
+
+
+# ---------------------------------------------------------------------------
+# Anthropic provider — output-limit truncation surfaces as a structured error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_truncation_raises_provider_truncated() -> None:
+    """stop_reason == "max_tokens" means the reply is incomplete — the
+    provider must raise (honest truncation message) rather than hand a
+    half-written body downstream to fail its JSON parse."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.providers.anthropic_provider import AnthropicProvider
+
+    message = SimpleNamespace(
+        stop_reason="max_tokens",
+        content=[SimpleNamespace(type="text", text="truncated body…")],
+        usage=SimpleNamespace(input_tokens=10, output_tokens=2048),
+    )
+    client = MagicMock()
+    client.messages.create = AsyncMock(return_value=message)
+
+    provider = AnthropicProvider(api_key="sk-test", default_model="claude-haiku-4-5")
+    with patch(
+        "app.providers.anthropic_provider.AsyncAnthropic", return_value=client
+    ):
+        with pytest.raises(ProviderUpstreamError) as excinfo:
+            await provider.call("long question")
+
+    assert excinfo.value.code == "provider_truncated"
+    assert "truncated at the output limit" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_normal_stop_returns_text() -> None:
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.providers.anthropic_provider import AnthropicProvider
+
+    message = SimpleNamespace(
+        stop_reason="end_turn",
+        content=[SimpleNamespace(type="text", text="complete body")],
+        usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+    )
+    client = MagicMock()
+    client.messages.create = AsyncMock(return_value=message)
+
+    provider = AnthropicProvider(api_key="sk-test", default_model="claude-haiku-4-5")
+    with patch(
+        "app.providers.anthropic_provider.AsyncAnthropic", return_value=client
+    ):
+        text, tokens = await provider.call("question", max_tokens=8192)
+
+    assert text == "complete body"
+    assert tokens == 30
+    assert client.messages.create.call_args.kwargs["max_tokens"] == 8192

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -332,11 +332,12 @@ async def test_adapter_maps_all_seven_provider_response_fields(
         captured.update(kwargs)
         return ModelResult(
             text="MODEL TEXT",
-            model_used="anthropic",
+            model_used="claude-opus-4-7",
             prompt_hash="h" * 64,
             response_hash="r" * 64,
             token_count=4321,
             latency_ms=100,
+            provider="anthropic",
         )
 
     monkeypatch.setattr(gateway_singleton, "call", _stub_call)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "legalise-frontend",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "legalise-frontend",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tanstack/react-router": "^1.85.0",
         "@tiptap/extension-color": "^3.25.0",
@@ -34,8 +34,10 @@
         "pdfjs-dist": "^5.6.205",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-markdown": "^10.1.0",
         "react-pdf": "^10.4.1",
         "recharts": "^2.13.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.5.4"
       },
       "devDependencies": {
@@ -2909,6 +2911,15 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2927,14 +2938,46 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -2955,11 +2998,23 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -3295,6 +3350,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3463,6 +3528,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3488,6 +3563,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -3556,6 +3671,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -3813,7 +3938,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3840,6 +3964,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3854,6 +3991,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -4164,6 +4314,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4199,6 +4359,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4439,6 +4605,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -4450,6 +4656,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4539,6 +4755,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -4546,6 +4768,30 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-binary-path": {
@@ -4577,6 +4823,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4600,6 +4856,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4608,6 +4874,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4856,6 +5134,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4970,6 +5258,298 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -5003,6 +5583,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5055,7 +6198,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -5230,6 +6372,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -5621,6 +6788,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/prosemirror-changeset": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
@@ -5818,6 +6995,33 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-pdf": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
@@ -5982,6 +7186,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -6236,6 +7506,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6265,6 +7545,20 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -6289,6 +7583,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -6568,6 +7880,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -6616,6 +7948,93 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6673,6 +8092,34 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
@@ -7055,6 +8502,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,8 +44,10 @@
     "pdfjs-dist": "^5.6.205",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
     "react-pdf": "^10.4.1",
     "recharts": "^2.13.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -293,7 +293,7 @@ function SettingsProfile({
               type="text"
               value={defaultModel}
               onChange={(e: ChangeEvent<HTMLInputElement>) => setDefaultModel(e.target.value)}
-              placeholder="claude-opus-4-7"
+              placeholder="claude-sonnet-4-6"
               className={inputCls + " tech-token"}
             />
           )}

--- a/frontend/src/matter/AssistantMarkdown.tsx
+++ b/frontend/src/matter/AssistantMarkdown.tsx
@@ -1,0 +1,90 @@
+import type { ComponentPropsWithoutRef } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+// Markdown renderer for assistant chat turns. Lazy-loaded by MessageBubble
+// (default export) so react-markdown + remark-gfm stay out of the
+// first-paint bundle — MatterDetail (and so MessageBubble) is statically
+// routed, unlike the editor stack.
+//
+// Styling stays inside the paper/ink/rule/seal token system and mirrors the
+// document-editor prose rules (index.css `.legalise-document-editor`):
+// restrained margins, disc/decimal lists, quiet bordered tables. Sizes are
+// em-relative so the compact demo bubbles inherit the caller's text size.
+
+type MdProps<T extends keyof React.JSX.IntrinsicElements> =
+  ComponentPropsWithoutRef<T>;
+
+const components = {
+  p: (props: MdProps<"p">) => <p className="mb-3 last:mb-0" {...props} />,
+  ul: (props: MdProps<"ul">) => (
+    <ul className="mb-3 list-disc pl-5 last:mb-0" {...props} />
+  ),
+  ol: (props: MdProps<"ol">) => (
+    <ol className="mb-3 list-decimal pl-5 last:mb-0" {...props} />
+  ),
+  li: (props: MdProps<"li">) => <li className="mb-1 last:mb-0" {...props} />,
+  // Claude occasionally opens with an h1/h2; in chat every heading renders
+  // at one modest tier — the answer is prose, not a document.
+  h1: (props: MdProps<"h1">) => (
+    <p className="mb-2 mt-4 text-[1.05em] font-semibold first:mt-0" {...props} />
+  ),
+  h2: (props: MdProps<"h2">) => (
+    <p className="mb-2 mt-4 text-[1.05em] font-semibold first:mt-0" {...props} />
+  ),
+  h3: (props: MdProps<"h3">) => (
+    <p className="mb-2 mt-3 font-semibold first:mt-0" {...props} />
+  ),
+  h4: (props: MdProps<"h4">) => (
+    <p className="mb-2 mt-3 font-semibold first:mt-0" {...props} />
+  ),
+  h5: (props: MdProps<"h5">) => (
+    <p className="mb-2 mt-3 font-semibold first:mt-0" {...props} />
+  ),
+  h6: (props: MdProps<"h6">) => (
+    <p className="mb-2 mt-3 font-semibold first:mt-0" {...props} />
+  ),
+  blockquote: (props: MdProps<"blockquote">) => (
+    <blockquote className="mb-3 border-l-2 border-rule pl-3 text-prose" {...props} />
+  ),
+  a: (props: MdProps<"a">) => (
+    <a
+      className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+      target="_blank"
+      rel="noreferrer"
+      {...props}
+    />
+  ),
+  code: (props: MdProps<"code">) => (
+    <code className="rounded-sm bg-wash px-1 py-0.5 text-[0.92em]" {...props} />
+  ),
+  pre: (props: MdProps<"pre">) => (
+    <pre
+      className="mb-3 overflow-x-auto rounded-item border border-rule bg-wash p-3 text-[0.92em] [&_code]:bg-transparent [&_code]:p-0"
+      {...props}
+    />
+  ),
+  table: (props: MdProps<"table">) => (
+    <div className="mb-3 overflow-x-auto">
+      <table className="w-full border-collapse text-[0.92em]" {...props} />
+    </div>
+  ),
+  th: (props: MdProps<"th">) => (
+    <th
+      className="border border-rule bg-wash px-2 py-1 text-left align-top font-semibold"
+      {...props}
+    />
+  ),
+  td: (props: MdProps<"td">) => (
+    <td className="border border-rule px-2 py-1 text-left align-top" {...props} />
+  ),
+  hr: (props: MdProps<"hr">) => <hr className="my-4 border-rule" {...props} />,
+};
+
+export default function AssistantMarkdown({ content }: { content: string }) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/src/matter/MessageBubble.test.tsx
+++ b/frontend/src/matter/MessageBubble.test.tsx
@@ -1,0 +1,109 @@
+// Pins the assistant-turn rendering contract: markdown renders as real
+// elements (not literal asterisks), the [doc:]/[chron:] citation
+// strip-and-chip pre-pass still runs BEFORE markdown, and user turns stay
+// plain text.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MessageBubble } from "./MessageBubble";
+import type { AssistantMessage, MatterDocument } from "../lib/api";
+
+const doc: MatterDocument = {
+  id: "doc-1",
+  matter_id: "m-1",
+  filename: "witness-statement.docx",
+  mime_type:
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  size_bytes: 1200,
+  sha256: "a".repeat(64),
+  tag: "draft",
+  from_disclosure: false,
+  uploaded_at: "2026-06-03T10:00:00",
+  uploaded_by_id: "u-1",
+} as never;
+
+function message(overrides: Partial<AssistantMessage>): AssistantMessage {
+  return {
+    id: "a-1",
+    role: "assistant",
+    content: "",
+    suggested_actions: [],
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  } as AssistantMessage;
+}
+
+function mount(m: AssistantMessage) {
+  return render(
+    <MessageBubble
+      message={m}
+      docs={[doc]}
+      chronology={[]}
+      onDocChip={vi.fn()}
+      onChronChip={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MessageBubble — assistant markdown", () => {
+  it("renders markdown as elements, not literal asterisks", async () => {
+    mount(
+      message({
+        content:
+          "The claim is **strong** on the facts.\n\n- late disclosure\n- no fair procedure",
+      }),
+    );
+
+    // The markdown chunk is lazy — findBy waits for it to mount.
+    const bold = await screen.findByText("strong");
+    expect(bold.tagName).toBe("STRONG");
+    expect(screen.queryByText(/\*\*strong\*\*/)).toBeNull();
+
+    const items = screen.getAllByRole("listitem");
+    expect(items.map((li) => li.textContent)).toEqual([
+      "late disclosure",
+      "no fair procedure",
+    ]);
+  });
+
+  it("strips citation markers before markdown and still renders the chips", async () => {
+    mount(
+      message({
+        content: "The dismissal letter is **key** [doc:doc-1].",
+      }),
+    );
+
+    const chip = await screen.findByRole("button", {
+      name: /Document.*witness-statement\.docx/i,
+    });
+    expect(chip).toBeInTheDocument();
+    // The raw marker never reaches the prose.
+    expect(screen.queryByText(/\[doc:doc-1\]/)).toBeNull();
+    const bold = await screen.findByText("key");
+    expect(bold.tagName).toBe("STRONG");
+  });
+
+  it("renders GFM tables through remark-gfm", async () => {
+    mount(
+      message({
+        content:
+          "| Event | Date |\n| --- | --- |\n| Dismissal | 2026-01-10 |",
+      }),
+    );
+
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Event" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Dismissal" })).toBeInTheDocument();
+  });
+
+  it("keeps user messages as plain text", () => {
+    mount(message({ id: "u-1", role: "user", content: "**not markdown**" }));
+
+    // Literal asterisks survive: user turns are never markdown-rendered.
+    expect(screen.getByText("**not markdown**")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -1,9 +1,16 @@
+import { lazy, Suspense } from "react";
 import type {
   AssistantMessage,
   ChronologyEvent,
   MatterDocument,
   SuggestedAction,
 } from "../lib/api";
+
+// react-markdown (+ remark-gfm) loads lazily: MessageBubble sits in the
+// statically-routed matter shell, so the markdown stack must not join the
+// first-paint bundle. The Suspense fallback is the old plain-text render,
+// so nothing flashes empty while the chunk arrives.
+const AssistantMarkdown = lazy(() => import("./AssistantMarkdown"));
 
 // Shared message renderer for matter assistant surfaces.
 //
@@ -110,8 +117,12 @@ function AssistantMessageView({
             ? ` · ${sourceCount} source${sourceCount === 1 ? "" : "s"}`
             : ""}
         </div>
-        <div className={`${proseSizing} text-ink leading-relaxed whitespace-pre-wrap`}>
-          {text}
+        {/* Citation strip-and-chip (extractCitations) has already run on
+            `text`; markdown renders the cleaned prose. */}
+        <div className={`${proseSizing} text-ink leading-relaxed`}>
+          <Suspense fallback={<div className="whitespace-pre-wrap">{text}</div>}>
+            <AssistantMarkdown content={text} />
+          </Suspense>
         </div>
         {citations.length > 0 && (
           <div className="flex flex-wrap gap-1.5 pt-1">
@@ -335,7 +346,13 @@ function extractCitations(
   const citations: Citation[] = [];
   const seen = new Set<string>();
   // Strip citation markers from inline text. Sources show as chips below.
-  const text = content.replace(CITATION_RE, "").replace(/[ \t]+([.,;:!?])/g, "$1").replace(/[ \t]{2,}/g, " ").trim();
+  // Only interior space runs collapse — leading indentation must survive
+  // for markdown nesting (lists, code blocks).
+  const text = content
+    .replace(CITATION_RE, "")
+    .replace(/[ \t]+([.,;:!?])/g, "$1")
+    .replace(/(\S)[ \t]{2,}/g, "$1 ")
+    .trim();
 
   let m: RegExpExecArray | null;
   CITATION_RE.lastIndex = 0;

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -20,6 +20,18 @@ const MATTER_TYPES: { value: string; label: string }[] = [
   { value: "other", label: "Other" },
 ];
 
+// Cause pre-fill per matter type. Only Employment Tribunal has a canonical
+// one; everything else starts blank. The field re-derives when the type
+// changes (unless the user has typed their own cause).
+const CAUSE_PREFILL: Record<string, string> = {
+  employment_tribunal: "s.94 ERA 1996, unfair dismissal",
+};
+
+// Aligned with the catalog's recommended default. Only used until
+// /api/models responds (or if it never does); once the list arrives the
+// recommended/usable model wins.
+const FALLBACK_MODEL_ID = "claude-sonnet-4-6";
+
 // Ledger-label form field (DESIGN.md P27): labels carry the 0.18em
 // clerk's-ledger tier rather than the generic eyebrow-sm.
 function Field({
@@ -55,10 +67,10 @@ export function NewMatter() {
   const [form, setForm] = useState(() => ({
     title: "",
     matter_type: "employment_tribunal",
-    cause: "s.94 ERA 1996, unfair dismissal",
+    cause: CAUSE_PREFILL.employment_tribunal,
     case_theory: "",
     pivot_fact: "",
-    default_model_id: user?.default_model_id ?? "claude-opus-4-7",
+    default_model_id: user?.default_model_id ?? FALLBACK_MODEL_ID,
   }));
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -77,8 +89,14 @@ export function NewMatter() {
         setForm((f) => {
           const has = rows.some((m) => m.id === f.default_model_id);
           if (has) return f;
+          // Prefer the catalog's recommended model (if the user can run
+          // it), then any usable model, then the first row.
           const usable =
-            rows.find((m) => !m.requires_key || m.key_configured) ?? rows[0];
+            rows.find(
+              (m) => m.recommended && (!m.requires_key || m.key_configured),
+            ) ??
+            rows.find((m) => !m.requires_key || m.key_configured) ??
+            rows[0];
           return usable ? { ...f, default_model_id: usable.id } : f;
         });
       })
@@ -143,7 +161,21 @@ export function NewMatter() {
         <Field label="Matter type">
           <select
             value={form.matter_type}
-            onChange={(e) => setForm({ ...form, matter_type: e.target.value })}
+            onChange={(e) => {
+              const nextType = e.target.value;
+              setForm((f) => {
+                // Re-derive the Cause pre-fill on type change — but never
+                // clobber a cause the user typed themselves.
+                const untouched =
+                  f.cause.trim() === "" ||
+                  f.cause === (CAUSE_PREFILL[f.matter_type] ?? "");
+                return {
+                  ...f,
+                  matter_type: nextType,
+                  cause: untouched ? CAUSE_PREFILL[nextType] ?? "" : f.cause,
+                };
+              });
+            }}
             className={inputCls}
           >
             {MATTER_TYPES.map((t) => (
@@ -172,7 +204,7 @@ export function NewMatter() {
             <input
               value={form.default_model_id}
               onChange={(e) => setForm({ ...form, default_model_id: e.target.value })}
-              placeholder="claude-opus-4-7"
+              placeholder={FALLBACK_MODEL_ID}
               className={inputCls + " tech-token"}
             />
           ) : (

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -571,3 +571,211 @@ describe("AssistantTab — pause affordance in the header meta line", () => {
     expect(screen.queryByTestId("chat-pause-toggle")).toBeNull();
   });
 });
+
+const someDoc = (
+  id: string,
+  filename: string,
+  uploadedAt = "2026-06-03T10:00:00",
+): MatterDocument =>
+  ({
+    id,
+    matter_id: "m-1",
+    filename,
+    mime_type: "text/plain",
+    size_bytes: 100,
+    sha256: "a".repeat(64),
+    tag: "draft",
+    from_disclosure: false,
+    uploaded_at: uploadedAt,
+    uploaded_by_id: "u-1",
+  }) as never;
+
+describe("AssistantTab — composer send keys", () => {
+  it("sends on Enter and keeps Shift+Enter as newline", async () => {
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "First line" } });
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(api.postAssistantMessageStream).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() =>
+      expect(api.postAssistantMessageStream).toHaveBeenCalledWith(
+        matter.slug,
+        expect.objectContaining({ content: "First line" }),
+      ),
+    );
+  });
+
+  it("still sends on Cmd/Ctrl+Enter", async () => {
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "Meta send" } });
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+    await waitFor(() =>
+      expect(api.postAssistantMessageStream).toHaveBeenCalledWith(
+        matter.slug,
+        expect.objectContaining({ content: "Meta send" }),
+      ),
+    );
+  });
+});
+
+describe("AssistantTab — failed send", () => {
+  it("restores the typed prompt into the composer on error", async () => {
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      // eslint-disable-next-line require-yield
+      async function* () {
+        throw new Error("boom");
+      },
+    );
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "Do not lose me" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText(/Could not send message/i)).toBeInTheDocument();
+    // The prompt is back in the composer — a failed send never eats the text.
+    expect(input).toHaveValue("Do not lose me");
+  });
+});
+
+describe("AssistantTab — doc-aware empty state", () => {
+  it("replaces starter chips with an upload action when the matter has no documents", async () => {
+    const setTabAndHash = vi.fn();
+    mountChat({ setTabAndHash, docs: [] });
+
+    const emptyState = await screen.findByTestId("chat-empty-state-no-docs");
+    expect(emptyState).toHaveTextContent(/Upload your first document/i);
+    expect(screen.queryByTestId("chat-empty-state")).toBeNull();
+    expect(screen.queryByText(/Stress-test this case/i)).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Upload your first document/i }),
+    );
+    expect(setTabAndHash).toHaveBeenCalledWith("documents");
+  });
+
+  it("shows the starter chips once the matter has documents", async () => {
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    expect(await screen.findByTestId("chat-empty-state")).toBeInTheDocument();
+    expect(screen.getByText(/Stress-test this case/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-empty-state-no-docs")).toBeNull();
+  });
+});
+
+describe("AssistantTab — attach popover", () => {
+  const manyDocs = Array.from({ length: 7 }, (_, i) =>
+    someDoc(`doc-${i}`, `bundle-${i}.pdf`, `2026-06-0${(i % 9) + 1}T10:00:00`),
+  );
+
+  it("lists every matter document, not just the 5 most recent", async () => {
+    mountChat({ docs: manyDocs });
+
+    fireEvent.click(await screen.findByTestId("chat-documents-toggle"));
+    const popover = await screen.findByTestId("chat-attach-popover");
+    expect(within(popover).getAllByRole("checkbox")).toHaveLength(7);
+  });
+
+  it("filters the list by title", async () => {
+    mountChat({ docs: manyDocs });
+
+    fireEvent.click(await screen.findByTestId("chat-documents-toggle"));
+    const filter = await screen.findByTestId("chat-attach-filter");
+    fireEvent.change(filter, { target: { value: "bundle-3" } });
+
+    const popover = screen.getByTestId("chat-attach-popover");
+    expect(within(popover).getAllByRole("checkbox")).toHaveLength(1);
+    expect(within(popover).getByText("bundle-3.pdf")).toBeInTheDocument();
+
+    fireEvent.change(filter, { target: { value: "no-such-doc" } });
+    expect(within(popover).queryAllByRole("checkbox")).toHaveLength(0);
+    expect(within(popover).getByText(/No documents match/i)).toBeInTheDocument();
+  });
+});
+
+describe("AssistantTab — no-key header notice", () => {
+  it("shows a passive notice when the matter's model needs a key the user lacks", async () => {
+    vi.spyOn(api, "listApiKeys").mockResolvedValue([]);
+    mountChat({
+      matter: { ...matter, required_provider: "anthropic" } as Matter,
+    });
+
+    const notice = await screen.findByTestId("chat-no-key-notice");
+    expect(notice).toHaveTextContent(/No Anthropic key yet/i);
+    expect(within(notice).getByRole("link")).toHaveAttribute(
+      "href",
+      "/settings/keys",
+    );
+  });
+
+  it("stays silent when the key is on file", async () => {
+    vi.spyOn(api, "listApiKeys").mockResolvedValue([
+      { provider: "anthropic", last_used_at: null, created_at: "2026-01-01" },
+    ]);
+    mountChat({
+      matter: { ...matter, required_provider: "anthropic" } as Matter,
+    });
+
+    await screen.findByTestId("docs-context-status");
+    await waitFor(() => expect(api.listApiKeys).toHaveBeenCalled());
+    expect(screen.queryByTestId("chat-no-key-notice")).toBeNull();
+  });
+
+  it("does not fetch keys for keyless models", async () => {
+    const spy = vi.spyOn(api, "listApiKeys").mockResolvedValue([]);
+    mountChat();
+    await screen.findByTestId("docs-context-status");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("AssistantTab — long-wait honesty line", () => {
+  it("does not show the note for a fast turn", async () => {
+    let releaseResult!: () => void;
+    const resultGate = new Promise<void>((resolve) => {
+      releaseResult = resolve;
+    });
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* () {
+        await resultGate;
+        yield {
+          event: "result",
+          data: {
+            user: {
+              id: "u-1",
+              role: "user",
+              content: "Slow question",
+              suggested_actions: [],
+              created_at: "",
+            },
+            assistant: {
+              id: "a-1",
+              role: "assistant",
+              content: "Slow answer",
+              suggested_actions: [],
+              created_at: "",
+            },
+          },
+        } as never;
+      },
+    );
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "Slow question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    // The ticker appears immediately; the honesty line waits for the timer.
+    expect(await screen.findByText("Working...")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-long-wait-note")).toBeNull();
+
+    releaseResult();
+    expect(await screen.findByText("Slow answer")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-long-wait-note")).toBeNull();
+  });
+});

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import {
   getModulesV2,
   documentOriginalUrl,
+  listApiKeys,
   listGrants,
   listAssistantMessages,
   listThreads,
@@ -151,6 +152,44 @@ export function AssistantTab({
     useState<RunnableMatterSkill | null>(null);
   const [workPane, setWorkPane] = useState<AssistantWorkPaneState | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Answers arrive whole (no token streaming) — after ~10s of a pending
+  // turn, one quiet honesty line appears under the step ticker.
+  const [longWait, setLongWait] = useState(false);
+  // Whether the user holds the key the matter's model needs. null =
+  // unknown/not applicable; false drives the passive header notice. Same
+  // source of truth as the Matters-page "Start here" banner (listApiKeys).
+  const [hasRequiredKey, setHasRequiredKey] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!thinking) {
+      setLongWait(false);
+      return;
+    }
+    const timer = window.setTimeout(() => setLongWait(true), 10_000);
+    return () => window.clearTimeout(timer);
+  }, [thinking]);
+
+  useEffect(() => {
+    if (disabled || !matter.required_provider) {
+      setHasRequiredKey(null);
+      return;
+    }
+    let cancelled = false;
+    listApiKeys()
+      .then((keys) => {
+        if (cancelled) return;
+        setHasRequiredKey(
+          keys.some((k) => k.provider === matter.required_provider),
+        );
+      })
+      // On error stay silent rather than nag (same call as MatterList).
+      .catch(() => {
+        if (!cancelled) setHasRequiredKey(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [disabled, matter.required_provider]);
 
   // Initial fetch (skip in demo: initialMessages provided). Load the
   // matter's threads and open the most-recently-active one. If retrieving
@@ -240,6 +279,19 @@ export function AssistantTab({
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [messages, thinking]);
 
+  // Composer autogrow: track content height up to ~8 rows, then scroll.
+  // Runs on every input change (including programmatic sets from the
+  // starter chips and the failed-send restore).
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    // 8 rows × 24px line-height + vertical padding (py-3 = 24px).
+    const max = 8 * 24 + 24;
+    el.style.height = `${Math.min(el.scrollHeight, max)}px`;
+    el.style.overflowY = el.scrollHeight > max ? "auto" : "hidden";
+  }, [input]);
+
   useEffect(() => {
     if (disabled) return;
     let cancelled = false;
@@ -290,12 +342,21 @@ export function AssistantTab({
     });
   }, [initialDocumentId, docsById]);
 
-  const recentDocs = useMemo(() => {
+  // All matter documents, newest first — the attach popover lists the lot
+  // (with a client-side title filter); the context rail shows the head.
+  const sortedDocs = useMemo(() => {
     if (!docs) return [];
-    return [...docs]
-      .sort((a, b) => (a.uploaded_at < b.uploaded_at ? 1 : -1))
-      .slice(0, 5);
+    return [...docs].sort((a, b) => (a.uploaded_at < b.uploaded_at ? 1 : -1));
   }, [docs]);
+
+  const recentDocs = useMemo(() => sortedDocs.slice(0, 5), [sortedDocs]);
+
+  const [attachFilter, setAttachFilter] = useState("");
+  const filteredAttachDocs = useMemo(() => {
+    const q = attachFilter.trim().toLowerCase();
+    if (!q) return sortedDocs;
+    return sortedDocs.filter((d) => (d.filename ?? "").toLowerCase().includes(q));
+  }, [sortedDocs, attachFilter]);
 
   const attachedDocs = useMemo(() => {
     const arr: MatterDocument[] = [];
@@ -390,6 +451,10 @@ export function AssistantTab({
       }
     } catch (err) {
       setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
+      // The optimistic message is gone — give the user their prompt back
+      // in the composer so a failed send never eats the text. Attached
+      // docs are untouched (selection only clears on explicit remove).
+      setInput(content);
       if (err instanceof ProviderKeyMissingError) {
         setKeyMissingProvider(err.provider);
       } else {
@@ -406,11 +471,14 @@ export function AssistantTab({
     await sendMessage(input);
   };
 
+  // Enter sends; Shift+Enter inserts a newline (the universal chat
+  // convention). ⌘/Ctrl+Enter still sends. The isComposing guard keeps
+  // IME confirmation (e.g. Japanese input) from firing a send.
   const onKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-      e.preventDefault();
-      onSend();
-    }
+    if (e.key !== "Enter" || e.shiftKey) return;
+    if (e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    onSend();
   };
 
   const dispatchAction = (a: SuggestedAction) => {
@@ -576,6 +644,23 @@ export function AssistantTab({
                 <span>{runnableSkillCount} runnable skill{runnableSkillCount === 1 ? "" : "s"}</span>
               </>
             )}
+            {matter.required_provider && hasRequiredKey === false && (
+              <>
+                <span aria-hidden="true">·</span>
+                {/* Passive notice: this matter's model needs a key the user
+                    hasn't added. Same muted register as the rest of the
+                    meta line — the hard stop stays with the send-time banner. */}
+                <span data-testid="chat-no-key-notice">
+                  No {providerLabel(matter.required_provider)} key yet —{" "}
+                  <a
+                    href="/settings/keys"
+                    className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                  >
+                    add one in Settings
+                  </a>
+                </span>
+              </>
+            )}
             {/* Activity lives on the matter rail (WS1); the old faint
                 header link was redundant chrome and has been removed.
                 openRecord is still used by the work pane + context rail. */}
@@ -649,45 +734,6 @@ export function AssistantTab({
           </div>
         )}
 
-        {attachedDocs.length > 0 && (
-          <section
-            className="mb-4 border-t border-rule py-2"
-            data-testid="chat-attached-document-context"
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="min-w-0">
-                <div className="flex flex-wrap gap-2">
-                  {attachedDocs.map((doc) => (
-                    <span
-                      key={doc.id}
-                      className="inline-flex max-w-full items-center gap-2 rounded-item border border-rule bg-paper px-2 py-1 tech-token text-xs text-ink"
-                    >
-                      <span className="max-w-[360px] truncate">{doc.filename}</span>
-                      <button
-                        type="button"
-                        onClick={() => removeDoc(doc.id)}
-                        className="text-muted hover:text-ink"
-                        aria-label={`Remove ${doc.filename}`}
-                      >
-                        x
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              </div>
-              {attachedDocs.length === 1 && (
-                <button
-                  type="button"
-                  onClick={() => dispatchDocChip(attachedDocs[0].id)}
-                  className="shrink-0 text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-                >
-                  Preview →
-                </button>
-              )}
-            </div>
-          </section>
-        )}
-
         <div
           ref={scrollRef}
           className="min-h-0 flex-1 space-y-6 overflow-y-auto border-t border-rule py-6"
@@ -698,7 +744,24 @@ export function AssistantTab({
             loading conversation
           </p>
         )}
-        {loaded && messages.length === 0 && (
+        {loaded && messages.length === 0 && docs !== null && docs.length === 0 && (
+          // With no documents, "Summarise the witness statement" is a doomed
+          // prompt — route to the Documents tab instead. The starter chips
+          // return once the matter has files.
+          <div className="grid gap-2 sm:grid-cols-2" data-testid="chat-empty-state-no-docs">
+            <button
+              type="button"
+              onClick={() => setTabAndHash("documents")}
+              className="group flex min-h-[44px] items-center justify-between gap-3 rounded-item border border-rule bg-paper px-3 text-left text-[14px] leading-5 text-ink transition-colors hover:border-ink hover:bg-paper-sunken"
+            >
+              <span>Upload your first document</span>
+              <span className="text-muted transition-colors group-hover:text-ink" aria-hidden>
+                →
+              </span>
+            </button>
+          </div>
+        )}
+        {loaded && messages.length === 0 && (docs === null || docs.length > 0) && (
           <div className="grid gap-2 sm:grid-cols-2" data-testid="chat-empty-state">
             {suggestions.map((s) => (
               <button
@@ -752,15 +815,22 @@ export function AssistantTab({
           />
         )}
         {thinking && (
-          <div className="flex justify-start">
-            <InlineAgentStatus steps={agentSteps} />
+          <div className="flex flex-col gap-1.5">
+            <div className="flex justify-start">
+              <InlineAgentStatus steps={agentSteps} />
+            </div>
+            {longWait && (
+              <p className="text-xs text-muted" data-testid="chat-long-wait-note">
+                Long answers can take up to a minute.
+              </p>
+            )}
           </div>
         )}
         </div>
 
         {keyMissingProvider && <ProviderKeyMissingBanner provider={keyMissingProvider} />}
         {error && (
-          <div className="border border-[#D9304F] bg-[#FEF2F2] text-[#B91C1C] text-sm p-3 mt-3">
+          <div className="bg-paper border border-seal text-seal text-sm p-3 mt-3">
             <div className="font-semibold mb-1">Could not send message</div>
             <p className="leading-relaxed whitespace-pre-wrap">{error}</p>
           </div>
@@ -793,9 +863,14 @@ export function AssistantTab({
           ) : null
         ) : (
           <div className="sticky bottom-0 bg-paper pt-2">
-          {/* Context attachments as chips ABOVE the composer */}
+          {/* Context attachments as chips ABOVE the composer — the single
+              attached-doc surface (the duplicate row above the message list
+              was cut, launch punch list 2026-07-02). */}
           {attachedDocs.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mb-2">
+            <div
+              className="flex flex-wrap items-center gap-x-3 gap-y-1.5 mb-2"
+              data-testid="chat-attached-document-context"
+            >
               {attachedDocs.map((d) => (
                 <button
                   key={d.id}
@@ -808,6 +883,15 @@ export function AssistantTab({
                   <span aria-hidden>×</span>
                 </button>
               ))}
+              {attachedDocs.length === 1 && (
+                <button
+                  type="button"
+                  onClick={() => dispatchDocChip(attachedDocs[0].id)}
+                  className="text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                >
+                  Preview →
+                </button>
+              )}
             </div>
           )}
 
@@ -924,10 +1008,26 @@ export function AssistantTab({
                   </button>
                 </div>
               )}
-              {attachOpen && recentDocs.length > 0 && (
-                <div className="absolute bottom-full left-0 mb-2 rounded-item border border-rule bg-paper p-2 w-[280px] z-10">
-                  <ul className="space-y-2">
-                    {recentDocs.map((d) => {
+              {attachOpen && sortedDocs.length > 0 && (
+                <div
+                  className="absolute bottom-full left-0 mb-2 rounded-item border border-rule bg-paper p-2 w-[280px] z-10"
+                  data-testid="chat-attach-popover"
+                >
+                  {/* Every matter document is attachable; the filter keeps
+                      long lists workable without changing the popover shape. */}
+                  {sortedDocs.length > 5 && (
+                    <input
+                      type="text"
+                      value={attachFilter}
+                      onChange={(e) => setAttachFilter(e.target.value)}
+                      placeholder="Filter documents"
+                      aria-label="Filter documents"
+                      data-testid="chat-attach-filter"
+                      className="mb-2 w-full rounded-item border border-rule bg-paper px-2 py-1 text-xs text-ink placeholder:text-muted focus:border-ink focus:outline-none"
+                    />
+                  )}
+                  <ul className="max-h-56 space-y-2 overflow-y-auto">
+                    {filteredAttachDocs.map((d) => {
                       const checked = selectedDocIds.has(d.id);
                       return (
                         <li key={d.id}>
@@ -943,6 +1043,11 @@ export function AssistantTab({
                         </li>
                       );
                     })}
+                    {filteredAttachDocs.length === 0 && (
+                      <li className="px-1 py-0.5 text-xs text-muted">
+                        No documents match.
+                      </li>
+                    )}
                   </ul>
                   <button
                     type="button"
@@ -1610,6 +1715,10 @@ function RailPanel({
       <div className="mt-3">{children}</div>
     </section>
   );
+}
+
+function providerLabel(provider: string): string {
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
 }
 
 function formatError(err: unknown): string {

--- a/frontend/src/ui/primitives.tsx
+++ b/frontend/src/ui/primitives.tsx
@@ -8,7 +8,7 @@ export const primaryBtn =
 
 // Inline banner for the canonical `provider_key_missing` 422 error.
 // Border + text tokens only. No fill, no radius, no shadow. The deep
-// link to `#/settings` is what makes this a one-click resolution
+// link to `/settings/keys` is what makes this a one-click resolution
 // instead of a dead-end blob.
 export function ProviderKeyMissingBanner({ provider }: { provider: string }) {
   const label = provider.charAt(0).toUpperCase() + provider.slice(1);
@@ -16,14 +16,23 @@ export function ProviderKeyMissingBanner({ provider }: { provider: string }) {
     <div className="border border-ink p-3 my-3 text-sm">
       <div className="font-semibold text-ink mb-1">{label} API key required</div>
       <p className="leading-relaxed text-prose m-0">
-        Add your {label} API key in Settings to use this model. Or switch to stub-echo for the demo.
+        No model key yet. Add your {label} key in Settings to get written
+        answers — or walk the guided demo.
       </p>
-      <a
-        href="/settings"
-        className="inline-block mt-2 text-ink underline underline-offset-2 hover:text-prose transition-colors"
-      >
-        Open Settings
-      </a>
+      <div className="mt-2 flex flex-wrap items-center gap-4">
+        <a
+          href="/settings/keys"
+          className="text-ink underline underline-offset-2 hover:text-prose transition-colors"
+        >
+          Open Settings
+        </a>
+        <a
+          href="/guided-demo"
+          className="text-muted underline underline-offset-2 hover:text-prose transition-colors"
+        >
+          Walk the demo
+        </a>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes out the full launch-readiness punch-list from today's review (4-track code review + live hosted walkthrough).

## Backend
- **Model passthrough (audit integrity):** the picked model now actually runs — the gateway forwards `model` to keyed providers and audit rows record the model served, not the provider name. Previously every call ran the config default while the audit stamped the requested model.
- **Output cap:** `max_tokens` plumbed through the gateway; assistant turns raised to 8192; Anthropic truncation (`stop_reason=max_tokens`) surfaces as an honest error instead of a JSON-parse mystery.
- **Auth:** `POST /auth/login` rate-limited (10/IP/h); `CF-Connecting-IP` trusted only when `Fly-Client-IP` is inside Cloudflare's published ranges (kills the direct-origin header-spoof bypass).
- **Limits:** archived matters no longer count against the matter cap or storage quota; `check_generated_artefact` wired into docx/pdf export; new `check_workflow_run` gates invocations; usage page aligned with enforcement.
- **Keyless UX:** a keyless turn with no retrieval hits persists the user message + an honest no-model reply (was: 422, lost message, ghost thread).
- **stub-echo:** chat on a stub-echo matter returns the labelled echo instead of a permanent parse-failure loop.
- **Tombstones:** upload/reindex blocked on archived matters (invariant: deleted means gone).
- **System prompt:** no citing case law/statutes from memory as fact; unsupported legal propositions must be flagged; never invent citations.

## Frontend
- Assistant messages render **markdown** (lazy chunk, first-paint bundle unchanged); `[doc:]`/`[chron:]` citation chips preserved.
- **Enter sends** (Shift+Enter newline); failed sends restore the prompt.
- No-key path: plain copy, `/settings/keys` routing, passive header notice, guided-demo pointer; "up to a minute" line on long waits.
- Zero-doc matters get an upload-first action instead of doomed starter chips; attach popover lists all documents with a filter; duplicate chip row removed.
- Error styles moved onto tokens; model defaults/placeholders follow the catalog recommendation; cause prefill re-derives on matter-type change; composer autogrows.

## Tests
- Backend: 911 passed, 0 failed (full suite; ~25 new/updated tests).
- Frontend: `tsc` clean, 338 tests passing (~18 new), production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant messages now render Markdown more richly, including tables, links, and formatted text.
  * New account and matter setup defaults improve model selection and cause prefill behavior.
  * Missing API key notices now offer clearer next steps.

* **Bug Fixes**
  * Login, exports, and workflow runs now respect daily/per-IP limits more consistently.
  * Archived matters no longer count toward usage caps and are blocked from related actions.
  * Assistant responses now handle long outputs and empty retrieval results more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->