### PR TITLE
Doc count in the chat header opens a document status popover

### DIFF
--- a/frontend/src/matter/indexStatus.ts
+++ b/frontend/src/matter/indexStatus.ts
@@ -1,0 +1,35 @@
+// One vocabulary for per-document retrieval index state, shared by the
+// Documents tab rows and the chat header document popover. Statuses come
+// from the backend document model: pending / indexed / failed / empty.
+export function indexStatusChip(
+  status: string | undefined,
+): { label: string; title: string; className: string } | null {
+  switch (status) {
+    case "indexed":
+      return {
+        label: "Searchable",
+        title: "Indexed for matter-wide retrieval",
+        className: "text-seal",
+      };
+    case "pending":
+      return {
+        label: "Indexing…",
+        title: "Being indexed for matter-wide retrieval",
+        className: "text-muted",
+      };
+    case "failed":
+      return {
+        label: "Not searchable",
+        title: "Indexing failed; this document is not retrievable",
+        className: "text-muted",
+      };
+    case "empty":
+      return {
+        label: "No text",
+        title: "No extractable text to index",
+        className: "text-muted",
+      };
+    default:
+      return null;
+  }
+}

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -698,6 +698,87 @@ describe("AssistantTab — attach popover", () => {
   });
 });
 
+describe("AssistantTab — header document popover", () => {
+  const docWithStatus = (
+    id: string,
+    filename: string,
+    indexStatus?: string,
+  ): MatterDocument =>
+    ({ ...someDoc(id, filename), index_status: indexStatus }) as never;
+
+  it("keeps the zero-doc header line as plain text with no popover", async () => {
+    mountChat({ docs: [] });
+
+    const status = await screen.findByTestId("docs-context-status");
+    expect(status).toHaveTextContent("No documents yet");
+    fireEvent.click(status);
+    expect(screen.queryByTestId("chat-docs-popover")).toBeNull();
+  });
+
+  it("opens a list of documents with their index status from the doc count", async () => {
+    mountChat({
+      docs: [
+        docWithStatus("doc-1", "contract.pdf", "indexed"),
+        docWithStatus("doc-2", "witness.docx", "pending"),
+        docWithStatus("doc-3", "bundle.pdf", "failed"),
+      ],
+    });
+
+    const count = await screen.findByTestId("docs-context-status");
+    expect(count).toHaveTextContent("3 documents");
+    fireEvent.click(count);
+
+    const popover = await screen.findByTestId("chat-docs-popover");
+    expect(within(popover).getByText("contract.pdf")).toBeInTheDocument();
+    expect(within(popover).getByText("Searchable")).toBeInTheDocument();
+    expect(within(popover).getByText("witness.docx")).toBeInTheDocument();
+    expect(within(popover).getByText("Indexing…")).toBeInTheDocument();
+    expect(within(popover).getByText("bundle.pdf")).toBeInTheDocument();
+    expect(within(popover).getByText("Not searchable")).toBeInTheDocument();
+  });
+
+  it("shows just the names when every document is indexed and status is absent", async () => {
+    // Older payloads omit index_status; the row stays quiet rather than
+    // guessing a state.
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    fireEvent.click(await screen.findByTestId("docs-context-status"));
+    const popover = await screen.findByTestId("chat-docs-popover");
+    expect(within(popover).getByText("note.txt")).toBeInTheDocument();
+    expect(within(popover).queryByText("Searchable")).toBeNull();
+    expect(within(popover).queryByText("Indexing…")).toBeNull();
+  });
+
+  it("navigates to the document on row click and closes the popover", async () => {
+    const onDocumentChip = vi.fn();
+    mountChat({
+      onDocumentChip,
+      docs: [docWithStatus("doc-1", "contract.pdf", "indexed")],
+    });
+
+    fireEvent.click(await screen.findByTestId("docs-context-status"));
+    fireEvent.click(await screen.findByTestId("chat-docs-row-doc-1"));
+
+    expect(onDocumentChip).toHaveBeenCalledWith("doc-1");
+    expect(screen.queryByTestId("chat-docs-popover")).toBeNull();
+  });
+
+  it("offers a filter for long lists, matching the attach popover", async () => {
+    const manyDocs = Array.from({ length: 7 }, (_, i) =>
+      docWithStatus(`doc-${i}`, `bundle-${i}.pdf`, "indexed"),
+    );
+    mountChat({ docs: manyDocs });
+
+    fireEvent.click(await screen.findByTestId("docs-context-status"));
+    const filter = await screen.findByTestId("chat-docs-filter");
+    fireEvent.change(filter, { target: { value: "bundle-3" } });
+
+    const popover = screen.getByTestId("chat-docs-popover");
+    expect(within(popover).getByText("bundle-3.pdf")).toBeInTheDocument();
+    expect(within(popover).queryByText("bundle-4.pdf")).toBeNull();
+  });
+});
+
 describe("AssistantTab — no-key header notice", () => {
   it("shows a passive notice when the matter's model needs a key the user lacks", async () => {
     vi.spyOn(api, "listApiKeys").mockResolvedValue([]);

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -30,6 +30,7 @@ import {
 } from "../../lib/api";
 import { InlineSpinner, ProviderKeyMissingBanner, primaryBtn } from "../../ui/primitives";
 import { posturePaused } from "../../lib/posture";
+import { indexStatusChip } from "../indexStatus";
 import { InlineAgentStatus, MessageBubble, type InlineAgentStep } from "../MessageBubble";
 import { GenericSkillRunner } from "../GenericSkillRunner";
 import {
@@ -563,6 +564,17 @@ export function AssistantTab({
 
   const [attachOpen, setAttachOpen] = useState(false);
 
+  // Header document popover: the doc count opens a list of the matter's
+  // documents with their index status, so grounding is visible before an
+  // answer — and a stuck "Indexing…" document has a user-visible surface.
+  const [docsOpen, setDocsOpen] = useState(false);
+  const [docsFilter, setDocsFilter] = useState("");
+  const filteredHeaderDocs = useMemo(() => {
+    const q = docsFilter.trim().toLowerCase();
+    if (!q) return sortedDocs;
+    return sortedDocs.filter((d) => (d.filename ?? "").toLowerCase().includes(q));
+  }, [sortedDocs, docsFilter]);
+
   const onPickRunnerSkill = (skill: RunnableMatterSkill) => {
     setSkillsOpen(false);
     if (disabled) {
@@ -632,13 +644,85 @@ export function AssistantTab({
             {matter.title}
           </h1>
           <div className="mt-4 flex flex-wrap items-center gap-2 text-[13px] text-muted">
-            <span data-testid="docs-context-status">
-              {docs === null
-                ? "Loading documents…"
-                : docs.length > 0
-                  ? `${docs.length} document${docs.length === 1 ? "" : "s"}`
-                  : "No documents yet"}
-            </span>
+            {docs !== null && docs.length > 0 ? (
+              <span className="relative inline-flex">
+                <button
+                  type="button"
+                  onClick={() => setDocsOpen((v) => !v)}
+                  aria-expanded={docsOpen}
+                  aria-haspopup="menu"
+                  data-testid="docs-context-status"
+                  className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                >
+                  {docs.length} document{docs.length === 1 ? "" : "s"}
+                </button>
+                {docsOpen && (
+                  <div
+                    className="absolute top-full left-0 mt-2 rounded-item border border-rule bg-paper p-2 w-[280px] z-10 text-left"
+                    data-testid="chat-docs-popover"
+                  >
+                    {sortedDocs.length > 5 && (
+                      <input
+                        type="text"
+                        value={docsFilter}
+                        onChange={(e) => setDocsFilter(e.target.value)}
+                        placeholder="Filter documents"
+                        aria-label="Filter documents"
+                        data-testid="chat-docs-filter"
+                        className="mb-2 w-full rounded-item border border-rule bg-paper px-2 py-1 text-xs text-ink placeholder:text-muted focus:border-ink focus:outline-none"
+                      />
+                    )}
+                    <ul className="max-h-56 space-y-1 overflow-y-auto">
+                      {filteredHeaderDocs.map((d) => {
+                        const chip = indexStatusChip(d.index_status);
+                        return (
+                          <li key={d.id}>
+                            <button
+                              type="button"
+                              role="menuitem"
+                              onClick={() => {
+                                setDocsOpen(false);
+                                dispatchDocChip(d.id);
+                              }}
+                              className="flex w-full items-baseline justify-between gap-2 rounded-item px-2 py-1.5 text-left text-xs hover:bg-panel-hover"
+                              data-testid={`chat-docs-row-${d.id}`}
+                            >
+                              <span className="tech-token min-w-0 truncate text-ink">
+                                {d.filename}
+                              </span>
+                              {chip && (
+                                <span
+                                  className={`shrink-0 text-[11px] ${chip.className}`}
+                                  title={chip.title}
+                                >
+                                  {chip.label}
+                                </span>
+                              )}
+                            </button>
+                          </li>
+                        );
+                      })}
+                      {filteredHeaderDocs.length === 0 && (
+                        <li className="px-1 py-0.5 text-xs text-muted">
+                          No documents match.
+                        </li>
+                      )}
+                    </ul>
+                    <button
+                      type="button"
+                      onClick={() => setDocsOpen(false)}
+                      className="mt-3 tech-token text-[10px] text-muted hover:text-ink"
+                    >
+                      Close
+                    </button>
+                  </div>
+                )}
+              </span>
+            ) : (
+              <span data-testid="docs-context-status">
+                {docs === null ? "Loading documents…" : "No documents yet"}
+              </span>
+            )}
             {showContextRail && (
               <>
                 <span aria-hidden="true">·</span>

--- a/frontend/src/matter/tabs/DocumentsTab.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.tsx
@@ -6,6 +6,7 @@ import type { MatterDocument } from "../../lib/api";
 import { UploadError, deleteDocument } from "../../lib/api";
 import { EmptyState, ErrorCallout, LoadingLine } from "../../ui/primitives";
 import { LedgerLine, SectionRule } from "../../ui/certificate";
+import { indexStatusChip } from "../indexStatus";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n}B`;
@@ -40,41 +41,6 @@ function formatDate(iso: string): string {
 
 function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : pluralLabel}`;
-}
-
-// Map the matter-wide retrieval index state to a light status chip.
-// Returns null for unknown/absent status so older payloads stay quiet.
-function indexStatusChip(
-  status: string | undefined,
-): { label: string; title: string; className: string } | null {
-  switch (status) {
-    case "indexed":
-      return {
-        label: "Searchable",
-        title: "Indexed for matter-wide retrieval",
-        className: "text-seal",
-      };
-    case "pending":
-      return {
-        label: "Indexing…",
-        title: "Being indexed for matter-wide retrieval",
-        className: "text-muted",
-      };
-    case "failed":
-      return {
-        label: "Not searchable",
-        title: "Indexing failed; this document is not retrievable",
-        className: "text-muted",
-      };
-    case "empty":
-      return {
-        label: "No text",
-        title: "No extractable text to index",
-        className: "text-muted",
-      };
-    default:
-      return null;
-  }
 }
 
 type IngressStatus =


### PR DESCRIPTION
Deferred-ledger item #3. Grounding was invisible until after an answer: the chat header showed a document count, but not which documents ground the chat or whether any are still indexing. This is also the only user-facing surface for a stuck-pending document (#257 added the worker-heartbeat doctor check; this is its user-visible counterpart).

## What changed

- The header doc count is now a button. It opens a popover listing the matter's documents (newest first) with each document's index status.
- Status vocabulary is the one the Documents tab already uses — Searchable / Indexing… / Not searchable / No text — extracted to `frontend/src/matter/indexStatus.ts` and shared by both surfaces so the copy can't drift. Unknown/absent status stays quiet.
- A row click opens the document (same `dispatchDocChip` routing as source chips and the attach popover) and closes the popover.
- Lists over 5 documents get the same filter input as the attach popover.
- Zero-doc ("No documents yet") and loading ("Loading documents…") header lines are unchanged plain text; the upload-first empty state is untouched.
- No backend changes — `index_status` was already on the document list payload.

## Tests

- New component tests: popover with indexed/pending/failed statuses, status-absent rows, zero-doc non-clickable header, row click-through, long-list filter.
- Full frontend suite: 44 files / 364 tests green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)