### PR TITLE
Plain-English pass on user-facing messages

### DIFF
--- a/backend/app/api/artifacts.py
+++ b/backend/app/api/artifacts.py
@@ -18,6 +18,7 @@ Matter-access predicate: matter owner OR workspace superuser. Uniform
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -35,6 +36,8 @@ from app.core.matter_artifacts import (
 from app.models import Matter, MatterArtifact, User
 from app.models.matter import STATUS_ARCHIVED
 
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -162,19 +165,19 @@ async def read_artifact_endpoint(
                 "error": "legacy_artifact_unavailable",
                 "artifact_id": str(row.id),
                 "message": (
-                    "This artifact predates object storage (or its object "
-                    "is missing) and is no longer retrievable. Its metadata "
-                    "and audit trail remain."
+                    "The file for this output is no longer available. "
+                    "Its details and audit trail remain."
                 ),
             },
         )
     except ValueError as exc:
+        logger.error("artifact %s did not parse as JSON: %s", row.id, exc)
         raise HTTPException(
             status_code=500,
             detail={
                 "error": "artifact_file_corrupt",
                 "artifact_id": str(row.id),
-                "message": f"artifact did not parse as JSON: {exc}",
+                "message": "The file for this output is damaged and can't be opened.",
             },
         ) from exc
 

