### PR TITLE
Gate the skill-install fast path on cryptographic VERIFIED only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,9 @@ them, the runtime enforces them.
   when a module is enabled on a matter; a manifest update that *expands*
   permissions forces a re-ceremony.
 - **The trust ceremony.** Installing a module runs a ceremony whose length
-  depends on signature status: **verified publisher → fast path (3 steps)**;
-  **everything else → full inspection (7 steps)**: inspect manifest → check
+  depends on signature status: **cryptographic `verified` → fast path (3
+  steps)**; **everything else, including `structure_verified` → full
+  inspection (7 steps)**: inspect manifest → check
   signature → check publisher → review permissions → review data movement →
   review gates → explicit trust + grant.
 - **Signing — two real tiers, five outcomes.** `verified` = publisher has a

--- a/backend/app/core/publishers.py
+++ b/backend/app/core/publishers.py
@@ -1,8 +1,10 @@
 """Verified publisher registry.
 
 Modules in the v2 catalogue declare a ``publisher`` string. The trust
-ceremony reads this registry to decide between the verified fast-path
-(3 steps) and the unverified full-inspection path (7 steps).
+ceremony reads this registry when checking signatures. The 3-step
+fast path requires a signature that cryptographically verifies against
+the publisher's registered ed25519 key; registry membership alone (no
+key) only reaches STRUCTURE_VERIFIED and takes the full 7-step path.
 
 Ships a hardcoded in-memory registry. May move to a DB-backed
 config so workspace admins can verify their firm's own publisher id.

--- a/backend/app/core/trust_ceremony.py
+++ b/backend/app/core/trust_ceremony.py
@@ -5,12 +5,15 @@ Per the PHASE_3_BUILD_PLAN plan (repo history) 5 and the
 
 Two install modes:
 
-**Verified publisher fast path** (3 steps):
+**Cryptographically verified fast path** (3 steps) — only when the
+manifest signature verifies against the publisher's registered ed25519
+key (``SignatureStatus.VERIFIED``). Structure-only results never
+qualify:
 1. show publisher
 2. show permission card
 3. enable
 
-**Unverified publisher full path** (7 steps):
+**Full inspection path** (7 steps, everything else):
 1. inspect manifest
 2. verify signature status
 3. show publisher / unknown-publisher warning
@@ -307,9 +310,11 @@ async def start_ceremony(
     sig_result = verify_manifest_signature(manifest, signature=signature)
     card.signature_status = sig_result.status.value
 
+    # Fast path requires real cryptographic provenance. STRUCTURE_VERIFIED
+    # proves shape only — a forged signature of the right shape passes it —
+    # so it takes the full inspection like everything else.
     fast_path = (
-        sig_result.status
-        in (SignatureStatus.VERIFIED, SignatureStatus.STRUCTURE_VERIFIED)
+        sig_result.status is SignatureStatus.VERIFIED
         and card.publisher_verified
     )
 

--- a/backend/tests/test_admin_api.py
+++ b/backend/tests/test_admin_api.py
@@ -369,7 +369,7 @@ async def test_post_promotion_invoke_on_b_mixed_succeeds(
     )
     assert start.status_code == 201
     ceremony_id = start.json()["ceremony_id"]
-    for _ in range(3):
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},

--- a/backend/tests/test_audit_coverage.py
+++ b/backend/tests/test_audit_coverage.py
@@ -442,7 +442,7 @@ async def _install_contract_review(client) -> None:
     )
     assert start.status_code == 201
     ceremony_id = start.json()["ceremony_id"]
-    for _ in range(3):
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},

--- a/backend/tests/test_grants_api.py
+++ b/backend/tests/test_grants_api.py
@@ -104,7 +104,7 @@ async def _install_contract_review(client) -> str:
     )
     assert start.status_code == 201, start.text
     ceremony_id = start.json()["ceremony_id"]
-    for _ in range(3):
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},

--- a/backend/tests/test_grants_lifecycle.py
+++ b/backend/tests/test_grants_lifecycle.py
@@ -337,7 +337,7 @@ async def test_grant_from_publisher_checked_raises(db_session) -> None:
         manifest=_verified_manifest(module_id="legalise.r2-mid"),
         actor_user_id=user.id,
     )
-    # Advance into PUBLISHER_CHECKED on the fast path.
+    # Two advances into the full inspection path.
     await advance_ceremony(
         db_session, ceremony_id=ceremony.id, action="trust", actor_user_id=user.id
     )
@@ -347,7 +347,7 @@ async def test_grant_from_publisher_checked_raises(db_session) -> None:
         action="trust",
         actor_user_id=user.id,
     )
-    # We're now in PERMISSIONS_REVIEWED — grant still not allowed.
+    # Mid-ceremony (signature_checked) — grant still not allowed.
     assert refreshed.state is not CeremonyState.GRANTED
     with pytest.raises(InvalidCeremonyTransition):
         await advance_ceremony(
@@ -401,7 +401,7 @@ async def test_update_rejects_missing_dependency(client) -> None:
     )
     assert install_start.status_code == 201, install_start.text
     ceremony_id = install_start.json()["ceremony_id"]
-    for _ in range(3):
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},
@@ -446,7 +446,7 @@ async def test_repeated_grant_does_not_double_insert(client) -> None:
         json={"source": "manifest", "manifest": manifest},
     )
     ceremony_id = install_start.json()["ceremony_id"]
-    for _ in range(3):
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},

--- a/backend/tests/test_invocations_api.py
+++ b/backend/tests/test_invocations_api.py
@@ -215,7 +215,7 @@ async def _install_contract_review(client) -> None:
     )
     assert start.status_code == 201
     ceremony_id = start.json()["ceremony_id"]
-    for _ in range(3):
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},
@@ -381,8 +381,8 @@ async def test_contract_review_vertical_slice(
     assert install_resp.status_code == 201, install_resp.text
     ceremony_id = install_resp.json()["ceremony_id"]
 
-    # Verified fast path: 3 trusts + 1 grant.
-    for _ in range(3):
+    # Full inspection path (structure-only signature): 6 trusts + 1 grant.
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},

--- a/backend/tests/test_module_install_api.py
+++ b/backend/tests/test_module_install_api.py
@@ -120,7 +120,7 @@ async def _install_via_ceremony(client, manifest) -> str:
     )
     assert start.status_code == 201, start.text
     ceremony_id = start.json()["ceremony_id"]
-    for _ in range(3):
+    for _ in range(6):
         r = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},
@@ -154,8 +154,9 @@ async def test_start_install_requires_admin(client) -> None:
 
 @pytest.mark.asyncio
 async def test_start_install_with_inline_manifest_succeeds(client) -> None:
-    """Superuser can install an inline manifest. Returns CeremonyResponse
-    with fast_path=true (publisher=legalise + signature)."""
+    """Superuser can install an inline manifest. The shape-only
+    signature reaches structure_verified, which never earns the fast
+    path — full inspection applies."""
     clear_ceremonies()
     await _register_admin(client)
     resp = await client.post(
@@ -165,7 +166,8 @@ async def test_start_install_with_inline_manifest_succeeds(client) -> None:
     assert resp.status_code == 201, resp.text
     body = resp.json()
     assert body["module_id"] == "legalise.test-install"
-    assert body["fast_path"] is True
+    assert body["fast_path"] is False
+    assert body["permission_card"]["signature_status"] == "structure_verified"
     assert body["state"] == "discovered"
     assert body["permission_card"]["publisher_verified"] is True
 
@@ -210,8 +212,8 @@ async def test_full_install_ceremony_persists_installed_module(client) -> None:
     assert start_resp.status_code == 201
     ceremony_id = start_resp.json()["ceremony_id"]
 
-    # 2-4. Advance through fast path with action=trust three times.
-    for _ in range(3):
+    # 2-7. Advance through the full inspection path with action=trust.
+    for _ in range(6):
         resp = await client.post(
             f"/api/modules/install/{ceremony_id}/advance",
             json={"action": "trust"},
@@ -243,7 +245,7 @@ async def test_full_install_ceremony_persists_installed_module(client) -> None:
         assert row.publisher == "legalise"
         assert row.enabled is True
         assert row.signature_status == "structure_verified"
-        assert row.verified_at is not None  # fast path took
+        assert row.verified_at is None  # structure-only never earns the fast path
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_trust_ceremony.py
+++ b/backend/tests/test_trust_ceremony.py
@@ -8,10 +8,15 @@ test_migration_discipline.py).
 
 from __future__ import annotations
 
+import json
 import uuid
+from pathlib import Path
 
 import pytest
 from sqlalchemy import select
+
+import app.core.signing as signing
+from scripts.sign_manifest import keygen, sign_manifest
 
 from app.core.trust_ceremony import (
     Ceremony,
@@ -26,7 +31,13 @@ from app.models import AuditEntry, User
 
 
 def _verified_manifest(**overrides) -> dict:
-    """A manifest that should take the verified-publisher fast path."""
+    """First-party manifest with a shape-only signature.
+
+    The publisher is in the registry (``card.publisher_verified`` is
+    True) but the signature is garbage, so it resolves to
+    STRUCTURE_VERIFIED and must take the full inspection path. Only a
+    real ed25519 VERIFIED result earns the fast path.
+    """
     m = {
         "schema_version": "2.0.0",
         "id": "legalise.test-module",
@@ -67,6 +78,27 @@ def _unverified_manifest(**overrides) -> dict:
     m["signed_by"] = None
     m.pop("signature", None)
     return m
+
+
+@pytest.fixture()
+def legalise_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Generate an ed25519 keypair and register the public key for 'legalise'."""
+    key_path = tmp_path / "priv.key"
+    public_b64 = keygen(key_path)
+    monkeypatch.setattr(
+        signing,
+        "publisher_signing_key",
+        lambda publisher_id: public_b64 if publisher_id == "legalise" else None,
+    )
+    return key_path
+
+
+def _signed_manifest(tmp_path: Path, key_path: Path, **overrides) -> dict:
+    """A first-party manifest with a real ed25519 signature — VERIFIED."""
+    manifest = _verified_manifest(**overrides)
+    path = tmp_path / "module.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return sign_manifest(path, key_path)
 
 
 async def _make_user(db_session) -> User:
