### PR TITLE
Token split, OpenAI truncation, worker liveness

### DIFF
--- a/backend/app/core/model_gateway.py
+++ b/backend/app/core/model_gateway.py
@@ -118,13 +118,19 @@ class ModelResult:
     # that need the provider name read this instead. Optional so existing
     # test fakes constructing ModelResult keep working.
     provider: str | None = None
+    # Input/output token split as reported by the provider. Optional for
+    # the same test-fake reason; `token_count` stays the summed total.
+    tokens_in: int | None = None
+    tokens_out: int | None = None
 
 
 class ModelProvider(Protocol):
     name: str
 
-    async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
-        """Return (response_text, approximate_token_count)."""
+    async def call(
+        self, prompt: str, *, system: str | None = None, **kwargs
+    ) -> tuple[str, int, int]:
+        """Return (response_text, input_token_count, output_token_count)."""
 
 
 class StubProvider:
@@ -134,11 +140,14 @@ class StubProvider:
     def __init__(self, name: str = "stub-echo"):
         self.name = name
 
-    async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
+    async def call(
+        self, prompt: str, *, system: str | None = None, **kwargs
+    ) -> tuple[str, int, int]:
         head = prompt.strip().splitlines()[0][:120] if prompt.strip() else "(empty)"
         text = f"[{self.name}] {head}"