--- a/backend/app/api/document_routes/assets.py
+++ b/backend/app/api/document_routes/assets.py
@@ -129,7 +129,7 @@ async def get_document_asset(
             502,
             detail={
                 "error": "storage_read_failed",
-                "message": "Failed to read document image.",
+                "message": "This image is no longer available.",
                 "storage_key": key,
                 "backend": exc.backend,
             },

--- a/backend/app/api/document_routes/body_versions.py
+++ b/backend/app/api/document_routes/body_versions.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter
 
 from .common import *  # noqa: F403
+
+logger = logging.getLogger(__name__)
 
 
 router = APIRouter()
@@ -127,7 +131,7 @@ async def post_upload_document_version(
             version_upload=True,
         )
         raise storage_write_http_exception(
-            message="Failed to write document version to object storage.",
+            message="This version could not be saved. Try again.",
             storage_key=obj_key,
             backend=exc.backend,
         ) from exc
@@ -554,11 +558,12 @@ async def get_document_version_pdf(
 
         data = await documents_api._html_to_pdf(html_doc)
     except RuntimeError as exc:
+        logger.error("pdf export failed for document %s: %s", doc.id, exc)
         raise HTTPException(
             502,
             detail={
                 "error": "pdf_export_failed",
-                "message": str(exc),
+                "message": "The PDF could not be generated. Try again in a moment.",
             },
         ) from exc
     filename = _pdf_export_filename(doc.filename, version.version_number)
@@ -637,7 +642,7 @@ async def get_document_version_original(
             502,
             detail={
                 "error": "storage_read_failed",
-                "message": "Failed to read the version original from object storage.",
+                "message": "The file for this version is no longer available.",
                 "storage_key": version.storage_uri,
                 "backend": exc.backend,
             },

--- a/backend/app/api/document_routes/crud.py
+++ b/backend/app/api/document_routes/crud.py
@@ -108,9 +108,9 @@ async def delete_document(
                 "error": "document_storage_delete_failed",
                 "document_id": doc_id_str,
                 "message": (
-                    "Failed to delete document storage objects. The "
-                    "document has NOT been deleted; please retry. If the "
-                    "error persists, contact the operator."
+                    "The document's files could not be deleted, so the "
+                    "document has NOT been removed. Try again; if it keeps "
+                    "failing, contact the operator."
                 ),
             },
         ) from exc

--- a/backend/app/api/document_routes/original_download.py
+++ b/backend/app/api/document_routes/original_download.py
@@ -75,7 +75,7 @@ async def download_generated_docx(
             502,
             detail={
                 "error": "storage_read_failed",
-                "message": "Failed to read generated document from object storage.",
+                "message": "The file for this generated document is no longer available. Generate it again.",
                 "storage_key": storage_uri,
                 "backend": exc.backend,
             },
@@ -153,7 +153,7 @@ async def get_document_original(
             502,
             detail={
                 "error": "storage_read_failed",
-                "message": "Failed to read the original document from object storage.",
+                "message": "The original file for this document is no longer available.",
                 "storage_key": doc.storage_uri,
                 "backend": exc.backend,
             },

--- a/backend/app/api/exports.py
+++ b/backend/app/api/exports.py
@@ -33,6 +33,7 @@ Registration in app/main.py:
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -56,6 +57,8 @@ from app.models import (
     User,
 )
 from app.models.job import JOB_KIND_EXPORT, JOB_STATUS_SUCCEEDED
+
+logger = logging.getLogger(__name__)
 
 
 router = APIRouter()
@@ -176,16 +179,24 @@ async def download_export(
             detail={
                 "error": "export_not_ready",
                 "status": job.status,
-                "message": "Export job has not completed. Poll the job status endpoint.",
+                "message": "The export isn't ready yet. Try again in a moment.",
             },
         )
 
     result = job.result_payload or {}
     export_key: str | None = result.get("export_key")
     if not export_key:
+        # Internal precision goes to the log; the user just needs a way out.
+        logger.error(
+            "export job %s succeeded but result_payload has no export_key",
+            export_job_id,
+        )
         raise HTTPException(
             500,
-            detail={"error": "export_key_missing", "message": "Export job succeeded but storage key is missing."},
+            detail={
+                "error": "export_key_missing",
+                "message": "The export finished but its file can't be found. Run the export again.",
+            },
         )
 
     # LMF-4: "who downloaded the export bundle" is part of the governance

--- a/backend/app/api/invocations.py
+++ b/backend/app/api/invocations.py
@@ -253,7 +253,8 @@ async def invoke_capability_endpoint(
         raise provider_error_http_exception(
             exc,
             missing_key_message=(
-                "User has not configured an API key for the selected provider."
+                "Add an API key for the selected provider in "
+                "Settings → API Keys, then run the skill again."
             ),
             upstream_shape="generic",
         ) from exc

--- a/backend/app/api/jobs.py
+++ b/backend/app/api/jobs.py
@@ -135,7 +135,7 @@ async def job_events(
             async with factory() as s:
                 row = await s.scalar(select(Job).where(Job.id == job_id))
             if row is None:
-                yield _sse_frame("error", {"message": "job row vanished"})
+                yield _sse_frame("error", {"message": "This job no longer exists."})
                 break
             yield _sse_frame("status", _job_row(row))
             if row.status in terminal:

--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -459,7 +459,7 @@ async def upload_document(
             error_code=exc.error_code,
         )
         raise storage_write_http_exception(
-            message="Failed to write document to object storage.",
+            message="The document could not be saved. Try uploading it again.",
             storage_key=obj_key,
             backend=exc.backend,
         ) from exc

--- a/backend/app/core/exports.py
+++ b/backend/app/core/exports.py
@@ -161,7 +161,7 @@ def _build_readme(
         "",
         "## Limitations",
         "- This is an application-level export, not a certified legal record.",
-        "- Original files / artefacts that predate object storage (or whose object is missing) are listed in metadata but their bytes are not included.",
+        "- Original files or artefacts whose stored bytes are no longer available are listed in metadata but not included.",
     ]
     if unavailable_artifacts:
         lines.append(

--- a/backend/app/core/jobs.py
+++ b/backend/app/core/jobs.py
@@ -287,9 +287,8 @@ async def enqueue_or_mark_failed(session: AsyncSession, job: Job) -> None:
                 "error": "job_enqueue_failed",
                 "job_id": str(job.id),
                 "message": (
-                    "Failed to queue the job for execution. Please try again; "
-                    "the previous attempt has been marked failed and freed your "
-                    "active-job slot."
+                    "The job couldn't be queued. Try again — the failed "
+                    "attempt does not count against your active jobs."
                 ),
             },
         ) from exc

--- a/backend/app/core/model_gateway.py
+++ b/backend/app/core/model_gateway.py
@@ -259,8 +259,8 @@ class ModelGateway:
                 raise PrivilegePaused(f"matter not found for matter_id={matter_id}")
             if PrivilegePosture(posture_row) is PrivilegePosture.C_PAUSED:
                 raise PrivilegePaused(
-                    "Matter privilege posture is C_paused — tool invocation is blocked. "
-                    "Change posture to A_cleared or B_mixed to proceed."
+                    "AI is paused on this matter, so tools cannot run. "
+                    "Resume AI from the matter's Overview to continue."
                 )
 
         result = await tool.handler(
@@ -357,8 +357,8 @@ class ModelGateway:
 
         if effective_posture is PrivilegePosture.C_PAUSED:
             raise PrivilegePaused(
-                "Matter privilege posture is C_paused — LLM calls are blocked. "
-                "Change posture to A_cleared or B_mixed to proceed."
+                "AI is paused on this matter. "
+                "Resume AI from the matter's Overview to continue."
             )
 
         # Runtime capability enforcement: if this call is attributed to a

--- a/backend/app/modules/assistant/pipeline.py
+++ b/backend/app/modules/assistant/pipeline.py
@@ -787,7 +787,7 @@ def _keyless_retrieval_answer(
         "over the matter. Below are the passages most relevant to your "
         f"question — {len(sources)} from {doc_count} {docs}, retrieved from "
         "this matter's own documents. Review them directly, or add a model "
-        "key in Settings to get a written answer."
+        "key in Settings → API Keys to get a written answer."
     )
     top = sources[0]
     return (
@@ -979,15 +979,29 @@ async def _dispatch_assistant_tool(
 def _tool_failure_message(exc: Exception) -> str:
     if isinstance(exc, CapabilityDenied):
         return (
-            "I couldn't run that skill because this matter does not grant "
-            f"{exc.capability} to {exc.plugin}/{exc.skill}."
+            "I couldn't run that skill: this matter doesn't grant it the "
+            "permission it needs. Check Activity for the failed run."
         )
     if isinstance(exc, PostureBlocked):
-        return "I couldn't run that skill because the matter posture blocked it."
+        if exc.result.reason == "posture_paused":
+            return (
+                "I couldn't run that skill: AI is paused on this matter. "
+                "Resume AI from the matter's Overview first."
+            )
+        return (
+            "I couldn't run that skill: your role doesn't allow skill "
+            "runs on this matter."
+        )
     if isinstance(exc, Phase1Blocked):
-        return "I couldn't run that skill because a runtime gate blocked it."
+        return (
+            "I couldn't run that skill: a workspace safety check blocked "
+            "it. Check Activity for the failed run."
+        )
     if isinstance(exc, AdviceBoundaryDenied):
-        return "I couldn't run that skill because the advice boundary blocked it."
+        return (
+            "I couldn't run that skill: it goes beyond what this "
+            "workspace may advise on. Check Activity for the failed run."
+        )
     if isinstance(exc, (CapabilityNotDeclared, EntrypointResolutionError, ValueError)):
         return f"I couldn't run that skill: {exc}"
     return "I couldn't run that skill. Check Activity for the failed run."
@@ -1185,8 +1199,8 @@ async def run_assistant_turn(
                 content=(
                     "This matter has reached its configured token budget "
                     f"({used} tokens used of {settings.matter_token_budget}). "
-                    "Raise LEGALISE_MATTER_TOKEN_BUDGET or continue in a new "
-                    "matter."
+                    "Continue in a new matter, or ask whoever runs this "
+                    "workspace to raise LEGALISE_MATTER_TOKEN_BUDGET."
                 ),
                 suggested_actions=[],
                 sources=[],
@@ -1436,9 +1450,9 @@ async def run_assistant_turn(
         # echo as the reply, clearly labelled as the keyless demo path.
         content_out = (
             f"{result.text}\n\n"
-            "Demo model (stub-echo) — this is a deterministic echo, not a "
-            "reasoned answer. Pick a real model in the matter's settings "
-            "to chat about the matter."
+            "Demo model — this echoes your message back; it does not "
+            "reason. Pick a real model in the matter's settings to chat "
+            "about the matter."
         )
         actions = []
         tool_calls = []

--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -115,8 +115,8 @@ class AnthropicProvider:
                 code="provider_truncated",
                 upstream_status=None,
                 message=(
-                    "anthropic: response truncated at the output limit — "
-                    "try a narrower question"
+                    "The answer was cut off at the model's output limit. "
+                    "Ask a narrower question."
                 ),
             )
 

--- a/backend/tests/test_assistant_pipeline.py
+++ b/backend/tests/test_assistant_pipeline.py
@@ -119,7 +119,10 @@ class _KeylessFakeGateway:
 
 class _PausedFakeGateway:
     async def call(self, **_kw) -> ModelResult:
-        raise PrivilegePaused("Matter privilege posture is C_paused — LLM calls are blocked.")
+        raise PrivilegePaused(
+            "AI is paused on this matter. "
+            "Resume AI from the matter's Overview to continue."
+        )
 
 
 class _Scalars:

--- a/backend/tests/test_provider_upstream_errors.py
+++ b/backend/tests/test_provider_upstream_errors.py
@@ -299,7 +299,7 @@ async def test_anthropic_truncation_raises_provider_truncated() -> None:
             await provider.call("long question")
 
     assert excinfo.value.code == "provider_truncated"
-    assert "truncated at the output limit" in str(excinfo.value)
+    assert "cut off at the model's output limit" in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -55,7 +55,7 @@ export function Settings({ tab }: { tab: SettingsTab }) {
       <PageHeader
         display
         title="Settings"
-        whisper="Your account at the registry"
+        whisper="Your account"
         description="The account holds your profile, your provider keys, and your defaults. Your name appears in audit rows; key changes are themselves recorded."
       />
       <div className="flex flex-col lg:flex-row gap-10">

--- a/frontend/src/matter/InvocationRunner.test.tsx
+++ b/frontend/src/matter/InvocationRunner.test.tsx
@@ -92,7 +92,7 @@ describe("InvocationRunner — happy path", () => {
 });
 
 describe("InvocationRunner — structured failure paths", () => {
-  it("renders posture banner with required role + actor role", async () => {
+  it("renders plain posture-blocked banner", async () => {
     vi.spyOn(api, "invokeCapability").mockRejectedValue(
       new api.PostureBlockedError(
         "posture blocked",
@@ -108,12 +108,15 @@ describe("InvocationRunner — structured failure paths", () => {
     fireEvent.click(runBtn);
 
     await waitFor(() => {
-      expect(screen.getByText(/Privilege gate blocked/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/This run is restricted on this matter/),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByText(/B_mixed/)).toBeInTheDocument();
-    expect(screen.getByText(/qualified_solicitor/)).toBeInTheDocument();
     expect(
-      screen.getByText(/posture_gate\.check\.blocked/),
+      screen.getByText(/Only qualified solicitors can run skills/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/recorded in Activity/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/matter/InvocationRunner.tsx
+++ b/frontend/src/matter/InvocationRunner.tsx
@@ -240,20 +240,24 @@ function ResultPanel({
   }
 
   if (state.kind === "posture_blocked") {
+    const paused =
+      state.err.posture === "C_paused" ||
+      state.err.reason === "posture_paused";
     return (
-      <Banner tone="amber" title="Privilege gate blocked invocation">
+      <Banner
+        tone="amber"
+        title={
+          paused
+            ? "AI is paused on this matter"
+            : "This run is restricted on this matter"
+        }
+      >
         <p>
-          This matter's privilege state (
-          <code className="tech-token text-xs">{state.err.posture}</code>)
-          requires role{" "}
-          <code className="tech-token text-xs">{state.err.requiredRole}</code>.
-          Your role is{" "}
-          <code className="tech-token text-xs">{state.err.actorRole}</code>.
+          {paused
+            ? "No skills can run while the matter is paused. Resume AI from the Overview tab, then run again."
+            : "Only qualified solicitors can run skills on this matter, and your role doesn't include that."}
         </p>
-        <p className="mt-1 text-xs">
-          Audit row:{" "}
-          <code className="tech-token">posture_gate.check.blocked</code>.
-        </p>
+        <p className="mt-1 text-xs">This refusal is recorded in Activity.</p>
       </Banner>
     );
   }

--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -202,7 +202,7 @@ export function MatterSkillsTab({ slug }: Props) {
           ))}
           {runnableSkills.length === 0 && enabledModules.length === 0 && (
             <p className="text-sm text-muted">
-              No skills hold standing in this matter yet.
+              No skills are enabled in this matter yet. Enable one from the list below.
             </p>
           )}
         </div>
@@ -216,7 +216,7 @@ export function MatterSkillsTab({ slug }: Props) {
         />
         {availableModules.length === 0 ? (
           <p className="mt-3 text-sm text-muted" data-testid="available-empty">
-            Nothing awaits enablement here. Skills trusted in the workspace
+            Nothing to enable yet. Skills trusted in the workspace
             appear in this section.{" "}
             <Link
               to="/skills"


### PR DESCRIPTION
Orwell pass over every message a user can see, with one rule: register vocabulary is allowed where the user is *reading* (ceremony, My skills, audit — untouched) and banned where the user is *stuck* (errors, settings, nudges). Every error now says what happened + what to do next, in the UI's own words.

Highlights (full before→after table in the review notes):
- Posture errors no longer leak enums: "Matter privilege posture is C_paused — … Change posture to A_cleared or B_mixed" → "AI is paused on this matter. Resume AI from the matter's Overview to continue."
- Storage/export plumbing talk gone: "Export job has not completed. Poll the job status endpoint." → "The export isn't ready yet. Try again in a moment." Internal detail (job ids, Gotenberg URLs) moved to logger lines instead of user messages.
- Chat system messages harmonised into one voice; skill-failure replies now name the real reason (paused / role / permission / advice boundary) and point at Activity.
- Frontend stuck-points: Settings whisper "Your account at the registry" → "Your account"; posture-blocked banner rewritten without raw enums; skills-tab empty states plained.
- Left alone on purpose: throttle/limit messages (already good), editor conflict messages, keyless chat replies (only a Settings-pointer harmonised), and every register-voice reading surface.

Tests: backend 919 passed (full suite, container), frontend tsc clean + 353 passed. Pinned message tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages across uploads, downloads, exports, job events, and assistant runs so users get clearer guidance when something can’t be saved, opened, queued, or accessed.
  * Added more specific instructions for missing API keys and paused/restricted AI actions.
  * Updated fallback messages for storage and provider limits to better explain next steps.

* **Style**
  * Refined several empty states and account labels for clearer, more consistent wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->