@@ -144,14 +176,17 @@ def test_highest_tier_picks_max() -> None:
 
 
 @pytest.mark.asyncio
-async def test_verified_path_reaches_enabled_in_three_advances(db_session) -> None:
+async def test_verified_path_reaches_enabled_in_three_advances(
+    db_session, tmp_path: Path, legalise_key: Path
+) -> None:
     clear_ceremonies()
     user = await _make_user(db_session)
     ceremony = await start_ceremony(
         db_session,
-        manifest=_verified_manifest(),
+        manifest=_signed_manifest(tmp_path, legalise_key),
         actor_user_id=user.id,
     )
+    assert ceremony.permission_card.signature_status == "verified"
     assert ceremony.fast_path is True
     assert ceremony.state is CeremonyState.DISCOVERED
 
@@ -178,6 +213,30 @@ async def test_verified_path_reaches_enabled_in_three_advances(db_session) -> No
         db_session, ceremony_id=ceremony.id, action="grant", actor_user_id=user.id
     )
     assert c4.state is CeremonyState.ENABLED
+
+
+@pytest.mark.asyncio
+async def test_forged_shape_signature_never_gets_fast_path(db_session) -> None:
+    """A garbage signature of the right shape on publisher 'legalise'
+    resolves to structure_verified and must take the full inspection
+    path — impersonating the first-party publisher buys no reduced
+    scrutiny."""
+    clear_ceremonies()
+    user = await _make_user(db_session)
+    ceremony = await start_ceremony(
+        db_session,
+        manifest=_verified_manifest(signature="A" * 16),
+        actor_user_id=user.id,
+    )
+    assert ceremony.permission_card.signature_status == "structure_verified"
+    assert ceremony.fast_path is False
+
+    # First advance lands on INSPECTED — the start of the 7-step walk,
+    # not the fast path's PUBLISHER_CHECKED.
+    c1 = await advance_ceremony(
+        db_session, ceremony_id=ceremony.id, action="trust", actor_user_id=user.id
+    )
+    assert c1.state is CeremonyState.INSPECTED
 
 
 @pytest.mark.asyncio

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,9 +204,13 @@ permissions forces a re-ceremony.
 ### The trust ceremony (manifest signing)
 
 Installing a module runs a trust ceremony
