### PR TITLE
PostureBanner: role tokens become display words (WI-5.1)

### DIFF
--- a/frontend/e2e/posture.spec.ts
+++ b/frontend/e2e/posture.spec.ts
@@ -112,10 +112,14 @@ test("B_mixed: solicitor sees the banner with required role + actor role", async
   await expect(
     page.getByText(/only qualified solicitors can run skills/i),
   ).toBeVisible();
-  await expect(page.getByText("qualified_solicitor")).toBeVisible();
-  // The actor's role appears verbatim.
+  // Role tokens render as display words in banner copy (WI-5.1):
+  // "qualified solicitor", never the raw substrate enum.
+  await expect(
+    page.getByText(/requires the qualified solicitor role/i),
+  ).toBeVisible();
   const bodyText = (await page.textContent("body")) ?? "";
-  expect(bodyText).toMatch(/Your role:.*solicitor/);
+  expect(bodyText).toMatch(/Your role: solicitor\./);
+  expect(bodyText).not.toContain("qualified_solicitor");
 });
 
 test("B_mixed: qualified_solicitor sees no banner", async ({

--- a/frontend/src/matter/PostureBanner.test.tsx
+++ b/frontend/src/matter/PostureBanner.test.tsx
@@ -48,12 +48,23 @@ describe("PostureBanner — B_mixed", () => {
     expect(
       screen.getByText(/only qualified solicitors can run skills/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/qualified_solicitor/)).toBeInTheDocument();
-    // The actor's role appears verbatim — match exact "solicitor"
-    // to avoid catching "qualified_solicitor" first.
+    // Role tokens render as display words in banner copy (WI-5.1):
+    // "qualified solicitor" / "solicitor", never the raw substrate token.
     expect(
-      screen.getByText((_, el) => el?.textContent?.trim() === "solicitor"),
+      screen.getByText(/requires the qualified solicitor role/i),
     ).toBeInTheDocument();
+    expect(screen.getByText(/your role: solicitor\./i)).toBeInTheDocument();
+    expect(screen.queryByText(/qualified_solicitor/)).toBeNull();
+  });
+
+  it("maps every role token to display words in banner copy", () => {
+    // workspace_admin does not satisfy B_mixed (substrate truth), so the
+    // banner shows — and its role reads as words, not the enum token.
+    render(<PostureBanner posture="B_mixed" user={user("workspace_admin")} />);
+    expect(
+      screen.getByText(/your role: workspace admin\./i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/workspace_admin/)).toBeNull();
   });
 
   it("renders nothing for qualified_solicitor", () => {

--- a/frontend/src/matter/PostureBanner.tsx
+++ b/frontend/src/matter/PostureBanner.tsx
@@ -50,6 +50,20 @@ interface Props {
 // substrate behaviour.
 const ROLE_THAT_SATISFIES_B_MIXED = "qualified_solicitor";
 
+// Display words for the substrate role tokens (ALLOWED_ROLES,
+// lib/api/admin.ts). Banner copy ONLY — role comparisons above and
+// anything sent to the API keep the raw token. This banner renders
+// role copy only in firm-role-gated mode (dormant on hosted).
+const ROLE_DISPLAY_WORDS: Record<string, string> = {
+  solicitor: "solicitor",
+  qualified_solicitor: "qualified solicitor",
+  workspace_admin: "workspace admin",
+};
+
+function roleDisplayWord(role: string): string {
+  return ROLE_DISPLAY_WORDS[role] ?? role.replace(/_/g, " ");
+}
+
 export function PostureBanner({
   posture,
   user,
@@ -95,15 +109,8 @@ export function PostureBanner({
           Only qualified solicitors can run skills on this matter.
         </p>
         <p className="mt-1 text-sm text-muted">
-          Requires{" "}
-          <code className="tech-token text-xs">qualified_solicitor</code>.
-          {user && (
-            <>
-              {" "}
-              Your role:{" "}
-              <code className="tech-token text-xs">{user.role}</code>.
-            </>
-          )}
+          Requires the {roleDisplayWord(ROLE_THAT_SATISFIES_B_MIXED)} role.
+          {user && <> Your role: {roleDisplayWord(user.role)}.</>}
         </p>
         {adminCanChange && (
           <ChangePostureControl

--- a/frontend/src/modules-v2/ModulesCatalog.test.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.test.tsx
@@ -379,10 +379,14 @@ describe("ModulesCatalog — integrations home", () => {
     expect(
       screen.getByText(/nothing runs until you have reviewed and approved it/i),
     ).toBeInTheDocument();
-    // The lede derives the count from the live feed.
-    expect(screen.getByTestId("shelf-lede")).toHaveTextContent(
-      "We've pulled 2 skills from Lawve's public GitHub feed.",
-    );
+    // The lede derives the count from the live feed — wait for the
+    // shelf fetch to land (asserting synchronously here raced it and
+    // flaked on CI).
+    await waitFor(() => {
+      expect(screen.getByTestId("shelf-lede")).toHaveTextContent(
+        "We've pulled 2 skills from Lawve's public GitHub feed.",
+      );
+    });
   });
 
   it("renders the catalogue as a grouped ledger: display names, descriptions, licence honesty, scripts marker", async () => {


### PR DESCRIPTION
## What

The B_mixed blocker banner printed substrate role enums (`qualified_solicitor`, `workspace_admin`) verbatim in user-facing copy. A small mapper now renders them as display words ("qualified solicitor", "workspace admin") in the banner text only.

## Why

Punch-list item 7 / WI-5 item 1 from the 2026-07-06 design handover: the user is stuck at this banner, so it speaks UI words, not internal enums.

## Scope guards

- Banner copy only. Role comparisons (`ROLE_THAT_SATISFIES_B_MIXED`) and API values keep the raw token.
- Unchanged gating: role copy renders only when firm role gates are enabled (dormant on hosted).
- Tests updated to pin the display words and assert the raw tokens no longer appear; one new test covers the workspace_admin mapping.

Full frontend suite green (44 files, 368 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)