### PR TITLE
Save assistant replies as draft outputs from chat

### DIFF
--- a/backend/app/models/matter_review.py
+++ b/backend/app/models/matter_review.py
@@ -53,8 +53,9 @@ REVIEW_STATE_VALUES = frozenset({REVIEW_PENDING} | REVIEW_TERMINAL_STATES)
 # findings pack plus prompt-runtime skill output — imported Lawve skills
 # produce `skill_response`, and their output must be reviewable for the
 # supervised-autonomy loop to apply equally to marketplace skills, not
-# just first-party modules.
-REVIEW_ELIGIBLE_KINDS = frozenset({"findings_pack", "skill_response"})
+# just first-party modules. `chat_draft` is an assistant reply saved as
+# a draft output from the chat surface — same loop, same reviewability.
+REVIEW_ELIGIBLE_KINDS = frozenset({"findings_pack", "skill_response", "chat_draft"})
 
 
 class MatterReview(Base):

--- a/backend/app/modules/assistant/router.py
+++ b/backend/app/modules/assistant/router.py
@@ -11,7 +11,7 @@ import json
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,12 +21,15 @@ from app.core.auth import current_user
 from app.core.db import get_session
 from app.core.limits import check_assistant_message
 from app.core.matter_access import resolve_owned_open_matter