-(`backend/app/core/trust_ceremony.py`): verified publishers take a 3-step
-fast path, everything else the 7-step inspection (manifest → signature →
-publisher → permissions → data movement → gates → trust + grant).
+(`backend/app/core/trust_ceremony.py`): a manifest whose signature
+cryptographically verifies against the publisher's registered ed25519 key
+(`verified`) takes a 3-step fast path; everything else — including
+`structure_verified`, which proves shape only — gets the 7-step inspection
+(manifest → signature → publisher → permissions → data movement → gates →
+trust + grant). Since no publisher has a registered key yet, every install
+today takes the full path.
 
 Signing (`backend/app/core/signing.py`) has two real tiers and five
 outcomes:

--- a/frontend/src/lib/api/modules.ts
+++ b/frontend/src/lib/api/modules.ts
@@ -219,6 +219,17 @@ export interface CeremonyResponse {
 
 export type CeremonyAction = "trust" | "reject" | "grant";
 
+// Display label for a manifest signature status. "structure_verified"
+// proves shape only — no cryptography ran — so it must never render
+// as verified or signed.
+export function signatureStatusLabel(
+  status: string | null | undefined,
+): string {
+  if (!status) return "unknown";
+  if (status === "structure_verified") return "structure checked";
+  return status.replaceAll("_", " ");
+}
+
 export interface StartInstallRequest {
   source: "registry" | "manifest";
   module_id?: string;

--- a/frontend/src/modules-v2/CounselRegister.tsx
+++ b/frontend/src/modules-v2/CounselRegister.tsx
@@ -15,6 +15,7 @@ import { Link } from "@tanstack/react-router";
 import {
   formatReviewDuration,
   listInstalledModules,
+  signatureStatusLabel,
   type InstalledModule,
 } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
@@ -160,11 +161,12 @@ function Certificate({ row, index }: { row: InstalledModule; index: number }) {
   const tier = adviceTier(row);
   const tierIdx = TIERS.indexOf(tier as (typeof TIERS)[number]);
   const src = sourceRef(row);
-  // "verified" = real ed25519 provenance; "structure_verified" = shape-only
-  // check against the publisher registry. Both carry standing on the register.
-  const verified =
-    row.signature_status === "verified" ||
-    row.signature_status === "structure_verified";
+  // "verified" = real ed25519 provenance. "structure_verified" is a
+  // shape-only check: it carries standing on the register but never
+  // the signed seal.
+  const cryptoVerified = row.signature_status === "verified";
+  const checked =
+    cryptoVerified || row.signature_status === "structure_verified";
   const revoked = !row.enabled;
   const admitted = new Date(row.installed_at);
 
@@ -227,8 +229,8 @@ function Certificate({ row, index }: { row: InstalledModule; index: number }) {
       <dl className="mt-3 space-y-1 text-[11px] text-muted">
         <div className="flex justify-between gap-3">
           <dt className="uppercase tracking-[0.18em]">Signature</dt>
-          <dd className={verified ? "text-ink" : ""}>
-            {(row.signature_status ?? "unknown").replaceAll("_", " ")}
+          <dd className={checked ? "text-ink" : ""}>
+            {signatureStatusLabel(row.signature_status)}
           </dd>
         </div>
         <div className="flex justify-between gap-3">
@@ -261,8 +263,8 @@ function Certificate({ row, index }: { row: InstalledModule; index: number }) {
         </p>
       )}
 
-      {/* The seal — only a skill with a verified signature carries it. */}
-      {verified && !revoked && (
+      {/* The seal — only a cryptographically verified signature carries it. */}
+      {cryptoVerified && !revoked && (
         <span
           aria-label="verified signature"
           className="absolute -right-2 -top-2 flex h-12 w-12 rotate-12 items-center justify-center rounded-full border-2 border-seal text-[8px] uppercase tracking-[0.15em] text-seal"

--- a/frontend/src/modules-v2/InstallCeremony.test.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.test.tsx
@@ -149,10 +149,10 @@ describe("InstallCeremony — the scan", () => {
 
     // The ledger shows the real verification results.
     expect(screen.getByTestId("scan-row-signature_checked")).toHaveTextContent(
-      "structure verified",
+      "structure checked",
     );
     expect(screen.getByTestId("scan-row-publisher_checked")).toHaveTextContent(
-      "legalise · verified",
+      "legalise · in publisher registry",
     );
     expect(screen.getByTestId("scan-row-gates_reviewed")).toHaveTextContent(
       "privilege_posture",

--- a/frontend/src/modules-v2/InstallCeremony.tsx
+++ b/frontend/src/modules-v2/InstallCeremony.tsx
@@ -13,7 +13,7 @@
  *   discovered → inspected → signature_checked → publisher_checked
  *     → permissions_reviewed → gates_reviewed → [decision] → granted
  *     → enabled.
- *   Fast path (verified publisher): discovered → publisher_checked
+ *   Fast path (cryptographically verified signature only): discovered → publisher_checked
  *     → permissions_reviewed → [decision] → granted → enabled.
  *   Terminal failures: rejected_by_user / signature_failed /
  *     publisher_blocked / permission_denied / sandbox_profile_missing.
@@ -29,6 +29,7 @@ import {
   advanceCeremony,
   getCeremony,
   InvalidCeremonyTransitionError,
+  signatureStatusLabel,
   type CeremonyPermissionCard,
   type CeremonyResponse,
 } from "../lib/api";
@@ -117,7 +118,7 @@ function entryFor(
       const status = card.signature_status ?? "unknown";
       return {
         label: "Signature",
-        value: status.replaceAll("_", " "),
+        value: signatureStatusLabel(status),
         bad: status === "failed" || status === "invalid",
       };
     }
@@ -125,7 +126,7 @@ function entryFor(
       return {
         label: "Publisher",
         value: `${card.publisher || "unknown"} · ${
-          card.publisher_verified ? "verified" : "community — unverified"
+          card.publisher_verified ? "in publisher registry" : "community — not in registry"
         }`,
       };
     case "permissions_reviewed": {

--- a/frontend/src/modules-v2/ModuleDetail.tsx
+++ b/frontend/src/modules-v2/ModuleDetail.tsx
@@ -31,6 +31,7 @@ import {
   getModuleV2,
   listInstalledModules,
   revokeModuleV2,
+  signatureStatusLabel,
   startInstall,
   updateModuleV2,
   type InstalledModule,
@@ -315,10 +316,9 @@ export function ModuleDetail({ moduleId }: { moduleId: string }) {
                   : "muted"
               }
             >
-              {(installedRow?.signature_status ?? "not yet inspected").replaceAll(
-                "_",
-                " ",
-              )}
+              {installedRow?.signature_status
+                ? signatureStatusLabel(installedRow.signature_status)
+                : "not yet inspected"}
             </LedgerRow>
             {version && <LedgerRow label="Version">v{version}</LedgerRow>}
             {installStatus.kind !== "unknown" && (


### PR DESCRIPTION
Fixes finding F2 from the trust-spine audit.

## The bug

No publisher in the registry has an ed25519 key, so `VERIFIED` is unreachable and every first-party manifest resolves to `STRUCTURE_VERIFIED` — a shape-only check whose own docstring admits a forged signature of the right shape passes. Yet the install ceremony granted its reduced-scrutiny 3-step fast path on `STRUCTURE_VERIFIED`. Net effect: `publisher: "legalise"` + a 16-character garbage signature impersonated the first-party publisher and skipped full inspection.

## The fix

- `start_ceremony` grants `fast_path` only on `SignatureStatus.VERIFIED` (real ed25519 against a registered key). `STRUCTURE_VERIFIED` takes the full 7-step inspection like everything else.
- New test `test_forged_shape_signature_never_gets_fast_path` pins the attack: garbage signature on `publisher: "legalise"` → `structure_verified` → full path.
- The fast-path happy test now earns its name: it mints a keypair, signs the manifest, and reaches real `VERIFIED`.
- Ceremony-walk tests that assumed 3 trusts for structure-only manifests now walk the full 6-trust path.

## Copy sweep

- `structure_verified` renders as "structure checked" everywhere (`signatureStatusLabel` in `lib/api/modules.ts`) — skill library detail, install ceremony, counsel register. Wording only; no page-structure changes.
- The register's "Signed" seal now appears only on a cryptographic `verified` result.
- Ceremony publisher line: "in publisher registry" / "community — not in registry" instead of "verified" / "unverified" (registry membership is not identity verification).
- `docs/ARCHITECTURE.md` and `AGENTS.md` fast-path descriptions updated; both now state that every install takes the full path until a publisher key is registered. `docs/TRUST.md` and the landing architecture page were already honest.

## Deferred

Minting a real first-party keypair is follow-up, not this PR: registering a public key without signing the catalogue would flip first-party manifests from `structure_verified` to `invalid`. It needs the release pipeline to sign manifests (`scripts/sign_manifest.py` already works) and a decision on private-key custody (CI secret or sigstore).

## Tests

- Backend: signing, ceremony, install, grants, invocations, audit-coverage, admin suites — failure profile identical to master baseline on the host runner (pre-existing storage/session-scope env failures only; CI runs in docker).
- Frontend: full vitest 353/353 green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)