### PR TITLE
docs: architecture decision records (ADR-001 to ADR-010)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Start with [`docs/`](./docs/):
 - [`docs/EVALUATING.md`](./docs/EVALUATING.md): the walkthrough and the evaluation gate
 - [`docs/THREAT_MODEL.md`](./docs/THREAT_MODEL.md): adversary model and what we don't defend
 - [`docs/LIMITATIONS.md`](./docs/LIMITATIONS.md): what is not production-grade and what a fork must build (read before building on top)
+- [`docs/adr/`](./docs/adr/): architecture decision records — why the system is shaped this way and what not to refactor
 - [`docs/ROADMAP.md`](./docs/ROADMAP.md): shipped, deferred, parked
 - [`docs/ATTRIBUTIONS.md`](./docs/ATTRIBUTIONS.md): credits and licence notes
 

--- a/docs/adr/ADR-001-byo-model-keys.md
+++ b/docs/adr/ADR-001-byo-model-keys.md
@@ -1,0 +1,67 @@
+# ADR-001 — BYO model keys only; no server-paid keys in production
+
+**Status:** Accepted, enforced in code.
+
+## Context
+
+Legalise is an open-source governance layer for UK legal AI (evaluation
+release). Two forces shape how model access works:
+
+1. **Economics.** A solo-maintained open-source project cannot subsidise LLM
+   inference. A server-paid key on a public deployment is an unbounded cost
+   liability and an abuse magnet.
+2. **Liability and positioning.** Legalise's public claim (docs/TRUST.md §2) is
+   that it "does not bundle, resell, or intermediate model access". The firm
+   using it is the data controller; the model contract (including no-training
+   terms) is between the *user* and the provider. If Legalise supplied the key,
+   it would sit in the data path as an intermediary — a different regulatory
+   product entirely.
+
+## Decision
+
+- Every user brings their own Anthropic/OpenAI key, stored AES-256-GCM
+  encrypted per user (`backend/app/core/user_keys.py`), decrypted only at call
+  time, never logged.
+- A server fallback key exists **only** for dev: it requires *both* a dev
+  environment *and* `LEGALISE_ALLOW_SERVER_KEY_FALLBACK=true` (default `false`,
+  `backend/app/core/config.py:77`).
+- In production, a missing user key raises `ProviderKeyMissing`
+  (`backend/app/core/model_gateway.py:446`), routers translate it to a 422
+  with a UI nudge, and a `…model.key_missing` audit row is written.
+- **Keyless behaviour is a designed product path, not a degraded error state.**
+  Three deliberate keyless modes exist:
+  - the deterministic `stub-echo` provider (demo, smoke tests, e2e);
+  - the **keyless extractive fallback** in the assistant pipeline
+    (`backend/app/modules/assistant/pipeline.py`,
+    `_keyless_retrieval_answer`): a keyless turn answers from retrieved
+    passages, labelled as an extract with `model_used="no-model"`, instead of
+    dead-ending. A keyless no-hits turn still persists the message and returns
+    an honest "no-model" reply (fixed in PR #248 — previously 422 + lost
+    message);
+  - keyless local embeddings for retrieval (see ADR-006).
+
+  This is what makes a fresh fork demo itself with zero credentials, and it is
+  what the golden-loop e2e deliberately tests (the sign leg runs on a
+  stub-echo matter *because* key-missing IS the deterministic fallback under
+  test).
+
+## Consequences
+
+- The first-run funnel has a real "BYO-key cliff": six gates to first keyed
+  value. Mitigation is the keyless retrieval answer as the conversion moment —
+  accepted trade-off, recorded in the launch punch list.
+- Anthropic/OpenAI keys are user secrets in our DB → the encryption-secret
+  discipline in ADR-007 is load-bearing.
+- Hosted demo cost exposure is ~zero by construction.
+
+## What not to change, and why
+
+- **Do not add a production server key "to smooth onboarding".** It converts
+  the maintainer into a model-access intermediary and an unbounded payer. This
+  is a repo non-negotiable ("no server-paid model keys in prod").
+- **Do not treat the keyless fallback as a bug or replace it with a hard
+  error.** It is the demo path, the fork cold-start path, and part of the
+  tested contract. Its outputs are honestly labelled ("extract, no model",
+  echo labelled as echo) — keep the labelling; the honesty is the feature.
+- **Do not flip `LEGALISE_ALLOW_SERVER_KEY_FALLBACK` default or widen it
+  beyond dev.**

--- a/docs/adr/ADR-002-audit-hash-chain-worm.md
+++ b/docs/adr/ADR-002-audit-hash-chain-worm.md
@@ -38,6 +38,16 @@ Two independent enforcement layers plus a chain, plus verification:
    hash, later re-verify), and the matter export bundle. An owner-scoped
    read-only `GET …/audit/verify` powers the one-click "Verify integrity"
    button on Overview.
+5. **Exports verify offline** (PR #258): every matter export ships
+   `audit_chain.json` (each chain row in the exact canonical string form the
+   hashes are computed over, plus a head summary) and `verify_chain.py`, a
+   stdlib-only verifier copied verbatim into the zip
+   (`backend/app/core/export_chain_verifier.py`). A recipient can prove the
+   trail intact on a bare Python 3 install — no app, no network, no database.
+   `AuditEntryCanonical.canonical_fields()` is the single source of truth for
+   the rendering; two anti-drift tests (a no-DB cross-test and a DB-backed
+   round trip that runs the shipped verifier as a subprocess) pin the
+   standalone copy to it in CI.
 
 Honest limit, stated everywhere it matters: this is tamper-**evident**, not
 tamper-proof. A DB superuser with trigger access can rewrite unanchored
@@ -76,6 +86,10 @@ idle-in-transaction + waiter on advisory).
   README points at.
 - **Do not move audit writes earlier in request flows** without checking the
   advisory-lock rule above.
