### PR TITLE
Matter export carries the audit hash chain + offline verifier (F5)

### DIFF
--- a/backend/app/core/audit_chain.py
+++ b/backend/app/core/audit_chain.py
@@ -24,7 +24,6 @@ from app.models.audit_chain import (
     AuditChainEntry,
 )
 
-
 ENTRY_PREFIX = "audit-chain-entry-v1"
 LINK_PREFIX = "audit-chain-link-v1"
 
@@ -99,31 +98,40 @@ class AuditEntryCanonical:
             payload_text=payload_text,
         )
 
+    def canonical_fields(self) -> dict[str, str | None]:
+        """Field values as canonical strings, in hash order.
+
+        This is the exact rendering the entry hash is computed over.
+        The matter export writes these strings into ``audit_chain.json``
+        so the offline verifier (``export_chain_verifier.py``) can
+        recompute hashes without re-deriving any rendering rules.
+        """
+        return {
+            "id": str(self.id),
+            "timestamp": _timestamp_utc(self.timestamp),
+            "actor_id": _text(self.actor_id),
+            "matter_id": _text(self.matter_id),
+            "action": self.action,
+            "module": self.module,
+            "resource_type": self.resource_type,
+            "resource_id": self.resource_id,
+            "model_used": self.model_used,
+            "prompt_hash": self.prompt_hash,
+            "response_hash": self.response_hash,
+            "token_count": _text(self.token_count),
+            "latency_ms": _text(self.latency_ms),
+            "tokens_in": _text(self.tokens_in),
+            "tokens_out": _text(self.tokens_out),
+            "cost_micros": _text(self.cost_micros),
+            "currency": self.currency,
+            "provider": self.provider,
+            "model_id": self.model_id,
+            "payload_text": self.payload_text,
+        }
+
     def canonical(self) -> str:
         return "\n".join(
-            [
-                ENTRY_PREFIX,
-                _field(str(self.id)),
-                _field(_timestamp_utc(self.timestamp)),
-                _field(_text(self.actor_id)),
-                _field(_text(self.matter_id)),
-                _field(self.action),
-                _field(self.module),
-                _field(self.resource_type),
-                _field(self.resource_id),
-                _field(self.model_used),
-                _field(self.prompt_hash),
-                _field(self.response_hash),
-                _field(_text(self.token_count)),
-                _field(_text(self.latency_ms)),
-                _field(_text(self.tokens_in)),
-                _field(_text(self.tokens_out)),
-                _field(_text(self.cost_micros)),
-                _field(self.currency),
-                _field(self.provider),
-                _field(self.model_id),
-                _field(self.payload_text),
-            ]
+            [ENTRY_PREFIX, *(_field(value) for value in self.canonical_fields().values())]
         )
 
     def entry_hash(self) -> str:

--- a/backend/app/core/export_chain_verifier.py
+++ b/backend/app/core/export_chain_verifier.py
@@ -1,0 +1,219 @@
+"""Offline verifier for the audit hash chain in a Legalise matter export.
+
+This file is copied verbatim into every export zip as ``verify_chain.py``.
+It must run on a bare Python 3 install: standard library only, no imports
+from the Legalise application.
+
+Usage (from inside an unpacked export):
+
+    python verify_chain.py
+
+It reads ``audit_chain.json`` from the same directory (or a path passed as
+the first argument), recomputes every entry hash and chain link hash from
+the exported field values, and checks the chain runs unbroken from
+sequence 1 to the head hash stated in the file. If ``audit.json`` sits
+alongside, it also checks the two files describe the same set of entries.
+
+Exit code 0 means the chain verified. Exit code 1 means it did not.
+
+The hash recipe below mirrors ``app/core/audit_chain.py`` (which in turn
+mirrors the PL/pgSQL trigger recipe). A test in the backend suite runs this
+script against a chain produced by the real database trigger, so any drift
+between the recipes fails CI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ENTRY_PREFIX = "audit-chain-entry-v1"
+LINK_PREFIX = "audit-chain-link-v1"
+SUPPORTED_FORMAT = "legalise-audit-chain-export-v1"
+
+# Order matters: this is the canonical field order the entry hash is
+# computed over. The export writes every value as a string (or null),
+# already rendered the way the canonical recipe expects — timestamps in
+# UTC ``%Y-%m-%dT%H:%M:%S.%fZ`` form, numbers as decimal strings, the
+# payload as the verbatim ``payload::text`` from Postgres.
+ENTRY_HASH_FIELDS = (
+    "id",
+    "timestamp",
+    "actor_id",
+    "matter_id",
+    "action",
+    "module",
+    "resource_type",
+    "resource_id",
+    "model_used",
+    "prompt_hash",
+    "response_hash",
+    "token_count",
+    "latency_ms",
+    "tokens_in",
+    "tokens_out",
+    "cost_micros",
+    "currency",
+    "provider",
+    "model_id",
+    "payload_text",
+)
+
+
+def _field(value: str | None) -> str:
+    if value is None:
+        return "-1:"
+    return f"{len(value)}:{value}"
+
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def entry_hash(entry: dict[str, Any]) -> str:
+    parts = [ENTRY_PREFIX]
+    for name in ENTRY_HASH_FIELDS:
+        value = entry.get(name)
+        parts.append(_field(None if value is None else str(value)))
+    return _hash("\n".join(parts))
+
+
+def chain_link_hash(entry: dict[str, Any], computed_entry_hash: str) -> str:
+    matter_id = entry.get("matter_id")
+    previous = entry.get("previous_chain_hash")
+    parts = [
+        LINK_PREFIX,
+        _field(str(entry["chain_version"])),
+        _field(str(entry["scope_type"])),
+        _field(None if matter_id is None else str(matter_id)),
+        _field(str(entry["scope_sequence"])),
+        _field(str(entry["id"])),
+        _field(None if previous is None else str(previous)),
+        _field(computed_entry_hash),
+    ]
+    return _hash("\n".join(parts))
+
+
+def verify(chain_path: Path) -> list[str]:
+    """Return a list of problems. Empty list means the chain verified."""
+    problems: list[str] = []
+
+    try:
+        data = json.loads(chain_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [f"could not read {chain_path.name}: {exc}"]
+
+    if data.get("format") != SUPPORTED_FORMAT:
+        return [f"unsupported format marker: {data.get('format')!r}"]
+
+    entries = data.get("entries", [])
+    head = data.get("head")
+
+    if not entries:
+        if head is not None:
+            problems.append("file states a head hash but contains no entries")
+        return problems
+
+    if head is None:
+        return ["file contains entries but states no head hash"]
+
+    previous_hash: str | None = None
+    for position, entry in enumerate(entries, start=1):
+        label = f"entry {position} (audit id {entry.get('id')})"
+
+        if entry.get("scope_sequence") != position:
+            problems.append(
+                f"{label}: expected sequence {position}, file says "
+                f"{entry.get('scope_sequence')}"
+            )
+
+        if entry.get("previous_chain_hash") != previous_hash:
+            problems.append(f"{label}: previous-hash link does not match the prior entry")
+
+        computed_entry = entry_hash(entry)
+        if entry.get("entry_hash") != computed_entry:
+            problems.append(
+                f"{label}: entry hash does not match its contents "
+                "(a field or the payload was altered)"
+            )
+
+        computed_chain = chain_link_hash(entry, computed_entry)
+        if entry.get("chain_hash") != computed_chain:
+            problems.append(f"{label}: chain hash does not match")
+
+        previous_hash = entry.get("chain_hash")
+
+    if head.get("chain_hash") != previous_hash:
+        problems.append(
+            "the chain does not terminate at the stated head hash "
+            f"(head says {head.get('chain_hash')}, chain ends at {previous_hash})"
+        )
+    if head.get("entry_count") != len(entries):
+        problems.append(
+            f"head states {head.get('entry_count')} entries, file contains {len(entries)}"
+        )
+
+    # Cross-check against audit.json when it travels in the same pack: the
+    # human-readable log and the hashed chain must describe the same rows.
+    audit_path = chain_path.parent / "audit.json"
+    if audit_path.exists():
+        try:
+            audit_rows = json.loads(audit_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            problems.append(f"could not read audit.json for cross-check: {exc}")
+        else:
+            chain_ids = {str(e.get("id")) for e in entries}
+            audit_ids = {str(r.get("id")) for r in audit_rows}
+            if audit_ids != chain_ids:
+                missing = sorted(audit_ids - chain_ids)
+                extra = sorted(chain_ids - audit_ids)
+                if missing:
+                    problems.append(
+                        f"{len(missing)} audit.json entr(y/ies) missing from the chain: "
+                        + ", ".join(missing[:5])
+                    )
+                if extra:
+                    problems.append(
+                        f"{len(extra)} chain entr(y/ies) missing from audit.json: "
+                        + ", ".join(extra[:5])
+                    )
+
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1:
+        chain_path = Path(argv[1])
+    else:
+        chain_path = Path(__file__).resolve().parent / "audit_chain.json"
+
+    problems = verify(chain_path)
+    if problems:
+        print("FAIL: the audit chain did NOT verify.")
+        for problem in problems:
+            print(f"  - {problem}")
+        print(
+            "The exported record does not match its hash chain. "
+            "Treat this pack as altered until explained."
+        )
+        return 1
+
+    data = json.loads(chain_path.read_text(encoding="utf-8"))
+    count = len(data.get("entries", []))
+    head = data.get("head") or {}
+    print(f"PASS: audit chain verified — {count} entries, unbroken from sequence 1.")
+    if head.get("chain_hash"):
+        print(f"Head hash: {head['chain_hash']}")
+    print(
+        "Every audit entry hashes to its recorded value and each link chains "
+        "to the next. Editing, deleting, or reordering any entry would have "
+        "failed this check."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/backend/app/core/exports.py
+++ b/backend/app/core/exports.py
@@ -13,6 +13,10 @@ The bundle includes:
   - artefacts.json         — generated artefact metadata (storage_uri list,
                              no bytes)
   - audit.json             — all audit rows for the matter
+  - audit_chain.json       — the audit hash chain: per-entry hashes, link
+                             hashes, and the chain head, in the canonical
+                             string form the hashes are computed over
+  - verify_chain.py        — stdlib-only offline verifier for the chain
   - jobs.json              — all job rows for the matter
 
 Out of scope:
@@ -41,33 +45,36 @@ import io
 import json
 import uuid
 import zipfile
-from datetime import datetime
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import String, cast, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.storage import get_storage_backend, matter_prefix
-from app.core.matter_artifacts import ArtifactBytesUnavailable, load_artifact_bytes
+from app.core.audit_chain import AuditEntryCanonical
 from app.core.audit_reconstruction import reconstruct
+from app.core.matter_artifacts import ArtifactBytesUnavailable, load_artifact_bytes
 from app.core.signoff import (
     compute_signoff_hash,
     current_signoff_ids,
     list_signoffs,
 )
+from app.core.storage import get_storage_backend, matter_prefix
 from app.models import (
+    SIGNOFF_REJECTED,
+    SIGNOFF_SIGNED,
+    SIGNOFF_SIGNED_WITH_OBSERVATIONS,
+    AuditChainEntry,
     AuditEntry,
     Document,
+    DocumentComment,
+    DocumentEdit,
+    DocumentVersion,
     Job,
     Matter,
     MatterArtifact,
     MatterReview,
-    SIGNOFF_REJECTED,
-    SIGNOFF_SIGNED,
-    SIGNOFF_SIGNED_WITH_OBSERVATIONS,
-    DocumentComment,
-    DocumentEdit,
-    DocumentVersion,
 )
 
 
@@ -129,6 +136,10 @@ def _build_readme(
         f"- `reviews.json` — {review_count} supervisor review decision(s).",
         f"- `reconstruction.json` — the rebuilt decision timeline ({recon_count} entries).",
         "- `audit.json` — raw audit entries for this matter.",
+        "- `audit_chain.json` — the audit hash chain: a per-entry hash, a link",
+        "  hash chaining each entry to the one before it, and the head hash.",
+        "- `verify_chain.py` — offline chain verifier. Run `python verify_chain.py`",
+        "  from the unpacked export; it needs only Python 3, no network, no database.",
         "- `jobs.json` — job records for this matter.",
         "",
         "## Sign-off status of outputs",
@@ -151,6 +162,8 @@ def _build_readme(
         "## What a human still needs to verify",
         "Before relying on anything in this pack:",
         "",
+        "- [ ] `python verify_chain.py` run and passing — confirms the audit",
+        "      trail in this pack has not been edited, reordered, or truncated.",
         "- [ ] Cited sources reviewed against the original documents.",
         "- [ ] Unsigned outputs treated as drafts, not final work product.",
         "- [ ] Rejected outputs not used as final material.",
@@ -232,7 +245,8 @@ def _build_working_pack(
         "- Document versions and edit decisions → `document_versions.json`",
         "  and `document_edits.json`.",
         "- The decision timeline → `reconstruction.json`.",
-        "- The raw audit chain → `audit.json`.",
+        "- The raw audit log → `audit.json`; its hash chain → `audit_chain.json`.",
+        "  Run `python verify_chain.py` to check the chain is intact.",
         "- Supervisor review state → `reviews.json`.",
         "",
         "## Before relying on this pack",
@@ -470,6 +484,66 @@ async def build_matter_export(
             for a in audit_rows
         ]
         zf.writestr("audit.json", _dumps(audit_list))
+
+        # --- audit_chain.json + verify_chain.py -------------------------------
+        # The hash chain is what makes the audit log tamper-evident; without
+        # it the export is a plain log. Ship the chain rows in the canonical
+        # string form the hashes are computed over, plus the head hash, plus
+        # a stdlib-only verifier — so a recipient can check the chain offline
+        # with no database and nothing but Python 3.
+        chain_rows = (
+            await session.execute(
+                select(
+                    AuditChainEntry,
+                    AuditEntry,
+                    cast(AuditEntry.payload, String).label("payload_text"),
+                )
+                .join(AuditEntry, AuditEntry.id == AuditChainEntry.audit_entry_id)
+                .where(AuditChainEntry.matter_id == matter.id)
+                .order_by(AuditChainEntry.scope_sequence)
+            )
+        ).all()
+        chain_entries: list[dict[str, Any]] = []
+        for chain, entry, payload_text in chain_rows:
+            canonical = AuditEntryCanonical.from_row(entry, payload_text or "{}")
+            chain_entries.append(
+                {
+                    **canonical.canonical_fields(),
+                    "scope_type": chain.scope_type,
+                    "scope_sequence": chain.scope_sequence,
+                    "chain_version": chain.chain_version,
+                    "previous_chain_hash": chain.previous_chain_hash,
+                    "entry_hash": chain.entry_hash,
+                    "chain_hash": chain.chain_hash,
+                }
+            )
+        chain_head: dict[str, Any] | None = None
+        if chain_entries:
+            last = chain_entries[-1]
+            chain_head = {
+                "chain_hash": last["chain_hash"],
+                "scope_sequence": last["scope_sequence"],
+                "entry_count": len(chain_entries),
+                "timestamp": last["timestamp"],
+            }
+        chain_doc: dict[str, Any] = {
+            "format": "legalise-audit-chain-export-v1",
+            "scope_type": "matter",
+            "matter_id": str(matter.id),
+            "exported_at": datetime.now(UTC).isoformat(),
+            "entry_count": len(chain_entries),
+            "head": chain_head,
+            "how_to_verify": (
+                "Run `python verify_chain.py` from the unpacked export. "
+                "It needs only a standard Python 3 install."
+            ),
+            "entries": chain_entries,
+        }
+        zf.writestr("audit_chain.json", _dumps(chain_doc))
+        zf.writestr(
+            "verify_chain.py",
+            (Path(__file__).parent / "export_chain_verifier.py").read_bytes(),
+        )
 
         # --- jobs.json -------------------------------------------------------
         job_rows = list(

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -111,6 +111,13 @@ class TestBuildMatterExportUnit:
 
             session.scalars.side_effect = _scalars_side_effect
 
+            async def _execute_se(query):
+                result = MagicMock()
+                result.all.return_value = []
+                return result
+
+            session.execute.side_effect = _execute_se
+
             export_key = await build_matter_export(session, matter, job_id)
 
             assert export_key.endswith(f"{job_id}.zip")
@@ -197,6 +204,13 @@ class TestBuildMatterExportUnit:
 
             session.scalars.side_effect = _scalars_se
 
+            async def _execute_se(query):
+                result = MagicMock()
+                result.all.return_value = []
+                return result
+
+            session.execute.side_effect = _execute_se
+
             export_key = await build_matter_export(session, matter, job_id)
 
             storage = get_storage_backend()
@@ -256,6 +270,13 @@ class TestWorkerDispatchExport:
             return result
 
         session.scalars.side_effect = _scalars_se
+
+        async def _execute_se(query):
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        session.execute.side_effect = _execute_se
 
         import os
 

--- a/backend/tests/test_export_audit_chain.py
+++ b/backend/tests/test_export_audit_chain.py
@@ -1,0 +1,243 @@
+"""Matter export — audit hash chain travels with the pack (F5).
+
+The export must be verifiable offline: ``audit_chain.json`` carries every
+chain row in canonical string form plus the head hash, and ``verify_chain.py``
+(a copy of ``app/core/export_chain_verifier.py``) recomputes the chain with
+nothing but the standard library.
+
+Two anti-drift properties are pinned here:
+  1. The standalone verifier validates a chain produced by the real
+     database trigger — if the canonical recipe in the verifier drifts from
+     the PL/pgSQL / ``audit_chain.py`` recipe, these tests fail.
+  2. A tampered export fails loudly: flip one byte in one exported entry
+     and the verifier exits non-zero.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import uuid
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.core.audit_chain import AuditEntryCanonical, chain_link_hash
+from app.core.exports import build_matter_export
+from app.core.storage import get_storage_backend
+from app.models import PRIVILEGE_CLEARED, STATUS_OPEN, AuditEntry, Matter, User
+
+VERIFIER_SOURCE = (
+    Path(__file__).parents[1] / "app" / "core" / "export_chain_verifier.py"
+)
+
+
+def _load_verifier_module():
+    spec = importlib.util.spec_from_file_location("export_chain_verifier", VERIFIER_SOURCE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# No-DB drift guard: standalone recipe == app recipe
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_verifier_recipe_matches_app_recipe() -> None:
+    """The verifier ships without app imports, so its hash recipe is a copy.
+
+    This pins the copy to the original: an entry hashed by
+    ``app.core.audit_chain`` must hash identically in the standalone
+    verifier, given the exported canonical field strings.
+    """
+    verifier = _load_verifier_module()
+
+    canonical = AuditEntryCanonical(
+        id=uuid.uuid4(),
+        timestamp=datetime(2026, 7, 5, 12, 30, 45, 123456, tzinfo=UTC),
+        actor_id=uuid.uuid4(),
+        matter_id=uuid.uuid4(),
+        action="model.call",
+        module="assistant",
+        resource_type="thread",
+        resource_id="t-1",
+        model_used="claude-sonnet-4-5",
+        prompt_hash="a" * 64,
+        response_hash=None,
+        token_count=1234,
+        latency_ms=None,
+        tokens_in=1000,
+        tokens_out=234,
+        cost_micros=4200,
+        currency="GBP",
+        provider="anthropic",
+        model_id="claude-sonnet-4-5",
+        payload_text='{"kind": "chain-drift-probe", "text": "quoted \\"bytes\\" — £ ünïcode"}',
+    )
+
+    app_entry_hash = canonical.entry_hash()
+    exported = canonical.canonical_fields()
+    assert verifier.entry_hash(exported) == app_entry_hash
+
+    link_kwargs = {
+        "chain_version": 1,
+        "scope_type": "matter",
+        "matter_id": canonical.matter_id,
+        "scope_sequence": 7,
+        "audit_entry_id": canonical.id,
+        "previous_chain_hash": "b" * 64,
+        "entry_hash": app_entry_hash,
+    }
+    app_chain_hash = chain_link_hash(**link_kwargs)
+    exported_entry = {
+        **exported,
+        "scope_type": "matter",
+        "scope_sequence": 7,
+        "chain_version": 1,
+        "previous_chain_hash": "b" * 64,
+    }
+    assert verifier.chain_link_hash(exported_entry, app_entry_hash) == app_chain_hash
+
+
+# ---------------------------------------------------------------------------
+# DB-backed: real trigger-built chain → export → offline verification
+# ---------------------------------------------------------------------------
+
+
+async def _seed(db_session) -> Matter:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"chain-exp-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x" * 32,
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+        role="solicitor",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    matter = Matter(
+        id=uuid.uuid4(),
+        slug=f"chain-exp-{uuid.uuid4().hex[:8]}",
+        title="Chain Export Test",
+        matter_type="employment_tribunal",
+        status=STATUS_OPEN,
+        privilege_posture=PRIVILEGE_CLEARED,
+        default_model_id="stub-echo",
+        created_by_id=user.id,
+    )
+    db_session.add(matter)
+    await db_session.flush()
+    for n in range(3):
+        db_session.add(
+            AuditEntry(
+                action=f"chain.export.step{n}",
+                module="test",
+                matter_id=matter.id,
+                actor_id=user.id,
+                payload={"n": n, "note": "seeded for export chain test — £"},
+            )
+        )
+    await db_session.flush()
+    await db_session.commit()
+    return matter
+
+
+def _unzip_export(export_key: str, target: Path) -> None:
+    raw = get_storage_backend().get_bytes(export_key)
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        zf.extractall(target)
+
+
+def _run_verifier(pack_dir: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(pack_dir / "verify_chain.py")],
+        capture_output=True,
+        text=True,
+        cwd=pack_dir,
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_carries_chain_and_verifies_offline(db_session, tmp_path) -> None:
+    matter = await _seed(db_session)
+
+    export_key = await build_matter_export(db_session, matter, uuid.uuid4())
+    _unzip_export(export_key, tmp_path)
+
+    chain_doc = json.loads((tmp_path / "audit_chain.json").read_text(encoding="utf-8"))
+    assert chain_doc["format"] == "legalise-audit-chain-export-v1"
+    assert chain_doc["matter_id"] == str(matter.id)
+    assert chain_doc["entry_count"] >= 3
+    assert chain_doc["head"]["entry_count"] == chain_doc["entry_count"]
+    assert len(chain_doc["head"]["chain_hash"]) == 64
+    assert chain_doc["head"]["timestamp"] == chain_doc["entries"][-1]["timestamp"]
+
+    entries = chain_doc["entries"]
+    assert entries[0]["scope_sequence"] == 1
+    assert entries[0]["previous_chain_hash"] is None
+    assert all(len(e["entry_hash"]) == 64 and len(e["chain_hash"]) == 64 for e in entries)
+
+    # The chain and the human-readable log describe the same rows.
+    audit_rows = json.loads((tmp_path / "audit.json").read_text(encoding="utf-8"))
+    assert {e["id"] for e in entries} == {r["id"] for r in audit_rows}
+
+    # README points at the verifier.
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "audit_chain.json" in readme
+    assert "verify_chain.py" in readme
+
+    # Offline verification: no DB, no app imports, just the pack.
+    result = _run_verifier(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "PASS" in result.stdout
+    assert chain_doc["head"]["chain_hash"] in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_tampered_export_fails_verification(db_session, tmp_path) -> None:
+    matter = await _seed(db_session)
+
+    export_key = await build_matter_export(db_session, matter, uuid.uuid4())
+    _unzip_export(export_key, tmp_path)
+
+    chain_path = tmp_path / "audit_chain.json"
+    chain_doc = json.loads(chain_path.read_text(encoding="utf-8"))
+
+    # Flip one byte in one exported entry's payload.
+    target = chain_doc["entries"][1]
+    payload_text = target["payload_text"]
+    flipped = chr(ord(payload_text[0]) ^ 1) + payload_text[1:]
+    assert flipped != payload_text
+    target["payload_text"] = flipped
+    chain_path.write_text(json.dumps(chain_doc, ensure_ascii=False), encoding="utf-8")
+
+    result = _run_verifier(tmp_path)
+    assert result.returncode == 1
+    assert "FAIL" in result.stdout
+    assert "entry hash does not match" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_truncated_chain_fails_verification(db_session, tmp_path) -> None:
+    """Dropping the newest entry (and keeping its head) must fail —
+    truncation is the cheap rewrite the head hash exists to catch."""
+    matter = await _seed(db_session)
+
+    export_key = await build_matter_export(db_session, matter, uuid.uuid4())
+    _unzip_export(export_key, tmp_path)
+
+    chain_path = tmp_path / "audit_chain.json"
+    chain_doc = json.loads(chain_path.read_text(encoding="utf-8"))
+    chain_doc["entries"] = chain_doc["entries"][:-1]
+    chain_path.write_text(json.dumps(chain_doc, ensure_ascii=False), encoding="utf-8")
+
+    result = _run_verifier(tmp_path)
+    assert result.returncode == 1
+    assert "FAIL" in result.stdout


### PR DESCRIPTION
Trust-spine finding F5: the matter export shipped `audit.json` — the rows — but nothing that let a recipient prove the trail was intact. The record only verified if you had our database. Now the pack verifies offline.

## What's in the pack now

- **`audit_chain.json`** — every audit chain row in the exact canonical string form the hashes are computed over: per-entry hash, previous/link hash, scope sequence, plus a head summary (head hash, entry count, timestamp).
- **`verify_chain.py`** — a stdlib-only verifier copied verbatim into every export zip. It recomputes every entry hash and link hash, walks the chain unbroken from sequence 1 to the stated head, cross-checks that `audit.json` and the chain describe the same rows, and exits 0 (verified) or 1 (not). Runs on a bare Python 3 install — no app imports, no network, no database.
- README (both packs) points at the verifier and adds it to the "before relying on this pack" checklist.

## How the verifier stays in lockstep with the canonical recipe

`AuditEntryCanonical` grows `canonical_fields()` — the single rendering the entry hash is computed over — and `canonical()` is now derived from it, so there is one source of truth in the app. The export writes those exact strings into `audit_chain.json`; the standalone verifier never re-derives timestamp/number rendering, it hashes what was exported.

Two anti-drift tests pin the copy to the original:

1. **No-DB cross-test** — an entry hashed by `app.core.audit_chain` must hash identically in the standalone verifier given the exported field strings (entry hash and link hash both).
2. **DB-backed round trip** — seeds audit rows, lets the real PL/pgSQL trigger build the chain, builds a real export, unzips it, and runs the shipped `verify_chain.py` as a subprocess. Any drift between the standalone recipe and the real one fails CI.

## Tamper coverage

- Flip one byte in one exported entry's payload → verifier exits 1 and names the entry ("entry hash does not match its contents").
- Drop the newest entry while keeping the head → verifier exits 1 (truncation is the cheap rewrite the head hash exists to catch).

## Register sidecar / external pack

Checked for the same gap, per the brief — **not fixed here**. The sidecar (`app/core/external_pack.py`, `app/api/external_packs.py`) is ingest-only today: it has no outbound export artifact of its own, so there is no equivalent pack missing a chain. Matters ingested from external packs are ordinary matters whose audit entries chain via the same trigger, so their exports get `audit_chain.json` + `verify_chain.py` from this PR automatically. If the sidecar ever grows an outbound "signed pack receipt" back to the source workspace, it should embed the chain the same way.

## Tests

- `tests/test_export_audit_chain.py` (new: cross-test, round trip, tamper, truncation), `tests/test_export.py`, `tests/test_audit_chain.py`, `tests/test_export_completeness.py` — all green locally against the real trigger-built chain.
- Full backend suite: 922 passed locally; the only failures were pre-existing macOS-environment artifacts (sandbox subprocess tests, Redis-dependent indexing test) unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)