### PR TITLE
docs: WORM role split is live on prod; correct hash-chain, C_paused and sign-up drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ No background calls. No invisible inference. If it touched the matter, it's logg
 ## Try it
 
 [legalise.dev](https://legalise.dev) hosts a guided demo of the Khan v Acme
-workspace and the architecture write-up. **Hosted evaluator access is by
-request** — open sign-up isn't enabled; email
-[andrew@legalise.dev](mailto:andrew@legalise.dev) for backend access. To run
+workspace and the architecture write-up. **Sign-up is open** — create an
+account at [legalise.dev/auth/join](https://legalise.dev/auth/join) (email
+verification required), or email
+[andrew@legalise.dev](mailto:andrew@legalise.dev) with questions. To run
 the full workspace yourself, fork and run it locally.
 
 Stack: Postgres, MinIO, Redis, Gotenberg, FastAPI, React.

--- a/REGULATORY_PLUMBING.md
+++ b/REGULATORY_PLUMBING.md
@@ -23,7 +23,7 @@ The plumbing in v1 is demonstrative, not certified. It is the shape of what prod
 
 **v1 implementation.** Postgres table + middleware on every FastAPI route + hook in `model_gateway`. Exposed as a matter tab in the UI. Exportable as CSV / JSONL.
 
-**Not in v1.** Hash chain (each entry hashing the previous), tamper evidence, off-site immutable storage. These come in v0.2.
+**Now built.** The hash chain and tamper evidence shipped: every entry is hash-chained through an append-only `audit_chain` table, WORM triggers reject UPDATE and DELETE, and `GET /api/matters/{slug}/audit/chain` recomputes every link (see `docs/TRUST.md` §8). Still open: off-site immutable storage.
 
 ### 2. Privilege posture
 
@@ -39,7 +39,7 @@ The posture flows through the chronology and contract review modules and influen
 
 **v1 implementation.** Matter form has the posture selector. Each module's behaviour is documented in `docs/ARCHITECTURE.md` §4. Posture changes create audit entries.
 
-**Not in v1.** Refusal to start an LLM call where posture/data combination is invalid (currently a soft warning). Hardened in v0.2.
+**Now built.** The hard refusal shipped: a C_paused matter blocks every capability before it runs (`backend/app/core/posture_gate.py`), and the block itself writes an audit row. No longer a soft warning.
 
 ### 3. CPR 31.22 implied undertaking gate
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -166,7 +166,10 @@ out of scope here.
   storage-media compromise, not the key-holder — `encryption.py`.
 - An operator with raw Postgres superuser access could disable the WORM
   trigger; it defends against app bugs and the app role, not a DB superuser.
-  The hardening role split is **not yet flipped on the hosted stack**.
+  The hardening role split **is live on the hosted stack** (flipped 2026-06-30):
+  the app connects as `legalise_app`, which does not own the audit tables and
+  cannot disable the triggers. The residual is the owner/superuser role, held
+  by the deployment operator.
 
 **Deferred**
 - Customer-managed / external KMS keys (no operator key custody) — not in v1
@@ -197,7 +200,7 @@ An index, not the argument — detail and file links are above.
 | Category | Primary control | Where | Residual / Deferred |
 | --- | --- | --- | --- |
 | **S**poofing | Session auth; per-IP auth throttle; prod boot invariants | `rate_limit.py`, `encryption.py` | Proxy-header IP spoofing → throttle bypass only |
-| **T**ampering | WORM trigger on `audit_entries`; hash-linked chain | `0011_audit_worm.py`, `audit_chain.py` | DB superuser can disable trigger; role split not flipped |
+| **T**ampering | WORM trigger on `audit_entries`; hash-linked chain; role split live on hosted stack | `0011_audit_worm.py`, `audit_chain.py`, `infra/postgres-roles.sql` | DB owner/superuser can still disable trigger |
 | **R**epudiation | Hash-chained, append-only, re-verifiable audit; sign-off pins payload hash | `audit_chain.py`, `signoff.py` | A signer can still rubber-stamp (out of scope) |
 | **I**nfo disclosure | Per-user slug scoping (404 not 403); BYO keys encrypted at rest | `matter_access.py`, `encryption.py`, `user_keys.py` | App-code isolation, no DB RLS; operator holds the key |
 | **D**oS | Per-IP rate limiting on auth surface | `rate_limit.py` | No WAF / dedicated DoS protection |
@@ -214,10 +217,10 @@ An index, not the argument — detail and file links are above.
 - **Multi-tenant isolation between organisations.** One deployment is one
   workspace; there is no cross-tenant layer. Do not run multiple untrusting
   organisations on one deployment.
-- **The WORM role split on the hosted stack.** The append-only trigger is
-  live, but the DB role split (separate app vs migration roles,
-  `REVOKE UPDATE, DELETE` on the app role) is a v0.6 runbook and a **no-op on
-  the current single-role Fly + Neon stack** — not flipped on the hosted eval
+- **A hosted DB owner/superuser rewriting history.** The WORM role split is
+  live on the hosted stack (the app connects as `legalise_app`, which cannot
+  disable the audit triggers), but the table-owner role and the Neon platform
+  itself sit above it. Tamper-evident, not tamper-proof
   (`0011_audit_worm.py`, `infra/postgres-roles.sql`).
 - **End-to-end UK data residency.** Backend (Fly `lhr`) and Postgres (Neon
   London) are UK-region, but R2 is EU-placed (Western Europe) and frontier

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -63,10 +63,6 @@ about the hosted environment should see them before the architecture.
   operator can decrypt user keys offline.
 - **Retention is recorded, not enforced.** Every matter has a `retention_until`
   field; nothing sweeps and deletes when that date passes.
-- **Audit WORM role split is exercised in CI, not yet enabled on the hosted
-  deployment.** The append-only trigger and hash chain (§8) are active, so any
-  out-of-band rewrite is detectable; the second-layer role split is asserted in
-  every CI build but not yet switched on for the hosted stack.
 - **Application-layer encryption of stored prompts/responses is not yet
   implemented.** We rely on Neon/Fly/R2 at-rest defaults.
 - **One deployment is one workspace.** No organisation or multi-tenant model in
@@ -202,8 +198,10 @@ integrity: semantic rows commit only when the operation commits.
 Postgres trigger that rejects UPDATE and DELETE on every row whatever the role,
 and a role split (`infra/postgres-roles.sql`) that removes UPDATE/DELETE from the
 application role by grant. The split is exercised in CI on every build (the build
-fails if `legalise_app` can mutate an audit row). Production adoption is a
-connection-string switch, in the operations runbook.
+fails if `legalise_app` can mutate an audit row) and is live on the hosted
+deployment: the app connects as `legalise_app` (role created 2026-06-30), and the
+audit tables are owned by a separate role, so the connect role cannot disable the
+WORM triggers. Last verified against the production database 2026-07-05.
 
 **Third-party verification.** Every row is hash-chained via an append-only
 `audit_chain` table, so the head hash commits to every entry beneath it.
