### PR TITLE
Provenance grade requires an actual check: verified_at_source only when bytes matched

### DIFF
--- a/backend/app/api/external_packs.py
+++ b/backend/app/api/external_packs.py
@@ -11,8 +11,8 @@ Two endpoints under ``/api/external``:
   artifact, and the ``external.pack.ingested`` audit row carrying the
   hash manifest.
 - ``GET /packs`` — list this user's external packs with their manifest
-  summary (source, counts: verified-at-source vs attested-at-ingest)
-  and sign-off tallies. Feeds the register face.
+  summary (source, counts: verified-at-source / attested-at-ingest /
+  claimed-by-source) and sign-off tallies. Feeds the register face.
 
 Sign-off over pack documents goes through the existing
 ``/api/matters/{slug}/signoffs`` surface — external artifacts carry

--- a/backend/app/core/external_pack.py
+++ b/backend/app/core/external_pack.py
@@ -6,17 +6,25 @@ matter per pack, one WORM artifact per document, sign-off through the
 existing ``core/signoff.py`` path.
 
 The honesty boundary: this workspace did not
-watch the external work happen. There are exactly two grades of hash
+watch the external work happen. There are exactly three grades of hash
 claim, and each document records which one it carries:
 
-- ``verified_at_source`` — the export is a *manifest* whose versions
-  carry ``content_sha256`` computed by the source workspace at write
-  time. The hash predates the export; where the document bytes also
-  travelled, they are re-hashed at ingest and any mismatch is recorded
-  (``hash_mismatch``), never papered over.
-- ``attested_at_ingest`` — the export carried bytes but no source hash,
-  so the sha256 is computed HERE, at ingest. It proves what this
-  workspace received, not what the source workspace held.
+- ``verified_at_source`` — the export manifest carried a
+  ``content_sha256`` computed by the source workspace at write time,
+  the document bytes ALSO travelled, and re-hashing them at ingest
+  matched the claim. This is the only grade granted by an actual
+  check; without the bytes, no verification happened and this grade
+  may not be used.
+- ``attested_at_ingest`` — the export carried bytes; the sha256 is
+  computed HERE, at ingest. It proves what this workspace received,
+  not what the source workspace held. When the manifest also carried
+  a source hash that DISAGREES with the received bytes, the document
+  lands here with ``hash_mismatch=True`` — the failed claim is
+  recorded, never repaired, and the canonical hash is the one this
+  workspace computed over bytes it actually holds.
+- ``claimed_by_source`` — the manifest carried a source hash but no
+  bytes travelled, so there was nothing to check. The hash is
+  preserved verbatim as the source's own unchecked claim.
 
 The provenance trail is the export's own claim, preserved verbatim and
 mapped, never improved.
@@ -90,9 +98,13 @@ AUTHOR_HUMAN = "human"
 AUTHOR_ASSISTANT = "assistant"
 AUTHOR_UNKNOWN = "unknown"
 
-# The two grades of hash claim — the honesty boundary, as data.
+# The three grades of hash claim — the honesty boundary, as data.
+# ``verified_at_source`` requires an actual check: source hash AND
+# travelled bytes AND a match. ``claimed_by_source`` is a source hash
+# with no bytes to check it against — a claim, stated as one.
 HASH_VERIFIED_AT_SOURCE = "verified_at_source"
 HASH_ATTESTED_AT_INGEST = "attested_at_ingest"
+HASH_CLAIMED_BY_SOURCE = "claimed_by_source"
 
 
 @dataclass
@@ -151,22 +163,26 @@ class NormalisedEdit:
 class NormalisedDocument:
     external_id: str | None
     filename: str
-    # Canonical sha256 (hex) for this document's current version. Where
-    # the export manifest carried a source hash, this IS that hash
-    # (``hash_origin=verified_at_source``); otherwise it is computed at
-    # ingest from the bytes the export carried
-    # (``hash_origin=attested_at_ingest``). None when neither existed —
+    # Canonical sha256 (hex) for this document's current version. When
+    # bytes travelled, this is the hash computed at ingest
+    # (``verified_at_source`` when it matched a source claim,
+    # ``attested_at_ingest`` otherwise). When only a source hash
+    # travelled, this is that unchecked claim
+    # (``hash_origin=claimed_by_source``). None when neither existed —
     # recorded as unhashed, never guessed.
     sha256: str | None
     size_bytes: int | None
     current_version: NormalisedVersion | None
