### PR TITLE
Mobile drawers: scrim, Escape, focus trap and return (WI-2)

### DIFF
--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -84,18 +84,15 @@ function AppShellInner() {
     navigate(HOSTED_ACCESS_WAITLIST ? "/waitlist" : "/auth/login");
   }, [auth.loading, auth.user, route]);
 
-  // body-scroll-lock + esc to close
+  // body-scroll-lock while a drawer is open. Escape/focus handling lives
+  // in the drawers themselves (ui/drawerA11y.tsx) so both the workspace
+  // rail and the public Drawer behave identically.
   useEffect(() => {
     if (!navOpen) return;
     const prev = document.body.style.overflow;
     document.body.style.overflow = "hidden";
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setNavOpen(false);
-    };
-    window.addEventListener("keydown", onKey);
     return () => {
       document.body.style.overflow = prev;
-      window.removeEventListener("keydown", onKey);
     };
   }, [navOpen]);
 
@@ -151,6 +148,7 @@ function AppShellInner() {
             type="button"
             onClick={() => setNavOpen(true)}
             aria-label="Open menu"
+            aria-expanded={navOpen}
             className="min-h-[44px] min-w-[44px] -ml-2 flex items-center justify-center text-ink"
           >
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">

--- a/frontend/src/ui/Drawer.tsx
+++ b/frontend/src/ui/Drawer.tsx
@@ -1,6 +1,8 @@
+import { useRef } from "react";
 import { navigate, type Route } from "../lib/route";
 import type { Matter } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
+import { FocusSentinel, useDrawerA11y } from "./drawerA11y";
 import { SIDEBAR_NAV, sidebarActiveFor, isTabKey } from "../matter/tabs/types";
 import { postureLabel } from "../lib/posture";
 
@@ -22,6 +24,11 @@ export function Drawer({
   health: HealthResponse | null;
 }) {
   const auth = useAuth();
+  // Drawer a11y (WI-2): focus in on open, restore to the hamburger on
+  // close, Escape closes, Tab trapped by the sentinels. Hooks run before
+  // the early return; the hook is inert while closed.
+  const panelRef = useRef<HTMLElement>(null);
+  useDrawerA11y({ open: navOpen, onClose: () => setNavOpen(false), panelRef });
   if (!navOpen) return null;
 
   const isDetail = route.name === "detail";
@@ -118,15 +125,18 @@ export function Drawer({
     <>
       <div
         onClick={close}
-        className="md:hidden fixed inset-0 z-50 bg-ink/40"
+        className="md:hidden fixed inset-0 z-50 bg-ink/20 transition-opacity duration-150"
         aria-hidden="true"
+        data-testid="drawer-scrim"
       />
       <aside
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-label="Navigation"
         className="md:hidden fixed inset-y-0 left-0 z-50 w-[min(320px,86vw)] bg-paper border-r border-rule flex flex-col overflow-y-auto"
       >
+        <FocusSentinel panelRef={panelRef} edge="start" />
         <div className="h-[64px] px-4 flex items-center justify-between border-b border-rule">
           <span className="font-bold text-lg tracking-tight2 text-ink">LEGALISE</span>
           <button
@@ -183,6 +193,7 @@ export function Drawer({
             </div>
           </div>
         )}
+        <FocusSentinel panelRef={panelRef} edge="end" />
       </aside>
     </>
   );

--- a/frontend/src/ui/SidebarView.tsx
+++ b/frontend/src/ui/SidebarView.tsx
@@ -11,8 +11,9 @@
  * an <a href> (real routes) or a <button onClick> (demo tab switch).
  */
 
-import type { ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { BrandMark } from "./BrandMark";
+import { FocusSentinel, useDrawerA11y } from "./drawerA11y";
 
 export type RailItem = {
   key: string;
@@ -125,19 +126,35 @@ export function SidebarView({
   open: boolean;
   onClose: () => void;
 }) {
+  // Drawer a11y (WI-2): focus into the panel on open, restore to the
+  // trigger on close, Escape closes, Tab trapped by the sentinels. The
+  // hook is inert while `open` is false, so the static desktop rail is
+  // unaffected.
+  const panelRef = useRef<HTMLElement>(null);
+  useDrawerA11y({ open, onClose, panelRef });
+
   return (
     <>
       {open && (
-        <div className="fixed inset-0 z-40 bg-ink/20 md:hidden" onClick={onClose} aria-hidden="true" />
+        <div
+          className="fixed inset-0 z-40 bg-ink/20 transition-opacity duration-150 md:hidden"
+          onClick={onClose}
+          aria-hidden="true"
+          data-testid="drawer-scrim"
+        />
       )}
       <aside
+        ref={panelRef}
         className={
           "fixed inset-y-0 left-0 z-50 w-64 bg-panel flex flex-col transition-transform " +
           "md:static md:z-auto md:h-full md:shrink-0 md:rounded-panel md:shadow-panel md:translate-x-0 " +
           (open ? "translate-x-0" : "-translate-x-full md:translate-x-0")
         }
         aria-label="Navigation"
+        role={open ? "dialog" : undefined}
+        aria-modal={open || undefined}
       >
+        {open && <FocusSentinel panelRef={panelRef} edge="start" />}
         {/* brand — links to app home when the caller wires a brandHref */}
         <div className="flex items-center px-4 h-[64px] border-b border-rule shrink-0">
           {brandHref ? (
@@ -221,6 +238,7 @@ export function SidebarView({
         )}
 
         {account}
+        {open && <FocusSentinel panelRef={panelRef} edge="end" />}
       </aside>
     </>
   );

--- a/frontend/src/ui/TopBar.tsx
+++ b/frontend/src/ui/TopBar.tsx
@@ -42,6 +42,7 @@ export function TopBar({
               onClick={() => setNavOpen(true)}
               className="flex items-center gap-2 text-ink min-h-[44px]"
               aria-label="Open menu"
+              aria-expanded={navOpen}
             >
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
                 <path

--- a/frontend/src/ui/drawerA11y.test.tsx
+++ b/frontend/src/ui/drawerA11y.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * WI-2 — mobile drawer a11y (scrim, Escape, focus trap/return).
+ *
+ * Both off-canvas drawers share ui/drawerA11y.tsx:
+ *   - SidebarView (the workspace rail's mobile drawer mode)
+ *   - Drawer (public-pages nav)
+ *
+ * Pins: open moves focus inside (first nav item); Escape closes and
+ * returns focus to the trigger; scrim click closes; Tab wraps at the
+ * sentinels instead of escaping the drawer.
+ */
+
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { SidebarView } from "./SidebarView";
+import { Drawer } from "./Drawer";
+import { AuthProvider } from "../auth/AuthProvider";
+import * as api from "../lib/api";
+import type { Route } from "../lib/route";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// SidebarView (workspace drawer)
+// ---------------------------------------------------------------------------
+
+function SidebarHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="trigger"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+      >
+        Open menu
+      </button>
+      <SidebarView
+        globalItems={[
+          { key: "matters", label: "Matters", href: "/matters" },
+          { key: "library", label: "Skill library", href: "/skills" },
+        ]}
+        utilItems={[]}
+        open={open}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+describe("SidebarView drawer a11y", () => {
+  it("moves focus to the first nav item on open", () => {
+    render(<SidebarHarness />);
+    const trigger = screen.getByTestId("trigger");
+    trigger.focus();
+    fireEvent.click(trigger);
+    const first = screen.getByRole("link", { name: "Matters" });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("exposes dialog semantics only while open", () => {
+    render(<SidebarHarness />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByTestId("trigger"));
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("closes on Escape and returns focus to the trigger", async () => {
+    render(<SidebarHarness />);
+    const trigger = screen.getByTestId("trigger");
+    trigger.focus();
+    fireEvent.click(trigger);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("closes on scrim click", async () => {
+    render(<SidebarHarness />);
+    fireEvent.click(screen.getByTestId("trigger"));
+    fireEvent.click(screen.getByTestId("drawer-scrim"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("wraps Tab at the sentinels instead of leaving the drawer", () => {
+    render(<SidebarHarness />);
+    fireEvent.click(screen.getByTestId("trigger"));
+    const sentinels = document.querySelectorAll("[data-focus-sentinel]");
+    expect(sentinels).toHaveLength(2);
+    // Tabbing past the end lands the end sentinel -> wraps to first item.
+    fireEvent.focus(sentinels[1]);
+    expect(document.activeElement).toBe(
+      screen.getByRole("link", { name: "Matters" }),
+    );
+    // Shift-tabbing before the start lands the start sentinel -> wraps
+    // to the last item.
+    fireEvent.focus(sentinels[0]);
+    expect(document.activeElement).toBe(
+      screen.getByRole("link", { name: "Skill library" }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drawer (public-pages nav)
+// ---------------------------------------------------------------------------
+
+function PublicDrawerHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="trigger"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+      >
+        Open menu
+      </button>
+      <Drawer
+        route={{ name: "landing" } as Route}
+        navOpen={open}
+        setNavOpen={setOpen}
+        matter={null}
+        health={null}
+      />
+    </>
+  );
+}
+
+function renderPublicDrawer() {
+  vi.spyOn(api, "getCurrentUser").mockResolvedValue(null);
+  return render(
+    <AuthProvider>
+      <PublicDrawerHarness />
+    </AuthProvider>,
+  );
+}
+
+describe("public Drawer a11y", () => {
+  it("moves focus to the first nav item on open", () => {
+    renderPublicDrawer();
+    const trigger = screen.getByTestId("trigger");
+    trigger.focus();
+    fireEvent.click(trigger);
+    expect(document.activeElement).toBe(
+      screen.getByRole("link", { name: "Demo" }),
+    );
+  });
+
+  it("closes on Escape and returns focus to the trigger", async () => {
+    renderPublicDrawer();
+    const trigger = screen.getByTestId("trigger");
+    trigger.focus();
+    fireEvent.click(trigger);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("closes on scrim click", async () => {
+    renderPublicDrawer();
+    fireEvent.click(screen.getByTestId("trigger"));
+    fireEvent.click(screen.getByTestId("drawer-scrim"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("wraps Tab at the sentinels", () => {
+    renderPublicDrawer();
+    fireEvent.click(screen.getByTestId("trigger"));
+    const sentinels = document.querySelectorAll("[data-focus-sentinel]");
+    expect(sentinels).toHaveLength(2);
+    fireEvent.focus(sentinels[1]);
+    // Wraps to the first focusable inside the panel (the close button).
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Close menu" }),
+    );
+  });
+});

--- a/frontend/src/ui/drawerA11y.tsx
+++ b/frontend/src/ui/drawerA11y.tsx
@@ -1,0 +1,92 @@
+/**
+ * drawerA11y — shared keyboard/focus behaviour for the off-canvas drawers.
+ *
+ * Two drawers use this: the workspace rail (SidebarView, mobile off-canvas
+ * mode) and the public-pages Drawer. Both get the same treatment (WI-2):
+ *   - focus moves to the first nav item when the drawer opens;
+ *   - focus returns to whatever had it (the hamburger) when it closes;
+ *   - Escape closes;
+ *   - Tab cannot leave the drawer while open (first/last sentinel trap —
+ *     no dependency, just two zero-size tab stops that wrap focus).
+ *
+ * The hook is inert while `open` is false, so SidebarView can keep calling
+ * it in its static desktop mode without side effects.
+ */
+
+import { useEffect, useRef, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function focusables(panel: HTMLElement): HTMLElement[] {
+  return Array.from(
+    panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((el) => !el.hasAttribute("data-focus-sentinel"));
+}
+
+export function useDrawerA11y({
+  open,
+  onClose,
+  panelRef,
+}: {
+  open: boolean;
+  onClose: () => void;
+  panelRef: RefObject<HTMLElement | null>;
+}) {
+  // Keep the latest close callback without re-running the effect when the
+  // caller passes a fresh closure each render.
+  const closeRef = useRef(onClose);
+  closeRef.current = onClose;
+
+  useEffect(() => {
+    if (!open) return;
+    const restoreTo = document.activeElement as HTMLElement | null;
+
+    const panel = panelRef.current;
+    if (panel) {
+      // First nav item if there is one, otherwise the first focusable
+      // (e.g. the close button) so keyboard users always land inside.
+      const first =
+        panel.querySelector<HTMLElement>("nav a, nav button") ??
+        focusables(panel)[0];
+      first?.focus();
+    }
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeRef.current();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      // Return focus to the trigger (the element focused at open time).
+      restoreTo?.focus?.();
+    };
+  }, [open, panelRef]);
+}
+
+/**
+ * Zero-size tab stop rendered as the first/last child of the drawer panel.
+ * Tabbing onto it wraps focus to the opposite end of the panel, so Tab and
+ * Shift+Tab cycle within the open drawer.
+ */
+export function FocusSentinel({
+  panelRef,
+  edge,
+}: {
+  panelRef: RefObject<HTMLElement | null>;
+  edge: "start" | "end";
+}) {
+  return (
+    <div
+      tabIndex={0}
+      data-focus-sentinel
+      onFocus={() => {
+        const panel = panelRef.current;
+        if (!panel) return;
+        const items = focusables(panel);
+        const target = edge === "start" ? items[items.length - 1] : items[0];
+        target?.focus();
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## What

Both mobile drawers (workspace rail off-canvas mode + public-pages Drawer) now behave as proper modal layers:

- Scrim: standard `bg-ink/20`, click closes, 150ms opacity transition (public Drawer was `bg-ink/40`).
- Escape closes; handling moved from AppShell into the drawers so both close paths live in one place.
- Focus moves to the first nav item on open and returns to the hamburger on close.
- Tab is trapped inside the open drawer via a first/last sentinel pair (`ui/drawerA11y.tsx`, shared by both, no new dependency).
- `role="dialog"` / `aria-modal` on the workspace drawer while open only (static desktop rail untouched); `aria-expanded` on the AppShell hamburger and TopBar matter-detail menu button.

## Why

WI-2 from the 2026-07-06 design handover: the drawers overlaid content with no focus management, so keyboard users could tab into the page underneath and never got focus back on close.

## Tests

9 new component tests (open focus, Escape + focus return, scrim click, sentinel wrap for both drawers). Full frontend suite green: 45 files, 376 tests. Verified live on the local stack at 390px (focus lands on first nav item, Escape restores the hamburger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)