@@ -327,6 +325,7 @@ prefer anonymity.
 | 2026-05-14 | §9 skill provenance added (Git review as approval trail, SHA pinning) |
 | 2026-06-11 | Filesystem plugin path removed; §1/§9 reframed around the import path |
 | 2026-06-12 | Audit WORM trigger-enforced with hash chain; single-workspace scope added; WORM role split now exercised in CI |
+| 2026-07-05 | WORM role split confirmed live on the hosted deployment (flipped 2026-06-30, verified read-only against production); removed from §3 gaps |
 
 This file changes when the architecture changes; `git log docs/TRUST.md` is the
 canonical history.


### PR DESCRIPTION
Docs-only. Settles today's contradiction about production WORM state and fixes three documented drift points.

## Prod WORM state — verified read-only against Neon (2026-07-05)

- App connects as `legalise_app` (5 live connections in `pg_stat_activity`; role created 2026-06-30, matching the flip).
- Audit tables (`audit_entries`, `audit_chain`) owned by `neondb_owner`, not the app role — the connect role cannot `DISABLE TRIGGER`.
- All WORM triggers present and enabled; `legalise_app` has no UPDATE/DELETE grant on `audit_entries` and is not a member of the owner role.

The role split is deployed and real, not cosmetic. Residual risk stays with the owner/superuser role, as the threat model already says.

## Doc fixes

- **REGULATORY_PLUMBING.md**: hash chain + tamper evidence and the hard C_paused refusal were still listed as "not in v1" — both are built and live.
- **README.md**: sign-up is open at /auth/join (shipped Jul 2); "open sign-up isn't enabled" removed.
- **docs/TRUST.md**: role-split gap bullet removed from §3; §8 states the split is live and when it was verified; change-log row added.
- **docs/THREAT_MODEL.md**: three "not flipped on the hosted stack" claims corrected; residual restated as owner/superuser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the hosted demo instructions to say sign-up is open, with email verification required, and clarified how to get help.
  * Revised security and trust documentation to reflect that audit protections are now active on the hosted deployment.
  * Updated threat-model and regulatory notes to describe current audit-chain behavior and paused-item enforcement more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->