### PR TITLE
Skill library: sources story + categorised catalogue

### DIFF
--- a/backend/app/api/module_routes/requests.py
+++ b/backend/app/api/module_routes/requests.py
@@ -32,11 +32,16 @@ class ModuleRequestIn(BaseModel):
     # Where the requester found the skill ("lawve", "registry",
     # "github", …). Free-form hint for the admin review link.
     source: str | None = None
+    # Where the skill lives (e.g. the GitHub repo URL) — lets the
+    # admin's Review-&-add link re-open sources the importer cannot
+    # resolve by slug.
+    source_url: str | None = None
 
 
 class ModuleRequestOut(BaseModel):
     module_id: str
     source: str | None
+    source_url: str | None = None
     requested_by: str | None
     requested_at: str  # ISO-8601, latest request for this module_id
 
@@ -71,6 +76,7 @@ async def create_module_request(
         payload={
             "module_id": module_id,
             "source": body.source,
+            "source_url": body.source_url,
             "requested_by": str(user.id),
         },
     )
@@ -122,6 +128,7 @@ async def list_module_requests(
             ModuleRequestOut(
                 module_id=module_id,
                 source=payload.get("source"),
+                source_url=payload.get("source_url"),
                 requested_by=payload.get("requested_by"),
                 requested_at=r.timestamp.isoformat(),
             )

--- a/backend/tests/test_module_requests.py
+++ b/backend/tests/test_module_requests.py
@@ -105,6 +105,34 @@ async def test_request_writes_audit_row(client, db_session) -> None:
 
 
 @pytest.mark.asyncio
+async def test_github_request_round_trips_source_url(client) -> None:
+    """A github-sourced request carries its repo URL so the admin's
+    Review-&-add link can re-open the exact source."""
+    await _register_and_login(client)
+    module_id = f"gh-skill-{uuid.uuid4().hex[:8]}"
+    repo_url = "https://github.com/example/legal-skill"
+
+    resp = await client.post(
+        "/api/modules/requests",
+        json={"module_id": module_id, "source": "github", "source_url": repo_url},
+    )
+    assert resp.status_code == 201, resp.text
+
+    admin_email = await _register_and_login(client)
+    await _promote_to_superuser(admin_email)
+    resp = await client.get("/api/modules/requests")
+    assert resp.status_code == 200, resp.text
+    row = next(r for r in resp.json() if r["module_id"] == module_id)
+    assert row["source"] == "github"
+    assert row["source_url"] == repo_url
+
+    # Lawve-style requests without a URL still list with a null field.
+    lawve_rows = [r for r in resp.json() if r["module_id"] != module_id]
+    for r in lawve_rows:
+        assert "source_url" in r
+
+
+@pytest.mark.asyncio
 async def test_request_rejects_blank_module_id(client) -> None:
     await _register_and_login(client)
     resp = await client.post("/api/modules/requests", json={"module_id": "   "})

--- a/frontend/src/lib/api/modules.ts
+++ b/frontend/src/lib/api/modules.ts
@@ -163,15 +163,27 @@ export const listInstalledModules = () =>
 export interface ModuleRequestRow {
   module_id: string;
   source: string | null;
+  /** Where the skill lives (e.g. the GitHub repo URL) — lets the admin
+   * Review-&-add link resolve sources the importer can't look up by
+   * slug. Optional: older rows won't carry it. */
+  source_url?: string | null;
   requested_by: string | null;
   requested_at: string;
 }
 
-export const requestModule = (moduleId: string, source?: string) =>
+export const requestModule = (
+  moduleId: string,
+  source?: string,
+  sourceUrl?: string,
+) =>
   apiFetch(`${API}/modules/requests`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ module_id: moduleId, source: source ?? null }),
+    body: JSON.stringify({
+      module_id: moduleId,
+      source: source ?? null,
+      source_url: sourceUrl ?? null,
+    }),
   }).then((r) => jsonOrThrow<{ ok: boolean }>(r));
 
 export const listModuleRequests = () =>