-    # verified_at_source | attested_at_ingest | None — WHICH claim the
-    # sha256 makes. Recorded per document; the register face counts it.
+    # verified_at_source | attested_at_ingest | claimed_by_source |
+    # None — WHICH claim the sha256 makes. Recorded per document; the
+    # register face counts it.
     hash_origin: str | None = None
-    # sha256 recomputed at ingest from travelled bytes (when present).
-    # Equal to ``sha256`` for attested-at-ingest documents; for
-    # verified-at-source documents it is the cross-check.
+    # sha256 recomputed at ingest from travelled bytes; None when no
+    # bytes travelled.
     ingest_sha256: str | None = None
+    # The source workspace's own hash claim, verbatim, when the
+    # manifest carried one. None otherwise.
+    source_sha256: str | None = None
     # True when a source hash AND travelled bytes both exist and
     # disagree. Recorded, never repaired.
     hash_mismatch: bool = False
@@ -194,6 +210,7 @@ class NormalisedDocument:
             "sha256": self.sha256,
             "hash_origin": self.hash_origin,
             "ingest_sha256": self.ingest_sha256,
+            "source_sha256": self.source_sha256,
             "hash_mismatch": self.hash_mismatch,
             "size_bytes": self.size_bytes,
             "author": self.author,
@@ -228,6 +245,9 @@ class NormalisedPack:
             ),
             "attested_at_ingest": sum(
                 1 for d in self.documents if d.hash_origin == HASH_ATTESTED_AT_INGEST
+            ),
+            "claimed_by_source": sum(
+                1 for d in self.documents if d.hash_origin == HASH_CLAIMED_BY_SOURCE
             ),
             "unhashed": sum(1 for d in self.documents if d.sha256 is None),
             "hash_mismatches": sum(1 for d in self.documents if d.hash_mismatch),
@@ -295,8 +315,9 @@ class MikeAdapter:
        detected by ``manifest_version``. Documents nest their
        ``versions`` (each carrying the source-computed
        ``content_sha256`` and the ``source`` provenance enum) and
-       ``edits``. Hashes here are *verified at source*: the source
-       workspace hashed the bytes at write time, before any export.
+       ``edits``. A source hash is *verified at source* only when the
+       bytes also travelled and re-hashing them at ingest matched;
+       with no bytes it stays *claimed by source* — unchecked.
     2. **Account export** (``GET /user/export``) — flat ``documents`` /
        ``document_versions`` / ``document_edits`` tables. No source
        hashes; documents are hashed at ingest from travelled bytes,
@@ -365,9 +386,9 @@ class MikeAdapter:
     def _normalise_manifest(
         self, export: dict[str, Any], files: dict[str, bytes]
     ) -> NormalisedPack:
-        """The preferred shape: per-document versions nested, hashes at
-        source (``content_sha256`` computed by the source workspace at
-        write time)."""
+        """The preferred shape: per-document versions nested, each
+        carrying the source workspace's own ``content_sha256`` claim
+        (checked against travelled bytes where present)."""
         docs_raw = export.get("documents")
         if not isinstance(docs_raw, list):
             raise MalformedExport("mike manifest: missing 'documents' list")
@@ -454,18 +475,31 @@ class MikeAdapter:
             hashlib.sha256(data).hexdigest() if data is not None else None
         )
         source_sha256 = current.content_sha256 if current else None
-        if source_sha256:
-            # The manifest carried a hash computed at the source — the
-            # stronger claim. Travelled bytes, when present, cross-check
-            # it; a disagreement is recorded, never repaired.
-            sha256 = source_sha256
-            hash_origin = HASH_VERIFIED_AT_SOURCE
-            hash_mismatch = (
-                ingest_sha256 is not None and ingest_sha256 != source_sha256
-            )
+        if source_sha256 and ingest_sha256 is not None:
+            if ingest_sha256 == source_sha256:
+                # The only path to verified_at_source: the manifest's
+                # claim was re-checked against bytes this workspace
+                # actually received, and they agree.
+                sha256 = source_sha256
+                hash_origin = HASH_VERIFIED_AT_SOURCE
+                hash_mismatch = False
+            else:
+                # The claim failed the check. Recorded, never repaired:
+                # the canonical hash is the one computed here over the
+                # bytes actually held; the failed claim stays on the
+                # record as source_sha256 with hash_mismatch=True.
+                sha256 = ingest_sha256
+                hash_origin = HASH_ATTESTED_AT_INGEST
+                hash_mismatch = True
         elif ingest_sha256 is not None:
             sha256 = ingest_sha256
             hash_origin = HASH_ATTESTED_AT_INGEST
