### PR TITLE
Design audit: launch-week correctness + polish pass

### DIFF
--- a/backend/app/modules/assistant/pipeline.py
+++ b/backend/app/modules/assistant/pipeline.py
@@ -777,17 +777,18 @@ def _document_summary_content(document: Document, text: str) -> str:
 
     lead = sentences[0]
     bullets = sentences[1:4]
+    # The citation rides on the lead bullet. A separate "Source: [doc:…]"
+    # line rendered as a bare "Source:" in the chat UI once the frontend
+    # lifted the [doc:] token out as a chip.
     lines = [
         f"Summary of {document.filename}:",
         "",
-        f"- {lead}",
+        f"- {lead} [doc:{document.id}]",
     ]
     for sentence in bullets:
         lines.append(f"- {sentence}")
     lines.extend(
         [
-            "",
-            f"Source: [doc:{document.id}]",
             "",
             "Extract of the opening text, generated without a model. "
             "Add an API key in Settings → API Keys for real summaries.",

--- a/docs/handovers/HANDOVER_DESIGN_NEXT_2026-07-06.md
+++ b/docs/handovers/HANDOVER_DESIGN_NEXT_2026-07-06.md
@@ -1,0 +1,301 @@
+# Design/UX implementation plan — post-audit handover (2026-07-06)
+
+For a build agent starting fresh. Context: a full design audit ran on 2026-07-06
+(PR #263) and closed the correctness floor — contrast tokens, 390px overflow,
+scroll restoration, project→matter copy, the Outputs rename, funnel routing,
+doc-viewer chrome, touch targets. This document is the plan for what remains.
+Everything here is speced to be executable without the audit session's context.
+
+Work items are ranked. WI-1 is the only substantial build; the rest are small.
+Do them as **one branch per work item, one PR each** unless told otherwise.
+
+---
+
+## 0. Operating rules (read before touching anything)
+
+**Local stack.** `cd infra && docker compose up -d db redis minio backend worker frontend`.
+Do NOT run the frontend with bare `npm run dev` — the Vite proxy targets
+`http://backend:8000` (a Docker hostname) and every `/auth` + `/api` call will
+500. The compose frontend serves on `localhost:3000`. Dev auto-verifies signup
+(`auth.dev_autoverify` in backend logs) and the first registered user becomes
+admin. A local account may already exist: `design-audit@example.com` /
+`audit-pass-2026`, with the seeded Khan v Acme matter.
+
+**Test discipline.** Run all test suites FOREGROUND (background suites wedge
+agents — established fleet lesson). Frontend: `cd frontend && npx tsc --noEmit
+&& npx vitest run` (fast, run the full suite). Backend: `cd backend &&
+.venv/bin/python -m pytest tests/<file> -q` (the repo venv works; the docker
+image has no pytest). Focused tests per sub-step, full suite before each commit.
+
+**CI.** Push, then check the WHOLE board once (`gh pr checks <n>`) — backend
+shards, e2e, frontend build, worker smoke, storage smoke, voice check. The e2e
+suite signs in repeatedly; if you add rate-limited auth calls to tests, the
+override pattern is `LEGALISE_RATE_LIMIT_LOGIN_PER_HOUR=0` in the e2e workflow
+env (see PR #248's `6ebe1df` for precedent).
+
+**Evidence discipline.** For anything visual: before/after screenshots at
+1440, 834 and 390 via Playwright against the local stack, one revertible
+commit per section-level change.
+
+**Copy rules (founder-ratified, do not relitigate).**
+- Register vocabulary (standing, admitted, ceremony, manifest, chain) is
+  allowed where the user READS (ceremony, audit, My skills). It is banned
+  where the user is STUCK (errors, settings, nudges) — there, write what
+  happened + what to do next, no internal enums/ids.
+- Vocabulary is "matter", never "project". The page under `/artifacts` is
+  "Outputs" (it holds drafts AND signed outputs). Nav sections: Chat /
+  Documents / Chronology / Skills / Outputs / Approvals / Activity.
+- No em/en dashes in chrome strings — CI's "Voice check" fails the build.
+- When copy feels wordy, delete sections, not adjectives.
+
+**Design law (DESIGN.md was deleted in doc-cleanup; this is the living law —
+the tokens carry inline comments explaining themselves).**
+- Palette: Almond & Ink (`frontend/tailwind.config.js`): ink `#221E17`, paper
+  `#F6F1E8`, wash `#EFE9DD`, rule `#E0D8C9`, muted `#6E6759` (≥4.5:1 on all
+  surfaces — do not lighten), prose `#564E42`, seal `#7E2B22`, canvas/panel
+  ladder for the floating-panel shell. NO cool greys (`text-gray-*` etc.), no
+  greens/blues/ambers for emphasis — if you need a quiet highlight, use
+  `bg-ink/[0.06]`; if you need a verdict, use seal.
+- Seal is for verdicts only: refusals, blocked rows, CPR 31.22, destructive
+  confirms, the stamp. NEVER nav accent, panel borders, backgrounds, or the
+  brand mark.
+- Type: everything is Redaction (serif). Grit grades (redaction20/35) only for
+  rare large display moments. Eyebrows are 10px bold uppercase tracked.
+- Geometry: radius/shadow live on the panel shell and content cards ONLY
+  (`rounded-panel`/`rounded-card`/`rounded-item` tokens); pills, inputs,
+  ledger rows stay square and flat. Hairline-ruled ledgers, not card grids.
+- The ledger idiom is `LedgerLine` (`frontend/src/ui/certificate.tsx`) — index
+  column, 0.18em label column, content, right meta. It wraps below `sm`; keep
+  that behaviour if you touch it.
+- Matter tabs share one header tier: `h1 text-lg font-semibold` + one-line
+  `text-sm text-muted` description in a `mb-6` block. Display-size Redaction
+  titles are reserved for workspace-level pages (Matters, Settings, Skill
+  library, Demo).
+- Small text links that must stay visually quiet get the `.hit` utility
+  (`frontend/src/index.css`) — a pseudo-element tap-target extender, zero
+  layout shift. Use it instead of padding when enlarging touch areas.
+- Taste: restraint. No decorative motion, no gradients, no emoji, no new
+  visual concepts. One discordant gesture already exists (seal + signature
+  squiggle). If a surface feels cheap, first suspect competing weights or
+  drifted spacing, not missing ornament.
+
+---
+
+## WI-1 — Chat turn control: Stop, then Regenerate
+
+**Why.** Token streaming shipped in #262 (`model.delta` SSE → draft bubble).
+A lawyer watching a wrong answer stream has no way to stop it, and no way to
+re-roll a poor answer without retyping. This is the last first-class gap on
+the launch-critical surface. Punch-list item #4's remainder.
+
+**Where things are.**
+- Client stream: `frontend/src/lib/api/assistant.ts:140`
+  `postAssistantMessageStream(...)` — already accepts an `AbortSignal`
+  (param at line ~143, passed to `apiFetch` at ~149). The signal is currently
+  unused by callers.
+- Consumer: `frontend/src/matter/tabs/AssistantTab.tsx` — `for await (const
+  event of stream)` at ~line 420; the draft bubble accumulates `model.delta`
+  text; the final persisted message arrives through the unchanged completion
+  path (audit identity by construction — do not change that invariant).
+- Backend: `backend/app/modules/assistant/pipeline.py` — streaming via
+  `_EnvelopeContentStreamer`; the SSE endpoint is
+  `POST /api/matters/{slug}/assistant/messages/stream`.
+- Message actions row (Copy / Save as draft): `frontend/src/matter/MessageBubble.tsx`
+  (~line 249 `linkCls`, actions container testid `message-actions`).
+
+**Step 1 — investigate the load-bearing unknown (do this first).**
+Determine what the backend does when the SSE client disconnects mid-stream:
+does the turn still run to completion and persist (server-side generator
+keeps executing), or is the pipeline coroutine cancelled (turn lost)?
+Check FastAPI's disconnect behaviour for this endpoint + the #262 tests
+(`backend/tests/test_assistant_streaming.py`). The answer picks the design:
+
+- **Case A — server completes anyway (likely, and the better invariant):**
+  Stop is purely client-side. Abort the fetch, keep the partial draft bubble
+  with a quiet "Stopped — the full answer is still being recorded" line, and
+  refresh the thread when the persisted message lands (poll the thread once
+  after ~2s, or reuse the existing thread-refresh path). The audit chain
+  stays exactly as today.
+- **Case B — disconnect cancels the pipeline:** do NOT ship silent client
+  abort (it would lose the user message + break the "every model call lands
+  on the record" promise). Instead have Stop call abort AND rely on the
+  existing failed-send recovery (composer restores the prompt — shipped in
+  #248). Add a backend test pinning whatever persistence behaviour you ship.
+
+**Step 2 — Stop UI.**
+- While a stream is active, swap the composer's disabled Send for a `Stop`
+  button (same geometry, bordered not dark; seal text is acceptable here — a
+  stop is a small verdict). One `AbortController` per in-flight turn, held in
+  a ref; abort on click, on thread switch, and on unmount.
+- The draft bubble keeps its partial text until the refreshed thread replaces
+  it (Case A) or the composer restores (Case B). No spinner theatre.
+- Keyless/stub turns don't stream (they fall back silently) — Stop simply
+  never appears for them. Guard on "stream active", not "request active".
+
+**Step 3 — Regenerate.**
+- Add `Regenerate` to the last assistant message's actions row in
+  `MessageBubble.tsx`, next to Copy / Save as draft, same `linkCls` + `.hit`.
+  Only on the LAST assistant message of the thread, only when no turn is in
+  flight.
+- Behaviour: resend the previous user message's content as a brand-new turn
+  through the normal send path (streaming included). No special backend: each
+  turn already gets its own audit rows; the record correctly shows both runs.
+  Do not delete or hide the earlier answer — the record is append-only and
+  the UI should match (the old turn stays in the transcript).
+- Wire the same attach/skill context the original turn used if it's carried
+  on the user message; if it isn't, plain content resend is acceptable v1 —
+  note it in the PR.
+
+**Tests.**
+- Frontend (`AssistantTab.test.tsx` has streaming fixtures from #262): Stop
+  mid-stream → fetch aborted, UI state per chosen case; Regenerate → second
+  POST with identical content, appears as a new turn; Regenerate hidden while
+  streaming; abort on unmount (no state-update-after-unmount warnings).
+- Backend: only if Case B forces a persistence decision — pin it.
+
+**Done when:** a streaming answer can be stopped within one frame of the
+click; a completed answer can be regenerated without retyping; the audit
+trail shows every model call including stopped/regenerated ones; full suites
+green; live walk on the local stack with a real Anthropic key if available,
+keyless otherwise (streaming needs a key — keyless falls back, so verify Stop
+with the stub by adding a temporary artificial delay ONLY in a test, never in
+shipped code).
+
+---
+
+## WI-2 — Mobile drawer: scrim, Escape, focus return
+
+**Why.** The `md:hidden` nav drawer overlays content with no backdrop dim, no
+Escape handling, and no focus management — the audit flagged it as the one
+remaining keyboard/overlay gap. (Body scroll IS already locked while open —
+`AppShell.tsx` ~line 91.)
+
+**Where.** `frontend/src/app/AppShell.tsx` (drawer state, `Open menu` button
+~line 149-156) and `frontend/src/ui/Drawer.tsx` (the public-pages drawer —
+check whether it already has a scrim; apply the same treatment to both if
+not).
+
+**Spec.**
+- Scrim: `fixed inset-0 bg-ink/20 z-<below drawer>` behind the panel, click
+  closes. No blur, no transition longer than 150ms (restraint).
+- Escape closes; focus moves to the first nav item on open and returns to the
+  hamburger button on close. `role="dialog"` `aria-modal="true"` on the
+  drawer container; the hamburger gets `aria-expanded`.
+- Tab must not escape the drawer while open (a simple focus trap — first/last
+  sentinel pattern is fine; no new dependency).
+
+**Tests.** Component test: open → focus inside; Escape → closed + focus on
+trigger; scrim click → closed. Screenshot at 390 with scrim visible.
+
+**Done when:** keyboard-only users can open, navigate and leave the drawer;
+the open drawer reads as a layer (scrim) instead of a slab beside live text.
+
+---
+
+## WI-3 — Chat empty state: give the void a spine
+
+**Why.** A new thread at desktop is suggestion chips pinned top-left, a
+composer at the bottom, and ~400px of dead panel between — no focal point
+(audit finding, deferred as taste-level).
+
+**Where.** `frontend/src/matter/tabs/AssistantTab.tsx` — the empty-thread
+branch that renders the suggestion chips.
+
+**Spec (restraint — this is composition, not content).**
+- When the thread has zero messages, vertically centre a single block in the
+  message area: the three suggestion chips (stacked, left-aligned, exactly as
+  styled today) with one muted line above them: "Ask about the documents in
+  this matter." Nothing else — no icon, no illustration, no card.
+- The moment a first message exists, layout returns to today's flow. No
+  animation on the transition.
+- At `<md` keep the current top-anchored layout (small screens don't have a
+  void to fill).
+
+**Tests.** Existing AssistantTab tests must stay green (chips keep testids);
+add one asserting the empty-state wrapper renders only when `messages.length
+=== 0`. Screenshots 1440 + 390.
+
+**Done when:** an empty chat reads as an invitation rather than an unfinished
+page, and nothing else about the surface moved.
+
+---
+
+## WI-4 — InvocationRunner failure banners: plain-English pass (gated)
+
+**Why.** Punch-list item #6, deliberately deferred: `capability_denied`,
+`phase1_blocked` and `provider_upstream_error` banners still show diagnostic
+codes. They were kept for the BYO-key eval audience; the founder's rule is
+"plain them if beta testers trip on them." **Gate: only do this item if beta
+feedback says testers hit these banners** — check with Andy first.
+
+**Where.** `frontend/src/matter/InvocationRunner.tsx` — state kinds at ~lines
+46-47, banner renders at ~lines 265 (`capability_denied`) and ~284
+(`phase1_blocked`); the upstream-error parse at `AssistantTab.tsx` ~1455 is a
+separate surface, same rule.
+
+**Spec.** Follow the ratified boundary rule (§0 Copy rules): the user is
+STUCK, so each banner becomes: what happened + what to do next, in UI words.
+The diagnostic code moves to a collapsed "Details" disclosure (keep it
+reachable — the eval audience reads it), and stays in logs untouched.
+Suggested shapes:
+- capability_denied → "This skill isn't allowed to do that in this matter.
+  Open Skills to review what it can touch." + link to the Skills tab.
+- phase1_blocked → "This request crossed the advice boundary, so Legalise
+  stopped it before anything left the workspace. The refusal is on the
+  record." + link to Activity.
+- provider upstream → "The model provider returned an error. Nothing was
+  recorded against the matter. Try again, or check your key in Settings."
+
+**Done when:** each failure banner answers "what do I do now" in one read,
+the code is still findable under Details, audit-page deep-links still work
+(ReconstructionView's header comment lists which actions these banners cite —
+keep the `?action=` links intact).
+
+---
+
+## WI-5 — Quick wins (bundle as one PR)
+
+1. **PostureBanner role tokens (punch-list #7).**
+   `frontend/src/matter/PostureBanner.tsx` renders role strings like
+   `qualified_solicitor` verbatim (see the UX matrix comment at the top of
+   the file). Map role tokens to display words ("qualified solicitor") in the
+   banner copy ONLY when firm-role gates are enabled
+   (`LEGALISE_FIRM_ROLE_GATES_ENABLED` — dormant on hosted, so this renders
+   only in firm mode). Do not touch the substrate's role strings.
+2. **skillDisplay ACRONYMS (punch-list #8).**
+   `frontend/src/modules-v2/skillDisplay.ts` — extend the ACRONYMS list only
+   if a specific catalogue name grates (current rule: NDA/GDPR/DPIA/CPR/EU/AI/
+   PDF uppercase; Docx/Xlsx/Pptx sentence-case). One-line change + test.
+3. **Matter-list mobile row order.** `LedgerLine` at `<sm` renders index/label
+   → right-meta → title-last. It was shipped as acceptable; if Andy wants
+   title-first, the fix is in `frontend/src/ui/certificate.tsx` — move the
+   content span's `order-last` to the meta span instead, and re-screenshot
+   /matters and /documents at 390. Ask before doing; do not silently reorder.
+
+---
+
+## Verification walk (run at the end of any WI)
+
+Playwright against the local stack, 1440 + 390:
+1. `/` → hero → demo section renders (video ≥sm, card <sm).
+2. `/guided-demo` → click through all five acts → end CTA "Create a
+   workspace →" present.
+3. Sign in (`/auth/login`) → `/matters` (no h-scroll at 390) → open Khan →
+   Chat: send keyless turn → honest extract, no dangling labels → Save as
+   draft → Outputs shows "Draft from chat".
+4. Documents → open the witness statement → one command row → back.
+5. Activity → rows show "you", links top-right are quiet links.
+6. Tab through the first screen of /matters — every stop has a visible ring.
+7. `npx tsc --noEmit && npx vitest run` (frontend), targeted pytest
+   (backend), push, check the whole CI board once.
+
+## Out of scope — do not do
+
+- No Model B / chat-dock restructure, no nav model changes, no new surfaces.
+- No public-copy rewrites beyond what a WI names (launch week; positioning is
+  Andy's).
+- Do not resurrect DESIGN.md as a file without asking — the law lives in §0
+  and in token comments; a stale duplicate is worse than none.
+- Do not touch the audit-chain / completion-path invariants (#262): the
+  persisted message must keep coming from the unchanged completion path.
+- Do not add dependencies for any of this.

--- a/frontend/src/app/AppHome.test.tsx
+++ b/frontend/src/app/AppHome.test.tsx
@@ -37,11 +37,11 @@ function mountAt(initialPath: string) {
     path: "/app",
     component: AppHome,
   });
-  // /auth/signin + /matters target stubs — AppHome may navigate to
+  // /auth/login + /matters target stubs — AppHome may navigate to
   // them and we need real routes for navigate() to resolve cleanly.
   const signinRoute = createRoute({
     getParentRoute: () => rootRoute,
-    path: "/auth/signin",
+    path: "/auth/login",
     component: () => <div data-testid="signin-stub" />,
   });
   const waitlistRoute = createRoute({

--- a/frontend/src/app/AppHome.tsx
+++ b/frontend/src/app/AppHome.tsx
@@ -16,7 +16,7 @@
  *      binary path. Deliberately no UI shortcut.
  *
  *   3. has_superuser === true
- *      If unauth → bounce to /auth/signin (or /waitlist when
+ *      If unauth → bounce to /auth/login (or /waitlist when
  *      HOSTED_ACCESS_WAITLIST). If authed → bounce to /matters, the
  *      canonical workspace index.
  *
@@ -145,7 +145,7 @@ function BootstrapRequiredState() {
 function SigninRedirect() {
   const nav = useNavigate();
   useEffect(() => {
-    void nav({ to: HOSTED_ACCESS_WAITLIST ? "/waitlist" : "/auth/signin" });
+    void nav({ to: HOSTED_ACCESS_WAITLIST ? "/waitlist" : "/auth/login" });
   }, [nav]);
   return <CenteredLoader label="Redirecting…" />;
 }

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -81,7 +81,7 @@ function AppShellInner() {
     if (auth.loading) return;
     if (auth.user) return;
     if (isPublicRoute(route)) return;
-    navigate(HOSTED_ACCESS_WAITLIST ? "/waitlist" : "/auth/signin");
+    navigate(HOSTED_ACCESS_WAITLIST ? "/waitlist" : "/auth/login");
   }, [auth.loading, auth.user, route]);
 
   // body-scroll-lock + esc to close

--- a/frontend/src/app/AuthGate.tsx
+++ b/frontend/src/app/AuthGate.tsx
@@ -36,7 +36,7 @@ export function AuthGate() {
   useEffect(() => {
     if (auth.loading) return;
     if (auth.user) return;
-    navigate(HOSTED_ACCESS_WAITLIST ? "/waitlist" : "/auth/signin");
+    navigate(HOSTED_ACCESS_WAITLIST ? "/waitlist" : "/auth/login");
   }, [auth.loading, auth.user]);
 
   if (auth.loading || !auth.user) {

--- a/frontend/src/auth/Register.tsx
+++ b/frontend/src/auth/Register.tsx
@@ -109,7 +109,6 @@ export function Register() {
         .
       </p>
       <p className="mt-4 border-t border-rule pt-4 text-xs text-muted">
-        Evaluation only — the hosted workspace is not for live client matters.
         We&apos;ll email a link to confirm your address.
       </p>
     </AuthCard>

--- a/frontend/src/auth/SignIn.tsx
+++ b/frontend/src/auth/SignIn.tsx
@@ -127,6 +127,10 @@ export function SignIn() {
         <a href="/auth/join" className="text-ink underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal">
           Create one
         </a>
+        . Prefer your own machine?{" "}
+        <a href="/auth/signin" className="text-ink underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal">
+          Run it yourself
+        </a>
         .
       </p>
     </AuthCard>

--- a/frontend/src/auth/SignIn.tsx
+++ b/frontend/src/auth/SignIn.tsx
@@ -129,9 +129,6 @@ export function SignIn() {
         </a>
         .
       </p>
-      <p className="mt-4 border-t border-rule pt-4 text-xs text-muted">
-        Evaluation only — the hosted workspace is not for live client matters.
-      </p>
     </AuthCard>
   );
 }

--- a/frontend/src/demo/DemoMatter.tsx
+++ b/frontend/src/demo/DemoMatter.tsx
@@ -16,7 +16,7 @@ import { postureDot, postureLabel } from "../lib/posture";
 
 const DEMO_NAV: ReadonlyArray<{ key: TabKey; label: string }> = [
   { key: "assistant", label: "Chat" },
-  { key: "documents", label: "Files" },
+  { key: "documents", label: "Documents" },
   { key: "workflows", label: "Skills" },
 ];
 
@@ -383,7 +383,7 @@ function DemoWorkflowsTab({
 
   return (
     <div className="max-w-5xl">
-      <SectionRule label="Skills in this project" right="2 admitted" />
+      <SectionRule label="Skills in this matter" right="2 admitted" />
       <p className="mt-5 max-w-xl text-sm leading-relaxed text-prose">
         A skill is a small piece of legal work: review an NDA, test a claim,
         draft a letter. Each one declares what it may read and write before
@@ -499,7 +499,7 @@ function DemoDocumentsTab({
 
   return (
     <div className="max-w-6xl">
-      <SectionRule label="Documents in this project" />
+      <SectionRule label="Documents in this matter" />
 
       <div className="mt-5 grid gap-5 lg:grid-cols-[420px_minmax(0,1fr)]">
         <div>

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -238,7 +238,7 @@ export function GuidedDemo() {
   // backward. Forward/back belongs to the footer step button + Back link.)
   const matterItems: RailItem[] = [
     { key: "assistant", label: "Chat", icon: <NavIcon name="assistant" />, active: railActive === "assistant" },
-    { key: "documents", label: "Files", icon: <NavIcon name="documents" />, active: railActive === "documents" },
+    { key: "documents", label: "Documents", icon: <NavIcon name="documents" />, active: railActive === "documents" },
     { key: "workflows", label: "Skills", icon: <NavIcon name="workflows" />, active: railActive === "workflows" },
     { key: "audit", label: "Record", icon: <NavIcon name="audit" />, active: railActive === "audit" },
   ];
@@ -314,7 +314,7 @@ export function GuidedDemo() {
             {primary ? (
               <PrimaryBtn onClick={primary.onClick}>{primary.label}</PrimaryBtn>
             ) : (
-              <span className="text-xs text-muted">Read the answer below, then continue.</span>
+              <span className="text-xs text-muted">Continue below.</span>
             )}
           </div>
 
@@ -533,7 +533,10 @@ export function GuidedDemo() {
 
                     <div className="relative mt-6 border border-ink/70 bg-paper p-5">
                       <span className="absolute right-5 top-5 -rotate-6 border-2 border-seal px-3 py-1 text-[11px] font-bold uppercase tracking-[0.2em] text-seal">Signed</span>
-                      <CertEyebrow left="Record · created by the sign-off" />
+                      {/* pr keeps the eyebrow clear of the stamp when it wraps at phone widths */}
+                      <div className="pr-24">
+                        <CertEyebrow left="Record · created by the sign-off" />
+                      </div>
                       <dl className="mt-4 space-y-1 text-[11px] text-muted">
                         <LedgerRow label="Matter" tone="ink">Khan v Acme Trading Ltd</LedgerRow>
                         <LedgerRow label="Decision" tone="ink">{decision === "sign" ? "Signed" : decision === "reject" ? "Rejected" : "Signed with observations"}</LedgerRow>

--- a/frontend/src/demo/GuidedDemo.tsx
+++ b/frontend/src/demo/GuidedDemo.tsx
@@ -373,7 +373,10 @@ export function GuidedDemo() {
                             <InkBands label="Writes" values={[s.writes]} />
                           </div>
                           <dl className="mt-4 space-y-1 border-t border-rule pt-3 text-[11px] text-muted">
-                            <LedgerRow label="Gate" tone="ink">privilege_posture</LedgerRow>
+                            {/* Plain words on the pick step — a stranger's first
+                                touch. The admission-scan ledger keeps the raw
+                                token; there the user is reading the register. */}
+                            <LedgerRow label="Gate" tone="ink">the matter's AI-access setting</LedgerRow>
                           </dl>
                         </CertCard>
                       </button>
@@ -554,14 +557,14 @@ export function GuidedDemo() {
                     <div className="mt-10 border-t border-rule pt-6">
                       <SectionRule label="Where this goes" />
                       <p className="mt-4 text-sm leading-relaxed text-prose">
-                        This walk was on rails. The same loop — admit a skill, run it inside the matter, sign it, read the record — is the product. It is open source, and in private beta for evaluators.
+                        This walk was on rails. The same loop — admit a skill, run it inside the matter, sign it, read the record — is the product. It is open source, and the hosted workspace is open for evaluation.
                       </p>
                       <div className="mt-5 flex flex-wrap gap-3">
-                        <a href="/architecture" className="inline-flex items-center bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px]">See how it's built →</a>
-                        <a href="https://github.com/b1rdmania/legalise" className="inline-flex items-center border border-ink text-ink px-4 py-2 hover:bg-wash transition-colors text-sm font-medium min-h-[44px]">Read the source</a>
+                        <a href="/auth/join" className="inline-flex items-center bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px]">Create a workspace →</a>
+                        <a href="/architecture" className="inline-flex items-center border border-ink text-ink px-4 py-2 hover:bg-wash transition-colors text-sm font-medium min-h-[44px]">See how it's built</a>
                       </div>
                       <p className="mt-4 text-xs text-muted">
-                        Evaluating it for a firm or a regulator? <a href="mailto:andrew@legalise.dev" className="text-seal hover:underline">Get in touch</a>.
+                        <a href="https://github.com/b1rdmania/legalise" className="text-seal hover:underline">Read the source</a>. Evaluating it for a firm or a regulator? <a href="mailto:andrew@legalise.dev" className="text-seal hover:underline">Get in touch</a>.
                       </p>
                     </div>
                   </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -83,6 +83,21 @@
     font-family: "Redaction", Georgia, serif;
   }
 
+  /* Hit-area extender for the ledger idiom's small text links (Open →,
+     Delete, Pause AI…). The visual design wants 11–13px quiet links; a
+     thumb wants ≥24px. The pseudo-element grows the tap target without
+     moving a pixel of layout. Horizontal inset stays small so adjacent
+     row actions don't overlap. */
+  .hit {
+    position: relative;
+  }
+
+  .hit::after {
+    content: "";
+    position: absolute;
+    inset: -8px -4px;
+  }
+
   .tech-token {
     font-family: "Redaction", Georgia, "Times New Roman", serif;
     font-variant-numeric: tabular-nums;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,10 +39,13 @@
 }
 
 @layer components {
+  /* Eyebrow colour is the warm muted token, not a cool grey: #9CA3AF was a
+     Tailwind-palette leftover from before Almond & Ink and read 2.3:1 on
+     paper — invisible to low-vision readers at 10px. */
   .eyebrow {
     text-transform: uppercase;
     letter-spacing: 0.2em;
-    color: #9CA3AF;
+    color: #6E6759;
     font-size: 10px;
     font-weight: 700;
   }
@@ -50,7 +53,7 @@
   .eyebrow-sm {
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: #9CA3AF;
+    color: #6E6759;
     font-size: 10px;
     font-weight: 700;
   }
@@ -87,7 +90,7 @@
   }
 
   .prose-p {
-    color: #4B5563;
+    color: #564E42;
     margin-bottom: 1.5rem;
     line-height: 1.7;
   }

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -108,7 +108,23 @@ export function Landing() {
         className="scroll-mt-8 px-4 sm:px-6 md:px-16 lg:px-24 py-16 md:py-20"
       >
         <div className="max-w-3xl mx-auto">
-          <div className="border border-ink/70 bg-paper p-2">
+          {/* The video is a desktop screen-scan — at phone widths it renders
+              a whole three-pane workspace ~350px wide, illegible and
+              autoplaying. Phones get the guided demo instead. */}
+          <a
+            href="/guided-demo"
+            className="block border border-ink/70 bg-paper p-6 sm:hidden"
+          >
+            <p className="eyebrow mb-3">Demo</p>
+            <p className="text-sm text-prose leading-relaxed mb-4">
+              The 30-second scan is filmed on a desktop screen. On a phone,
+              walk the demo instead — the same loop, step by step.
+            </p>
+            <span className="text-sm font-semibold text-ink">
+              Walk the demo →
+            </span>
+          </a>
+          <div className="hidden border border-ink/70 bg-paper p-2 sm:block">
             <video
               src="/media/backend-demo-v2.mp4"
               poster="/media/backend-demo-v2-poster.jpg"
@@ -119,7 +135,8 @@ export function Landing() {
               controls
               preload="metadata"
               ref={(el) => {
-                if (el) {
+                // Don't spin the video up behind the phone-width swap card.
+                if (el && window.matchMedia("(min-width: 640px)").matches) {
                   el.muted = true;
                   void el.play().catch(() => undefined);
                 }

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -51,7 +51,7 @@ export function Landing() {
                 onClick={onOpenDemo}
                 className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px]"
               >
-                Open demo project
+                Open the demo matter
               </button>
             ) : (
               <a

--- a/frontend/src/matter/ArtifactDetail.tsx
+++ b/frontend/src/matter/ArtifactDetail.tsx
@@ -104,7 +104,7 @@ export function ArtifactDetail({
             params={{ slug }}
             className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
           >
-            ← Signed outputs
+            ← Outputs
           </Link>
         </p>
         <h1 className="text-xl font-bold tracking-tight2">Output not found</h1>
@@ -124,7 +124,7 @@ export function ArtifactDetail({
           params={{ slug }}
           className="text-sm text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
         >
-          ← Signed outputs
+          ← Outputs
         </Link>
       </p>
       {/* The artifact's certificate header — its entry in the record

--- a/frontend/src/matter/ArtifactsList.test.tsx
+++ b/frontend/src/matter/ArtifactsList.test.tsx
@@ -131,7 +131,7 @@ describe("ArtifactsList", () => {
     vi.spyOn(api, "listArtifacts").mockResolvedValue([]);
     mountAt();
     await waitFor(() => {
-      expect(screen.getByText(/No signed outputs yet/i)).toBeInTheDocument();
+      expect(screen.getByText(/No outputs yet/i)).toBeInTheDocument();
     });
   });
 
@@ -139,7 +139,7 @@ describe("ArtifactsList", () => {
     vi.spyOn(api, "listArtifacts").mockRejectedValue(new Error("boom"));
     mountAt();
     await waitFor(() => {
-      expect(screen.getByText(/Could not load signed outputs/i)).toBeInTheDocument();
+      expect(screen.getByText(/Could not load outputs/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -153,7 +153,7 @@ export function ArtifactsList({ slug }: { slug: string }) {
                   <Link
                     to="/matters/$slug/artifacts/$artifactId"
                     params={{ slug, artifactId: r.id }}
-                    className="text-[11px] text-muted hover:text-seal"
+                    className="hit text-[11px] text-muted hover:text-seal"
                   >
                     Open →
                   </Link>

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -108,11 +108,19 @@ export function ArtifactsList({ slug }: { slug: string }) {
 
   return (
     <div className="page-shell">
-      {/* Drafts appear here too (SignoffMark renders Draft), so the old
-          "Signed outputs" label under-promised and hid the save-as-draft
-          path from anyone scanning the nav for their draft. */}
+      {/* Same header tier as Documents — this tab previously opened with a
+          bare section rule and no page name. Drafts appear here too
+          (SignoffMark renders Draft), so the old "Signed outputs" label
+          under-promised and hid the save-as-draft path. */}
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold text-ink">Outputs</h1>
+        <p className="mt-1 text-sm text-muted">
+          Drafts and signed outputs on this matter. Open one to review,
+          sign, or export it.
+        </p>
+      </div>
       <SectionRule
-        label="Outputs"
+        label="All outputs"
         right={q.status === "ready" ? String(q.rows.length) : undefined}
       />
 

--- a/frontend/src/matter/ArtifactsList.tsx
+++ b/frontend/src/matter/ArtifactsList.tsx
@@ -108,22 +108,25 @@ export function ArtifactsList({ slug }: { slug: string }) {
 
   return (
     <div className="page-shell">
+      {/* Drafts appear here too (SignoffMark renders Draft), so the old
+          "Signed outputs" label under-promised and hid the save-as-draft
+          path from anyone scanning the nav for their draft. */}
       <SectionRule
-        label="Signed outputs"
+        label="Outputs"
         right={q.status === "ready" ? String(q.rows.length) : undefined}
       />
 
       {q.status === "loading" && (
-        <p className="mt-4 text-sm text-muted">Loading signed outputs…</p>
+        <p className="mt-4 text-sm text-muted">Loading outputs…</p>
       )}
       {q.status === "error" && (
         <p className="mt-4 text-sm text-seal">
-          Could not load signed outputs: {q.message}
+          Could not load outputs: {q.message}
         </p>
       )}
       {q.status === "ready" && q.rows.length === 0 && (
         <p className="mt-4 text-sm text-muted">
-          No signed outputs yet on this matter. Run a skill to produce one.
+          No outputs yet on this matter. Save an assistant answer as a draft, or run a skill.
         </p>
       )}
       {q.status === "ready" && q.rows.length > 0 && (

--- a/frontend/src/matter/CprGateBanner.tsx
+++ b/frontend/src/matter/CprGateBanner.tsx
@@ -9,7 +9,7 @@ export function CprGateBanner({ count, onConfirm }: { count: number; onConfirm: 
         {count} chronology {count === 1 ? "entry traces" : "entries trace"} to documents obtained
         under disclosure. CPR 31.22(1) restricts use of disclosed material to the proceedings in
         which it was disclosed. Until you acknowledge the implied undertaking, the server
-        withholds detail of those {count === 1 ? "entry" : "entries"} - the rows below show them
+        withholds detail of {count === 1 ? "that entry - the row below shows it" : "those entries - the rows below show them"}{" "}
         as redacted.
       </p>
       <p className="text-prose leading-relaxed mb-4">

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1013,7 +1013,10 @@ export function DocumentDetail({
           aria-label="Document command surface"
           data-testid="document-command-bar"
         >
-          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-rule px-3 py-2.5">
+          {/* One command row: views left, actions right. This was two
+              stacked toolbars — three rows of chrome (with the page header)
+              before any document showed. */}
+          <div className="flex flex-wrap items-center gap-2 px-3 py-2.5 text-[13px]">
             <nav
               className="flex flex-wrap items-center gap-2"
               aria-label="Document workspace views"
@@ -1064,13 +1067,11 @@ export function DocumentDetail({
                 ))}
               </div>
             )}
-          </div>
-          <div className="flex flex-wrap items-center gap-2 px-3 py-2.5 text-[13px]">
             <Link
               to="/matters/$slug/$tab"
               params={{ slug, tab: "assistant" }}
               search={{ document: documentId }}
-              className="inline-flex min-h-[34px] items-center rounded-item border border-ink bg-ink px-3 text-paper hover:bg-seal"
+              className="ml-auto inline-flex min-h-[34px] items-center rounded-item border border-ink bg-ink px-3 text-paper hover:bg-seal"
               data-testid="document-ask-chat-link"
             >
               Ask about this file
@@ -1098,7 +1099,7 @@ export function DocumentDetail({
               onClick={() => setShowPanel((v) => !v)}
               aria-expanded={showPanel}
               data-testid="document-panel-toggle"
-              className="ml-auto inline-flex min-h-[34px] items-center rounded-item border border-rule bg-paper px-3 text-ink hover:border-ink"
+              className="inline-flex min-h-[34px] items-center rounded-item border border-rule bg-paper px-3 text-ink hover:border-ink"
             >
               {showPanel ? "Hide panel" : "Panel"}
             </button>

--- a/frontend/src/matter/DocumentDetail.tsx
+++ b/frontend/src/matter/DocumentDetail.tsx
@@ -1621,7 +1621,7 @@ export function DocumentDetail({
                     Run a skill with this file selected.
                   </h2>
                   <p className="mt-1 text-sm leading-6 text-muted">
-                    Skills use the same project runner as Chat, with {doc.filename} already in context.
+                    Skills use the same matter runner as Chat, with {doc.filename} already in context.
                   </p>
                 </div>
                 <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
@@ -1662,10 +1662,10 @@ export function DocumentDetail({
                   />
                 </div>
               ) : skillLoadState === "loading" ? (
-                <p className="mt-3 text-sm text-muted">Loading project skills...</p>
+                <p className="mt-3 text-sm text-muted">Loading matter skills...</p>
               ) : skillLoadState === "error" ? (
                 <p className="mt-3 text-sm text-muted">
-                  Skills could not be loaded here. Open the project Skills page to check setup.
+                  Skills could not be loaded here. Open the matter's Skills page to check setup.
                 </p>
               ) : documentSkills.length === 0 ? (
                 <div className="mt-3 text-sm text-muted">
@@ -1678,7 +1678,7 @@ export function DocumentDetail({
                     params={{ slug, tab: "workflows" }}
                     className="mt-2 inline-block underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
                   >
-                    Open project Skills →
+                    Open matter Skills →
                   </Link>
                 </div>
               ) : (

--- a/frontend/src/matter/GenericSkillRunner.tsx
+++ b/frontend/src/matter/GenericSkillRunner.tsx
@@ -137,11 +137,11 @@ export function GenericSkillRunner({
         <div>
           <p className="text-sm font-semibold text-ink">{skill.title}</p>
           <p className="mt-1 max-w-xl text-xs text-muted">
-            {skill.description || "Runs against this project and writes an output to Activity."}
+            {skill.description || "Runs against this matter and writes an output to Activity."}
           </p>
         </div>
         <span className="rounded-full border border-line px-2 py-0.5 text-[11px] text-muted">
-          Ready in this project
+          Ready in this matter
         </span>
       </div>
 
@@ -159,7 +159,7 @@ export function GenericSkillRunner({
 
         <div>
           <p className="text-[11px] uppercase tracking-widest text-muted">
-            {needsDocument ? "Documents selected" : "Project material"}
+            {needsDocument ? "Documents selected" : "Matter material"}
           </p>
           {documents === null ? (
             <p className="mt-2 text-xs text-muted">Loading documents…</p>
@@ -443,7 +443,7 @@ function defaultPromptFor(
   if (skill.reads.includes("document.body.read")) {
     return "Run this skill on the selected document.";
   }
-  return "Run this skill on the project.";
+  return "Run this skill on the matter.";
 }
 
 function errorToState(err: unknown): RunnerState {
@@ -451,7 +451,7 @@ function errorToState(err: unknown): RunnerState {
     return {
       kind: "blocked",
       title: "Privilege state blocks this skill",
-      body: "This project is not currently allowed to run that skill.",
+      body: "This matter is not currently allowed to run that skill.",
       detail: err.reason,
     };
   }
@@ -459,7 +459,7 @@ function errorToState(err: unknown): RunnerState {
     return {
       kind: "blocked",
       title: "This skill needs setup",
-      body: "A required project permission is missing. Open Skills to enable it.",
+      body: "A required matter permission is missing. Open Skills to enable it.",
     };
   }
   if (err instanceof Phase1BlockedError) {

--- a/frontend/src/matter/MatterList.tsx
+++ b/frontend/src/matter/MatterList.tsx
@@ -35,9 +35,13 @@ export function MatterList() {
         title="Matters"
         description="Every matter in this workspace. Each row shows its type, status, and AI-access state. Open a matter to work on it."
         actions={
+          /* From md up the rail already pins its own "+ New matter" CTA a
+             few hundred pixels away; two identical dark buttons on one
+             screen fight for the same weight. Below md the rail is behind
+             the drawer, so the header button stays. */
           <a
             href="/matters/new"
-            className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px] inline-flex items-center"
+            className="bg-ink text-paper px-4 py-2 hover:bg-seal transition-colors text-sm font-medium min-h-[44px] inline-flex items-center md:hidden"
           >
             New matter
           </a>

--- a/frontend/src/matter/MatterSkillsTab.test.tsx
+++ b/frontend/src/matter/MatterSkillsTab.test.tsx
@@ -176,7 +176,7 @@ describe("MatterSkillsTab — enable truth", () => {
     expect(btn).toBeDisabled();
     expect(
       screen.getByTestId("available-disabled-reason-workspace-only"),
-    ).toHaveTextContent(/cannot be enabled inside a project/i);
+    ).toHaveTextContent(/cannot be enabled inside a matter/i);
   });
 
   it("keeps the modal open and surfaces the error on grant failure", async () => {

--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -165,6 +165,15 @@ export function MatterSkillsTab({ slug }: Props) {
 
   return (
     <section>
+      {/* Same header tier as Documents — this tab previously opened with a
+          bare section eyebrow and no page name. */}
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold text-ink">Skills</h1>
+        <p className="mt-1 text-sm text-muted">
+          What can run inside this matter, and what it is allowed to touch.
+        </p>
+      </div>
+
       {error && (
         <p className="mb-4 text-sm text-seal" data-testid="matter-skills-error">
           {error}

--- a/frontend/src/matter/MatterSkillsTab.tsx
+++ b/frontend/src/matter/MatterSkillsTab.tsx
@@ -59,7 +59,7 @@ function matterCapabilityIds(entry: V2ManifestEntry): string[] {
 }
 
 function friendlyCapabilitySummary(values: string[]): string {
-  if (values.length === 0) return "Project context";
+  if (values.length === 0) return "Matter context";
   const labels = new Set<string>();
   for (const value of values) {
     if (value.includes("document")) labels.add("Documents");
@@ -361,7 +361,7 @@ function AvailableModuleRow({
       const disabledReason = !entry.is_valid
     ? "This skill needs setup in the workspace before enabling."
     : !hasMatterCaps
-      ? "This skill cannot be enabled inside a project yet."
+      ? "This skill cannot be enabled inside a matter yet."
       : null;
 
   return (
@@ -391,7 +391,7 @@ function AvailableModuleRow({
       <dl className="mt-3 grid grid-cols-2 gap-3 border-t border-rule pt-3 text-[11px] sm:grid-cols-3">
         <Meta label="Reads" value={friendlyCapabilitySummary(reads)} />
         <Meta label="Writes" value={friendlyCapabilitySummary(writes)} />
-        <Meta label="Project actions" value={String(matterCaps.length)} />
+        <Meta label="Matter actions" value={String(matterCaps.length)} />
       </dl>
       {disabledReason && (
         <p

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -247,7 +247,7 @@ function MessageActions({
   };
 
   const linkCls =
-    "text-muted underline underline-offset-4 hover:text-ink transition-colors";
+    "hit text-muted underline underline-offset-4 hover:text-ink transition-colors";
 
   return (
     <div

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -273,18 +273,20 @@ export function ReconstructionView({ slug }: { slug: string }) {
       <PageHeader
         title="What happened here"
         actions={
-          <div className="flex flex-wrap gap-2">
+          /* Cross-links, not actions — as a bordered pair with one dark
+             they read as a view toggle. Quiet links match what they are. */
+          <div className="flex flex-wrap items-center gap-4 text-sm">
             <a
               href={`/matters/${encodeURIComponent(slug)}/artifacts`}
-              className="inline-flex items-center rounded-item border border-rule px-3 py-2 text-sm hover:border-ink"
+              className="hit text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
             >
-              Signed outputs
+              Outputs →
             </a>
             <a
               href={`/matters/${encodeURIComponent(slug)}/lifecycle`}
-              className="inline-flex items-center bg-ink px-3 py-2 text-sm text-paper hover:opacity-90"
+              className="hit text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
             >
-              Working pack
+              Working pack →
             </a>
           </div>
         }

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -427,7 +427,7 @@ export function ReconstructionView({ slug }: { slug: string }) {
                   <button
                     type="button"
                     onClick={() => setShowBackground((v) => !v)}
-                    className="text-xs uppercase tracking-widest text-muted hover:text-seal"
+                    className="hit text-xs uppercase tracking-widest text-muted hover:text-seal"
                     data-testid="toggle-background"
                     aria-expanded={showBackground}
                   >

--- a/frontend/src/matter/ReconstructionView.tsx
+++ b/frontend/src/matter/ReconstructionView.tsx
@@ -46,6 +46,7 @@ import {
   type RowClass,
 } from "./auditClassify";
 import { humanActionLabel } from "./auditHumanLabel";
+import { useAuth } from "../auth/AuthProvider";
 import { PageHeader } from "../ui/primitives";
 
 // Class filter chips (AT-2). No `artifact` chip — artifacts are not an
@@ -682,6 +683,7 @@ function AdvancedDetails({
 
 function TimelineRow({ entry }: { entry: TimelineEntry }) {
   const [expanded, setExpanded] = useState(false);
+  const auth = useAuth();
   const tone = sourceTone(entry.source);
   const rowClass = classifyEntry(entry);
   const isProminent = rowClass === "signed" || rowClass === "review";
@@ -734,9 +736,16 @@ function TimelineRow({ entry }: { entry: TimelineEntry }) {
         {entry.actor.user_id && (
           <span>
             user:{" "}
-            <code className="tech-token">
-              {String(entry.actor.user_id).slice(0, 8)}…
-            </code>
+            {/* The chain only carries the actor's id. Name the one actor we
+                can resolve client-side — the signed-in user — instead of
+                showing them their own UUID. */}
+            {auth.user && String(entry.actor.user_id) === String(auth.user.id) ? (
+              <span className="text-ink">you</span>
+            ) : (
+              <code className="tech-token">
+                {String(entry.actor.user_id).slice(0, 8)}…
+              </code>
+            )}
           </span>
         )}
       </div>

--- a/frontend/src/matter/tabs/ApprovalsTab.tsx
+++ b/frontend/src/matter/tabs/ApprovalsTab.tsx
@@ -73,7 +73,7 @@ export function ApprovalsTab({ slug }: { slug: string }) {
         <div className="mt-6">
           <EmptyState
             title="No reviews yet"
-            body='Open a Contract Review findings pack in Signed outputs and choose "Request review" to start one.'
+            body='Open an output under Signed outputs and choose "Request review" to start one.'
           />
         </div>
       )}

--- a/frontend/src/matter/tabs/ApprovalsTab.tsx
+++ b/frontend/src/matter/tabs/ApprovalsTab.tsx
@@ -59,12 +59,15 @@ export function ApprovalsTab({ slug }: { slug: string }) {
 
   return (
     <div className="max-w-3xl">
-      <p className="text-sm text-muted">
-        <span className="text-ink">
+      {/* Same header tier as Documents — this tab previously opened with a
+          bare disclaimer sentence and no page name. */}
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold text-ink">Approvals</h1>
+        <p className="mt-1 text-sm text-muted">
           "Approved in Legalise" records that a human reviewed an output —
           it is not legal advice certification or SRA approval.
-        </span>
-      </p>
+        </p>
+      </div>
 
       {q.status === "loading" && <LoadingLine label="loading reviews" />}
       {q.status === "error" && <ErrorCallout message={q.message} />}

--- a/frontend/src/matter/tabs/ApprovalsTab.tsx
+++ b/frontend/src/matter/tabs/ApprovalsTab.tsx
@@ -73,7 +73,7 @@ export function ApprovalsTab({ slug }: { slug: string }) {
         <div className="mt-6">
           <EmptyState
             title="No reviews yet"
-            body='Open an output under Signed outputs and choose "Request review" to start one.'
+            body='Open an output under Outputs and choose "Request review" to start one.'
           />
         </div>
       )}

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -1101,7 +1101,7 @@ export function AssistantTab({
                                     {skill.title}
                                   </span>
                                   <span className="mt-0.5 block text-[11px] text-muted">
-                                    Ready in this project
+                                    Ready in this matter
                                   </span>
                                 </span>
                                 <span aria-hidden="true" className="text-muted">
@@ -1755,7 +1755,7 @@ function MatterContextRail({
         actionTestId="open-documents-link"
       >
         {docs === null ? (
-          <p className="text-sm text-muted">Loading project files…</p>
+          <p className="text-sm text-muted">Loading matter documents…</p>
         ) : docs.length === 0 ? (
           <p className="text-sm text-muted">No documents loaded yet.</p>
         ) : (

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -668,7 +668,7 @@ export function AssistantTab({
                   aria-expanded={docsOpen}
                   aria-haspopup="menu"
                   data-testid="docs-context-status"
-                  className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                  className="hit underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
                 >
                   {docs.length} document{docs.length === 1 ? "" : "s"}
                 </button>
@@ -755,7 +755,7 @@ export function AssistantTab({
                   No {providerLabel(matter.required_provider)} key yet —{" "}
                   <a
                     href="/settings/keys"
-                    className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                    className="hit underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
                   >
                     add one in Settings
                   </a>
@@ -787,7 +787,7 @@ export function AssistantTab({
                     type="button"
                     onClick={onTogglePause}
                     disabled={postureSubmitting}
-                    className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal disabled:opacity-50"
+                    className="hit underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal disabled:opacity-50"
                     data-testid="chat-pause-toggle"
                   >
                     {posturePaused(matter.privilege_posture) ? "Resume AI" : "Pause AI"}

--- a/frontend/src/matter/tabs/ChronologyTab.tsx
+++ b/frontend/src/matter/tabs/ChronologyTab.tsx
@@ -85,6 +85,16 @@ export function ChronologyTab({
 
   return (
     <div className="max-w-4xl">
+      {/* Same header tier as Documents — this tab previously opened with
+          the CPR banner or the auto-build button, no page name. */}
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold text-ink">Chronology</h1>
+        <p className="mt-1 text-sm text-muted">
+          The matter's events in date order. Proposed events count only
+          once a person accepts them.
+        </p>
+      </div>
+
       {chron.gate.required && !chron.gate.confirmed && (
         <CprGateBanner count={chron.gate.tainted_event_count} onConfirm={onConfirmGate} />
       )}

--- a/frontend/src/matter/tabs/ChronologyTab.tsx
+++ b/frontend/src/matter/tabs/ChronologyTab.tsx
@@ -180,7 +180,10 @@ function ChronologyTable({
             }`}
           >
             <div
-              className="absolute right-0 top-0 bottom-0 bg-[#00A35C]/15 pointer-events-none"
+              /* Significance bar. Was #00A35C green — the one flat green in an
+                 Almond & Ink UI, and at sig 5 it flooded the whole row like a
+                 broken selection state. A quiet ink wash keeps the encoding. */
+              className="absolute right-0 top-0 bottom-0 bg-ink/[0.06] pointer-events-none"
               style={{ width: sigBarWidth }}
               aria-hidden="true"
             />

--- a/frontend/src/matter/tabs/DocumentsTab.tsx
+++ b/frontend/src/matter/tabs/DocumentsTab.tsx
@@ -361,14 +361,14 @@ export function DocumentsTab({
                       <Link
                         to="/matters/$slug/documents/$documentId"
                         params={{ slug, documentId: d.id }}
-                        className="text-sm text-muted hover:text-seal"
+                        className="hit text-sm text-muted hover:text-seal"
                       >
                         Open →
                       </Link>
                       <button
                         type="button"
                         onClick={() => onDelete(d)}
-                        className="text-sm text-muted hover:text-seal"
+                        className="hit text-sm text-muted hover:text-seal"
                       >
                         Delete
                       </button>

--- a/frontend/src/matter/tabs/OverviewTab.tsx
+++ b/frontend/src/matter/tabs/OverviewTab.tsx
@@ -360,7 +360,7 @@ export function OverviewTab({
                 <Link
                   to="/matters/$slug/$tab"
                   params={{ slug, tab: "documents" }}
-                  className="text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                  className="hit text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
                 >
                   Open →
                 </Link>
@@ -382,7 +382,7 @@ export function OverviewTab({
                 <Link
                   to="/matters/$slug/artifacts"
                   params={{ slug }}
-                  className="text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                  className="hit text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
                 >
                   Outputs →
                 </Link>
@@ -445,7 +445,7 @@ export function OverviewTab({
           <Link
             to="/matters/$slug/audit"
             params={{ slug }}
-            className="text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+            className="hit text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
           >
             Activity →
           </Link>
@@ -554,7 +554,7 @@ export function OverviewTab({
                   <button
                     type="button"
                     onClick={() => setEditingModel(true)}
-                    className="text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                    className="hit text-xs text-muted underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
                   >
                     Change
                   </button>

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -292,7 +292,7 @@ export function ModulesCatalog() {
           />
           <DemoStep
             title="2. Run it in a matter"
-            body="The skill works against the project documents, not a loose prompt."
+            body="The skill works against the matter's documents, not a loose prompt."
           />
           <DemoStep
             title="3. Check the record"

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -664,6 +664,10 @@ const routeTree = rootRoute.addChildren([
 export const router = createRouter({
   routeTree,
   defaultPreload: "intent",
+  // SPA navigations otherwise keep the previous page's scroll offset —
+  // e.g. submitting /auth/join from a scrolled position landed
+  // /auth/verify-pending with its heading under the fixed header.
+  scrollRestoration: true,
 });
 
 declare module "@tanstack/react-router" {

--- a/frontend/src/ui/Drawer.tsx
+++ b/frontend/src/ui/Drawer.tsx
@@ -110,7 +110,7 @@ export function Drawer({
       { href: GITHUB_REPO, label: "GitHub", external: true },
     ];
     secondary = [
-      { href: "/auth/signin", label: "Sign in" },
+      { href: "/auth/login", label: "Sign in" },
     ];
   }
 

--- a/frontend/src/ui/Footer.tsx
+++ b/frontend/src/ui/Footer.tsx
@@ -7,11 +7,11 @@ export function Footer() {
           href="https://github.com/b1rdmania/legalise"
           target="_blank"
           rel="noreferrer"
-          className="hover:text-ink"
+          className="hit hover:text-ink"
         >
           View on GitHub
         </a>
-        <a href="mailto:andrew@legalise.dev" className="hover:text-ink">
+        <a href="mailto:andrew@legalise.dev" className="hit hover:text-ink">
           Email
         </a>
       </div>

--- a/frontend/src/ui/TopBar.tsx
+++ b/frontend/src/ui/TopBar.tsx
@@ -167,7 +167,7 @@ export function TopBar({
                   <Github size={18} strokeWidth={1.75} aria-hidden="true" />
                 </a>
                 <a
-                  href="/auth/signin"
+                  href="/auth/login"
                   className="text-muted hover:text-ink transition-colors"
                 >
                   Sign in

--- a/frontend/src/ui/certificate.tsx
+++ b/frontend/src/ui/certificate.tsx
@@ -152,20 +152,27 @@ export function LedgerLine({
   testid?: string;
 }) {
   return (
+    /* Below sm the fixed columns (index 40px + label 160px + right meta)
+       exceed the viewport and force horizontal scroll, so the row wraps:
+       line one carries index · label · right-aligned meta, and the entry
+       text drops to its own full-width line. From sm up, the original
+       single-line ledger geometry is unchanged. */
     <div
-      className="flex items-baseline gap-4 border-b border-rule/60 py-2.5"
+      className="flex flex-wrap items-baseline gap-x-4 gap-y-1 border-b border-rule/60 py-2.5 sm:flex-nowrap"
       data-testid={testid}
     >
       <span className="tech-token w-10 shrink-0 text-[11px] text-muted">
         {String(index).padStart(4, "0")}
       </span>
       {label != null && (
-        <span className="w-40 shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted">
+        <span className="shrink-0 text-[10px] uppercase tracking-[0.18em] text-muted sm:w-40">
           {label}
         </span>
       )}
-      <span className="min-w-0 flex-1 text-sm text-ink">{children}</span>
-      {right != null && <span className="shrink-0">{right}</span>}
+      <span className="order-last min-w-0 basis-full text-sm text-ink sm:order-none sm:flex-1 sm:basis-auto">
+        {children}
+      </span>
+      {right != null && <span className="ml-auto shrink-0 sm:ml-0">{right}</span>}
     </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -28,7 +28,10 @@ export default {
         paper: '#F6F1E8',
         wash: '#EFE9DD',
         rule: '#E0D8C9',
-        muted: '#8B8273',
+        // Darkened 2026-07-06 from #8B8273: that value sat at 3.4:1 on paper,
+        // under WCAG AA for the 11–13px meta text it labels. #6E6759 holds the
+        // same warm hue at ≥4.5:1 on paper, panel and wash.
+        muted: '#6E6759',
         prose: '#564E42',
         // Tertiary accent — sealing wax. v0.5: verdicts, the seal/stamp,
         // privilege C_paused, audit blocked rows, CPR 31.22 flag,


### PR DESCRIPTION
Full design audit + fix pass, walked in a real browser at 1440/834/390 against the local stack (real signup → chat → draft → outputs). Nine commits; the original L3 proposals were subsequently approved and are now in the diff.

## Correctness floor
- Horizontal page scroll at 390px on Matters/Documents — shared `LedgerLine` now wraps below `sm` (also un-crushes the guided-demo record)
- Contrast: `.eyebrow` 2.26:1 and `muted` 3.4:1 → warm `#6E6759` at ≥4.5:1 on paper/panel/wash; `.prose-p` cool grey → prose token
- `scrollRestoration` on the router (SPA navs kept old scroll; verify-pending heading clipped under the fixed header)
- Guided demo: SIGNED stamp overlapped the record eyebrow at 390; CPR banner singular grammar
- Touch targets: `.hit` utility (pseudo-element tap-area extender, zero layout shift) on the ledger idiom's small links — row Open→/Delete, chat header controls, message Copy/Save-as-draft, overview quick links, footer

## Copy / coherence
- All user-facing project→matter leftovers; demo rails say Documents
- "Sign in" (header/drawer/session-expiry) → the `/auth/login` form, with a deliberate "Run it yourself" link back to the OSS onramp on the login card
- **"Signed outputs" → "Outputs"** — the list holds drafts; a chat-saved draft (#259) previously had no findable home. Empty state names both paths. Verified live.
- One header tier for every matter tab (Outputs/Approvals/Skills/Chronology previously opened header-less)
- Chronology significance bar: off-palette `#00A35C` green → ink wash; approvals stale Contract-Review copy; audit rows say "you" not your own UUID; auth cards state the eval caveat once
- Keyless extract reply: citation rides the lead bullet — no more dangling "Source:" (backend, verified live)

## Funnel
- **Guided demo now ends at "Create a workspace →"** (/auth/join) — signup has been self-serve since #219 but the demo still said "private beta" and routed to the architecture page. "See how it's built" demotes to secondary; source link joins the footer line.
- Landing on phones: the desktop screen-scan video (illegible ~350px autoplay) swaps for a guided-demo card below `sm`; video neither renders nor plays there
- Skill cards on the demo pick step spell the gate in plain words; the admission-scan ledger keeps the raw token (register boundary rule)
- Doc viewer: views + actions merged into one command row (two rows of chrome before the document instead of three)
- Matters page: duplicate New-matter CTA hidden where the rail pins one

tsc clean · 367/367 vitest · backend pipeline tests green · prod build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)