-from app.models import Matter, User
+from app.core.matter_artifacts import write_artifact
+from app.models import Matter, MatterArtifact, User
+from app.models.assistant import ROLE_ASSISTANT
 from app.models.assistant import AssistantMessage as AssistantMessageRow
 from app.models.assistant import AssistantThread as AssistantThreadRow
 
 from .pipeline import derive_thread_title, run_assistant_turn
 from .schemas import (
+    AssistantDraftSaveResponse,
     AssistantMessage,
     AssistantPostRequest,
     AssistantPostResponse,
@@ -310,6 +313,140 @@ async def post_message(
         user=_to_schema(user_row),
         assistant=_to_schema(assistant_row),
         thread_id=thread.id,
+    )
+
+
+# Artifact kind for an assistant reply saved as a draft output. Listed in
+# REVIEW_ELIGIBLE_KINDS (matter_review.py) so the saved draft enters the
+# existing review/sign-off flow with no special-casing downstream.
+CHAT_DRAFT_KIND = "chat_draft"
+SAVE_DRAFT_MODULE_ID = "assistant"
+SAVE_DRAFT_CAPABILITY_ID = "assistant.save_draft"
+
+
+def _draft_payload(row: AssistantMessageRow) -> dict[str, Any]:
+    """Artifact payload for a chat-saved draft.
+
+    Shape matches `skill_response` (`output` + `model_id` +
+    `source_anchors`) so the existing preview/review/sign surfaces render
+    it without new code paths, plus explicit chat provenance: the source
+    message id, hashes, and the retrieval sources exactly as persisted on
+    the message. `model_id` may be null (keyless / extractive answers) —
+    the provenance records what happened, it does not gate.
+    """
+    sources = [s for s in (row.sources or []) if isinstance(s, dict)]
+    anchors: list[dict[str, Any]] = []
+    for i, s in enumerate(sources):
+        anchors.append(
+            {
+                "id": f"src-{i + 1}",
+                "source_type": "document",
+                "document_id": s.get("document_id"),
+                "filename": s.get("title"),
+                "label": s.get("title"),
+                "quote": s.get("snippet"),
+            }
+        )
+    return {
+        "output": row.content,
+        "model_id": row.model_used,
+        "saved_from": "assistant_message",
+        "source_message_id": str(row.id),
+        "thread_id": str(row.thread_id) if row.thread_id else None,
+        "prompt_hash": row.prompt_hash,
+        "response_hash": row.response_hash,
+        "sources": sources,
+        "source_anchors": anchors,
+    }
+
+
+@router.post(
+    "/{slug}/assistant/messages/{message_id}/save-draft",
+    response_model=AssistantDraftSaveResponse,
+    status_code=201,
+)
+async def save_message_as_draft(
+    slug: str,
+    message_id: uuid.UUID,
+    response: Response,
+    session: AsyncSession = Depends(get_session),
+    user: User = Depends(current_user),
+) -> AssistantDraftSaveResponse:
+    """Save an assistant reply as a draft output on the matter.
+
+    Creates a `chat_draft` matter artifact from the persisted message —
+    content plus provenance (source message id, model, hashes, retrieval
+    sources). The artifact is the same first-class output the review and
+    sign-off endpoints already operate on, so the saved draft flows into
+    draft → review → sign with no special-casing.
+
+    Idempotent per message: saving the same reply again returns the
+    existing draft (200, `already_existed=true`). Uses the shared
+    archived-aware matter resolver — no drafts on tombstoned matters.
+    """
+    matter = await _resolve_matter(session, slug, user.id)
+    row = await session.scalar(
+        select(AssistantMessageRow).where(
+            AssistantMessageRow.id == message_id,
+            AssistantMessageRow.matter_id == matter.id,
+        )
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Message not found")
+    if row.role != ROLE_ASSISTANT:
+        raise HTTPException(
+            status_code=422,
+            detail="Only assistant replies can be saved as drafts",
+        )
+
+    # Idempotency: the message id doubles as the artifact's invocation id,
+    # and (invocation_id, kind) is unique — one draft per message.
+    existing = await session.scalar(
+        select(MatterArtifact).where(
+            MatterArtifact.invocation_id == row.id,
+            MatterArtifact.kind == CHAT_DRAFT_KIND,
+            MatterArtifact.matter_id == matter.id,
+        )
+    )
+    if existing is not None:
+        response.status_code = 200
+        return AssistantDraftSaveResponse(
+            artifact_id=existing.id, kind=existing.kind, already_existed=True
+        )
+
+    artifact = await write_artifact(
+        session,
+        matter=matter,
+        capability_id=SAVE_DRAFT_CAPABILITY_ID,
+        module_id=SAVE_DRAFT_MODULE_ID,
+        invocation_id=row.id,
+        kind=CHAT_DRAFT_KIND,
+        payload=_draft_payload(row),
+        actor_user_id=user.id,
+    )
+    # Supervision legibility (M13): the record states that this draft was
+    # prepared by AI in chat and which message it came from.
+    await audit.log(
+        session,
+        "assistant.draft.saved",
+        actor_id=user.id,
+        matter_id=matter.id,
+        module=SAVE_DRAFT_MODULE_ID,
+        resource_type="matter_artifact",
+        resource_id=str(artifact.id),
+        payload={
+            "source_message_id": str(row.id),
+            "thread_id": str(row.thread_id) if row.thread_id else None,
+            "model_used": row.model_used,
+            "prompt_hash": row.prompt_hash,
+            "response_hash": row.response_hash,
+            "source_count": len(row.sources or []),
+            "kind": CHAT_DRAFT_KIND,
+        },
+    )
+    await session.commit()
+    return AssistantDraftSaveResponse(
+        artifact_id=artifact.id, kind=artifact.kind, already_existed=False
     )
 
 

--- a/backend/app/modules/assistant/schemas.py
+++ b/backend/app/modules/assistant/schemas.py
@@ -90,6 +90,16 @@ class AssistantPostResponse(BaseModel):
     thread_id: UUID | None = None
 
 
+class AssistantDraftSaveResponse(BaseModel):
+    """Result of saving an assistant reply as a draft output."""
+
+    artifact_id: UUID
+    kind: str = "chat_draft"
+    # True when this message was already saved — the existing draft is
+    # returned instead of a duplicate.
+    already_existed: bool = False
+
+
 class AssistantResponseEnvelope(BaseModel):
     """Shape the model is asked to return — `parse_model_json` validates it."""
 

--- a/backend/tests/test_assistant_save_draft.py
+++ b/backend/tests/test_assistant_save_draft.py
@@ -1,0 +1,314 @@
+"""Save-as-draft on assistant messages — API tests.
+
+The chat surface's exit into the product's core loop: an assistant reply
+becomes a `chat_draft` matter artifact carrying provenance (source
+message id, model, hashes, retrieval sources), and that artifact flows
+through the EXISTING review + sign-off endpoints with no special-casing.
+
+Covers:
+  - save creates the artifact with full provenance payload + audit row
+  - idempotency (second save returns the same artifact, 200)
+  - user-role messages are refused (422)
+  - archived (tombstoned) matters 404 — same guard as other chat writes
+  - cross-user 404
+  - keyless / extractive replies (model_used is null) save fine
+  - the full walk: message → draft → supervisor review → sign-off
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.models import AuditEntry, Matter, MatterArtifact, User
+from app.models.assistant import AssistantMessage as AssistantMessageRow
+
+
+PASSWORD = "save-draft-tests-2026"
+
+
+@pytest.fixture(autouse=True)
+def _writable_matters_root(tmp_path, monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "matters_root", str(tmp_path), raising=False)
+
+
+async def _register_and_login(client) -> str:
+    email = f"draft-{uuid.uuid4().hex[:8]}@example.com"
+    await client.post("/auth/register", json={"email": email, "password": PASSWORD})
+    await client.post(
+        "/auth/login",
+        data={"username": email, "password": PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    return email
+
+
+async def _login(client, email: str) -> None:
+    await client.post(
+        "/auth/login",
+        data={"username": email, "password": PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+
+async def _create_matter(client) -> str:
+    resp = await client.post(
+        "/api/matters",
+        json={"title": f"Draft test {uuid.uuid4().hex[:6]}"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["slug"]
+
+
+async def _seed_assistant_message(
+    slug: str,
+    *,
+    role: str = "assistant",
+    content: str = "Draft grounds of resistance based on the ET3.",
+    model_used: str | None = "claude-sonnet-4-6",
+    sources: list | None = None,
+) -> str:
+    """Insert a persisted message row directly — no model call needed."""
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        matter = await session.scalar(select(Matter).where(Matter.slug == slug))
+        row = AssistantMessageRow(
+            matter_id=matter.id,
+            actor_id=matter.created_by_id,
+            role=role,
+            content=content,
+            model_used=model_used if role == "assistant" else None,
+            prompt_hash="a" * 64 if role == "assistant" else None,
+            response_hash="b" * 64 if role == "assistant" else None,
+            sources=sources or [],
+        )
+        session.add(row)
+        await session.commit()
+        return str(row.id)
+
+
+@pytest.mark.asyncio
+async def test_save_draft_creates_artifact_with_provenance(client) -> None:
+    email = await _register_and_login(client)
+    slug = await _create_matter(client)
+    sources = [
+        {
+            "document_id": str(uuid.uuid4()),
+            "title": "et3-response.pdf",
+            "snippet": "The claimant was dismissed for gross misconduct.",
+            "char_start": 10,
+            "char_end": 58,
+            "score": 0.91,
+        }
+    ]
+    message_id = await _seed_assistant_message(slug, sources=sources)
+
+    resp = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["kind"] == "chat_draft"
+    assert body["already_existed"] is False
+    artifact_id = body["artifact_id"]
+
+    # The draft is a first-class matter artifact, readable via the
+    # existing artifacts API, with the chat provenance in the payload.
+    read = await client.get(f"/api/matters/{slug}/artifacts/{artifact_id}")
+    assert read.status_code == 200, read.text
+    art = read.json()
+    assert art["kind"] == "chat_draft"
+    assert art["module_id"] == "assistant"
+    assert art["capability_id"] == "assistant.save_draft"
+    assert art["invocation_id"] == message_id
+    payload = art["payload"]
+    assert payload["output"].startswith("Draft grounds of resistance")
+    assert payload["model_id"] == "claude-sonnet-4-6"
+    assert payload["source_message_id"] == message_id
+    assert payload["prompt_hash"] == "a" * 64
+    assert payload["response_hash"] == "b" * 64
+    assert payload["sources"] == sources
+    assert payload["source_anchors"][0]["document_id"] == sources[0]["document_id"]
+    assert payload["source_anchors"][0]["quote"] == sources[0]["snippet"]
+
+    # Supervision legibility: the audit trail states the draft came from
+    # an AI chat message.
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        entry = await session.scalar(
+            select(AuditEntry).where(
+                AuditEntry.action == "assistant.draft.saved",
+                AuditEntry.resource_id == artifact_id,
+            )
+        )
+        assert entry is not None
+        assert entry.payload["source_message_id"] == message_id
+        assert entry.payload["model_used"] == "claude-sonnet-4-6"
+        assert entry.payload["source_count"] == 1
+        user = await session.scalar(select(User).where(User.email == email))
+        assert entry.actor_id == user.id
+
+
+@pytest.mark.asyncio
+async def test_save_draft_is_idempotent_per_message(client) -> None:
+    await _register_and_login(client)
+    slug = await _create_matter(client)
+    message_id = await _seed_assistant_message(slug)
+
+    first = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert first.status_code == 201
+    second = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert second.status_code == 200
+    assert second.json()["already_existed"] is True
+    assert second.json()["artifact_id"] == first.json()["artifact_id"]
+
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        count = len(
+            (
+                await session.scalars(
+                    select(MatterArtifact).where(
+                        MatterArtifact.invocation_id == uuid.UUID(message_id)
+                    )
+                )
+            ).all()
+        )
+        assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_user_messages_cannot_be_saved(client) -> None:
+    await _register_and_login(client)
+    slug = await _create_matter(client)
+    message_id = await _seed_assistant_message(
+        slug, role="user", content="Please draft the response."
+    )
+    resp = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_missing_message_is_404(client) -> None:
+    await _register_and_login(client)
+    slug = await _create_matter(client)
+    resp = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{uuid.uuid4()}/save-draft"
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_archived_matter_is_404(client) -> None:
+    # Tombstone guard: same resolve_owned_open_matter gate as every other
+    # chat write. No drafts on deleted matters.
+    await _register_and_login(client)
+    slug = await _create_matter(client)
+    message_id = await _seed_assistant_message(slug)
+    deleted = await client.delete(f"/api/matters/{slug}")
+    assert deleted.status_code in (200, 204), deleted.text
+
+    resp = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cross_user_is_404(client) -> None:
+    await _register_and_login(client)
+    slug = await _create_matter(client)
+    message_id = await _seed_assistant_message(slug)
+
+    await _register_and_login(client)  # second user, fresh session cookie
+    resp = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_keyless_extractive_reply_saves_with_null_model(client) -> None:
+    # Keyless / stub matters: any persisted assistant message can be
+    # saved; provenance records what happened (no model), nothing gates.
+    await _register_and_login(client)
+    slug = await _create_matter(client)
+    message_id = await _seed_assistant_message(
+        slug,
+        content="Extracted summary of the bundle (no model).",
+        model_used=None,
+    )
+    resp = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert resp.status_code == 201, resp.text
+    artifact_id = resp.json()["artifact_id"]
+    read = await client.get(f"/api/matters/{slug}/artifacts/{artifact_id}")
+    assert read.json()["payload"]["model_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_message_to_draft_to_review_and_signoff(client) -> None:
+    """The whole loop, zero special-casing: chat reply → saved draft →
+    supervisor review (request + decide) → professional sign-off."""
+    email = await _register_and_login(client)
+    slug = await _create_matter(client)
+    message_id = await _seed_assistant_message(slug)
+
+    saved = await client.post(
+        f"/api/matters/{slug}/assistant/messages/{message_id}/save-draft"
+    )
+    assert saved.status_code == 201, saved.text
+    artifact_id = saved.json()["artifact_id"]
+
+    # Review: chat_draft is review-eligible like findings_pack /
+    # skill_response — the existing endpoint accepts it as-is.
+    review = await client.post(
+        f"/api/matters/{slug}/reviews", json={"artifact_id": artifact_id}
+    )
+    assert review.status_code == 201, review.text
+    review_id = review.json()["id"]
+    assert review.json()["kind"] == "chat_draft"
+
+    # Reviewer ≠ author: a second user (workspace superuser) decides.
+    reviewer = await _register_and_login(client)
+    from app.main import app
+
+    factory = app.state.session_factory
+    async with factory() as session:
+        u = await session.scalar(select(User).where(User.email == reviewer))
+        u.is_superuser = True
+        await session.commit()
+    decided = await client.post(
+        f"/api/matters/{slug}/reviews/{review_id}/decide",
+        json={"decision": "approve"},
+    )
+    assert decided.status_code == 200, decided.text
+    assert decided.json()["state"] == "approved"
+
+    # Sign-off: the author signs their own AI-assisted draft.
+    await _login(client, email)
+    signed = await client.post(
+        f"/api/matters/{slug}/signoffs",
+        json={"artifact_id": artifact_id, "decision": "signed"},
+    )
+    assert signed.status_code == 201, signed.text
+    body = signed.json()
+    assert body["kind"] == "chat_draft"
+    assert body["signer_is_author"] is True
+    assert len(body["artifact_hash"]) == 64

--- a/frontend/src/lib/api/assistant.ts
+++ b/frontend/src/lib/api/assistant.ts
@@ -118,6 +118,22 @@ export const postAssistantMessage = (
     body: JSON.stringify(body),
   }).then((r) => jsonOrThrow<AssistantPostResponse>(r));
 
+// Save an assistant reply as a draft output — a `chat_draft` matter
+// artifact carrying the message's content + provenance (source message
+// id, model, hashes, retrieval sources). Idempotent per message: saving
+// the same reply again returns the existing draft.
+export interface AssistantDraftSaveResponse {
+  artifact_id: string;
+  kind: string;
+  already_existed: boolean;
+}
+
+export const saveMessageAsDraft = (slug: string, messageId: string) =>
+  apiFetch(
+    `${API}/matters/${encodeURIComponent(slug)}/assistant/messages/${encodeURIComponent(messageId)}/save-draft`,
+    { method: "POST" },
+  ).then((r) => jsonOrThrow<AssistantDraftSaveResponse>(r));
+
 export async function* postAssistantMessageStream(
   slug: string,
   body: { content: string; selected_document_ids?: string[]; thread_id?: string },

--- a/frontend/src/lib/api/signoffs.ts
+++ b/frontend/src/lib/api/signoffs.ts
@@ -45,6 +45,7 @@ export const listSupervisorReviews = (slug: string) =>
 export const REVIEW_ELIGIBLE_KINDS: readonly string[] = [
   "findings_pack",
   "skill_response",
+  "chat_draft",
 ];
 
 export const requestReview = (slug: string, artifactId: string) =>

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -44,6 +44,8 @@ function outputLabel(kind: string): string {
       return "Evidence list";
     case "skill_response":
       return "Skill response";
+    case "chat_draft":
+      return "Draft from chat";
     default:
       return kind.replace(/_/g, " ");
   }

--- a/frontend/src/matter/ArtifactPreview.tsx
+++ b/frontend/src/matter/ArtifactPreview.tsx
@@ -154,6 +154,11 @@ export function ArtifactPreview({
   if (kind === "skill_response" && looksLikeSkillResponse(payload)) {
     return <SkillResponseView payload={payload} matterSlug={matterSlug} />;
   }
+  // chat_draft (assistant reply saved as a draft) shares the
+  // skill_response payload shape: output + model_id + source_anchors.
+  if (kind === "chat_draft" && looksLikeSkillResponse(payload)) {
+    return <SkillResponseView payload={payload} matterSlug={matterSlug} />;
+  }
   return <JsonFallback payload={payload} />;
 }
 

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -38,6 +38,8 @@ function outputLabel(kind: string): string {
       return "Evidence list";
     case "skill_response":
       return "Skill response";
+    case "chat_draft":
+      return "Draft from chat";
     default:
       return kind.replace(/_/g, " ");
   }

--- a/frontend/src/matter/MessageBubble.test.tsx
+++ b/frontend/src/matter/MessageBubble.test.tsx
@@ -107,3 +107,81 @@ describe("MessageBubble — assistant markdown", () => {
     expect(screen.getByText("**not markdown**")).toBeInTheDocument();
   });
 });
+
+describe("MessageBubble — per-turn actions (copy / save as draft)", () => {
+  it("copies the raw message content to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    mount(message({ content: "Draft paragraph for the ET3." }));
+
+    const { default: userEvent } = await import("@testing-library/user-event");
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(writeText).toHaveBeenCalledWith("Draft paragraph for the ET3.");
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+    vi.unstubAllGlobals();
+  });
+
+  it("saves the reply as a draft and offers to open it", async () => {
+    const onSaveDraft = vi.fn().mockResolvedValue("artifact-9");
+    const onOpenDraft = vi.fn();
+    render(
+      <MessageBubble
+        message={message({ content: "Grounds of resistance, first cut." })}
+        docs={[doc]}
+        chronology={[]}
+        onDocChip={vi.fn()}
+        onChronChip={vi.fn()}
+        onSaveDraft={onSaveDraft}
+        onOpenDraft={onOpenDraft}
+      />,
+    );
+
+    const { default: userEvent } = await import("@testing-library/user-event");
+    await userEvent.click(screen.getByRole("button", { name: "Save as draft" }));
+
+    expect(onSaveDraft).toHaveBeenCalledTimes(1);
+    expect(await screen.findByTestId("draft-saved")).toHaveTextContent(
+      "Saved as draft",
+    );
+    // The save action is gone — one draft per reply.
+    expect(screen.queryByRole("button", { name: "Save as draft" })).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "open" }));
+    expect(onOpenDraft).toHaveBeenCalledWith("artifact-9");
+  });
+
+  it("shows a plain error and keeps the action when saving fails", async () => {
+    const onSaveDraft = vi.fn().mockRejectedValue(new Error("boom"));
+    render(
+      <MessageBubble
+        message={message({ content: "x" })}
+        docs={[doc]}
+        chronology={[]}
+        onDocChip={vi.fn()}
+        onChronChip={vi.fn()}
+        onSaveDraft={onSaveDraft}
+      />,
+    );
+
+    const { default: userEvent } = await import("@testing-library/user-event");
+    await userEvent.click(screen.getByRole("button", { name: "Save as draft" }));
+
+    expect(
+      await screen.findByText("Couldn't save — try again"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save as draft" })).toBeInTheDocument();
+  });
+
+  it("hides the save action when no handler is supplied (read-only surfaces)", () => {
+    mount(message({ content: "demo reply" }));
+    expect(screen.queryByRole("button", { name: "Save as draft" })).toBeNull();
+    // Copy still renders.
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("never renders actions on user turns", () => {
+    mount(message({ id: "u-2", role: "user", content: "hello" }));
+    expect(screen.queryByTestId("message-actions")).toBeNull();
+  });
+});

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import type {
   AssistantMessage,
   ChronologyEvent,
@@ -41,6 +41,11 @@ interface Props {
   onSources?: (message: AssistantMessage) => void;
   onVersions?: (message: AssistantMessage) => void;
   onRecord?: (message: AssistantMessage) => void;
+  // Save this reply as a draft output. Resolves to the artifact id.
+  // Omitted on read-only surfaces (demo) — the action doesn't render.
+  onSaveDraft?: (message: AssistantMessage) => Promise<string>;
+  // Open a saved draft (the artifact detail page).
+  onOpenDraft?: (artifactId: string) => void;
   compact?: boolean;
 }
 
@@ -54,6 +59,8 @@ export function MessageBubble({
   onSources,
   onVersions,
   onRecord,
+  onSaveDraft,
+  onOpenDraft,
   compact = false,
 }: Props) {
   const isUser = message.role === "user";
@@ -69,6 +76,8 @@ export function MessageBubble({
       onSources={onSources}
       onVersions={onVersions}
       onRecord={onRecord}
+      onSaveDraft={onSaveDraft}
+      onOpenDraft={onOpenDraft}
       compact={compact}
     />
   );
@@ -97,6 +106,8 @@ function AssistantMessageView({
   onSources,
   onVersions,
   onRecord,
+  onSaveDraft,
+  onOpenDraft,
   compact,
 }: Props) {
   const { text, citations } = extractCitations(message.content, docs, chronology);
@@ -173,7 +184,109 @@ function AssistantMessageView({
             onRecord={onRecord}
           />
         )}
+        {!compact && (
+          <MessageActions
+            message={message}
+            onSaveDraft={onSaveDraft}
+            onOpenDraft={onOpenDraft}
+          />
+        )}
       </div>
+    </div>
+  );
+}
+
+// Quiet per-turn actions under an assistant reply: copy the text, and
+// save it as a draft output on the matter (the on-ramp into the
+// review/sign flow). Same understated idiom as the output-row links.
+type SaveState =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "saved"; artifactId: string }
+  | { kind: "error" };
+
+function MessageActions({
+  message,
+  onSaveDraft,
+  onOpenDraft,
+}: {
+  message: AssistantMessage;
+  onSaveDraft?: (message: AssistantMessage) => Promise<string>;
+  onOpenDraft?: (artifactId: string) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [save, setSave] = useState<SaveState>({ kind: "idle" });
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (copyTimer.current) clearTimeout(copyTimer.current);
+    },
+    [],
+  );
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.content);
+      setCopied(true);
+      if (copyTimer.current) clearTimeout(copyTimer.current);
+      copyTimer.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (permissions, insecure context) — do nothing.
+    }
+  };
+
+  const saveDraft = async () => {
+    if (!onSaveDraft || save.kind === "saving") return;
+    setSave({ kind: "saving" });
+    try {
+      const artifactId = await onSaveDraft(message);
+      setSave({ kind: "saved", artifactId });
+    } catch {
+      setSave({ kind: "error" });
+    }
+  };
+
+  const linkCls =
+    "text-muted underline underline-offset-4 hover:text-ink transition-colors";
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]"
+      data-testid="message-actions"
+    >
+      <button type="button" onClick={() => void copy()} className={linkCls}>
+        {copied ? "Copied" : "Copy"}
+      </button>
+      {onSaveDraft && save.kind !== "saved" && (
+        <button
+          type="button"
+          onClick={() => void saveDraft()}
+          disabled={save.kind === "saving"}
+          className={linkCls + " disabled:opacity-50"}
+        >
+          {save.kind === "saving" ? "Saving…" : "Save as draft"}
+        </button>
+      )}
+      {save.kind === "saved" && (
+        <span className="text-muted" data-testid="draft-saved">
+          Saved as draft
+          {onOpenDraft && (
+            <>
+              {" — "}
+              <button
+                type="button"
+                onClick={() => onOpenDraft(save.artifactId)}
+                className={linkCls}
+              >
+                open
+              </button>
+            </>
+          )}
+        </span>
+      )}
+      {save.kind === "error" && (
+        <span className="text-seal">Couldn't save — try again</span>
+      )}
     </div>
   );
 }

--- a/frontend/src/matter/auditHumanLabel.ts
+++ b/frontend/src/matter/auditHumanLabel.ts
@@ -13,6 +13,7 @@ const EXACT: Record<string, string> = {
   "module.capability.invoked": "Skill run started",
   "module.capability.completed": "Skill run completed",
   "module.capability.failed": "Skill run failed",
+  "assistant.draft.saved": "Chat reply saved as draft",
   "retrieval.search": "Searched the matter",
   "model.invoked": "Model called",
   "model.completed": "Model response received",

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -10,6 +10,7 @@ import {
   getThreadMessages,
   listInstalledModules,
   postAssistantMessageStream,
+  saveMessageAsDraft,
   ProviderKeyMissingError,
   ProviderUpstreamError,
   providerKeyMissingFromBody,
@@ -792,6 +793,20 @@ export function AssistantTab({
                 onSources={(message) => setWorkPane({ kind: "sources", message })}
                 onVersions={(message) => setWorkPane({ kind: "versions", message })}
                 onRecord={(message) => setWorkPane({ kind: "activity", message })}
+                onSaveDraft={
+                  disabled
+                    ? undefined
+                    : (message) =>
+                        saveMessageAsDraft(matter.slug, message.id).then(
+                          (r) => r.artifact_id,
+                        )
+                }
+                onOpenDraft={(artifactId) =>
+                  void navigate({
+                    to: "/matters/$slug/artifacts/$artifactId",
+                    params: { slug: matter.slug, artifactId },
+                  })
+                }
               />
               {m.role === "assistant" && (
                 <AssistantSawPanel


### PR DESCRIPTION
Deferred-ledger item #2: chat no longer dead-ends. Each assistant reply gets a quiet action row (Copy / Save as draft). Saving creates a `chat_draft` matter artifact from the persisted message and it flows straight into the existing review/sign-off path.

## Backend
- `POST /api/matters/{slug}/assistant/messages/{id}/save-draft` — owner-only via the shared archived-aware resolver (no drafts on tombstoned matters), assistant rows only, idempotent per message (message id doubles as invocation id; a second save returns the existing draft with 200 + `already_existed`).
- Provenance carried on the artifact payload: source message id, thread id, `model_used`, prompt/response hashes, and the retrieval sources exactly as persisted (also mapped to `source_anchors` so existing preview/review surfaces render citations).
- `assistant.draft.saved` audit row (M13 legibility: prepared by AI in chat, from which message, with model + hashes).
- `chat_draft` added to `REVIEW_ELIGIBLE_KINDS` — same review/sign loop, zero special-casing.
- Keyless/extractive replies save fine: `model_id` is null, provenance records what happened, nothing gates.

## Frontend
- MessageBubble action row (Copy / Save as draft) in the existing understated link idiom; after save: "Saved as draft — open" linking to the output page. Hidden on read-only/demo surfaces.
- `chat_draft` renders via the `skill_response` preview (same payload shape), labelled "Draft from chat" in outputs list + detail; audit timeline label added.

## Tests
- 8 backend tests in `tests/test_assistant_save_draft.py`, including the full message → draft → review → sign-off walk, archived-matter 404, non-assistant-row 422, idempotency, and keyless/null-model save.
- 9 frontend tests on MessageBubble (action row, copy, save states).
- Verified locally: new suite + assistant pipeline + review + sign-off suites green; full frontend vitest (358 tests) + tsc + vite build green. Full backend suite green apart from known environment-only failures on macOS (Linux sandbox/rlimits, `examples.modules` path) that CI covers.

## Open questions (smallest honest version shipped)
- Drafts are one-per-message (idempotent). If a reply is regenerated, the new message saves as a new draft — no draft versioning.
- The draft payload freezes the message as persisted; no editing before save (edit lives on the output/review surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)