--- a/frontend/src/modules-v2/CounselRegister.tsx
+++ b/frontend/src/modules-v2/CounselRegister.tsx
@@ -1,5 +1,5 @@
 /**
- * /register — "Your skills": the skills installed in this workspace,
+ * /register — "My skills": the skills installed in this workspace,
  * each with what it can read, what it can write, its advice limit, and
  * its track record.
  *
@@ -97,7 +97,7 @@ export function CounselRegister() {
   return (
     <div className="page-shell">
       <h1 className="font-redaction35 text-[64px] leading-none tracking-tight2 sm:text-[88px]">
-        Your skills
+        My skills
       </h1>
 
       <p className="mt-8 max-w-xl text-sm leading-relaxed text-prose">
@@ -130,11 +130,17 @@ export function CounselRegister() {
       )}
 
       {q.status === "ready" && q.rows.length > 0 && (
-        <div className="mt-12 grid gap-6 sm:grid-cols-2" data-testid="register-grid">
+        <>
+          <p className="mt-12 text-[11px] text-muted" data-testid="advice-ceiling-legend">
+            Advice ceiling — how far a skill may go, from factual extraction
+            (●○○○○) to approved final advice (●●●●●).
+          </p>
+          <div className="mt-4 grid gap-6 sm:grid-cols-2" data-testid="register-grid">
           {q.rows.map((row, i) => (
             <Certificate key={row.module_id} row={row} index={i} />
           ))}
-        </div>
+          </div>
+        </>
       )}
 
       <ExternalPacksSection />
@@ -202,6 +208,7 @@ function Certificate({ row, index }: { row: InstalledModule; index: number }) {
       <div className="mt-4 flex items-center justify-between border-t border-rule pt-3">
         <span
           aria-label={`advice ceiling: ${tier.replaceAll("_", " ")}`}
+          title={`Advice ceiling — how far this skill may go: ${tier.replaceAll("_", " ")} (${tierIdx + 1} of ${TIERS.length}, from factual extraction to approved final advice)`}
           className="tracking-[0.25em] text-ink text-sm"
         >
           {TIERS.map((_t, i) => (i <= tierIdx ? "●" : "○")).join("")}
@@ -247,6 +254,12 @@ function Certificate({ row, index }: { row: InstalledModule; index: number }) {
           </div>
         )}
       </dl>
+
+      {revoked && (
+        <p className="mt-2 text-[11px] text-muted" data-testid="superseded-note">
+          Superseded — re-import from its current source to use again.
+        </p>
+      )}
 
       {/* The seal — only a skill with a verified signature carries it. */}
       {verified && !revoked && (

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -544,7 +544,11 @@ function Decision({
         )}
         <p className="flex items-center gap-2">
           <span>Advice ceiling:</span>
-          <span aria-hidden="true" className="tracking-[0.2em] text-ink">
+          <span
+            aria-hidden="true"
+            title={`Advice ceiling — how far this skill may go: ${(card.advice_tier_max ?? "factual_extraction").replaceAll("_", " ")} (${tierIdx + 1} of ${TIERS.length}, from factual extraction to approved final advice)`}
+            className="tracking-[0.2em] text-ink"
+          >
             {TIERS.map((_t, i) => (i <= tierIdx ? "●" : "○")).join("")}
           </span>
           <span className="text-xs text-muted">

--- a/frontend/src/modules-v2/LawveImport.test.tsx
+++ b/frontend/src/modules-v2/LawveImport.test.tsx
@@ -139,6 +139,40 @@ describe("LawveImport", () => {
     expect(screen.getByTestId("lawve-card-office-processor")).toBeInTheDocument();
   });
 
+  it("renders the picker as a grouped ledger with display names and descriptions", async () => {
+    mountLawve();
+    await waitFor(() =>
+      expect(screen.getByTestId("lawve-card-contract-review-anthropic")).toBeInTheDocument(),
+    );
+    // Derived display name leads; raw slug stays as secondary text.
+    expect(screen.getByText("Contract review")).toBeInTheDocument();
+    expect(screen.getByText("contract-review-anthropic")).toBeInTheDocument();
+    // The catalogue description is finally visible (both rows share it).
+    expect(screen.getAllByText("Review contracts.").length).toBeGreaterThan(0);
+    // Group headers by what they do; scripts get the manual-review marker.
+    expect(screen.getByTestId("lawve-group-contracts")).toBeInTheDocument();
+    expect(screen.getByText(/ships scripts — manual review/)).toBeInTheDocument();
+  });
+
+  it("auto-fetches a ?github= deep link into the GitHub panel", async () => {
+    const repoUrl = "https://github.com/example/legal-skill";
+    const getGithubSkill = vi
+      .spyOn(api, "getGithubSkill")
+      .mockResolvedValue(
+        detail({ slug: "legal-skill", name: "Legal Skill" }),
+      );
+    window.history.pushState({}, "", `/skills/lawve?github=${encodeURIComponent(repoUrl)}`);
+    try {
+      mountLawve();
+      await waitFor(() => expect(getGithubSkill).toHaveBeenCalledWith(repoUrl));
+      await waitFor(() => expect(screen.getByTestId("lawve-detail")).toBeInTheDocument());
+      // The URL lands in the GitHub field too, so re-fetch just works.
+      expect(screen.getByTestId("github-url")).toHaveValue(repoUrl);
+    } finally {
+      window.history.pushState({}, "", "/skills/lawve");
+    }
+  });
+
   it("opens a scripted skill and shows the non-execution flag", async () => {
     vi.spyOn(api, "getLawveSkill").mockResolvedValue(
       detail({ slug: "office-processor", name: "Office Processor", has_scripts: true, scripts: ["skills/office-processor/scripts/run.py"] }),

--- a/frontend/src/modules-v2/LawveImport.tsx
+++ b/frontend/src/modules-v2/LawveImport.tsx
@@ -25,6 +25,11 @@ import { useAuth } from "../auth/AuthProvider";
 import { ErrorCallout, LoadingLine, PageHeader } from "../ui/primitives";
 import { LedgerLine, SectionRule } from "../ui/certificate";
 import { RequestSkillButton } from "./RequestSkillButton";
+import {
+  groupSkills,
+  licenceLabel,
+  skillDisplayName,
+} from "./skillDisplay";
 
 type ListQuery =
   | { status: "loading" }
@@ -86,6 +91,21 @@ export function LawveImport() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q.status]);
 
+  // Deep-link a GitHub source: /skills/lawve?github=<repo url> — the
+  // admin's Review-&-add link for a github-sourced request lands here
+  // and the URL is fetched straight into the GitHub panel.
+  useEffect(() => {
+    const url =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search).get("github")
+        : null;
+    if (url) {
+      setGhUrl(url);
+      void openGithub(url);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const licenses = useMemo(
     () => [...new Set(skills.map((s) => s.license).filter((l): l is string => !!l))].sort(),
     [skills],
@@ -99,12 +119,16 @@ export function LawveImport() {
       if (!term) return true;
       return (
         s.name.toLowerCase().includes(term) ||
+        skillDisplayName(s.slug, s.author_name).toLowerCase().includes(term) ||
         s.description.toLowerCase().includes(term) ||
         (s.author_name ?? "").toLowerCase().includes(term) ||
         (s.license ?? "").toLowerCase().includes(term)
       );
     });
   }, [skills, search, licenseFilter, scriptsOnly, refsOnly]);
+  // Same what-they-do grouping as the Skill library shelf; a group
+  // with no surviving rows disappears with its header.
+  const grouped = useMemo(() => groupSkills(filtered), [filtered]);
 
   const openSkill = async (slug: string) => {
     setSelecting(true);
@@ -120,8 +144,8 @@ export function LawveImport() {
     }
   };
 
-  const openGithub = async () => {
-    const url = ghUrl.trim();
+  const openGithub = async (rawUrl?: string) => {
+    const url = (rawUrl ?? ghUrl).trim();
     if (!url) return;
     setSelecting(true);
     setDetailErr(null);
@@ -240,45 +264,77 @@ export function LawveImport() {
               <span className="text-muted">{filtered.length} of {skills.length}</span>
             </div>
 
-            {/* The catalogue ledger — index, licence, name + author, chevron.
-                Same scan rhythm as the register's admission lists. */}
-            <ul className="mt-4">
-              {filtered.map((s, i) => (
-                <li key={s.slug}>
-                  <button
-                    type="button"
-                    onClick={() => openSkill(s.slug)}
-                    className={
-                      "group block w-full text-left " +
-                      (selected?.slug === s.slug ? "bg-wash" : "")
-                    }
-                    data-testid={`lawve-card-${s.slug}`}
-                  >
-                    <LedgerLine
-                      index={i + 1}
-                      label={s.license ?? "licence ?"}
-                      right={
-                        <span
-                          aria-hidden="true"
-                          className="text-sm text-muted group-hover:text-seal"
-                        >
-                          →
-                        </span>
-                      }
-                    >
-                      <span className="text-ink group-hover:text-seal">
-                        {s.name}
-                      </span>
-                      <span className="ml-2 hidden text-[12px] text-muted sm:inline">
-                        {s.author_name ?? "unknown"}
-                        {s.has_scripts ? " · scripts" : ""}
-                        {s.has_references ? " · refs" : ""}
-                      </span>
-                    </LedgerLine>
-                  </button>
-                </li>
-              ))}
-            </ul>
+            {/* The catalogue ledger — grouped by what the skills do,
+                same scan rhythm and grouping as the Skill library. */}
+            {(() => {
+              let n = 0;
+              return grouped.map((group) => (
+                <div key={group.id} data-testid={`lawve-group-${group.id}`}>
+                  <div className="mt-5 flex items-baseline justify-between border-b border-rule pb-1.5">
+                    <h3 className="text-[10px] uppercase tracking-[0.18em] text-muted">
+                      {group.label}
+                    </h3>
+                    <span className="tech-token text-[11px] text-muted">
+                      {group.skills.length}
+                    </span>
+                  </div>
+                  {group.note && (
+                    <p className="mt-1.5 text-[11px] text-muted">{group.note}</p>
+                  )}
+                  <ul>
+                    {group.skills.map((s) => {
+                      n += 1;
+                      return (
+                        <li key={s.slug}>
+                          <button
+                            type="button"
+                            onClick={() => openSkill(s.slug)}
+                            className={
+                              "group block w-full text-left " +
+                              (selected?.slug === s.slug ? "bg-wash" : "")
+                            }
+                            data-testid={`lawve-card-${s.slug}`}
+                          >
+                            <LedgerLine
+                              index={n}
+                              label={licenceLabel(s.license)}
+                              right={
+                                <span
+                                  aria-hidden="true"
+                                  className="text-sm text-muted group-hover:text-seal"
+                                >
+                                  →
+                                </span>
+                              }
+                            >
+                              <span className="block min-w-0">
+                                <span className="text-ink group-hover:text-seal">
+                                  {skillDisplayName(s.slug, s.author_name)}
+                                </span>
+                                <span className="ml-2 hidden text-[11px] text-muted sm:inline">
+                                  <span className="tech-token">{s.slug}</span>
+                                  {" · "}
+                                  {s.author_name ?? "unknown"}
+                                  {s.has_references ? " · refs" : ""}
+                                  {(s.has_scripts || s.script_review_required) && (
+                                    <span className="text-seal">
+                                      {" · ships scripts — manual review"}
+                                    </span>
+                                  )}
+                                </span>
+                                <span className="block truncate text-[12px] text-muted">
+                                  {s.description}
+                                </span>
+                              </span>
+                            </LedgerLine>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ));
+            })()}
           </div>
 
           {/* Detail + convert */}
@@ -337,7 +393,13 @@ export function LawveImport() {
                   {drafting ? "Converting…" : "Convert to skill draft"}
                 </button>
 
-                {draft && <DraftReview draft={draft} slug={selected.slug} />}
+                {draft && (
+                  <DraftReview
+                    draft={draft}
+                    slug={selected.slug}
+                    githubUrl={selectedGhUrl}
+                  />
+                )}
               </div>
             )}
           </div>
@@ -347,7 +409,18 @@ export function LawveImport() {
   );
 }
 
-function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string }) {
+function DraftReview({
+  draft,
+  slug,
+  githubUrl,
+}: {
+  draft: LawveDraftResult;
+  slug: string;
+  /** Set when the skill was fetched from a GitHub URL rather than the
+   * Lawve catalogue — carried on the request so the admin's
+   * Review-&-add link can resolve the source. */
+  githubUrl: string | null;
+}) {
   const manifestJson = JSON.stringify(draft.manifest, null, 2);
   const [copied, setCopied] = useState(false);
   const [installing, setInstalling] = useState(false);
@@ -483,7 +556,8 @@ function DraftReview({ draft, slug }: { draft: LawveDraftResult; slug: string })
                       ? draft.manifest.id
                       : slug
                   }
-                  source="lawve"
+                  source={githubUrl ? "github" : "lawve"}
+                  sourceUrl={githubUrl ?? undefined}
                 />
               </div>
             </div>

--- a/frontend/src/modules-v2/ModuleDetail.test.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.test.tsx
@@ -258,7 +258,7 @@ describe("ModuleDetail", () => {
     fireEvent.click(screen.getByTestId("request-skill"));
 
     await waitFor(() => {
-      expect(request).toHaveBeenCalledWith("contract-review", "registry");
+      expect(request).toHaveBeenCalledWith("contract-review", "registry", undefined);
     });
     await waitFor(() => {
       expect(

--- a/frontend/src/modules-v2/ModulesCatalog.test.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.test.tsx
@@ -266,7 +266,7 @@ describe("ModulesCatalog — integrations home", () => {
     expect(screen.queryByTestId("skill-requests")).toBeNull();
   });
 
-  it("Schedule B: shelf facets, sort, Lawve attribution, and the gap strip", async () => {
+  it("Schedule B: shelf facets, Lawve attribution, and the gap strip", async () => {
     vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
     vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
     mockLawveShelf([
@@ -314,12 +314,8 @@ describe("ModulesCatalog — integrations home", () => {
       target: { value: "" },
     });
 
-    // Sort control offers name / author / licence.
-    expect(screen.getByTestId("shelf-sort")).toBeInTheDocument();
-    fireEvent.change(screen.getByTestId("shelf-sort"), {
-      target: { value: "licence" },
-    });
-    expect(screen.getByTestId("shelf-count")).toHaveTextContent("2 of 2");
+    // Ordering comes from the grouped ledger — no sort control.
+    expect(screen.queryByTestId("shelf-sort")).toBeNull();
 
     // Search empties honestly.
     fireEvent.change(screen.getByTestId("shelf-search"), {
@@ -370,6 +366,141 @@ describe("ModulesCatalog — integrations home", () => {
       expect(screen.getByText("contract-review-anthropic")).toBeInTheDocument();
     });
     expect(screen.getByTestId("shelf-search")).toBeInTheDocument();
+  });
+
+  it("tells the sources story: three routes, review rule, and the pulled-catalogue lede", async () => {
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+    mockLawveShelf([lawveRow(), lawveRow({ slug: "nda-review-jamie-tso", name: "nda-review-jamie-tso", author_name: "Jamie Tso", license: "AGPL-3.0" })]);
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByTestId("skill-sources")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Where skills come from")).toBeInTheDocument();
+    // Lawve is a text wordmark linking out — never a hotlinked logo.
+    expect(screen.getByTestId("lawve-link").getAttribute("href")).toBe(
+      "https://lawve.ai",
+    );
+    expect(screen.getByText("Any public GitHub repo")).toBeInTheDocument();
+    expect(screen.getByText("Write your own")).toBeInTheDocument();
+    expect(
+      screen.getByText(/nothing runs on import/i),
+    ).toBeInTheDocument();
+    // The lede derives the count from the live feed.
+    expect(screen.getByTestId("shelf-lede")).toHaveTextContent(
+      "We've already pulled the Lawve catalogue — 2 skills to choose from below.",
+    );
+  });
+
+  it("renders the catalogue as a grouped ledger: display names, descriptions, licence honesty, scripts marker", async () => {
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+    mockLawveShelf([
+      lawveRow({
+        slug: "nda-review-jamie-tso",
+        name: "nda-review-jamie-tso",
+        description: "Guide for reviewing incoming commercial NDAs.",
+        author_name: "Jamie Tso",
+        license: "AGPL-3.0",
+      }),
+      lawveRow({
+        slug: "docx-processing-anthropic",
+        name: "docx-processing-anthropic",
+        description: "Document creation, editing, and analysis.",
+        author_name: "Anthropic",
+        license: null,
+        has_scripts: true,
+        script_review_required: true,
+      }),
+      lawveRow({
+        slug: "politique-cookies-malik-taiar",
+        name: "politique-cookies-malik-taiar",
+        description: "Guide pour la rédaction de politiques cookies.",
+        author_name: "Malik Taiar",
+        license: "AGPL-3.0",
+      }),
+    ]);
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByTestId("shelf-group-contracts")).toBeInTheDocument();
+    });
+    // Legible derived names lead; the raw slug stays as secondary text.
+    expect(screen.getByText("NDA review")).toBeInTheDocument();
+    expect(screen.getByText("nda-review-jamie-tso")).toBeInTheDocument();
+    // The one-line description finally shows.
+    expect(
+      screen.getByText("Guide for reviewing incoming commercial NDAs."),
+    ).toBeInTheDocument();
+    // Groups render in what-they-do order with French law last.
+    expect(screen.getByTestId("shelf-group-documents")).toBeInTheDocument();
+    const french = screen.getByTestId("shelf-group-french");
+    expect(french).toHaveTextContent("French law (FR)");
+    expect(french).toHaveTextContent(/England & Wales/);
+    // Licence honesty + the scripts marker.
+    expect(screen.getByText("unlicensed — check source")).toBeInTheDocument();
+    expect(
+      screen.getByText(/ships scripts — manual review/),
+    ).toBeInTheDocument();
+    // Filtering to AGPL hides the emptied Documents group with its header.
+    fireEvent.change(screen.getByTestId("shelf-license-filter"), {
+      target: { value: "AGPL-3.0" },
+    });
+    expect(screen.queryByTestId("shelf-group-documents")).toBeNull();
+    expect(screen.getByTestId("shelf-group-contracts")).toBeInTheDocument();
+  });
+
+  it("hides the Workspace skills section entirely when the registry is empty", async () => {
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+    mockLawveShelf([lawveRow()]);
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByText("Add skill")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Workspace skills")).toBeNull();
+    expect(
+      screen.queryByText("No reference skills in the registry yet."),
+    ).toBeNull();
+    // The library ↔ register pair is named consistently.
+    expect(screen.getByText("My skills →")).toBeInTheDocument();
+  });
+
+  it("admin: a github-sourced request links the importer to its repo URL", async () => {
+    vi.spyOn(api, "getCurrentUser").mockResolvedValue({
+      id: "u-1",
+      email: "admin@example.com",
+      name: "admin",
+      role: "qualified_solicitor",
+      plan: "free",
+      default_model_id: null,
+      default_privilege_posture: null,
+      is_active: true,
+      is_verified: true,
+      is_superuser: true,
+    });
+    vi.spyOn(api, "getModulesV2").mockResolvedValue({ modules: [], ui_slots: [] });
+    vi.spyOn(api, "listInstalledModules").mockResolvedValue([]);
+    vi.spyOn(api, "listModuleRequests").mockResolvedValue([
+      {
+        module_id: "lawve.gh-skill",
+        source: "github",
+        source_url: "https://github.com/example/legal-skill",
+        requested_by: "u-2",
+        requested_at: "2026-06-10T12:00:00+00:00",
+      },
+    ]);
+
+    mountAt();
+    await waitFor(() => {
+      expect(screen.getByTestId("skill-requests")).toBeInTheDocument();
+    });
+    const link = screen.getByText("Review & add →");
+    expect(link.getAttribute("href")).toBe(
+      "/skills/lawve?github=https%3A%2F%2Fgithub.com%2Fexample%2Flegal-skill",
+    );
   });
 
   it("renders without the retired open-skill-library browse section", async () => {

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -14,7 +14,7 @@
  * not make it "ready everywhere" — running it is granted from a matter.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import {
   getModulesV2,
@@ -41,13 +41,14 @@ import {
   type LawveSkillRow,
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
+import {
+  groupSkills,
+  licenceLabel,
+  skillDisplayName,
+} from "./skillDisplay";
 
 type ModuleState = "available" | "installed" | "disabled";
 type SkillTab = "installed" | "available" | "revoked";
-// Shelf sort keys. The catalogue's real metadata is marketplace.json's
-// name / author / licence (the SKILL.md frontmatter vocabulary carries
-// nothing beyond it — surveyed upstream), so those are the facets.
-type ShelfSort = "name" | "author" | "licence";
 
 // "disabled" in the substrate (InstalledModule.enabled === false) is the
 // user-facing "Revoked" state per blueprint §7: a skill that was
@@ -211,12 +212,13 @@ export function ModulesCatalog() {
     return counts;
   }, [installed, modules]);
 
-  // Schedule B shelf controls — client-side search, facets, and sort
-  // over the open catalogue, in the importer's filter idiom.
+  // Schedule B shelf controls — client-side search + facets over the
+  // open catalogue, in the importer's filter idiom. Ordering comes from
+  // the shared grouping (skillDisplay.ts): quiet what-they-do sections,
+  // alphabetical by display name inside each.
   const [shelfQuery, setShelfQuery] = useState("");
   const [shelfLicense, setShelfLicense] = useState("");
   const [shelfAuthor, setShelfAuthor] = useState("");
-  const [shelfSort, setShelfSort] = useState<ShelfSort>("name");
 
   const shelfLicenses = useMemo(
     () =>
@@ -230,27 +232,21 @@ export function ModulesCatalog() {
   );
   const shelf = useMemo(() => {
     const term = shelfQuery.trim().toLowerCase();
-    const rows = (lawve ?? []).filter((s) => {
+    return (lawve ?? []).filter((s) => {
       if (shelfLicense && s.license !== shelfLicense) return false;
       if (shelfAuthor && s.author_name !== shelfAuthor) return false;
       if (!term) return true;
       return (
         s.name.toLowerCase().includes(term) ||
+        skillDisplayName(s.slug, s.author_name).toLowerCase().includes(term) ||
         s.description.toLowerCase().includes(term) ||
         (s.author_name ?? "").toLowerCase().includes(term) ||
         (s.license ?? "").toLowerCase().includes(term)
       );
     });
-    const key = (s: LawveSkillRow) =>
-      shelfSort === "author"
-        ? (s.author_name ?? "")
-        : shelfSort === "licence"
-          ? (s.license ?? "")
-          : s.name;
-    return rows.sort(
-      (a, b) => key(a).localeCompare(key(b)) || a.name.localeCompare(b.name),
-    );
-  }, [lawve, shelfQuery, shelfLicense, shelfAuthor, shelfSort]);
+  }, [lawve, shelfQuery, shelfLicense, shelfAuthor]);
+  // A group with no surviving rows disappears with its header.
+  const shelfGroups = useMemo(() => groupSkills(shelf), [shelf]);
 
   // Default to Added if anything is already trusted, otherwise show
   // Available so a fresh workspace lands on the discovery view.
@@ -269,7 +265,7 @@ export function ModulesCatalog() {
         whisper="Browse and add skills"
         description={
           authed
-            ? "Browse skills and add them to your workspace. A skill is a piece of legal work — review an NDA, screen a dismissal, draft a letter. Once added, enable it on a matter and run it from Chat. To see the skills you've already added, with their track record, go to Your skills."
+            ? "Browse skills and add them to your workspace. A skill is a piece of legal work — review an NDA, screen a dismissal, draft a letter. Once added, enable it on a matter and run it from Chat. To see the skills you've already added, with their track record, go to My skills."
             : "Legal skills are small pieces of legal work: review an NDA, test a claim, draft a letter, check authorities. Browse the library, then open the demo to see one run against a matter."
         }
         actions={
@@ -292,7 +288,7 @@ export function ModulesCatalog() {
                   to="/register"
                   className="inline-flex items-center px-2 py-2 text-sm text-muted hover:text-seal"
                 >
-                  Your skills →
+                  My skills →
                 </Link>
               </>
             ) : (
@@ -347,18 +343,6 @@ export function ModulesCatalog() {
           />
         </div>
 
-        <p className="mt-6 text-sm text-muted">
-          Looking for more?{" "}
-          <a
-            href="https://lawve.ai"
-            target="_blank"
-            rel="noreferrer"
-            className="text-ink underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
-            data-testid="lawve-link"
-          >
-            Browse community skills on Lawve →
-          </a>
-        </p>
       </section>
 
       {!authed && (
@@ -405,7 +389,11 @@ export function ModulesCatalog() {
                         ? // Lawve draft ids are "lawve.{slug}"; the importer
                           // deep-link takes the bare slug.
                           `/skills/lawve?skill=${encodeURIComponent(r.module_id.replace(/^lawve\./, ""))}`
-                        : "/skills/lawve"
+                        : r.source?.startsWith("github") && r.source_url
+                          ? // GitHub-sourced requests carry their repo URL;
+                            // the importer auto-fetches it on mount.
+                            `/skills/lawve?github=${encodeURIComponent(r.source_url)}`
+                          : "/skills/lawve"
                     }
                     className="text-sm text-muted hover:text-seal"
                   >
@@ -430,8 +418,10 @@ export function ModulesCatalog() {
 
       {/* Primary: reference skills (v2 registry).
           §7 tab structure: Added / Available / Revoked
-          (Revoked is operator-only). */}
-      {authed && (
+          (Revoked is operator-only). Hidden entirely when the registry
+          is empty — hosted has no filesystem reference modules, and an
+          empty schedule is noise, not information. */}
+      {authed && modules !== null && modules.length > 0 && (
       <section>
         <SectionRule
           label="Workspace skills"
@@ -484,13 +474,7 @@ export function ModulesCatalog() {
             )}
           </div>
         )}
-        {modules === null ? (
-          <p className="mt-3 text-sm text-muted">Loading skills…</p>
-        ) : modules.length === 0 ? (
-          <p className="mt-3 text-sm text-muted">
-            No reference skills in the registry yet.
-          </p>
-        ) : filteredModules?.length === 0 ? (
+        {filteredModules?.length === 0 ? (
           <p className="mt-3 text-sm text-muted">
             {tab === "installed"
               ? "No skills added to this workspace yet. Switch to Available to browse the registry."
@@ -587,6 +571,50 @@ export function ModulesCatalog() {
               )
             }
           />
+          {/* Where skills come from — the three admission routes, then
+              the review rule. A labelled row, not a hero. */}
+          <p className="mt-4 text-[10px] uppercase tracking-[0.18em] text-muted">
+            Where skills come from
+          </p>
+          <div
+            className="mt-2 grid gap-px border border-rule bg-rule sm:grid-cols-3"
+            data-testid="skill-sources"
+          >
+            <SourceRoute
+              name={
+                <a
+                  href="https://lawve.ai"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                  data-testid="lawve-link"
+                >
+                  Lawve
+                </a>
+              }
+              body="The community catalogue of legal skills."
+            />
+            <SourceRoute
+              name="Any public GitHub repo"
+              body="A SKILL.md at the repo root, pinned to the exact commit on import."
+            />
+            <SourceRoute
+              name={
+                <Link
+                  to="/skills/create"
+                  className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                >
+                  Write your own
+                </Link>
+              }
+              body="Author a skill for this workspace from scratch."
+            />
+          </div>
+          <p className="mt-2 text-[11px] text-muted">
+            Every skill, whatever the source, goes through review and
+            admission before it can run — nothing runs on import.
+          </p>
+
           {lawve == null ? (
             <p className="mt-3 text-sm text-muted">Loading catalogue…</p>
           ) : lawve.length === 0 ? (
@@ -595,7 +623,11 @@ export function ModulesCatalog() {
             </p>
           ) : (
             <>
-              {/* Shelf controls — search, licence/author facets, sort.
+              <p className="mt-5 text-sm text-prose" data-testid="shelf-lede">
+                We've already pulled the Lawve catalogue — {lawve.length}{" "}
+                skills to choose from below.
+              </p>
+              {/* Shelf controls — search + licence/author facets.
                   Facets are the catalogue's real metadata (the upstream
                   SKILL.md frontmatter carries nothing beyond name /
                   description / author / licence / version). */}
@@ -632,17 +664,6 @@ export function ModulesCatalog() {
                     <option key={a} value={a}>{a}</option>
                   ))}
                 </select>
-                <select
-                  value={shelfSort}
-                  onChange={(e) => setShelfSort(e.target.value as ShelfSort)}
-                  className="rounded-md border border-rule bg-paper px-2 py-1 text-ink"
-                  aria-label="Sort catalogue"
-                  data-testid="shelf-sort"
-                >
-                  <option value="name">sort: name</option>
-                  <option value="author">sort: author</option>
-                  <option value="licence">sort: licence</option>
-                </select>
                 <span className="text-muted" data-testid="shelf-count">
                   {shelf.length} of {lawve.length}
                 </span>
@@ -653,39 +674,77 @@ export function ModulesCatalog() {
                     No catalogue skills match that filter.
                   </p>
                 ) : (
-                  shelf.map((s, i) => (
-                    <LedgerLine
-                      key={s.slug}
-                      index={i + 1}
-                      label={s.license ?? "licence ?"}
-                      right={
-                        <span className="flex items-baseline gap-4">
-                          {s.lawve_url && (
-                            <a
-                              href={s.lawve_url}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="hidden text-[12px] text-muted hover:text-seal sm:inline"
-                              data-testid={`shelf-lawve-link-${s.slug}`}
+                  (() => {
+                    // Continuous ledger numbering across the groups.
+                    let n = 0;
+                    return shelfGroups.map((group) => (
+                      <div key={group.id} data-testid={`shelf-group-${group.id}`}>
+                        <div className="mt-6 flex items-baseline justify-between border-b border-rule pb-1.5">
+                          <h3 className="text-[10px] uppercase tracking-[0.18em] text-muted">
+                            {group.label}
+                          </h3>
+                          <span className="tech-token text-[11px] text-muted">
+                            {group.skills.length}
+                          </span>
+                        </div>
+                        {group.note && (
+                          <p className="mt-1.5 text-[11px] text-muted">
+                            {group.note}
+                          </p>
+                        )}
+                        {group.skills.map((s) => {
+                          n += 1;
+                          return (
+                            <LedgerLine
+                              key={s.slug}
+                              index={n}
+                              label={licenceLabel(s.license)}
+                              right={
+                                <span className="flex items-baseline gap-4">
+                                  {s.lawve_url && (
+                                    <a
+                                      href={s.lawve_url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      className="hidden text-[12px] text-muted hover:text-seal sm:inline"
+                                      data-testid={`shelf-lawve-link-${s.slug}`}
+                                    >
+                                      View on Lawve →
+                                    </a>
+                                  )}
+                                  <a
+                                    href={`/skills/lawve?skill=${encodeURIComponent(s.slug)}`}
+                                    className="text-sm text-muted hover:text-seal"
+                                  >
+                                    Review &amp; add →
+                                  </a>
+                                </span>
+                              }
                             >
-                              View on Lawve →
-                            </a>
-                          )}
-                          <a
-                            href={`/skills/lawve?skill=${encodeURIComponent(s.slug)}`}
-                            className="text-sm text-muted hover:text-seal"
-                          >
-                            Review &amp; add →
-                          </a>
-                        </span>
-                      }
-                    >
-                      <span className="text-ink">{s.name}</span>
-                      <span className="ml-2 hidden text-[12px] text-muted sm:inline">
-                        {s.author_name ?? "unknown"}
-                      </span>
-                    </LedgerLine>
-                  ))
+                              <span className="block min-w-0">
+                                <span className="text-ink">
+                                  {skillDisplayName(s.slug, s.author_name)}
+                                </span>
+                                <span className="ml-2 hidden text-[11px] text-muted sm:inline">
+                                  <span className="tech-token">{s.slug}</span>
+                                  {" · "}
+                                  {s.author_name ?? "unknown"}
+                                  {(s.has_scripts || s.script_review_required) && (
+                                    <span className="text-seal">
+                                      {" · ships scripts — manual review"}
+                                    </span>
+                                  )}
+                                </span>
+                                <span className="block truncate text-[12px] text-muted">
+                                  {s.description}
+                                </span>
+                              </span>
+                            </LedgerLine>
+                          );
+                        })}
+                      </div>
+                    ));
+                  })()
                 )}
               </div>
               {/* The honest gap strip — the directory is larger than the
@@ -714,7 +773,7 @@ export function ModulesCatalog() {
           <Colophon>
             Adding a skill takes a few steps: review it, check its
             signature, grant its permissions. After that it shows up in
-            Your skills.
+            My skills.
           </Colophon>
       </section>
     </div>
@@ -737,6 +796,16 @@ function IntroStep({
         <h3 className="text-sm font-semibold text-ink">{title}</h3>
       </div>
       <p className="mt-2 text-sm leading-relaxed text-prose">{body}</p>
+    </div>
+  );
+}
+
+/** One admission route in the "Where skills come from" strip. */
+function SourceRoute({ name, body }: { name: ReactNode; body: string }) {
+  return (
+    <div className="bg-paper p-4">
+      <h3 className="text-sm font-semibold text-ink">{name}</h3>
+      <p className="mt-1 text-[12px] leading-relaxed text-muted">{body}</p>
     </div>
   );
 }

--- a/frontend/src/modules-v2/RequestSkillButton.tsx
+++ b/frontend/src/modules-v2/RequestSkillButton.tsx
@@ -14,9 +14,13 @@ type RequestState = "idle" | "sending" | "done" | "error";
 export function RequestSkillButton({
   moduleId,
   source,
+  sourceUrl,
 }: {
   moduleId: string;
   source?: string;
+  /** Where the skill lives (e.g. GitHub repo URL) so the admin's
+   * Review-&-add link can re-open the exact source. */
+  sourceUrl?: string;
 }) {
   const [state, setState] = useState<RequestState>("idle");
   const [err, setErr] = useState<string | null>(null);
@@ -33,7 +37,7 @@ export function RequestSkillButton({
     setErr(null);
     setState("sending");
     try {
-      await requestModule(moduleId, source);
+      await requestModule(moduleId, source, sourceUrl);
       setState("done");
     } catch (e) {
       setErr(String(e));

--- a/frontend/src/modules-v2/skillDisplay.test.ts
+++ b/frontend/src/modules-v2/skillDisplay.test.ts
@@ -1,0 +1,142 @@
+/**
+ * skillDisplay — shared catalogue legibility helpers.
+ *
+ * Display names strip the author suffix and fix known acronyms;
+ * grouping is keyword-derived with French-language skills always
+ * collected under the final "French law (FR)" section.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  groupSkills,
+  licenceLabel,
+  skillCategory,
+  skillDisplayName,
+} from "./skillDisplay";
+
+function skill(slug: string, description: string, author: string | null) {
+  return { slug, description, author_name: author };
+}
+
+describe("skillDisplayName", () => {
+  it("strips the author suffix and spaces the hyphens", () => {
+    expect(skillDisplayName("nda-review-jamie-tso", "Jamie Tso")).toBe(
+      "NDA review",
+    );
+    expect(skillDisplayName("docx-processing-anthropic", "Anthropic")).toBe(
+      "Docx processing",
+    );
+  });
+
+  it("strips partial author suffixes with folded diacritics", () => {
+    // Author "Rafał Stanisław Fryc" → slug tail is only "-rafal-fryc".
+    expect(
+      skillDisplayName("statute-analysis-rafal-fryc", "Rafał Stanisław Fryc"),
+    ).toBe("Statute analysis");
+    expect(
+      skillDisplayName("legal-risk-assessment-zacharie-laik", "Zacharie Laïk"),
+    ).toBe("Legal risk assessment");
+  });
+
+  it("uppercases known acronyms anywhere in the name", () => {
+    expect(
+      skillDisplayName(
+        "gdpr-privacy-notice-eu-oliver-schmidt-prietz",
+        "Oliver Schmidt-Prietz",
+      ),
+    ).toBe("GDPR privacy notice EU");
+    expect(
+      skillDisplayName("dpia-sentinel-oliver-schmidt-prietz", "Oliver Schmidt-Prietz"),
+    ).toBe("DPIA sentinel");
+  });
+
+  it("never strips the whole slug and survives a null author", () => {
+    expect(skillDisplayName("anthropic", "Anthropic")).toBe("Anthropic");
+    expect(skillDisplayName("contract-review", null)).toBe("Contract review");
+  });
+});
+
+describe("skillCategory", () => {
+  it("routes by slug + description keywords", () => {
+    expect(
+      skillCategory(skill("nda-review-jamie-tso", "Guide for reviewing NDAs", "Jamie Tso")),
+    ).toBe("contracts");
+    expect(
+      skillCategory(skill("docx-processing-anthropic", "Document creation and editing", "Anthropic")),
+    ).toBe("documents");
+    expect(
+      skillCategory(
+        skill("compliance-anthropic", "Navigate privacy regulations (GDPR, CCPA)", "Anthropic"),
+      ),
+    ).toBe("privacy");
+    expect(
+      skillCategory(skill("statute-analysis-rafal-fryc", "Applying US statutes", "Rafał Fryc")),
+    ).toBe("disputes");
+    expect(
+      skillCategory(
+        skill("legal-risk-assessment-anthropic", "Assess and classify legal risks", "Anthropic"),
+      ),
+    ).toBe("research");
+    expect(
+      skillCategory(skill("skill-creator-anthropic", "Guide for creating skills", "Anthropic")),
+    ).toBe("practice");
+  });
+
+  it("keeps GDPR drafting skills under privacy even when the description mentions .docx", () => {
+    expect(
+      skillCategory(
+        skill(
+          "gdpr-privacy-notice-eu-oliver-schmidt-prietz",
+          "Draft GDPR-compliant privacy notices as .docx for any EU/EEA jurisdiction",
+          "Oliver Schmidt-Prietz",
+        ),
+      ),
+    ).toBe("privacy");
+  });
+
+  it("collects French-language skills regardless of topic", () => {
+    expect(
+      skillCategory(
+        skill(
+          "politique-confidentialite-malik-taiar",
+          "Guide pour la rédaction de politiques de confidentialité",
+          "Malik Taiar",
+        ),
+      ),
+    ).toBe("french");
+    expect(
+      skillCategory(
+        skill(
+          "notification-licenciement-selim-brihi",
+          "Guide pour la rédaction de notifications de licenciement",
+          "Sélim Brihi",
+        ),
+      ),
+    ).toBe("french");
+  });
+});
+
+describe("groupSkills", () => {
+  it("orders groups with French law last, drops empty groups, sorts by display name", () => {
+    const groups = groupSkills([
+      skill("politique-cookies-malik-taiar", "Guide pour la rédaction de politiques cookies", "Malik Taiar"),
+      skill("vendor-due-diligence-patrick-munro", "Framework for assessing IT vendors", "Patrick Munro"),
+      skill("nda-triage-anthropic", "Screen incoming NDAs", "Anthropic"),
+    ]);
+    expect(groups.map((g) => g.id)).toEqual(["contracts", "french"]);
+    expect(groups[0].skills.map((s) => s.slug)).toEqual([
+      "nda-triage-anthropic",
+      "vendor-due-diligence-patrick-munro",
+    ]);
+    // The French section carries the England & Wales note.
+    expect(groups[1].note).toMatch(/England & Wales/);
+  });
+});
+
+describe("licenceLabel", () => {
+  it("is honest about missing licences", () => {
+    expect(licenceLabel("Apache-2.0")).toBe("Apache-2.0");
+    expect(licenceLabel(null)).toBe("unlicensed — check source");
+  });
+});

--- a/frontend/src/modules-v2/skillDisplay.ts
+++ b/frontend/src/modules-v2/skillDisplay.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared display helpers for the external skill catalogue — used by the
+ * Skill library shelf (ModulesCatalog) and the importer picker
+ * (LawveImport) so both render the same names and groupings.
+ *
+ * The catalogue rows carry raw slugs like "nda-review-jamie-tso"; the
+ * legible name is derived client-side (strip the author suffix, space
+ * the hyphens, fix known acronyms). Grouping is keyword-derived from
+ * slug + description — a reading aid, not a taxonomy of record.
+ */
+
+export interface SkillLike {
+  slug: string;
+  description: string;
+  author_name: string | null;
+}
+
+// Acronyms restored to caps after sentence-casing.
+const ACRONYMS = new Set(["NDA", "GDPR", "DPIA", "CPR", "EU", "AI", "PDF"]);
+
+/** Slug-safe tokens of the author name (diacritics folded), so
+ * "Rafał Stanisław Fryc" strips "-rafal-fryc" from a slug tail. */
+function authorTokens(authorName: string | null): Set<string> {
+  if (!authorName) return new Set();
+  return new Set(
+    authorName
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      // Stroked letters don't decompose under NFD (\u0142 \u219b l + mark).
+      .replace(/\u0142/gi, "l")
+      .replace(/\u00f8/gi, "o")
+      .replace(/\u0111/gi, "d")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+}
+
+/** "nda-review-jamie-tso" → "NDA review"; "docx-processing-anthropic"
+ * → "Docx processing". Keeps at least one token. */
+export function skillDisplayName(slug: string, authorName: string | null): string {
+  const author = authorTokens(authorName);
+  const tokens = slug.split("-").filter(Boolean);
+  while (tokens.length > 1 && author.has(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+  const words = tokens.map((t, i) => {
+    const upper = t.toUpperCase();
+    if (ACRONYMS.has(upper)) return upper;
+    if (i === 0) return t.charAt(0).toUpperCase() + t.slice(1);
+    return t;
+  });
+  return words.join(" ");
+}
+
+export type SkillCategoryId =
+  | "contracts"
+  | "documents"
+  | "privacy"
+  | "disputes"
+  | "research"
+  | "practice"
+  | "french";
+
+export interface SkillCategory {
+  id: SkillCategoryId;
+  label: string;
+  /** One-line note rendered under the group header, if any. */
+  note?: string;
+}
+
+/** Display order. French law is deliberately last so England & Wales
+ * skills lead the page. */
+export const SKILL_CATEGORIES: SkillCategory[] = [
+  { id: "contracts", label: "Contracts & NDAs" },
+  { id: "documents", label: "Documents & drafting" },
+  { id: "privacy", label: "Privacy & data" },
+  { id: "disputes", label: "Disputes & litigation" },
+  { id: "research", label: "Research & analysis" },
+  { id: "practice", label: "Practice & workflow" },
+  {
+    id: "french",
+    label: "French law (FR)",
+    note:
+      "Legalise's workspace is England & Wales — imported skills run under the same review either way.",
+  },
+];
+
+// French-language skills group together regardless of topic.
+const FRENCH_SLUG = /(assignation|politique|requete|licenciement|lanceur-alerte|confidentialite|cph|refere)/;
+const FRENCH_DESCRIPTION = /(guide pour|rédaction|conformes? (?:au|à)|droit du travail)/i;
+
+// Topical rules, checked in this order (privacy and disputes before
+// documents, so "Draft GDPR privacy notices as .docx" lands under
+// Privacy & data rather than Documents & drafting).
+const TOPIC_RULES: Array<{ id: SkillCategoryId; pattern: RegExp }> = [
+  { id: "contracts", pattern: /\bnda\b|\bcontract|\bnegotiat|\bvendor|\bclause/ },
+  { id: "privacy", pattern: /\bgdpr\b|\bdpia\b|\bprivacy|\bbreach|\bconfidentialite|\bcookie|data protection/ },
+  { id: "disputes", pattern: /\blitigation|\bdisput|\bmotion\b|\bstatute|\bcourt\b|\brefere\b|\bassignation/ },
+  { id: "documents", pattern: /\bdocx\b|\bdocument|\bdraft|\bprocessing\b|\bword\b/ },
+  { id: "research", pattern: /\bresearch|\banalysis\b|\brisk\b|\bbriefing\b|review of law/ },
+];
+
+export function skillCategory(skill: SkillLike): SkillCategoryId {
+  const slug = skill.slug.toLowerCase();
+  const haystack = `${slug} ${skill.description}`.toLowerCase();
+  if (FRENCH_SLUG.test(slug) || FRENCH_DESCRIPTION.test(skill.description)) {
+    return "french";
+  }
+  for (const rule of TOPIC_RULES) {
+    if (rule.pattern.test(haystack)) return rule.id;
+  }
+  return "practice";
+}
+
+export interface SkillGroup<T extends SkillLike> extends SkillCategory {
+  skills: T[];
+}
+
+/** Group + sort (alphabetical by display name within each group).
+ * Empty groups are dropped, so filters hide a group cleanly. */
+export function groupSkills<T extends SkillLike>(skills: T[]): SkillGroup<T>[] {
+  const byId = new Map<SkillCategoryId, T[]>();
+  for (const s of skills) {
+    const id = skillCategory(s);
+    const bucket = byId.get(id);
+    if (bucket) bucket.push(s);
+    else byId.set(id, [s]);
+  }
+  return SKILL_CATEGORIES.flatMap((cat) => {
+    const bucket = byId.get(cat.id);
+    if (!bucket || bucket.length === 0) return [];
+    bucket.sort((a, b) =>
+      skillDisplayName(a.slug, a.author_name).localeCompare(
+        skillDisplayName(b.slug, b.author_name),
+      ),
+    );
+    return [{ ...cat, skills: bucket }];
+  });
+}
+
+/** Licence chip text — honest when the source declares none. */
+export function licenceLabel(license: string | null): string {
+  return license ?? "unlicensed — check source";
+}


### PR DESCRIPTION
Founder feedback: it wasn't clear skills can come from any source, and the catalogue read like an audit trail — 42 raw slugs, no descriptions, French skills sorted first.

- **Sources strip** at the top of the catalogue: Lawve (linked), any public GitHub repo (SKILL.md, pinned commit), write your own — with the review-before-run line, then "We've already pulled the Lawve catalogue — 42 skills to choose from below."
- **Grouped ledger** replaces the flat list: Contracts & NDAs / Documents & drafting / Privacy & data / Disputes & litigation / Research & analysis / Practice & workflow, French law (FR) last with an E&W note. Display names derived from slugs ("NDA review", "PDF processing"), descriptions finally rendered, "unlicensed — check source" instead of "licence ?", ships-scripts marker. Shared helper `skillDisplay.ts` drives both the library and the importer picker.
- **Naming unified** to Skill library / My skills; empty "Workspace skills 0" section hidden; advice-ceiling dots get a legend + tooltips; removed rows say how to re-import.
- **Bug fix**: admin "Review & add" on GitHub-sourced skill requests dead-ended in the Lawve importer; requests now carry `source_url` and deep-link `?github=<url>` which auto-fetches.

Tests: frontend 353 passing + tsc + build clean; backend request tests 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill catalog and request flows now support source URLs, including deep links to open the exact source again.
  * Skills are shown in grouped sections with clearer names, licence labels, and better source/origin messaging.
  * Added improved labels and tooltips for advice ceiling and skill status details.

* **Bug Fixes**
  * Requests now return the saved source URL consistently in admin listings.
  * Non-admin “Request this skill” actions preserve the full request context.

* **Tests**
  * Added coverage for source URL round-tripping, grouped skill listings, and GitHub deep-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->