-        tokens = max(1, len(prompt) // 4 + len(text) // 4)
-        return text, tokens
+        tokens_in = max(1, len(prompt) // 4)
+        tokens_out = max(1, len(text) // 4)
+        return text, tokens_in, tokens_out
 
 
 def _sha(s: str) -> str:
@@ -451,7 +460,9 @@ class ModelGateway:
 
         start = time.perf_counter()
         try:
-            response_text, tokens = await provider.call(prompt, system=system, **provider_kwargs)
+            response_text, tokens_in, tokens_out = await provider.call(
+                prompt, system=system, **provider_kwargs
+            )
         except ProviderUpstreamError as exc:
             # Audit provenance is mandatory on failure: a failed model call
             # is just as accountable as a successful one. R3 review: use
@@ -504,9 +515,11 @@ class ModelGateway:
             model_used=served_model,
             prompt_hash=_sha(prompt),
             response_hash=_sha(response_text),
-            token_count=tokens,
+            token_count=tokens_in + tokens_out,
             latency_ms=latency_ms,
             provider=provider.name,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
         )
 
         # Audit the call. Session lifecycle is the caller's responsibility.
@@ -526,6 +539,8 @@ class ModelGateway:
             prompt_hash=result.prompt_hash,
             response_hash=result.response_hash,
             token_count=result.token_count,
+            tokens_in=result.tokens_in,
+            tokens_out=result.tokens_out,
             latency_ms=result.latency_ms,
             payload={
                 "requested_model": requested,

--- a/backend/app/core/runtime.py
+++ b/backend/app/core/runtime.py
@@ -140,13 +140,8 @@ def make_provider_call(
             # result.provider carries the provider name.
             model_id=result.model_used or matter.default_model_id,
             provider=result.provider or result.model_used,
-            tokens_in=result.token_count,
-            # Sentinel — pinned at 0 so the audit row's
-            # token_count = tokens_in + tokens_out stays honestly equal
-            # to the gateway's authoritative combined count. A future
-            # provider-protocol extension can split correctly without
-            # touching modules.
-            tokens_out=0,
+            tokens_in=result.tokens_in,
+            tokens_out=result.tokens_out,
             # The gateway doesn't price calls today; cost_micros +
             # currency stay None together (DB check constraint pairs them).
             cost_micros=None,

--- a/backend/app/modules/assistant/pipeline.py
+++ b/backend/app/modules/assistant/pipeline.py
@@ -922,8 +922,8 @@ def _make_assistant_provider_call(
             text=result.text,
             model_id=result.model_used or matter.default_model_id,
             provider=result.provider or result.model_used,
-            tokens_in=result.token_count,
-            tokens_out=0,
+            tokens_in=result.tokens_in,
+            tokens_out=result.tokens_out,
             cost_micros=None,
             currency=None,
         )

--- a/backend/app/providers/__init__.py
+++ b/backend/app/providers/__init__.py
@@ -4,7 +4,7 @@ Each provider implements `app.core.model_gateway.ModelProvider`:
 
     name: str
     async def call(prompt: str, *, system: str | None = None, **kwargs)
-        -> tuple[str, int]
+        -> tuple[str, int, int]
 
 The `register_providers()` helper inspects environment settings and
 registers every provider that has credentials/URL configured. Called

--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -62,7 +62,9 @@ class AnthropicProvider:
         # when the caller didn't pass one.
         self.default_model = default_model or settings.default_model_id
 
-    async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
+    async def call(
+        self, prompt: str, *, system: str | None = None, **kwargs
+    ) -> tuple[str, int, int]:
         model = kwargs.get("model") or self.default_model
         max_tokens = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
         api_key = kwargs.get("api_key") or self._fallback_key
@@ -128,10 +130,4 @@ class AnthropicProvider:
         text = "".join(text_parts)
 
         usage = message.usage
-        # Summed: the ModelProvider protocol returns one count and the
-        # audit plumbing carries one token_count column. Splitting
-        # input/output ripples through ModelResult, AssistantMessage and
-        # AuditEntry — not worth it for v0.1.
-        tokens = (usage.input_tokens or 0) + (usage.output_tokens or 0)
-
-        return text, tokens
+        return text, usage.input_tokens or 0, usage.output_tokens or 0

--- a/backend/app/providers/ollama_provider.py
+++ b/backend/app/providers/ollama_provider.py
@@ -56,7 +56,9 @@ class OllamaProvider:
         self.default_model = default_model
         self._client = httpx.AsyncClient(timeout=DEFAULT_TIMEOUT_SECONDS)
 
-    async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
+    async def call(
+        self, prompt: str, *, system: str | None = None, **kwargs
+    ) -> tuple[str, int, int]:
         model = kwargs.get("model") or self.default_model
         # Strip an `ollama/` prefix if the caller passed a fully-qualified id.
         if model.startswith("ollama/"):
@@ -104,9 +106,10 @@ class OllamaProvider:
 
         data = response.json()
         text = (data.get("message") or {}).get("content", "")
-        # Ollama returns eval_count for the response tokens; prompt_eval_count for the prompt.
-        tokens = int(data.get("eval_count", 0)) + int(data.get("prompt_eval_count", 0))
-        return text, tokens
+        # Ollama returns prompt_eval_count for the prompt tokens; eval_count for the response.
+        tokens_in = int(data.get("prompt_eval_count", 0))
+        tokens_out = int(data.get("eval_count", 0))
+        return text, tokens_in, tokens_out
 
     async def aclose(self) -> None:
         await self._client.aclose()

--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -51,7 +51,9 @@ class OpenAIProvider:
         # when the caller didn't pass one.
         self.default_model = default_model
 
-    async def call(self, prompt: str, *, system: str | None = None, **kwargs) -> tuple[str, int]:
+    async def call(
+        self, prompt: str, *, system: str | None = None, **kwargs
+    ) -> tuple[str, int, int]:
         model = kwargs.get("model") or self.default_model
         max_tokens = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
         api_key = kwargs.get("api_key") or self._fallback_key
@@ -94,7 +96,29 @@ class OpenAIProvider:
                 message=f"openai: {type(exc).__name__}: {exc}",
             ) from exc
 
-        text = response.choices[0].message.content or ""
+        choice = response.choices[0]
+
+        # A hard stop at the output cap means the response is incomplete —
+        # surfacing the truncation honestly beats handing the caller a
+        # half-written body that fails its JSON-envelope parse downstream.
+        if getattr(choice, "finish_reason", None) == "length":
+            logger.warning(
+                "legalise.provider.openai.truncated",
+                model=model,
+                max_tokens=max_tokens,
+            )
+            raise ProviderUpstreamError(
+                provider="openai",
+                code="provider_truncated",
+                upstream_status=None,
+                message=(
+                    "The answer was cut off at the model's output limit. "
+                    "Ask a narrower question."
+                ),
+            )
+
+        text = choice.message.content or ""
         usage = response.usage
-        tokens = (usage.prompt_tokens + usage.completion_tokens) if usage else 0
-        return text, tokens
+        tokens_in = usage.prompt_tokens if usage else 0
+        tokens_out = usage.completion_tokens if usage else 0
+        return text, tokens_in, tokens_out

--- a/backend/app/tools/doctor.py
+++ b/backend/app/tools/doctor.py
@@ -279,6 +279,55 @@ async def check_redis_reachable() -> CheckResult:
     )
 
 
+async def check_worker_heartbeat() -> CheckResult:
+    """Read the arq worker's health key from Redis.
+
+    The worker writes the key every ``health_check_interval`` seconds
+    (see app.worker.WorkerSettings) and Redis expires it one second
+    after the next write is due, so presence == a live worker and
+    absence == no worker has run recently. The value is arq's own
+    counters line (jobs complete/failed/ongoing, queue depth) — job
+    ids and counts only, never matter content.
+    """
+    try:
+        import redis.asyncio as redis_asyncio
+        from arq.constants import default_queue_name, health_check_key_suffix
+    except ImportError:
+        return CheckResult(
+            "worker.heartbeat",
+            "fail",
+            "redis/arq packages not importable",
+            "rebuild backend image",
+        )
+    key = default_queue_name + health_check_key_suffix
+    client = redis_asyncio.from_url(settings.redis_url)  # type: ignore[no-untyped-call]
+    try:
+        raw = await client.get(key)
+    except Exception as exc:  # noqa: BLE001
+        return CheckResult(
+            "worker.heartbeat",
+            "fail",
+            f"cannot read {key} at {_mask_dsn(settings.redis_url)}: {exc.__class__.__name__}",
+            "is the `redis` service up? `docker compose ps redis`",
+        )
+    finally:
+        try:
+            await client.aclose()
+        except Exception:  # noqa: BLE001
+            pass
+    if raw is None:
+        return CheckResult(
+            "worker.heartbeat",
+            "fail",
+            f"no worker health key at {key} — the arq worker is not running, "
+            "so document indexing and exports will sit queued forever",
+            "start the worker: `docker compose ps worker` locally, or "
+            "`fly scale count worker=1 -a legalise-backend` on Fly",
+        )
+    detail = raw.decode("utf-8", errors="replace") if isinstance(raw, bytes) else str(raw)
+    return CheckResult("worker.heartbeat", "ok", detail)
+
+
 def _build_s3_client():
     import boto3
     from botocore.config import Config
@@ -604,7 +653,10 @@ async def _run_all(*, create_bucket: bool) -> int:
         # Skip downstream DB-needing checks if DB is unreachable.
 
     # Redis (own client).
-    results.append(await check_redis_reachable())
+    redis_ok = await check_redis_reachable()
+    results.append(redis_ok)
+    if redis_ok.status == "ok":
+        results.append(await check_worker_heartbeat())
 
     # S3 endpoint + bucket.
     endpoint = check_s3_endpoint_reachable()

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -294,6 +294,12 @@ class WorkerSettings:
     max_jobs = 10
     job_timeout = 600  # 10 minutes max per pipeline run
     keep_result = 3600  # keep result 1 hour in Redis (id only, not content)
+    # Heartbeat: arq writes a health key to Redis every interval, expiring
+    # after interval + 1s. Doctor's `worker.heartbeat` check reads it, so a
+    # stopped worker (deploy anomaly, manual scale-to-zero) is detectable
+    # instead of jobs sitting queued forever. The key holds job counters
+    # only — no matter content.
+    health_check_interval = 60
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 from app.core.registry.discovery import DiscoveredModule
-from app.tools.doctor import check_manifests_valid
+from app.tools.doctor import check_manifests_valid, check_worker_heartbeat
 
 
 def _bad_v2_payload() -> dict:
@@ -65,3 +65,47 @@ def test_check_manifests_valid_ok_on_empty(monkeypatch):
     )
     result = check_manifests_valid()
     assert result.status == "note"
+
+
+class _FakeRedis:
+    """Stand-in for redis.asyncio client — GET returns the wired value."""
+
+    def __init__(self, value: bytes | None):
+        self._value = value
+        self.requested_key: str | None = None
+
+    async def get(self, key: str) -> bytes | None:
+        self.requested_key = key
+        return self._value
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_worker_heartbeat_ok_when_health_key_present(monkeypatch):
+    fake = _FakeRedis(b"Jul-05 12:00:00 j_complete=3 j_failed=0 j_retried=0 j_ongoing=0 queued=0")
+    monkeypatch.setattr("redis.asyncio.from_url", lambda url: fake)
+
+    result = await check_worker_heartbeat()
+
+    assert result.name == "worker.heartbeat"
+    assert result.status == "ok"
+    assert "j_complete=3" in result.detail
+    # arq's default health key: queue name + suffix.
+    assert fake.requested_key == "arq:queue:health-check"
+
+
+@pytest.mark.asyncio
+async def test_worker_heartbeat_fails_when_health_key_absent(monkeypatch):
+    """No health key means no worker has run within its heartbeat window —
+    queued jobs (indexing, exports) would sit forever. Must be a hard fail."""
+    fake = _FakeRedis(None)
+    monkeypatch.setattr("redis.asyncio.from_url", lambda url: fake)
+
+    result = await check_worker_heartbeat()
+
+    assert result.status == "fail"
+    assert "not running" in result.detail
+    assert result.remediation is not None
+    assert "fly scale count worker=1" in result.remediation

--- a/backend/tests/test_gateway_fallback.py
+++ b/backend/tests/test_gateway_fallback.py
@@ -40,7 +40,7 @@ class _AnthropicStub:
     async def call(self, prompt: str, *, system=None, **kwargs):
         self.last_api_key = kwargs.get("api_key")
         self.last_kwargs = dict(kwargs)
-        return ("ok", 1)
+        return ("ok", 3, 2)
 
 
 class _FakeUserKeyRow:
@@ -175,6 +175,29 @@ async def test_user_key_passed_through_when_present(
             posture=PrivilegePosture.B_MIXED,
         )
     assert stub.last_api_key == "sk-user-key"
+
+
+@pytest.mark.asyncio
+@patch.object(gw_module, "mark_user_key_used")
+@patch.object(gw_module, "get_user_provider_key", return_value="sk-user-key")
+async def test_token_split_carried_on_model_result(
+    _mock_lookup, _mock_mark, gateway, actor_id
+):
+    g, _stub = gateway
+
+    with patch.object(gw_module.settings, "environment", "demo"), \
+         patch.object(gw_module.settings, "allow_server_key_fallback", False):
+        result = await g.call(
+            session=_StubSession(),
+            matter_id=None,
+            actor_id=actor_id,
+            prompt="hi",
+            model="claude-opus-4-7",
+            posture=PrivilegePosture.B_MIXED,
+        )
+    assert result.tokens_in == 3
+    assert result.tokens_out == 2
+    assert result.token_count == 5
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_invocations_api.py
+++ b/backend/tests/test_invocations_api.py
@@ -179,6 +179,8 @@ def stub_gateway_two_findings(monkeypatch):
             token_count=1850,
             latency_ms=120,
             provider="anthropic",
+            tokens_in=1500,
+            tokens_out=350,
         )
 
     monkeypatch.setattr(gateway_singleton, "call", _stub_call)