+            hash_mismatch = False
+        elif source_sha256:
+            # Manifest-only: a source hash with no bytes to check it
+            # against. An unchecked claim, graded as one.
+            sha256 = source_sha256
+            hash_origin = HASH_CLAIMED_BY_SOURCE
             hash_mismatch = False
         else:
             sha256 = None
@@ -478,6 +512,7 @@ class MikeAdapter:
             sha256=sha256,
             hash_origin=hash_origin,
             ingest_sha256=ingest_sha256,
+            source_sha256=source_sha256,
             hash_mismatch=hash_mismatch,
             size_bytes=len(data) if data is not None else None,
             current_version=current,
@@ -641,11 +676,14 @@ async def ingest_external_pack(
         "ingested_at": datetime.now(UTC).isoformat(),
         # The honesty boundary, stated in the record itself.
         "attestation": (
-            "Two grades of hash claim, recorded per document: "
-            "verified_at_source (the source workspace hashed the bytes at "
-            "write time; travelled bytes cross-checked where present) and "
-            "attested_at_ingest (hashed here from the bytes the export "
-            "carried). This workspace did not watch the work happen."
+            "Three grades of hash claim, recorded per document: "
+            "verified_at_source (the source's hash was re-checked against "
+            "the bytes the export carried, and matched), attested_at_ingest "
+            "(hashed here from the bytes the export carried; any failed "
+            "source claim is recorded as a hash mismatch, never repaired) "
+            "and claimed_by_source (the source's own hash, no bytes to "
+            "check it against — an unverified claim). This workspace did "
+            "not watch the work happen."
         ),
     }
     manifest = await write_artifact(

--- a/backend/tests/test_external_packs.py
+++ b/backend/tests/test_external_packs.py
@@ -3,9 +3,10 @@
 Covers the honesty boundary end to end with synthetic Mike-shaped
 fixtures (no vendored external code):
 
-- normalisation of the project export *manifest* (hashes at source →
-  ``verified_at_source``, travelled bytes cross-checked, mismatch
-  recorded);
+- normalisation of the project export *manifest* (source hash checked
+  against travelled bytes → ``verified_at_source``; no bytes →
+  ``claimed_by_source``, unchecked; mismatch → ``attested_at_ingest``
+  with the mismatch recorded);
 - normalisation of the flat account export (no source hashes →
   ``attested_at_ingest`` from travelled bytes, ``unhashed`` otherwise);
 - provenance enum mapping (upload / assistant_edit / user_accept /
@@ -33,6 +34,7 @@ from app.core.external_pack import (
     AUTHOR_ASSISTANT,
     AUTHOR_HUMAN,
     HASH_ATTESTED_AT_INGEST,
+    HASH_CLAIMED_BY_SOURCE,
     HASH_VERIFIED_AT_SOURCE,
     MalformedExport,
     UnknownAdapter,
@@ -191,9 +193,10 @@ def docs_zip(entries: dict[str, bytes]) -> bytes:
 # ---------------------------------------------------------------------------
 
 
-def test_manifest_with_source_hashes_is_verified_at_source() -> None:
+def test_manifest_with_checked_source_hashes_is_verified_at_source() -> None:
     # The assistant-edited active version's bytes travel under the
-    # decorated download name; the manifest already carries the hash.
+    # decorated download name; the manifest's hash is re-checked
+    # against them and matches — the only path to verified_at_source.
     pack = normalise_export(
         "mike",
         mike_manifest(with_hashes=True),
@@ -201,42 +204,55 @@ def test_manifest_with_source_hashes_is_verified_at_source() -> None:
     )
     assert len(pack.documents) == 1
     doc = pack.documents[0]
-    assert doc.sha256 == DOC_SHA  # the SOURCE's hash is the record
+    assert doc.sha256 == DOC_SHA
     assert doc.hash_origin == HASH_VERIFIED_AT_SOURCE
-    assert doc.ingest_sha256 == DOC_SHA  # cross-check agreed
+    assert doc.ingest_sha256 == DOC_SHA  # the check that earns the grade
+    assert doc.source_sha256 == DOC_SHA
     assert doc.hash_mismatch is False
     assert doc.author == AUTHOR_ASSISTANT
     assert doc.provenance == "assistant_edit"
     assert pack.counts["verified_at_source"] == 1
     assert pack.counts["attested_at_ingest"] == 0
+    assert pack.counts["claimed_by_source"] == 0
     assert pack.counts["unhashed"] == 0
     assert pack.source_project and pack.source_project["name"] == (
         "Hart v Mercia Logistics"
     )
 
 
-def test_manifest_source_hash_stands_without_travelled_bytes() -> None:
-    # Manifest-only ingest: no ZIP. The source hash still carries the
-    # claim; there is simply no ingest cross-check.
+def test_manifest_only_source_hash_is_claimed_not_verified() -> None:
+    # Manifest-only ingest: no ZIP, so nothing was checked. The source
+    # hash is preserved as a claim and graded as one — an arbitrary
+    # string in the manifest must never mint verified_at_source.
     pack = normalise_export("mike", mike_manifest(with_hashes=True), {})
     doc = pack.documents[0]
     assert doc.sha256 == DOC_SHA
-    assert doc.hash_origin == HASH_VERIFIED_AT_SOURCE
+    assert doc.hash_origin == HASH_CLAIMED_BY_SOURCE
     assert doc.ingest_sha256 is None
+    assert doc.source_sha256 == DOC_SHA
     assert doc.hash_mismatch is False
+    assert pack.counts["verified_at_source"] == 0
+    assert pack.counts["claimed_by_source"] == 1
 
 
 def test_manifest_hash_mismatch_is_recorded_not_repaired() -> None:
+    # Tampered bytes: the source claim fails the check. The document
+    # is NOT verified_at_source — the canonical hash is the one
+    # computed here, the failed claim stays on the record, and the
+    # mismatch is counted.
     pack = normalise_export(
         "mike",
         mike_manifest(with_hashes=True),
         {"settlement [Edited V2].docx": b"tampered bytes"},
     )
     doc = pack.documents[0]
-    assert doc.sha256 == DOC_SHA  # the source claim stays the record
-    assert doc.hash_origin == HASH_VERIFIED_AT_SOURCE
-    assert doc.ingest_sha256 == hashlib.sha256(b"tampered bytes").hexdigest()
+    tampered_sha = hashlib.sha256(b"tampered bytes").hexdigest()
+    assert doc.sha256 == tampered_sha  # what this workspace holds
+    assert doc.hash_origin == HASH_ATTESTED_AT_INGEST
+    assert doc.ingest_sha256 == tampered_sha
+    assert doc.source_sha256 == DOC_SHA  # the failed claim, on record
     assert doc.hash_mismatch is True
+    assert pack.counts["verified_at_source"] == 0
     assert pack.counts["hash_mismatches"] == 1
 
 
@@ -288,6 +304,7 @@ def test_account_export_normalises_with_ingest_hashes_and_unhashed() -> None:
         "edits": 1,
         "verified_at_source": 0,
         "attested_at_ingest": 1,
+        "claimed_by_source": 0,
         "unhashed": 1,
         "hash_mismatches": 0,
     }
@@ -377,6 +394,37 @@ async def test_ingest_manifest_pack_end_to_end(client) -> None:
     assert len(packs) == 1
     assert packs[0]["matter_slug"] == body["matter_slug"]
     assert packs[0]["signoffs"]["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_manifest_only_pack_lands_as_claimed(client) -> None:
+    # No ZIP through the API: every hash is an unchecked claim, and the
+    # response, manifest artifact and audit row must all say so.
+    await _register_and_login(client)
+    resp = await _post_pack(client, mike_manifest(with_hashes=True))
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["counts"]["verified_at_source"] == 0
+    assert body["counts"]["claimed_by_source"] == 1
+    assert body["counts"]["hash_mismatches"] == 0
+
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        matter = await session.scalar(
+            select(Matter).where(Matter.slug == body["matter_slug"])
+        )
+        row = await session.scalar(
+            select(AuditEntry).where(
+                AuditEntry.action == "external.pack.ingested",
+                AuditEntry.matter_id == matter.id,
+            )
+        )
+        assert row is not None
+        manifest = row.payload["hash_manifest"]
+        assert manifest[0]["hash_origin"] == "claimed_by_source"
+        assert row.payload["counts"]["verified_at_source"] == 0
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api/external.ts
+++ b/frontend/src/lib/api/external.ts
@@ -1,8 +1,9 @@
 // External packs — imported read-only matter bundles.
 //
 // An external workspace's export, ingested as a read-only matter and
-// supervised here: per-document hash manifest (verified-at-source vs
-// attested-at-ingest), sign-off through the existing signoffs surface.
+// supervised here: per-document hash manifest (verified-at-source /
+// attested-at-ingest / claimed-by-source), sign-off through the
+// existing signoffs surface.
 
 import { API, apiFetch, jsonOrThrow } from "./_core";
 
@@ -22,7 +23,7 @@ export interface ExternalPack {
   exported_at: string | null;
   ingested_at: string | null;
   // documents / versions / edits / verified_at_source /
-  // attested_at_ingest / unhashed / hash_mismatches
+  // attested_at_ingest / claimed_by_source / unhashed / hash_mismatches
   counts: Record<string, number>;
   manifest_artifact_id: string;
   document_artifact_ids: string[];

--- a/frontend/src/modules-v2/ExternalPacks.test.tsx
+++ b/frontend/src/modules-v2/ExternalPacks.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Supervised exports — the pack certificate states the honesty boundary
- * as counts: verified-at-source vs attested-at-ingest, mismatches in
- * seal, sign-offs tallied.
+ * as counts: verified-at-source / attested-at-ingest / claimed-by-source
+ * (labelled unchecked), mismatches in seal, sign-offs tallied.
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -27,6 +27,7 @@ function pack(overrides: Partial<ExternalPack> = {}): ExternalPack {
       edits: 2,
       verified_at_source: 2,
       attested_at_ingest: 1,
+      claimed_by_source: 0,
       unhashed: 0,
       hash_mismatches: 0,
     },
@@ -53,10 +54,36 @@ describe("PackCertificate", () => {
     expect(screen.getByTestId("pack-doc-count")).toHaveTextContent("3");
     expect(screen.getByTestId("pack-verified-count")).toHaveTextContent("2");
     expect(screen.getByTestId("pack-attested-count")).toHaveTextContent("1");
+    expect(screen.queryByTestId("pack-claimed-count")).not.toBeInTheDocument();
     expect(screen.queryByTestId("pack-mismatch-count")).not.toBeInTheDocument();
     expect(screen.getByTestId("pack-signoffs")).toHaveTextContent("none yet");
     expect(
       screen.getByText("External pack — mike: Hart v Mercia Logistics"),
+    ).toBeInTheDocument();
+  });
+
+  it("labels manifest-only hashes as claimed and unchecked", () => {
+    render(
+      <PackCertificate
+        pack={pack({
+          counts: {
+            documents: 2,
+            versions: 2,
+            edits: 0,
+            verified_at_source: 0,
+            attested_at_ingest: 0,
+            claimed_by_source: 2,
+            unhashed: 0,
+            hash_mismatches: 0,
+          },
+        })}
+        index={0}
+      />,
+    );
+    expect(screen.getByTestId("pack-verified-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("pack-claimed-count")).toHaveTextContent("2");
+    expect(
+      screen.getByText("Claimed by source — unchecked"),
     ).toBeInTheDocument();
   });
 
@@ -68,8 +95,9 @@ describe("PackCertificate", () => {
             documents: 2,
             versions: 2,
             edits: 0,
-            verified_at_source: 2,
-            attested_at_ingest: 0,
+            verified_at_source: 1,
+            attested_at_ingest: 1,
+            claimed_by_source: 0,
             unhashed: 0,
             hash_mismatches: 1,
           },

--- a/frontend/src/modules-v2/ExternalPacks.tsx
+++ b/frontend/src/modules-v2/ExternalPacks.tsx
@@ -4,8 +4,11 @@
  *
  * Each certificate is an external workspace's export held under
  * supervision here: where it came from, how many documents, how each
- * hash claim grades (verified at source vs attested at ingest — the
- * honesty boundary, counted, never blurred), and what has been signed.
+ * hash claim grades (verified at source / attested at ingest /
+ * claimed by source — the honesty boundary, counted, never blurred),
+ * and what has been signed. "Verified" is only ever a hash this
+ * workspace re-checked against received bytes; a manifest-only claim
+ * renders as exactly that, a claim.
  * Rendered in the P27 certificate/ledger idiom from ui/certificate.tsx.
  */
 
@@ -55,9 +58,11 @@ export function ExternalPacksSection() {
         Work done in another workspace, held to account in this one. Each
         pack below is an external export ingested read-only — no model may
         touch it here — with every document's hash claim graded: verified
-        at the source workspace, or attested at ingest from the bytes the
-        export carried. Sign-off runs through the same register as native
-        work.
+        at source (the source's hash, re-checked here against the bytes
+        the export carried), attested at ingest (hashed here from received
+        bytes), or claimed by source (the source's own hash, nothing to
+        check it against). Sign-off runs through the same register as
+        native work.
       </p>
       <div className="mt-8 grid gap-6 sm:grid-cols-2">
         {q.packs.map((pack, i) => (
@@ -118,15 +123,31 @@ export function PackCertificate({
           <span data-testid="pack-doc-count">{c.documents ?? 0}</span>
         </LedgerRow>
         <LedgerRow label="Verified at source" tone="ink">
-          <span data-testid="pack-verified-count">
+          <span
+            data-testid="pack-verified-count"
+            title="Source hash re-checked here against the bytes the export carried — matched"
+          >
             {c.verified_at_source ?? 0}
           </span>
         </LedgerRow>
         <LedgerRow label="Attested at ingest">
-          <span data-testid="pack-attested-count">
+          <span
+            data-testid="pack-attested-count"
+            title="Hashed here from the bytes the export carried"
+          >
             {c.attested_at_ingest ?? 0}
           </span>
         </LedgerRow>
+        {(c.claimed_by_source ?? 0) > 0 && (
+          <LedgerRow label="Claimed by source — unchecked">
+            <span
+              data-testid="pack-claimed-count"
+              title="The source's own hash; no bytes travelled, so nothing was checked"
+            >
+              {c.claimed_by_source}
+            </span>
+          </LedgerRow>
+        )}
         {(c.unhashed ?? 0) > 0 && (
           <LedgerRow label="Unhashed">{c.unhashed}</LedgerRow>
         )}


### PR DESCRIPTION
Trust-spine audit finding F1: the register sidecar granted `verified_at_source` whenever the uploaded manifest carried any `content_sha256` string. The hash was taken verbatim from the JSON and only cross-checked when the optional documents ZIP travelled — so a manifest-only import with arbitrary hashes landed every document as verified, zero mismatches. The grade names inverted real epistemic strength.

## Corrected semantics — three grades

- **`verified_at_source`** — the source's hash was re-checked against the bytes the export carried, and matched. The only path to the word "verified".
- **`attested_at_ingest`** — hashed here from received bytes. A source hash that fails the check lands here with `hash_mismatch=true`; the failed claim is preserved as `source_sha256`, counted, and rendered in seal tone. Recorded, never repaired.
- **`claimed_by_source`** — the source's own hash, no bytes to check it against. Preserved verbatim, labelled "Claimed by source — unchecked" on the register face.

No migration needed: grades live in artifact/audit JSON payloads, not a DB enum. Counts gain a `claimed_by_source` key; document payloads gain `source_sha256`.

## Tests

- Manifest + matching ZIP → `verified_at_source` (the check that earns the grade)
- Manifest-only → `claimed_by_source`, never verified
- Tampered ZIP → `attested_at_ingest` with `hash_mismatch=true`, failed claim kept on record
- End-to-end API ingest of a manifest-only pack: response, manifest artifact and audit row all say "claimed"
- Frontend: claimed row rendered and labelled unchecked; mismatch seal unchanged

Local: `test_external_packs.py` 11/11, signoff + audit-chain suites 21/21, ExternalPacks component tests 3/3, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “claimed by source” status for external pack hashes, alongside existing verified and attested states.
  * External pack details now show clearer labels and tooltips for hash provenance and unchecked source claims.

* **Bug Fixes**
  * Improved hash handling so source-only claims, verified hashes, and mismatches are counted and displayed correctly.
  * Updated pack summaries and certificate views to reflect the new count breakdown accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->