+- **Do not edit the exported verifier or the canonical rendering
+  independently.** `verify_chain.py` in exports is a verbatim copy; the
+  anti-drift tests exist because a diverged verifier quietly invalidates
+  every previously issued export.
 - Note: `REGULATORY_PLUMBING.md` once claimed the hash chain was "not in v1"
   (corrected in PR #254). If a doc drifts that way again, the chain is built —
   fix the doc, don't "implement" the chain a second time. ARCHITECTURE.md and

--- a/docs/adr/ADR-002-audit-hash-chain-worm.md
+++ b/docs/adr/ADR-002-audit-hash-chain-worm.md
@@ -1,0 +1,82 @@
+# ADR-002 — Append-only audit hash-chain + WORM posture, verified in CI
+
+**Status:** Accepted, enforced in DB triggers + role grants + CI.
+
+## Context
+
+The product's entire claim is that the audit trail is a *record*, not a log:
+"every step writes to an audit log the application cannot edit or delete"
+(README). A regulator/insurer-facing record that the application could quietly
+rewrite is worthless. Hostile diligence (IC report, 2026-06) specifically
+called out the missing hash chain; migration `0030` closed it.
+
+## Decision
+
+Two independent enforcement layers plus a chain, plus verification:
+
+1. **WORM trigger** (migration `0011_audit_worm.py`): a Postgres trigger
+   rejects UPDATE and DELETE on `audit_entries` for every role.
+2. **Role split** (`infra/postgres-roles.sql`): the application role
+   (`legalise_app`) has UPDATE/DELETE revoked by grant. **Exercised in CI on
+   every build** — `.github/workflows/ci.yml` applies the grants and runs
+   `infra/verify-worm-role-split.sh`; the build fails if `legalise_app` can
+   mutate an audit row. The split is live on hosted prod (flipped ON
+   2026-06-30, re-verified read-only against the production database
+   2026-07-05: app connects as `legalise_app`, migrations via `MIGRATION_DSN`
+   as owner, no mutation grants on audit tables).
+3. **Hash chain** (migration `0030_audit_hash_chain.py`): an append-only
+   `audit_chain` table, one row per audit row, written synchronously by an
+   `AFTER INSERT` trigger. Canonical `len:value` serialisation is defined in
+   `backend/app/core/audit_chain.py` and mirrored byte-for-byte in PL/pgSQL —
+   two implementations on purpose, so CI catches trigger/verifier drift.
+   Chains link per scope (`matter` / `system`), serialised with
+   `pg_advisory_xact_lock`. `audit_chain` has its own WORM trigger and
+   `ON DELETE RESTRICT` FK.
+4. **Verification lives in three places:** `verify_audit_chain` (Python
+   re-computation, structured issue codes), `GET
+   /api/matters/{slug}/audit/chain` (third-party verification: export the head
+   hash, later re-verify), and the matter export bundle. An owner-scoped
+   read-only `GET …/audit/verify` powers the one-click "Verify integrity"
+   button on Overview.
+
+Honest limit, stated everywhere it matters: this is tamper-**evident**, not
+tamper-proof. A DB superuser with trigger access can rewrite unanchored
+history. External anchoring (e.g. Rekor) and per-entry Ed25519 signing are
+specced, deferred, and named as not-built (docs/ARCHITECTURE.md §8).
+
+**Operational trap you must know about (learned twice, 2026-06-29):** the
+per-scope `pg_advisory_xact_lock` is held until the request transaction
+commits. Any in-session audit write taken *before* a long/fallible operation
+(a model call) deadlocks against out-of-band audit writes on separate
+committed connections (`audit_failure` / `audit_out_of_band`). This produced a
+prod hang twice. The rule, recorded at `backend/app/core/api.py:342` and in
+the assistant router: **never hold the chain advisory lock across a long
+operation that may spawn separate-connection audit writes** — write
+out-of-band, or commit first. Diagnose via `pg_stat_activity` (holder
+idle-in-transaction + waiter on advisory).
+
+## Consequences
+
+- Audit-table schema changes are effectively append-only too: the canonical
+  serialisation (`audit-chain-entry-v1`) commits to specific columns. Changing
+  column semantics or serialisation breaks every existing chain.
+- Deleting a matter cannot delete its audit rows (see ADR-010: tombstone, not
+  purge, of the record).
+- CI is a compliance gate, not just a test gate.
+
+## What not to change, and why
+
+- **Never add UPDATE/DELETE paths to `audit_entries` or `audit_chain`**, never
+  "fix" the WORM triggers to allow admin edits, never grant the app role
+  mutation rights. Any migration that does this destroys the product's one
+  claim.
+- **Never change the canonical serialisation or the PL/pgSQL mirror
+  independently.** They must stay byte-identical; CI drift-checks assume it.
+- **Do not remove the role-split assertion from CI** — it is the proof the
+  README points at.
+- **Do not move audit writes earlier in request flows** without checking the
+  advisory-lock rule above.
+- Note: `REGULATORY_PLUMBING.md` once claimed the hash chain was "not in v1"
+  (corrected in PR #254). If a doc drifts that way again, the chain is built —
+  fix the doc, don't "implement" the chain a second time. ARCHITECTURE.md and
+  TRUST.md are current.

--- a/docs/adr/ADR-003-author-signer-legibility.md
+++ b/docs/adr/ADR-003-author-signer-legibility.md
@@ -1,0 +1,63 @@
+# ADR-003 — Author ≠ signer: sign-off legibility as a product invariant
+
+**Status:** Accepted. Legibility always on; separation opt-in.
+
+## Context
+
+The regulatory story (SRA supervision, post-Mazur guidance): AI can draft, but
+a named human must stay accountable, and a workspace that lets AI-authored
+work be silently rubber-stamped — or lets an author quietly certify their own
+output — has no supervision story. This is the thesis: *the machine signs its
+own record; the human signs the work.* It is a product invariant, not a
+workflow preference, because it is the thing competitors structurally don't
+have (sign-off + posture on an output is "the lane none of them occupy").
+
+## Decision
+
+Precision matters here — the invariant is **legibility**, not mandatory
+separation:
+
+- Sign-off (`backend/app/core/signoff.py`) records `signed` /
+  `signed_with_observations` / `rejected`; non-clean decisions require
+  reasoning. Each sign-off **pins the exact output by hash** (SHA-256 of
+  canonical `{artifact_id, kind, payload}`) and is append-only (a new decision
+  never mutates a prior one; the live decision derives from newest row).
+- **By default, an author MAY sign their own work** — the design target is the
+  sole practitioner. But the record never hides it: `signer_is_author`
+  (computed against `artifact.created_by_id`, `signoff.py:264`) is written
+  into the audit payload and rendered in UI/exports as "author — self-signed,
+  not independent review".
+- Firms needing four-eyes set `SIGNOFF_AUTHOR_MUST_DIFFER` (default `false`,
+  `config.py:99`): signing your own work raises `AuthorCannotSign` (403) —
+  **rejecting your own work is always allowed** (blocking self-rejection would
+  be perverse).
+- In the Mike-fork experiment the same rule appears as: `signer_is_author` is
+  forced false when the version is AI-authored — a human signing AI output is
+  author≠signer by construction.
+- **Rubber-stamp detection (M13):** first open of a sign surface writes an
+  idempotent `output.review.opened` row; review latency is derived at read
+  time; an implausibly fast sign-off is flagged `implausible_speed` on the
+  payload — **recorded, not blocked**. Admin surface shows scrutiny bands.
+
+## Consequences
+
+- "Who stayed accountable, and did they actually look?" is answerable from the
+  record alone. That is the pitch to regulators/insurers.
+- Sign-off history can grow long on contested outputs; that is intentional
+  (disciplinary-record semantics — rejections recorded as faithfully as
+  approvals, or the standing claim dies).
+
+## What not to change, and why
+
+- **Never make sign-offs mutable or collapse the history to "latest wins" at
+  the storage layer.** Derive-latest at read time is the pattern.
+- **Never drop or default-hide `signer_is_author`** from payloads, UI, or
+  exports. Hiding self-signing converts the record from honest to misleading.
+- **Do not make M13 blocking.** It is deliberately record-not-block: the
+  product's stance is legibility over enforcement (a blocked signer just waits
+  out a timer; a *flagged* signer is visible to their supervisor forever).
+- **Do not "simplify" by making `SIGNOFF_AUTHOR_MUST_DIFFER` default true** —
+  it kills the sole-practitioner loop the eval release targets.
+- **Do not let any new output path (new artifact kinds, external packs, chat
+  "save as draft" when built) bypass sign-off/pinning.** Every reviewable
+  output must be hash-pinned at decision time.

--- a/docs/adr/ADR-004-matter-first.md
+++ b/docs/adr/ADR-004-matter-first.md
@@ -1,0 +1,53 @@
+# ADR-004 — Matter-first, not a global assistant
+
+**Status:** Accepted, repeatedly re-ratified (most recently 2026-07-02 against
+the "chat window vs Harvey/Legora" question).
+
+## Context
+
+Every legal-AI incumbent ships a general chat assistant. Chat UX is a
+commodity arms race Legalise cannot win and must not enter (recorded caution:
+"do NOT get into a chat-UX arms race — the shell is commodity; the value is
+what it invokes + the governance-on-the-card"). Legalise's differentiation is
+that every AI action is *scoped, gated, and recorded against a matter* — the
+unit a solicitor, regulator, or insurer actually reasons about.
+
+## Decision
+
+- **The matter is the unit of isolation.** Every matter-scoped route checks
+  ownership; grants, audit scope, privilege posture, retention, and the hash
+  chain are all keyed per matter (docs/ARCHITECTURE.md §2). Cross-user reads
+  404 (not 403) so slugs don't leak.
+- **Chat is scoped to one matter and cannot see others.** Context is assembled
+  per turn: matter spine (document *index* — titles not bodies, capped),
+  chronology digest, recent messages (rolling summary + cap), and audited
+  retrieval hits (ADR-006), under a token budget. The system prompt forces the
+  model to distinguish what it can SEE (index) from what it has READ (bodies).
+- Chat is the primary *surface* (chat-led reshape, 2026-06-05: "chat IS the
+  product"), but it is a window onto the matter, not a global assistant. There
+  is deliberately no cross-matter or workspace-level chat.
+- The turn loop is deliberately a **single governed turn** (one model call +
+  one tool round-trip), not a multi-step agent harness. This was decided
+  explicitly (2026-06-29): a planning/retry agent loop fights the
+  "every turn governed and inspectable" thesis. It is documented as deliberate
+  scope in docs/LIMITATIONS.md, not as debt.
+
+## Consequences
+
+- Answers are grounded and citable per matter; "what did the AI see" has a
+  per-matter answer. This is the differentiation vs Harvey/Legora — they have
+  citations; they don't have posture + sign-off + audit scope *per matter*.
+- Users who want ChatGPT-at-work ergonomics (cross-matter questions, global
+  memory) will find it constrained. That constraint is the product.
+
+## What not to change, and why
+
+- **Do not add a workspace-global or cross-matter chat.** It instantly breaks
+  the isolation claim ("the assistant is scoped to one matter and can't see
+  others" — README question 1), un-scopes the audit story, and moves the
+  product into the commodity lane where it loses.
+- **Do not replace the single governed turn with an autonomous agent loop**
+  without redesigning the audit story first. Every additional autonomous hop
+  is an unrecorded decision unless the substrate grows with it.
+- **Do not un-scope retrieval or context assembly from the matter** (e.g. a
+  "search all my matters" feature) — same reason.

--- a/docs/adr/ADR-005-skills-import-only.md
+++ b/docs/adr/ADR-005-skills-import-only.md
@@ -1,0 +1,84 @@
+# ADR-005 — Skills arrive only by import at a pinned SHA; no bundled skills
+
+**Status:** Accepted. Native skill modules deleted (PR #175, −12,741 LOC);
+filesystem plugin path deleted (PR #180, −4.1k LOC). Both deliberate.
+
+## Context
+
+Legalise once shipped five native Python skill modules (pre-motion, contract
+review, tabular review, case law, letters) plus a filesystem plugin path that
+cloned an external repo at boot. Both were killed on purpose:
+
+- Bundled skills made Legalise a *content* product competing on skill quality
+  (a losing lane) instead of a *governance* product.
+- Native code modules widened the attack/liability surface (arbitrary Python
+  in-process) and made the trust story incoherent: why ceremony-gate imported
+  skills while shipping ungated native ones?
+- The reframe (2026-06-11): Legalise is "the regulator and chambers for AI
+  lawyers" — manifest = practising certificate, import ceremony = admission.
+  A regulator that authors the practitioners is marking its own homework.
+
+## Decision
+
+- Skills arrive **only** via import, from two sources: the Lawve catalogue
+  (`backend/app/core/lawve_import.py`, list + draft) and any public GitHub
+  repo with a `SKILL.md` (`backend/app/core/github_import.py`). Every import
+  is **pinned to a commit SHA** (`_resolve_ref` resolves branch/tag → SHA;
+  the SHA lands in the manifest `source_url`). Updating a skill is a fresh
+  import through the ceremony — a prompt change can never reach the runtime
+  silently.
+- Imported skills run as **prompt-runtime** modules
+  (`backend/app/core/prompt_runtime.py`): the SKILL.md body becomes the system
+  prompt; **no arbitrary code import**. The full governance seam runs on every
+  invocation (posture gate → read grants → advice-boundary → invocation audit
+  → provider call → model audit → write grants → artifact → completion audit).
+- **Install ceremony = trust review** (`backend/app/core/trust_ceremony.py`):
+  manifest → signature → publisher → permissions → data movement → gates →
+  grant. Signature grades are honest: `verified` (real Ed25519 against a
+  registered publisher key) vs `structure_verified` (shape-only; a
+  well-formed forgery would pass — deliberately not called `verified`, and
+  rendered in the UI as "structure checked"). The 3-step fast path is gated
+  on cryptographic `verified` **only** (PR #255 — `structure_verified`
+  previously qualified); everything else takes the full 7-step inspection.
+  Since no publisher has a registered key yet, every install today takes the
+  full path (first-party manifest signing is a tracked follow-up —
+  `scripts/sign_manifest.py` exists, the release pipeline doesn't sign yet).
+  Permission-expanding manifest updates force a re-ceremony.
+- **Entrypoint-resolvability guard** (PR #249, after a prod incident where two
+  legacy installed rows pointed at modules deleted in #175 and the model's
+  tool calls died): `native_entrypoint_error`
+  (`backend/app/core/runtime.py:183`, `find_spec`, no code execution) runs at
+  install ceremony and module update (422 `entrypoint_unresolvable`), at chat
+  tool-advertising time (skip + log), and in `doctor`
+  (`modules.entrypoints_resolvable`).
+- What remains in-repo: `examples/modules/{contract_review,pre_motion}` as
+  *reference implementations of the governance order* — installable examples
+  that tests, first-run e2e, and the demo fixture on. They are examples, not
+  bundled product skills. Four internal native modules remain as substrate
+  (`assistant`, `chronology`, `anonymisation`, `document_edit`) — these are
+  platform plumbing, not legal skills.
+
+## Consequences
+
+- The catalogue is only as good as its sources (Lawve's public feed is frozen
+  at 42 skills vs 194 on lawve.ai — stated honestly in the UI).
+- Old installed rows referencing deleted code can linger in a database — the
+  resolvability guard exists precisely for this class.
+
+## What not to change, and why
+
+- **Do not reintroduce bundled/native legal skills.** The −12.7k LOC deletion
+  was a strategic decision, not tech debt cleanup. Bundling skills re-couples
+  Legalise's credibility to skill content and breaks the regulator framing.
+- **Do not add an unpinned import path** (floating branch, "latest", direct
+  paste-without-provenance). SHA pinning IS the approval trail ("reviewing a
+  skill means reviewing its SKILL.md at that SHA").
+- **Do not bypass or streamline away the trust ceremony** for "known" sources,
+  and do not soften the `structure_verified` label into something that sounds
+  cryptographic. In particular, do not re-admit `structure_verified` to the
+  fast path — a forged signature of the right shape passes the structure
+  check; that is exactly why PR #255 removed it.
+- **Do not remove the entrypoint guard** — it prevents a recurring prod
+  failure class (install-clean, fail-on-dispatch).
+- **Do not delete `examples/modules/`** without re-fixturing the governance
+  tests, e2e golden loop, and demo that depend on them.

--- a/docs/adr/ADR-006-hybrid-local-retrieval.md
+++ b/docs/adr/ADR-006-hybrid-local-retrieval.md
@@ -1,0 +1,64 @@
+# ADR-006 — Hybrid local retrieval (pgvector + full-text), audited per search
+
+**Status:** Accepted, shipped 2026-06-29 (migrations 0036–0038).
+
+## Context
+
+Before P3, chat context was "the 3 most recent docs" — indefensible. But the
+obvious fix (call a hosted embeddings API) breaks the privilege story: legal
+professional privilege can be waived by disclosure to a third party, and
+Legalise's TRUST.md §1 promise is "indexing privileged documents does not send
+text to a model provider". The model gateway is supposed to be the *single*
+egress point for matter content (THREAT_MODEL); a second egress via an
+embedding API would double the sub-processor surface for every document —
+including on `C_paused` matters, which must generate zero cloud traffic.
+
+## Decision
+
+- **Embeddings are computed locally, in-tenant, keyless by default:**
+  `fastembed` BAAI/bge-small-en-v1.5, 384-dim ONNX, CPU, no torch
+  (`backend/app/core/embeddings.py`). The Docker image pre-bakes the model
+  (no runtime download). A deterministic 384-dim `hash` backend
+  (`LEGALISE_EMBEDDING_BACKEND=hash`) is the slim/offline/CI fallback —
+  lexical-ish, NOT semantic, and honest about it.
+- **Retrieval is hybrid:** pgvector cosine (HNSW) + Postgres full-text (GIN
+  tsvector) with reciprocal-rank fusion, over `document_chunks`
+  (migration 0036: text + char offsets + `vector(384)` + generated tsvector),
+  indexed-docs-only (`documents.index_status`, migration 0037). One store
+  (Postgres) holds relational, audit, and vectors — no separate vector DB.
+- **Every search is audited:** each turn writes a `retrieval.search` row
+  (query hashed, k, hit_count, document_ids) — "what did the AI see" is a
+  precise per-turn trail, replayable not inferred. The retrieval functions
+  themselves are pure data (`backend/app/core/retrieval.py` writes no audit;
+  auditing is the caller's job so the row commits with the work — but note
+  the assistant writes it **out-of-band** via `audit_out_of_band` to avoid
+  the advisory-lock deadlock in ADR-002).
+- **Sources are first-class:** the assistant persists the passages it relied
+  on (`assistant_messages.sources`, migration 0038), rendered as clickable
+  citations into the document reader at the char range. Reviewable before
+  sign-off.
+- The pgvector column and index are **fixed at 384 dims for v1**; both
+  backends emit unit-norm 384-dim vectors by contract.
+
+## Consequences
+
+- Retrieval quality is bounded by a small local model — a deliberate
+  privilege-over-quality trade-off, framed as a *choice* in LIMITATIONS.md.
+- Changing the embedding model/dimension is a re-index migration, not a config
+  flip.
+- History note: pgvector was *removed* from deps in June (post-IC-report
+  cleanup, when unused) and deliberately re-added as a main dependency when
+  retrieval shipped. Don't read the June removal as "pgvector is unwanted".
+
+## What not to change, and why
+
+- **Do not route embedding of matter content through any third-party API**
+  (OpenAI embeddings, Voyage, Cohere, etc.). This silently breaks the LPP
+  promise and the single-egress threat model. If a better embedder is needed,
+  it must run in-tenant.
+- **Do not remove the `retrieval.search` audit row or batch it away** — the
+  per-turn evidence trail is a stated product promise ("What did it see?").
+- **Do not swap the hash fallback for a "small remote model"** in slim
+  installs — offline means offline.
+- **Keep retrieval functions audit-free and callers audit-responsible**, and
+  keep the out-of-band write pattern (see the deadlock rule in ADR-002).

--- a/docs/adr/ADR-007-infrastructure-non-negotiables.md
+++ b/docs/adr/ADR-007-infrastructure-non-negotiables.md
@@ -1,0 +1,77 @@
+# ADR-007 — Infrastructure non-negotiables: Redis, Fly filesystem, Neon, key encryption
+
+**Status:** Accepted. These are standing rules, recorded in the maintainer's
+non-negotiables list and enforced/documented in code.
+
+## Context
+
+Hosted topology: Cloudflare (CDN/Pages/R2) → Fly.io `lhr` (backend app +
+worker) → Neon London (Postgres) + Upstash Redis. Each rule below exists
+because the tempting shortcut it forbids would break a privilege, durability,
+or audit promise.
+
+## Decision
+
+1. **Redis never holds matter content.** Redis is a job *queue* only
+   (`backend/app/core/jobs.py`, arq): "Workers receive only the job id from
+   the queue and read everything else from Postgres" (jobs.py:13,250 — the
+   rule is written into the module docstring and the enqueue function).
+   Rate-limiting deliberately does NOT use Redis either — auth throttles are
+   sliding windows recomputed **from Postgres** so limits hold across
+   instances (TRUST.md §10). The one other thing in Redis is the worker
+   heartbeat key (PR #257): counters only, never matter content — it exists
+   so `doctor`'s `worker.heartbeat` check can tell a dead worker from an
+   idle one. Rationale for the rule: Redis is unencrypted-at-rest by
+   default, ephemeral, and outside the audit/WORM perimeter; content in Redis
+   is content with no privilege posture attached.
+2. **The Fly filesystem is never the source of truth.** The matter filesystem
+   materialisation (`backend/app/core/matter_fs.py`: `matter.md`,
+   `history.md`, `chronology.md` under `matters_root`) is a *mirror* for
+   interchange (deliberately matches the Stella matter-folder schema) and
+   convenience. Postgres rows are authoritative; document blobs live in
+   S3-compatible object storage (R2 hosted / MinIO local), not the Fly
+   volume. Forensic/tamper-evidence claims are scoped to the Postgres copy
+   only — the `.jsonl`/markdown mirrors carry no tamper protection (known,
+   accepted, recorded in the IC-report review). Fly machines are cattle;
+   anything only on their disk is one redeploy from gone.
+3. **Neon Postgres is the source of truth** for matters, documents metadata,
+   audit entries, chain, chunks, vectors, sign-offs, users, and encrypted
+   keys. It is UK-region (London), point-in-time-restorable (restore
+   rehearsal done 2026-06-30), and the WORM role split is live on it
+   (app connects as reduced-privilege `legalise_app`; migrations use
+   `MIGRATION_DSN` as owner).
+4. **User provider keys are AES-256-GCM encrypted** under a master key from
+   `LEGALISE_KEY_ENCRYPTION_SECRET` (32-byte hex), decrypted only at call
+   time, never logged. Operational rules learned the hard way:
+   - The secret must be **stable and explicitly set** in any real deployment.
+     An empty secret makes dev auto-generate per-process → container recreate
+     orphans every stored key (this broke chat mid-session once, and an
+     invalid placeholder in `.env.example` once broke every fresh fork's
+     boot; `.env.example` now ships it EMPTY on purpose — dev auto-generates,
+     stored keys don't survive restart, documented).
+   - Undecryptable keys raise a typed `KeyDecryptionError` with a "re-add
+     your key" message (was a blank-string cryptography error).
+   - `doctor` masks DSN passwords in output.
+
+## Consequences
+
+- Losing the master key = stored provider keys unrecoverable (stated in
+  TRUST.md §3 — the self-host operator owns this).
+- Everything durable funnels through Neon; Neon PITR + the audit chain are
+  the recovery and integrity story respectively.
+
+## What not to change, and why
+
+- **Never cache prompts, responses, document text, or chunks in Redis** (no
+  "speed up retrieval with a Redis cache" PRs). Job id and heartbeat counters
+  only.
+- **Never make the Fly volume authoritative for anything** — no
+  "read matter.md instead of the DB" optimisations, no accepting writes into
+  the mirror. `matter_fs.py` must remain the *only writer* under
+  `matters_root`, one-directional DB→disk.
+- **Never move rate-limit state to Redis** without accepting that limits
+  then reset on Redis loss and diverge across regions — the Postgres window
+  was chosen deliberately.
+- **Never log or persist decrypted provider keys**, and never ship a
+  non-empty `LEGALISE_KEY_ENCRYPTION_SECRET` placeholder in `.env.example`
+  (it must be valid hex or empty; the boot assertion rejects junk).

--- a/docs/adr/ADR-008-register-sidecar-provenance.md
+++ b/docs/adr/ADR-008-register-sidecar-provenance.md
@@ -1,0 +1,85 @@
+# ADR-008 — The register sidecar: three-grade provenance for external exports
+
+**Status:** Accepted and merged (PR #227, migration 0035). Strategic scope
+deliberately narrowed 2026-06-24 — read the whole ADR before extending it.
+Grade semantics corrected in PR #256 (2026-07-05, trust-spine audit finding
+F1): the original two-grade scheme granted `verified_at_source` on an
+*unchecked* manifest hash, so a manifest-only import with arbitrary hashes
+rendered as verified. The fix adds a third grade and makes verification a
+precondition of the word "verified".
+
+## Context
+
+The register pivot (ratified 2026-06-12): Legalise is "not another AI
+workspace — the register underneath them". If the governance layer only
+governs work produced *inside* Legalise, it is a workspace feature. To be a
+register, it must be able to supervise exports from *other* tools. Mike
+(MikeOSS, Will Chen's open-source Harvey-parity workspace) is the first
+adapter and the proof-of-concept target; a companion PR (willchen96/mike#181)
+adds content hashes to Mike's exports so they can arrive verifiable.
+
+## Decision
+
+- `backend/app/core/external_pack.py` (mounted at `/api/external`) ingests an
+  external workspace export via an **adapter registry** (Mike first) into an
+  **external matter that is read-only**: created `C_paused`, no model calls,
+  no skills. Documents land as WORM artifacts; ingestion writes an
+  `external.pack.ingested` audit row. Sign-off and the M13 supervision
+  machinery apply to external packs unchanged.
+- **Three-grade provenance, recorded per document** — an honesty boundary,
+  not a quality score (`external_pack.py`, `HASH_*` constants). Ranked by
+  real epistemic strength:
+  - `verified_at_source` — the export manifest carried a source-side content
+    hash (e.g. a Mike export post-#181), the document bytes ALSO travelled
+    (ZIP present), and re-hashing them at ingest matched the claim. **This is
+    the only grade granted by an actual check.** A source hash without bytes
+    can never earn it.
+  - `attested_at_ingest` — bytes travelled; we hashed them at ingest. The
+    claim starts at our door, and says so. When the manifest also carried a
+    source hash that disagrees with the received bytes, the document lands
+    here with `hash_mismatch=true`: the canonical hash is the one this
+    workspace computed over bytes it holds, the failed claim is preserved as
+    `source_sha256`, and the mismatch is counted and rendered in seal tone on
+    the register face. Recorded, never repaired — ingest does not refuse a
+    tampered pack, because refusing would discard the evidence.
+  - `claimed_by_source` — the manifest carried a source hash but no bytes,
+    so nothing was checked. The hash is preserved verbatim as the source's
+    own claim, and the register face labels it "Claimed by source —
+    unchecked".
+
+  The grade states *which claim is being made*, never upgrades itself, and is
+  surfaced on the register face. No schema churn was needed: grades live in
+  artifact/audit JSON payloads, not a DB enum.
+- **Boundary rules (standing maintainer rule):** only the content-hashes PR
+  (#181) ever goes to Mike's upstream repo. The sidecar/register/supervision
+  layer is never PR'd into Mike (AGPL — never copy Mike code either).
+  Building supervision *inside* another workspace destroys the register's
+  independence value ("a workspace certifying its own output is marking its
+  own homework") and gives the moat away under AGPL. The surviving strategic
+  form is: Mike (and peers) as customer-zero of an *independent* register.
+- Strategic status: the code is clean and live; the *thesis* is deliberately
+  parked pending a demand signal (nobody in the user intersection asked for
+  it yet). Don't delete it; don't extend it speculatively either.
+
+## Consequences
+
+- Legalise can answer the four questions about work it didn't produce — the
+  claim that makes "register underneath them" more than copy.
+- An interchange-manifest proposal exists (docs/REGISTER_SIDECAR.md) for
+  source systems that want `verified_at_source` natively.
+
+## What not to change, and why
+
+- **Never collapse the provenance grades**, and never let a grade render as
+  more than it proved. In particular: `verified_at_source` requires a check
+  that actually ran (source hash + received bytes + match) — granting it on a
+  manifest hash alone is the exact bug fixed in PR #256, and reintroducing it
+  lets an importer mint "verified" from an unchecked self-asserted string.
+  The distinction IS the honesty of the register; blurring it is the one
+  refactor that turns a register into marketing.
+- **Never make external matters writable / model-callable / skill-enabled.**
+  Read-only C_paused is what makes the supervision independent of the tool
+  being supervised.
+- **Never push governance code to Mike's upstream** (only #181-class hash
+  plumbing, and only with explicit instruction). The independent-register
+  position is the strategy.

--- a/docs/adr/ADR-009-model-gateway.md
+++ b/docs/adr/ADR-009-model-gateway.md
@@ -1,0 +1,66 @@
+# ADR-009 — One model gateway: passthrough + audit-stamping contract
+
+**Status:** Accepted. The passthrough contract was violated once (bug fixed in
+PR #248) — that incident is why this is written down.
+
+## Context
+
+All LLM traffic leaves through exactly one chokepoint,
+`backend/app/core/model_gateway.py`. No module calls a provider SDK directly.
+This is the single egress in docs/THREAT_MODEL.md: the only place matter
+content crosses to a third party, therefore the only place posture, keys, and
+audit stamping need to be *provably* correct.
+
+The bug that makes the contract explicit: until PR #248 the gateway never
+passed the requested `model` to providers — every call silently ran the
+provider's config default while **the audit trail stamped the model the user
+requested**. On a product whose entire claim is "the record is true", audit
+rows asserting a model that didn't serve the call is the worst class of bug:
+not a malfunction, a false record. (Pre-fix rows in the prod chain still show
+it: `model_used=anthropic`, requested `opus-4-7`.)
+
+## Decision
+
+- **Single chokepoint.** Providers: Anthropic, OpenAI (keyed, BYO — ADR-001),
+  Ollama (local), `stub-echo` (deterministic). Posture is read from the DB at
+  call time (not caller-passed); `C_paused` raises `PrivilegePaused` before
+  any network traffic; on `B_mixed` a registered local Ollama is preferred
+  when a frontier model was requested.
+- **Passthrough contract:** the requested model id is passed to keyed
+  providers (`model_gateway.py`) so the model the user picked is the model
+  that runs; `max_tokens` is plumbed (assistant turns 8192); truncation
+  raises `provider_truncated` instead of silently returning a cut-off
+  answer — Anthropic via `stop_reason=max_tokens`, OpenAI via
+  `finish_reason=length` (the OpenAI side added in PR #257).
+- **Audit-stamping contract:** the audit row records what actually happened —
+  `model_used` = the model that *served* the call, `requested_model` kept
+  separately, plus `provider`, prompt/response SHA-256 hashes (never the
+  prompt/response bodies themselves), tokens, latency, posture. Token counts
+  are recorded as a real split since PR #257: providers return
+  `(text, tokens_in, tokens_out)` and both land in the audit row
+  (`token_count` stays the summed total, so the chain's canonical
+  serialisation is untouched — see ADR-002 on why that matters). Failures
+  emit `model.call.error` via `audit_failure` (independent transaction,
+  survives rollback).
+
+## Consequences
+
+- Adding a provider = one gateway provider class + catalog entry; the
+  governance seam comes for free.
+- The gateway is the right (only) place for future spend guards, streaming,
+  and model-policy routing.
+
+## What not to change, and why
+
+- **Never let any code path call a provider SDK outside the gateway** —
+  including "quick" features like title generation, summarisation of UI
+  strings, or embeddings (ADR-006 keeps those local for the same reason).
+  One egress is the threat model.
+- **Never write an audit row describing a model call before/without the call
+  resolving to an actual provider+model** — stamp what ran, not what was
+  asked for. Keep `requested_model` and `model_used` as separate fields.
+- **Do not store prompt/response bodies in audit rows.** Hash-only is the
+  privacy contract (TRUST.md §8).
+- **Do not bypass posture-read-at-call-time** by threading posture through
+  caller arguments — the DB read closes a real race (stale `B_mixed` after a
+  flip to `C_paused`).

--- a/docs/adr/ADR-010-fail-closed-deletes.md
+++ b/docs/adr/ADR-010-fail-closed-deletes.md
@@ -1,0 +1,55 @@
+# ADR-010 — Fail-closed deletes and the tombstone lifecycle
+
+**Status:** Accepted. Named by external reviewers as a strength ("fail-closed
+deletes" in the launch-readiness verdict).
+
+## Context
+
+Deletion in a legal workspace has two opposing obligations: the *content* must
+be genuinely deletable (GDPR, client instruction, retention expiry), while the
+*record that things happened* must survive (SRA six-year retention, the audit
+chain's append-only promise, ADR-002). And a delete that reports success while
+bytes linger in object storage is a confidentiality lie.
+
+## Decision
+
+- **Deletes are fail-closed.** A document delete only commits — and only
+  writes its `document.deleted` audit row — after the storage bytes are
+  actually gone; if blob deletion fails, the transaction rolls back and the
+  document stays live (`backend/app/api/document_routes/crud.py:89`,
+  `backend/app/core/matter_lifecycle.py:97,130`). No success-reported,
+  bytes-remaining state.
+- **Matters tombstone, they don't vanish.** Matter deletion/retention-purge
+  goes through one shared audited path,
+  `core.matter_lifecycle.tombstone_matter` (extracted so the API route and
+  the retention sweeper cannot drift): content is purged, an audited
+  tombstone row records that the purge happened (`matter.retention.purged`,
+  system actor `actor_id=None` for sweeper runs), and the audit
+  entries/chain for the matter remain (they are WORM; ADR-002 forbids
+  deleting them). Tombstoned matters reject uploads/reindex.
+- **Retention is enforced opt-in, dry-run by default:** the sweeper
+  (`app.tools.retention_sweep`) defaults to dry-run; `--apply` purges expired
+  matters via the shared tombstone path. (Known follow-up: no `--limit`
+  blast-cap before putting it on a cron.)
+- FK design supports this: deleting a document cascades its chunks;
+  audit tables are `ON DELETE RESTRICT`.
+
+## Consequences
+
+- "We deleted it" is a verifiable claim: the bytes are gone *and* the record
+  of deletion is in the chain.
+- A storage outage makes deletes fail loudly rather than lie — correct, but
+  worth knowing when debugging "delete doesn't work" reports.
+
+## What not to change, and why
+
+- **Do not reorder delete flows to "audit first, delete storage best-effort"**
+  or wrap storage deletion in a swallow-and-continue. The audit row asserting
+  deletion must only exist if deletion happened.
+- **Do not add a hard-delete path for matters that removes audit rows** —
+  impossible by trigger anyway (ADR-002); don't try to migrate around it.
+- **Do not fork a second deletion code path** — route and sweeper share
+  `tombstone_matter` on purpose; a second path is where the audit/tombstone
+  guarantees will silently diverge.
+- **Do not flip the retention sweeper to apply-by-default** or schedule it
+  without the blast-cap.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture decision records
+
+Handover documents. The sessions that made these decisions won't be available
+to explain them. Each ADR states why the system is shaped the way it is and —
+most importantly — what a future contributor or AI coding session must **not**
+"helpfully refactor". Written for a smart engineer with zero project history;
+claims verified against master as of 2026-07-05.
+
+- [ADR-001](./ADR-001-byo-model-keys.md) — BYO model keys only; no server-paid keys in production
+- [ADR-002](./ADR-002-audit-hash-chain-worm.md) — Append-only audit hash-chain + WORM posture, verified in CI
+- [ADR-003](./ADR-003-author-signer-legibility.md) — Author ≠ signer: sign-off legibility as a product invariant
+- [ADR-004](./ADR-004-matter-first.md) — Matter-first, not a global assistant
+- [ADR-005](./ADR-005-skills-import-only.md) — Skills arrive only by import at a pinned SHA; no bundled skills
+- [ADR-006](./ADR-006-hybrid-local-retrieval.md) — Hybrid local retrieval (pgvector + full-text), audited per search
+- [ADR-007](./ADR-007-infrastructure-non-negotiables.md) — Infrastructure non-negotiables: Redis, Fly filesystem, Neon, key encryption
+- [ADR-008](./ADR-008-register-sidecar-provenance.md) — The register sidecar: three-grade provenance for external exports
+- [ADR-009](./ADR-009-model-gateway.md) — One model gateway: passthrough + audit-stamping contract
+- [ADR-010](./ADR-010-fail-closed-deletes.md) — Fail-closed deletes and the tombstone lifecycle


### PR DESCRIPTION
Ten handover ADRs at docs/adr/, indexed from the README docs list. Each records why the system is shaped the way it is and what a future contributor or AI session must not "helpfully refactor". Claims verified against master as of tonight, including #254–#258:

- ADR-002: role split re-verified live on prod; exports now verify offline (audit_chain.json + stdlib verify_chain.py, #258); REGULATORY_PLUMBING drift note updated post-#254
- ADR-005: install fast path gated on cryptographic VERIFIED only (#255); "structure checked" wording
- ADR-008: three-grade provenance as merged (#256) — verified_at_source only on a check that ran
- ADR-009: tokens_in/tokens_out split, OpenAI truncation parity (#257)
- ADR-007: worker heartbeat noted as the one non-queue Redis key (counters only)

Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)