@@ -504,12 +506,10 @@ async def test_contract_review_vertical_slice(
         assert parsed["findings"][0]["clause_id"] == "5.2"
 
     # ------- (7) confirm model.invoked carries provider/model + tokens -------
-    # Phase 10 adapter mapping (Decision #4 v3):
-    #   tokens_in   = gateway result.token_count (combined)
-    #   tokens_out  = 0 (sentinel; honest until providers split)
+    # Adapter mapping:
+    #   tokens_in / tokens_out = the split reported by the provider
     #   cost_micros = None (gateway doesn't price yet)
     #   currency    = None (paired)
-    # See PHASE_10_INVOKE_ENDPOINT_BUILD_PLAN.md Decision #4.
     async with factory() as session:
         model_row = await session.scalar(
             select(AuditEntry).where(
@@ -520,8 +520,8 @@ async def test_contract_review_vertical_slice(
         assert model_row is not None
         assert model_row.cost_micros is None
         assert model_row.currency is None
-        assert model_row.tokens_in == 1850
-        assert model_row.tokens_out == 0
+        assert model_row.tokens_in == 1500
+        assert model_row.tokens_out == 350
         assert model_row.provider == "anthropic"
         # Matter uses the default model (settings.default_model_id).
         assert model_row.model_id == "claude-sonnet-4-6"

--- a/backend/tests/test_provider_audit_completeness.py
+++ b/backend/tests/test_provider_audit_completeness.py
@@ -89,7 +89,7 @@ class _SucceedingProvider:
     name = "anthropic"
 
     async def call(self, prompt: str, *, system=None, **kwargs):
-        return "ok", 10
+        return "ok", 7, 3
 
 
 class _RaisingProvider:

--- a/backend/tests/test_provider_upstream_errors.py
+++ b/backend/tests/test_provider_upstream_errors.py
@@ -321,8 +321,78 @@ async def test_anthropic_normal_stop_returns_text() -> None:
     with patch(
         "app.providers.anthropic_provider.AsyncAnthropic", return_value=client
     ):
-        text, tokens = await provider.call("question", max_tokens=8192)
+        text, tokens_in, tokens_out = await provider.call("question", max_tokens=8192)
 
     assert text == "complete body"
-    assert tokens == 30
+    assert tokens_in == 10
+    assert tokens_out == 20
     assert client.messages.create.call_args.kwargs["max_tokens"] == 8192
+
+
+# ---------------------------------------------------------------------------
+# OpenAI provider — output-limit truncation surfaces as a structured error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_truncation_raises_provider_truncated() -> None:
+    """finish_reason == "length" means the reply is incomplete — the
+    provider must raise (honest truncation message) rather than hand a
+    half-written body downstream to fail its JSON parse."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.providers.openai_provider import OpenAIProvider
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=SimpleNamespace(content="truncated body…"),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=2048),
+    )
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+
+    provider = OpenAIProvider(api_key="sk-test", default_model="gpt-4o-mini")
+    with patch(
+        "app.providers.openai_provider.AsyncOpenAI", return_value=client
+    ):
+        with pytest.raises(ProviderUpstreamError) as excinfo:
+            await provider.call("long question")
+
+    assert excinfo.value.code == "provider_truncated"
+    assert "cut off at the model's output limit" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_openai_normal_stop_returns_text() -> None:
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.providers.openai_provider import OpenAIProvider
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="complete body"),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20),
+    )
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+
+    provider = OpenAIProvider(api_key="sk-test", default_model="gpt-4o-mini")
+    with patch(
+        "app.providers.openai_provider.AsyncOpenAI", return_value=client
+    ):
+        text, tokens_in, tokens_out = await provider.call("question", max_tokens=8192)
+
+    assert text == "complete body"
+    assert tokens_in == 10
+    assert tokens_out == 20
+    assert client.chat.completions.create.call_args.kwargs["max_tokens"] == 8192

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -338,6 +338,8 @@ async def test_adapter_maps_all_seven_provider_response_fields(
             token_count=4321,
             latency_ms=100,
             provider="anthropic",
+            tokens_in=4000,
+            tokens_out=321,
         )
 
     monkeypatch.setattr(gateway_singleton, "call", _stub_call)
@@ -361,10 +363,8 @@ async def test_adapter_maps_all_seven_provider_response_fields(
     assert response.text == "MODEL TEXT"
     assert response.model_id == matter.default_model_id  # "claude-opus-4-7"
     assert response.provider == "anthropic"
-    assert response.tokens_in == 4321
-    # Sentinel — keeps audit token_count = tokens_in + tokens_out
-    # equal to the gateway's combined count.
-    assert response.tokens_out == 0
+    assert response.tokens_in == 4000
+    assert response.tokens_out == 321
     # Gateway doesn't price; paired None.
     assert response.cost_micros is None
     assert response.currency is None

--- a/backend/tests/test_smoke_evals.py
+++ b/backend/tests/test_smoke_evals.py
@@ -141,7 +141,7 @@ class _KeyedProviderStub:
         self.name = name
 
     async def call(self, prompt: str, *, system: str | None = None, **kwargs):
-        return ("ok", 1)
+        return ("ok", 1, 0)
 
 
 class TestPostureRouting:

--- a/infra/deploy/cloudflare.md
+++ b/infra/deploy/cloudflare.md
@@ -115,6 +115,15 @@ fly secrets set \
 fly deploy
 ```
 
+**Verify the worker survived the deploy.** The `worker` process group has no HTTP health check, so a deploy (or an earlier manual scale-to-zero) can leave it stopped with no error anywhere — document indexing and exports then sit queued forever. After every `fly deploy`:
+
+```bash
+fly status -a legalise-backend        # expect a started machine in the worker group
+fly scale count worker=1 -a legalise-backend   # if it shows 0
+```
+
+`python -m app.tools.doctor` also fails its `worker.heartbeat` check when no worker has written arq's Redis health key recently.
+
 **Startup invariants will refuse to boot otherwise.** `main.lifespan` calls `assert_master_key_present` and `assert_auth_secrets_present` before binding the HTTP listener. In any non-dev `ENVIRONMENT`, the following are mandatory:
 
 - `LEGALISE_KEY_ENCRYPTION_SECRET` — 32-byte hex; encrypts `user_api_keys` at rest. Generate once, store forever; rotation is a v0.2 ops task.


### PR DESCRIPTION
Closes deferred-ledger items #10, #11, #15.

## Token split (tokens_in / tokens_out)

Providers now return `(text, tokens_in, tokens_out)` instead of a single summed count. `runtime.py` and `assistant/pipeline.py` write the real split to the audit columns instead of sum-into-`tokens_in` with a `tokens_out=0` sentinel. `token_count` remains the summed total, so audit canonical serialisation is unchanged — columns already existed, no migration.

## OpenAI truncation

`finish_reason == "length"` now raises `ProviderUpstreamError(code="provider_truncated")`, mirroring the Anthropic `stop_reason` handling, instead of handing a half-written body downstream to fail its JSON-envelope parse.

## Worker liveness

- arq worker sets `health_check_interval = 60`, so it writes its health key to Redis (job counters only — never matter content; Redis stays health-state-only).
- Doctor gains a `worker.heartbeat` check (runs only when Redis is reachable): key absent = hard fail with remediation (`docker compose ps worker` / `fly scale count worker=1`).
- Deploy runbook (`infra/deploy/cloudflare.md`) gains a post-deploy worker-count verification step.

## Tests

- Provider stubs updated to the 3-tuple protocol.
- New: gateway carries the split on `ModelResult`; OpenAI truncation raises / normal stop returns split; doctor heartbeat ok/absent paths.
- Vertical-slice + runtime adapter tests updated from the 0-sentinel to the real split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)