### PR TITLE
Stream chat answers token by token

### DIFF
--- a/backend/app/core/model_gateway.py
+++ b/backend/app/core/model_gateway.py
@@ -345,6 +345,7 @@ class ModelGateway:
         resource_id: str | None = None,
         payload: dict | None = None,
         caller_module: str | None = None,
+        on_delta: Callable[[str], Awaitable[None]] | None = None,
     ) -> ModelResult:
         # Privilege posture is authoritative from the matter row in this
         # session, never from a caller-supplied argument. This closes the
@@ -401,6 +402,11 @@ class ModelGateway:
         provider_kwargs: dict = {}
         if max_tokens is not None:
             provider_kwargs["max_tokens"] = max_tokens
+        # Token streaming: providers that support it call `on_delta` with
+        # each text delta; providers that don't (stub-echo, ollama) accept
+        # and ignore the kwarg, falling back to a whole answer.
+        if on_delta is not None:
+            provider_kwargs["on_delta"] = on_delta
         # Pass the requested model through to keyed providers so the picked
         # model actually runs (not the provider's construct-time default).
         # Skipped when `requested` is a bare provider name (test passthrough)

--- a/backend/app/modules/assistant/pipeline.py
+++ b/backend/app/modules/assistant/pipeline.py
@@ -153,6 +153,105 @@ _SUMMARY_SYSTEM_PROMPT = (
 
 AssistantEventHandler = Callable[[str, dict[str, Any]], Awaitable[None]]
 
+# The model's reply is a JSON envelope, so raw token deltas would show the
+# user braces and field names. The streamer below extracts only the
+# `content` string as it grows and emits that as `model.delta` events.
+# Display-only: persistence still parses the complete envelope, so the
+# final message is authoritative regardless of what streamed.
+
+_CONTENT_FIELD_RE = re.compile(r'"content"\s*:\s*"')
+_JSON_STRING_ESCAPES = {
+    '"': '"',
+    "\\": "\\",
+    "/": "/",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+}
+
+
+def _partial_envelope_content(raw: str) -> str:
+    """Decode the envelope's `content` string value from a raw-text prefix.
+
+    Walks from the first `"content": "` to the closing quote or the end of
+    the prefix, unescaping as it goes. Incomplete trailing escapes (and a
+    high surrogate still waiting for its pair) are held back, so the output
+    only ever grows as more raw text arrives.
+    """
+    match = _CONTENT_FIELD_RE.search(raw)
+    if match is None:
+        return ""
+    out: list[str] = []
+    i = match.end()
+    n = len(raw)
+    while i < n:
+        ch = raw[i]
+        if ch == '"':
+            break
+        if ch != "\\":
+            out.append(ch)
+            i += 1
+            continue
+        if i + 1 >= n:
+            break
+        esc = raw[i + 1]
+        if esc != "u":
+            out.append(_JSON_STRING_ESCAPES.get(esc, esc))
+            i += 2
+            continue
+        if i + 6 > n:
+            break
+        try:
+            code = int(raw[i + 2 : i + 6], 16)
+        except ValueError:
+            i += 6
+            continue
+        if 0xD800 <= code <= 0xDBFF:
+            # High surrogate: needs the following \uXXXX low surrogate.
+            if i + 12 > n:
+                break
+            low_esc = raw[i + 6 : i + 12]
+            if low_esc.startswith("\\u"):
+                try:
+                    low = int(low_esc[2:], 16)
+                except ValueError:
+                    low = None
+                if low is not None and 0xDC00 <= low <= 0xDFFF:
+                    out.append(
+                        chr(0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00))
+                    )
+                    i += 12
+                    continue
+            out.append("�")
+            i += 6
+            continue
+        if 0xDC00 <= code <= 0xDFFF:
+            out.append("�")
+        else:
+            out.append(chr(code))
+        i += 6
+    return "".join(out)
+
+
+class _EnvelopeContentStreamer:
+    """Feed raw model deltas in; emit `model.delta` events carrying only the
+    new user-visible text of the envelope's `content` field."""
+
+    def __init__(self, on_event: AssistantEventHandler) -> None:
+        self._on_event = on_event
+        self._raw = ""
+        self._emitted = 0
+
+    async def feed(self, chunk: str) -> None:
+        self._raw += chunk
+        content = _partial_envelope_content(self._raw)
+        if len(content) > self._emitted:
+            delta = content[self._emitted :]
+            self._emitted = len(content)
+            await self._on_event("model.delta", {"text": delta})
+
 
 @dataclass(frozen=True)
 class AssistantToolSpec:
@@ -1382,6 +1481,14 @@ async def run_assistant_turn(
         await session.refresh(assistant_row)
         return assistant_row
 
+    # Token streaming: extract the envelope's `content` as it arrives and
+    # forward it as `model.delta` SSE events. Skipped for stub-echo (its
+    # output is not an envelope) and for the non-SSE route (no on_event).
+    def _delta_stream() -> dict[str, Any]:
+        if on_event is None or matter.default_model_id == "stub-echo":
+            return {}
+        return {"on_delta": _EnvelopeContentStreamer(on_event).feed}
+
     if on_event is not None:
         await on_event("model.start", {"stage": "assistant"})
     try:
@@ -1398,6 +1505,7 @@ async def run_assistant_turn(
             resource_id=str(user_row.id),
             payload={"stage": "assistant", "module": "assistant"},
             caller_module="assistant",
+            **_delta_stream(),
         )
     except ProviderKeyMissing:
         # Keyless fallback so a fresh, keyless fork still demos itself.
@@ -1533,6 +1641,7 @@ async def run_assistant_turn(
                     "tool_invocation_id": str(tool_invocation_id),
                 },
                 caller_module="assistant",
+                **_delta_stream(),
             )
             try:
                 final_envelope = parse_model_json(

--- a/backend/app/providers/anthropic_provider.py
+++ b/backend/app/providers/anthropic_provider.py
@@ -68,17 +68,29 @@ class AnthropicProvider:
         model = kwargs.get("model") or self.default_model
         max_tokens = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
         api_key = kwargs.get("api_key") or self._fallback_key
+        # Optional token-streaming callback: awaited with each text delta as
+        # it arrives. The returned text, usage, and stop_reason come from the
+        # SDK's accumulated final message, so downstream hashing/persistence
+        # sees exactly the text the deltas spelled out.
+        on_delta = kwargs.get("on_delta")
         if not api_key:
             raise RuntimeError("anthropic: no api_key supplied")
         client = AsyncAnthropic(api_key=api_key)
 
+        request_kwargs = dict(
+            model=model,
+            max_tokens=max_tokens,
+            system=system or "You are a UK legal AI assistant. Draft for solicitor review.",
+            messages=[{"role": "user", "content": prompt}],
+        )
         try:
-            message = await client.messages.create(
-                model=model,
-                max_tokens=max_tokens,
-                system=system or "You are a UK legal AI assistant. Draft for solicitor review.",
-                messages=[{"role": "user", "content": prompt}],
-            )
+            if on_delta is None:
+                message = await client.messages.create(**request_kwargs)
+            else:
+                async with client.messages.stream(**request_kwargs) as stream:
+                    async for text_delta in stream.text_stream:
+                        await on_delta(text_delta)
+                    message = await stream.get_final_message()
         except APIStatusError as exc:
             logger.exception(
                 "legalise.provider.anthropic.error",

--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -57,6 +57,10 @@ class OpenAIProvider:
         model = kwargs.get("model") or self.default_model
         max_tokens = kwargs.get("max_tokens", DEFAULT_MAX_TOKENS)
         api_key = kwargs.get("api_key") or self._fallback_key
+        # Optional token-streaming callback: awaited with each content delta.
+        # The returned text is the concatenation of exactly those deltas;
+        # finish_reason and usage arrive on the stream's final chunks.
+        on_delta = kwargs.get("on_delta")
         if not api_key:
             raise RuntimeError("openai: no api_key supplied")
         client = AsyncOpenAI(api_key=api_key)
@@ -67,11 +71,40 @@ class OpenAIProvider:
         messages.append({"role": "user", "content": prompt})
 
         try:
-            response = await client.chat.completions.create(
-                model=model,
-                max_tokens=max_tokens,
-                messages=messages,
-            )
+            if on_delta is None:
+                response = await client.chat.completions.create(
+                    model=model,
+                    max_tokens=max_tokens,
+                    messages=messages,
+                )
+                choice = response.choices[0]
+                finish_reason = getattr(choice, "finish_reason", None)
+                text = choice.message.content or ""
+                usage = response.usage
+            else:
+                stream = await client.chat.completions.create(
+                    model=model,
+                    max_tokens=max_tokens,
+                    messages=messages,
+                    stream=True,
+                    stream_options={"include_usage": True},
+                )
+                parts: list[str] = []
+                finish_reason = None
+                usage = None
+                async for chunk in stream:
+                    if chunk.choices:
+                        chunk_choice = chunk.choices[0]
+                        delta = getattr(chunk_choice, "delta", None)
+                        content = getattr(delta, "content", None) if delta else None
+                        if content:
+                            parts.append(content)
+                            await on_delta(content)
+                        if getattr(chunk_choice, "finish_reason", None):
+                            finish_reason = chunk_choice.finish_reason
+                    if getattr(chunk, "usage", None):
+                        usage = chunk.usage
+                text = "".join(parts)
         except APIStatusError as exc:
             logger.exception(
                 "legalise.provider.openai.error",
@@ -96,12 +129,10 @@ class OpenAIProvider:
                 message=f"openai: {type(exc).__name__}: {exc}",
             ) from exc
 
-        choice = response.choices[0]
-
         # A hard stop at the output cap means the response is incomplete —
         # surfacing the truncation honestly beats handing the caller a
         # half-written body that fails its JSON-envelope parse downstream.
-        if getattr(choice, "finish_reason", None) == "length":
+        if finish_reason == "length":
             logger.warning(
                 "legalise.provider.openai.truncated",
                 model=model,
@@ -117,8 +148,6 @@ class OpenAIProvider:
                 ),
             )
 
-        text = choice.message.content or ""
-        usage = response.usage
         tokens_in = usage.prompt_tokens if usage else 0
         tokens_out = usage.completion_tokens if usage else 0
         return text, tokens_in, tokens_out

--- a/backend/tests/test_assistant_pipeline.py
+++ b/backend/tests/test_assistant_pipeline.py
@@ -82,6 +82,7 @@ class _AssistantFakeGateway:
         resource_id=None,
         payload=None,
         caller_module=None,
+        on_delta=None,
     ) -> ModelResult:
         self.calls.append(
             {
@@ -91,6 +92,7 @@ class _AssistantFakeGateway:
                 "posture": posture,
                 "max_tokens": max_tokens,
                 "payload": payload or {},
+                "on_delta": on_delta,
             }
         )
         envelope = self.envelopes.pop(0) if self.envelopes else self.envelope

--- a/backend/tests/test_assistant_streaming.py
+++ b/backend/tests/test_assistant_streaming.py
@@ -1,0 +1,483 @@
+"""Token streaming for chat answers.
+
+Covers the four invariants of the streaming path:
+
+- what streams is what persists — the `model.delta` events assemble to the
+  exact `content` the assistant row stores (display never forks from record);
+- usage is still recorded — streaming providers report tokens at stream end
+  and the gateway's ModelResult/audit row carries them;
+- truncation still fires — stop_reason/finish_reason arrive at stream end
+  and raise `provider_truncated` exactly as the non-streaming path does;
+- providers that can't stream fall back silently — no deltas, same reply.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.model_gateway import ModelGateway, ModelResult, PrivilegePosture
+from app.core.user_keys import ProviderUpstreamError
+from app.modules.assistant.pipeline import (
+    _EnvelopeContentStreamer,
+    _partial_envelope_content,
+    run_assistant_turn,
+)
+from app.modules.assistant.schemas import AssistantPostRequest
+
+from tests.test_assistant_pipeline import (
+    _AssistantSession,
+    _make_matter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Envelope content extraction — raw JSON deltas in, user-visible text out
+# ---------------------------------------------------------------------------
+
+
+class TestPartialEnvelopeContent:
+    def test_extracts_complete_content(self) -> None:
+        raw = json.dumps({"content": "The dismissal was on 10 March.", "suggested_actions": []})
+        assert _partial_envelope_content(raw) == "The dismissal was on 10 March."
+
+    def test_extracts_prefix_of_unterminated_string(self) -> None:
+        assert _partial_envelope_content('{"content": "The dism') == "The dism"
+
+    def test_no_content_field_yields_nothing(self) -> None:
+        assert _partial_envelope_content('{"suggested_act') == ""
+        assert _partial_envelope_content("") == ""
+
+    def test_unescapes_json_escapes(self) -> None:
+        raw = '{"content": "line one\\nline \\"two\\" and \\\\ back"'
+        assert _partial_envelope_content(raw) == 'line one\nline "two" and \\ back'
+
+    def test_holds_back_incomplete_escape(self) -> None:
+        assert _partial_envelope_content('{"content": "end\\') == "end"
+        assert _partial_envelope_content('{"content": "end\\u26') == "end"
+
+    def test_unicode_escape_and_surrogate_pair(self) -> None:
+        assert _partial_envelope_content('{"content": "\\u00a3500"') == "£500"
+        assert _partial_envelope_content('{"content": "\\ud83d\\ude00 done"') == "😀 done"
+        # High surrogate still waiting for its pair is held back.
+        assert _partial_envelope_content('{"content": "hi \\ud83d') == "hi "
+
+    def test_fenced_envelope(self) -> None:
+        raw = '```json\n{"content": "Fenced answer"'
+        assert _partial_envelope_content(raw) == "Fenced answer"
+
+
+class TestEnvelopeContentStreamer:
+    @pytest.mark.asyncio
+    async def test_deltas_assemble_to_content_across_arbitrary_splits(self) -> None:
+        envelope = json.dumps(
+            {
+                "content": 'Khan was dismissed on 10 March 2026.\nSee "the letter" — £500 due. 😀',
+                "suggested_actions": [{"type": "view_audit", "label": "Open", "params": {}}],
+            }
+        )
+        for size in (1, 3, 7, len(envelope)):
+            events: list[tuple[str, dict[str, Any]]] = []
+
+            async def _capture(name: str, payload: dict[str, Any]) -> None:
+                events.append((name, payload))
+
+            streamer = _EnvelopeContentStreamer(_capture)
+            for i in range(0, len(envelope), size):
+                await streamer.feed(envelope[i : i + size])
+
+            assert all(name == "model.delta" for name, _ in events)
+            assembled = "".join(payload["text"] for _, payload in events)
+            assert assembled == json.loads(envelope)["content"]
+
+    @pytest.mark.asyncio
+    async def test_emits_nothing_for_non_envelope_text(self) -> None:
+        events: list[Any] = []
+
+        async def _capture(name: str, payload: dict[str, Any]) -> None:
+            events.append((name, payload))
+
+        streamer = _EnvelopeContentStreamer(_capture)
+        await streamer.feed("[stub-echo] plain text, no envelope")
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Pipeline — streamed deltas equal the persisted reply; fallback stays silent
+# ---------------------------------------------------------------------------
+
+
+_STREAMED_ENVELOPE = {
+    "content": "Khan was dismissed without notice on 10 March 2026.",
+    "suggested_actions": [],
+}
+
+
+class _StreamingFakeGateway:
+    """Feeds the envelope through on_delta in chunks, then returns it whole —
+    the shape of a real streaming provider behind the gateway."""
+
+    def __init__(self, envelope: dict[str, Any] | None = None) -> None:
+        self.envelope = envelope or _STREAMED_ENVELOPE
+        self.calls: list[dict[str, Any]] = []
+
+    async def call(self, *, on_delta=None, **kwargs) -> ModelResult:
+        self.calls.append({**kwargs, "on_delta": on_delta})
+        text = json.dumps(self.envelope)
+        if on_delta is not None:
+            for i in range(0, len(text), 9):
+                await on_delta(text[i : i + 9])
+        return ModelResult(
+            text=text,
+            model_used="claude-opus-4-7",
+            prompt_hash="ph",
+            response_hash=hashlib.sha256(text.encode()).hexdigest(),
+            token_count=63,
+            latency_ms=5,
+            provider="anthropic",
+            tokens_in=42,
+            tokens_out=21,
+        )
+
+
+class TestPipelineStreaming:
+    @pytest.mark.asyncio
+    async def test_deltas_assemble_to_the_persisted_reply(self) -> None:
+        matter = _make_matter()
+        session = _AssistantSession(matter)
+        gateway = _StreamingFakeGateway()
+        events: list[tuple[str, dict[str, Any]]] = []
+
+        async def _capture(name: str, payload: dict[str, Any]) -> None:
+            events.append((name, payload))
+
+        _, assistant_row = await run_assistant_turn(
+            session=session,
+            matter=matter,
+            actor_id=uuid.uuid4(),
+            thread_id=uuid.uuid4(),
+            request=AssistantPostRequest(content="When was Khan dismissed?"),
+            gateway=gateway,
+            on_event=_capture,
+        )
+
+        deltas = [p["text"] for name, p in events if name == "model.delta"]
+        assert deltas, "streaming turn emitted no model.delta events"
+        assert "".join(deltas) == assistant_row.content
+        assert assistant_row.content == _STREAMED_ENVELOPE["content"]
+        # Usage from stream end still lands on the persisted row.
+        assert assistant_row.token_count == 63
+        # Delta events sit between model.start and turn.end.
+        names = [name for name, _ in events]
+        assert names.index("model.start") < names.index("model.delta")
+        assert names.index("model.delta") < names.index("turn.end")
+
+    @pytest.mark.asyncio
+    async def test_non_sse_turn_requests_no_streaming(self) -> None:
+        matter = _make_matter()
+        session = _AssistantSession(matter)
+        gateway = _StreamingFakeGateway()
+
+        await run_assistant_turn(
+            session=session,
+            matter=matter,
+            actor_id=uuid.uuid4(),
+            thread_id=uuid.uuid4(),
+            request=AssistantPostRequest(content="When was Khan dismissed?"),
+            gateway=gateway,
+            on_event=None,
+        )
+
+        assert gateway.calls[0]["on_delta"] is None
+
+    @pytest.mark.asyncio
+    async def test_stub_echo_matter_falls_back_without_deltas(self) -> None:
+        matter = _make_matter()
+        matter.default_model_id = "stub-echo"
+        session = _AssistantSession(matter)
+        gateway = _StreamingFakeGateway()
+        events: list[tuple[str, dict[str, Any]]] = []
+
+        async def _capture(name: str, payload: dict[str, Any]) -> None:
+            events.append((name, payload))
+
+        _, assistant_row = await run_assistant_turn(
+            session=session,
+            matter=matter,
+            actor_id=uuid.uuid4(),
+            thread_id=uuid.uuid4(),
+            request=AssistantPostRequest(content="Hello"),
+            gateway=gateway,
+            on_event=_capture,
+        )
+
+        assert gateway.calls[0]["on_delta"] is None
+        assert all(name != "model.delta" for name, _ in events)
+        assert assistant_row.content
+
+
+# ---------------------------------------------------------------------------
+# Gateway — on_delta reaches the provider; keyless providers ignore it
+# ---------------------------------------------------------------------------
+
+
+class _StreamingFakeProvider:
+    name = "stream-fake"
+    default_model = "stream-fake"
+
+    async def call(self, prompt: str, *, system=None, **kwargs):
+        on_delta = kwargs.get("on_delta")
+        text = "streamed answer"
+        if on_delta is not None:
+            for piece in ("stream", "ed ", "answer"):
+                await on_delta(piece)
+        return text, 11, 4
+
+
+class TestGatewayStreaming:
+    @pytest.mark.asyncio
+    async def test_result_matches_streamed_deltas_and_records_usage(self) -> None:
+        gw = ModelGateway({"stream-fake": _StreamingFakeProvider()})
+        deltas: list[str] = []
+
+        async def _on_delta(text: str) -> None:
+            deltas.append(text)
+
+        with patch("app.core.api.audit") as fake_audit:
+            fake_audit.log = AsyncMock()
+            result = await gw.call(
+                session=MagicMock(),
+                matter_id=None,
+                actor_id=None,
+                prompt="q",
+                model="stream-fake",
+                posture=PrivilegePosture.A_CLEARED,
+                on_delta=_on_delta,
+            )
+
+        assert "".join(deltas) == "streamed answer"
+        assert result.text == "streamed answer"
+        assert result.response_hash == hashlib.sha256(b"streamed answer").hexdigest()
+        assert (result.tokens_in, result.tokens_out) == (11, 4)
+        assert fake_audit.log.await_count == 1
+        audit_kwargs = fake_audit.log.await_args.kwargs
+        assert audit_kwargs["response_hash"] == result.response_hash
+        assert audit_kwargs["tokens_in"] == 11
+        assert audit_kwargs["tokens_out"] == 4
+
+    @pytest.mark.asyncio
+    async def test_stub_provider_ignores_on_delta(self) -> None:
+        gw = ModelGateway()
+        deltas: list[str] = []
+
+        async def _on_delta(text: str) -> None:
+            deltas.append(text)
+
+        with patch("app.core.api.audit") as fake_audit:
+            fake_audit.log = AsyncMock()
+            result = await gw.call(
+                session=MagicMock(),
+                matter_id=None,
+                actor_id=None,
+                prompt="hello",
+                model="stub-echo",
+                posture=PrivilegePosture.A_CLEARED,
+                on_delta=_on_delta,
+            )
+
+        assert deltas == []
+        assert result.text.startswith("[stub-echo]")
+
+
+# ---------------------------------------------------------------------------
+# Anthropic provider — streaming path
+# ---------------------------------------------------------------------------
+
+
+class _FakeAnthropicStream:
+    def __init__(self, deltas: list[str], final: Any) -> None:
+        self._deltas = deltas
+        self._final = final
+
+    async def __aenter__(self) -> "_FakeAnthropicStream":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    @property
+    def text_stream(self):
+        async def _gen():
+            for d in self._deltas:
+                yield d
+
+        return _gen()
+
+    async def get_final_message(self) -> Any:
+        return self._final
+
+
+class TestAnthropicStreaming:
+    @pytest.mark.asyncio
+    async def test_streams_deltas_and_returns_final_usage(self) -> None:
+        from app.providers.anthropic_provider import AnthropicProvider
+
+        final = SimpleNamespace(
+            stop_reason="end_turn",
+            content=[SimpleNamespace(type="text", text="complete body")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=20),
+        )
+        client = MagicMock()
+        client.messages.stream = MagicMock(
+            return_value=_FakeAnthropicStream(["complete ", "body"], final)
+        )
+        deltas: list[str] = []
+
+        async def _on_delta(text: str) -> None:
+            deltas.append(text)
+
+        provider = AnthropicProvider(api_key="sk-test", default_model="claude-haiku-4-5")
+        with patch(
+            "app.providers.anthropic_provider.AsyncAnthropic", return_value=client
+        ):
+            text, tokens_in, tokens_out = await provider.call(
+                "question", on_delta=_on_delta
+            )
+
+        assert deltas == ["complete ", "body"]
+        assert text == "".join(deltas) == "complete body"
+        assert (tokens_in, tokens_out) == (10, 20)
+        client.messages.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_streaming_truncation_still_raises(self) -> None:
+        from app.providers.anthropic_provider import AnthropicProvider
+
+        final = SimpleNamespace(
+            stop_reason="max_tokens",
+            content=[SimpleNamespace(type="text", text="truncated…")],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=2048),
+        )
+        client = MagicMock()
+        client.messages.stream = MagicMock(
+            return_value=_FakeAnthropicStream(["truncated…"], final)
+        )
+
+        async def _on_delta(_text: str) -> None:
+            return None
+
+        provider = AnthropicProvider(api_key="sk-test", default_model="claude-haiku-4-5")
+        with patch(
+            "app.providers.anthropic_provider.AsyncAnthropic", return_value=client
+        ):
+            with pytest.raises(ProviderUpstreamError) as excinfo:
+                await provider.call("long question", on_delta=_on_delta)
+
+        assert excinfo.value.code == "provider_truncated"
+
+    @pytest.mark.asyncio
+    async def test_without_on_delta_uses_create(self) -> None:
+        from app.providers.anthropic_provider import AnthropicProvider
+
+        message = SimpleNamespace(
+            stop_reason="end_turn",
+            content=[SimpleNamespace(type="text", text="whole body")],
+            usage=SimpleNamespace(input_tokens=5, output_tokens=6),
+        )
+        client = MagicMock()
+        client.messages.create = AsyncMock(return_value=message)
+
+        provider = AnthropicProvider(api_key="sk-test", default_model="claude-haiku-4-5")
+        with patch(
+            "app.providers.anthropic_provider.AsyncAnthropic", return_value=client
+        ):
+            text, _, _ = await provider.call("question")
+
+        assert text == "whole body"
+        client.messages.stream.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI provider — streaming path
+# ---------------------------------------------------------------------------
+
+
+def _openai_chunk(content: str | None = None, finish_reason: str | None = None, usage=None):
+    choices = []
+    if content is not None or finish_reason is not None:
+        choices.append(
+            SimpleNamespace(
+                delta=SimpleNamespace(content=content),
+                finish_reason=finish_reason,
+            )
+        )
+    return SimpleNamespace(choices=choices, usage=usage)
+
+
+async def _openai_stream(chunks):
+    for c in chunks:
+        yield c
+
+
+class TestOpenAIStreaming:
+    @pytest.mark.asyncio
+    async def test_streams_deltas_and_captures_usage_from_final_chunk(self) -> None:
+        from app.providers.openai_provider import OpenAIProvider
+
+        chunks = [
+            _openai_chunk("complete "),
+            _openai_chunk("body"),
+            _openai_chunk(finish_reason="stop"),
+            _openai_chunk(usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20)),
+        ]
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=_openai_stream(chunks))
+        deltas: list[str] = []
+
+        async def _on_delta(text: str) -> None:
+            deltas.append(text)
+
+        provider = OpenAIProvider(api_key="sk-test", default_model="gpt-4o-mini")
+        with patch(
+            "app.providers.openai_provider.AsyncOpenAI", return_value=client
+        ):
+            text, tokens_in, tokens_out = await provider.call(
+                "question", on_delta=_on_delta
+            )
+
+        assert deltas == ["complete ", "body"]
+        assert text == "complete body"
+        assert (tokens_in, tokens_out) == (10, 20)
+        create_kwargs = client.chat.completions.create.call_args.kwargs
+        assert create_kwargs["stream"] is True
+        assert create_kwargs["stream_options"] == {"include_usage": True}
+
+    @pytest.mark.asyncio
+    async def test_streaming_truncation_still_raises(self) -> None:
+        from app.providers.openai_provider import OpenAIProvider
+
+        chunks = [
+            _openai_chunk("truncated…"),
+            _openai_chunk(finish_reason="length"),
+            _openai_chunk(usage=SimpleNamespace(prompt_tokens=10, completion_tokens=2048)),
+        ]
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=_openai_stream(chunks))
+
+        async def _on_delta(_text: str) -> None:
+            return None
+
+        provider = OpenAIProvider(api_key="sk-test", default_model="gpt-4o-mini")
+        with patch(
+            "app.providers.openai_provider.AsyncOpenAI", return_value=client
+        ):
+            with pytest.raises(ProviderUpstreamError) as excinfo:
+                await provider.call("long question", on_delta=_on_delta)
+
+        assert excinfo.value.code == "provider_truncated"

--- a/frontend/src/lib/api/assistant.ts
+++ b/frontend/src/lib/api/assistant.ts
@@ -68,6 +68,9 @@ export type AssistantStreamEvent =
   | { event: "turn.accepted"; data: { user_message_id: string } }
   | { event: "turn.deterministic"; data: { assistant_message_id: string; kind: string } }
   | { event: "model.start"; data: { stage: string } }
+  // A token-streamed slice of the answer being written. Only emitted for
+  // providers that stream; the final `result` message stays authoritative.
+  | { event: "model.delta"; data: { text: string } }
   | { event: "tool.start"; data: { module_id: string; capability_id: string } }
   | {
       event: "tool.end";

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -734,6 +734,137 @@ describe("AssistantTab — no-key header notice", () => {
   });
 });
 
+describe("AssistantTab — token-streamed draft", () => {
+  it("renders deltas in a draft bubble, then the final message replaces it", async () => {
+    let releaseResult!: () => void;
+    const resultGate = new Promise<void>((resolve) => {
+      releaseResult = resolve;
+    });
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* () {
+        yield { event: "model.start", data: { stage: "assistant" } } as never;
+        yield { event: "model.delta", data: { text: "Khan was " } } as never;
+        yield { event: "model.delta", data: { text: "dismissed." } } as never;
+        await resultGate;
+        yield {
+          event: "result",
+          data: {
+            user: {
+              id: "u-1",
+              role: "user",
+              content: "When was Khan dismissed?",
+              suggested_actions: [],
+              created_at: "",
+            },
+            assistant: {
+              id: "a-1",
+              role: "assistant",
+              content: "Khan was dismissed.",
+              suggested_actions: [],
+              created_at: "",
+            },
+          },
+        } as never;
+      },
+    );
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "When was Khan dismissed?" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    const bubble = await screen.findByTestId("chat-draft-bubble");
+    expect(bubble).toHaveTextContent("Khan was dismissed.");
+    // Draft is plain text with no per-message actions — those belong to
+    // the final message only.
+    expect(within(bubble).queryByTestId("message-actions")).toBeNull();
+    // Streaming is visible progress, so the honesty line stays hidden.
+    expect(screen.queryByTestId("chat-long-wait-note")).toBeNull();
+
+    releaseResult();
+    await waitFor(() =>
+      expect(screen.queryByTestId("chat-draft-bubble")).toBeNull(),
+    );
+    expect(await screen.findByText("Khan was dismissed.")).toBeInTheDocument();
+    expect(await screen.findByTestId("message-actions")).toBeInTheDocument();
+  });
+
+  it("resets the draft when a tool turn starts a second model call", async () => {
+    let releaseResult!: () => void;
+    const resultGate = new Promise<void>((resolve) => {
+      releaseResult = resolve;
+    });
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* () {
+        yield { event: "model.start", data: { stage: "assistant" } } as never;
+        yield { event: "model.delta", data: { text: "I'll run the tool." } } as never;
+        yield {
+          event: "model.start",
+          data: { stage: "assistant.final" },
+        } as never;
+        yield { event: "model.delta", data: { text: "Final answer." } } as never;
+        await resultGate;
+        yield {
+          event: "result",
+          data: {
+            user: {
+              id: "u-1",
+              role: "user",
+              content: "Run it",
+              suggested_actions: [],
+              created_at: "",
+            },
+            assistant: {
+              id: "a-1",
+              role: "assistant",
+              content: "Final answer.",
+              suggested_actions: [],
+              created_at: "",
+            },
+          },
+        } as never;
+      },
+    );
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "Run it" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    const bubble = await screen.findByTestId("chat-draft-bubble");
+    await waitFor(() => expect(bubble).toHaveTextContent("Final answer."));
+    expect(bubble).not.toHaveTextContent(/I'll run the tool\./);
+
+    releaseResult();
+    await waitFor(() =>
+      expect(screen.queryByTestId("chat-draft-bubble")).toBeNull(),
+    );
+  });
+
+  it("discards a partial draft and restores the prompt when the stream fails", async () => {
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* () {
+        yield { event: "model.start", data: { stage: "assistant" } } as never;
+        yield { event: "model.delta", data: { text: "Half an ans" } } as never;
+        yield {
+          event: "error",
+          data: { message: "provider fell over" },
+        } as never;
+      },
+    );
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "Do not lose me" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText(/Could not send message/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-draft-bubble")).toBeNull();
+    expect(screen.queryByText("Half an ans")).toBeNull();
+    expect(input).toHaveValue("Do not lose me");
+  });
+});
+
 describe("AssistantTab — long-wait honesty line", () => {
   it("does not show the note for a fast turn", async () => {
     let releaseResult!: () => void;

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -153,8 +153,12 @@ export function AssistantTab({
     useState<RunnableMatterSkill | null>(null);
   const [workPane, setWorkPane] = useState<AssistantWorkPaneState | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  // Answers arrive whole (no token streaming) — after ~10s of a pending
-  // turn, one quiet honesty line appears under the step ticker.
+  // Token-streamed draft of the answer being written. Streaming providers
+  // fill this via model.delta events; the final message replaces it on
+  // result. null = no draft (non-streaming providers never set it).
+  const [draft, setDraft] = useState<string | null>(null);
+  // Fallback for non-streaming paths: after ~10s of a pending turn with no
+  // draft text, one quiet honesty line appears under the step ticker.
   const [longWait, setLongWait] = useState(false);
   // Whether the user holds the key the matter's model needs. null =
   // unknown/not applicable; false drives the passive header notice. Same
@@ -274,11 +278,11 @@ export function AssistantTab({
     setTimeout(() => textareaRef.current?.focus(), 0);
   };
 
-  // Auto-scroll to newest message.
+  // Auto-scroll to newest message (and follow the draft as it streams).
   useEffect(() => {
     if (!scrollRef.current) return;
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-  }, [messages, thinking]);
+  }, [messages, thinking, draft]);
 
   // Composer autogrow: track content height up to ~8 rows, then scroll.
   // Runs on every input change (including programmatic sets from the
@@ -417,6 +421,15 @@ export function AssistantTab({
           throw streamEventError(event);
         }
         setAgentSteps((prev) => nextAgentSteps(prev, event));
+        // Each model call starts a fresh draft (a tool turn writes twice);
+        // deltas append the answer as it is written.
+        if (event.event === "model.start") {
+          setDraft(null);
+        }
+        if (event.event === "model.delta") {
+          const text = event.data.text;
+          setDraft((prev) => (prev ?? "") + text);
+        }
         if (event.event === "context.loaded") {
           const docs = event.data.retrieved_document_count ?? 0;
           const chunks = event.data.retrieved_chunk_count ?? 0;
@@ -465,6 +478,9 @@ export function AssistantTab({
       setPending(false);
       setThinking(false);
       setAgentSteps([]);
+      // A partial draft never persists as a message: the final message
+      // already replaced it on success, and a failed turn discards it.
+      setDraft(null);
     }
   };
 
@@ -834,7 +850,22 @@ export function AssistantTab({
             <div className="flex justify-start">
               <InlineAgentStatus steps={agentSteps} />
             </div>
-            {longWait && (
+            {/* Token-streamed draft. Plain text while writing — markdown,
+                citation chips, and the action row belong to the final
+                message, which replaces this bubble on result. */}
+            {draft !== null && draft.length > 0 && (
+              <div className="flex justify-start" data-testid="chat-draft-bubble">
+                <div className="flex w-full flex-col gap-2">
+                  <div className="tech-token text-[11px] text-muted">
+                    Assistant · writing
+                  </div>
+                  <div className="whitespace-pre-wrap text-[15px] leading-relaxed text-ink">
+                    {draft}
+                  </div>
+                </div>
+              </div>
+            )}
+            {longWait && !draft && (
               <p className="text-xs text-muted" data-testid="chat-long-wait-note">
                 Long answers can take up to a minute.
               </p>


### PR DESCRIPTION
Deferred-ledger item #5. Chat answers now stream into the thread as they are written instead of sitting behind a spinner.

## What streams
- Anthropic and OpenAI turns: the provider streams tokens; the pipeline extracts the envelope's `content` string as it grows and forwards it as `model.delta` events on the existing turn SSE stream.
- The chat renders deltas in a plain-text draft bubble (`Assistant · writing`). Markdown, citation chips, and the per-message action row belong to the final message, which replaces the draft on `result`.

## What falls back
- stub-echo, ollama, and the keyless/extractive paths ignore the streaming callback and behave exactly as before — no deltas, no special UI, and the "Long answers can take up to a minute" line still covers the wait (it hides once deltas flow).

## Invariants held
- **Display never forks from record.** The provider returns the SDK-accumulated final text; hashing, persistence, and the audit row all run on that single string, through the unchanged completion path.
- **Usage still recorded.** Streaming APIs report usage at stream end; both providers capture it, so tokens_in/tokens_out (#257) land on the audit row as before.
- **Truncation still fires.** stop_reason/finish_reason are read at stream end; `provider_truncated` raises exactly as in the non-streaming path.
- **Failed sends unchanged.** A mid-stream error discards the partial draft and restores the prompt to the composer; a draft can never persist as a message.

## Tests
- Backend: envelope-content extractor (escapes, chunk splits, surrogate pairs, fences), pipeline (deltas assemble byte-identical to the persisted reply; non-SSE and stub-echo turns request no streaming), gateway pass-through + audit fields, provider streaming for both SDKs incl. truncation and usage capture.
- Frontend: draft bubble lifecycle (appear → replace on result), reset on the tool turn's second model call, discard on mid-stream error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)