### PR TITLE
Chat turn control: Stop, then Regenerate (WI-1)

### DIFF
--- a/backend/tests/test_assistant_streaming.py
+++ b/backend/tests/test_assistant_streaming.py
@@ -8,11 +8,15 @@ Covers the four invariants of the streaming path:
   and the gateway's ModelResult/audit row carries them;
 - truncation still fires — stop_reason/finish_reason arrive at stream end
   and raise `provider_truncated` exactly as the non-streaming path does;
-- providers that can't stream fall back silently — no deltas, same reply.
+- providers that can't stream fall back silently — no deltas, same reply;
+- a client disconnect mid-stream never cancels the turn — the detached
+  task persists the message and its audit row anyway (the Case A pin the
+  chat Stop control rests on).
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import uuid
@@ -481,3 +485,133 @@ class TestOpenAIStreaming:
                 await provider.call("long question", on_delta=_on_delta)
 
         assert excinfo.value.code == "provider_truncated"
+
+
+# ---------------------------------------------------------------------------
+# SSE endpoint — client disconnect never cancels the turn (the Case A pin)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamDisconnectPersistence:
+    @pytest.mark.asyncio
+    async def test_client_drop_mid_stream_still_persists_message_and_audit(self) -> None:
+        """Pins the guarantee the chat Stop control rests on: the stream
+        endpoint runs the turn in a detached task with its own session, so
+        dropping the SSE client mid-stream (which closes only the relay
+        generator) leaves the turn running to completion — the assistant
+        message row and the module.assistant.message audit row still land.
+        """
+        from types import SimpleNamespace as _NS
+
+        from app.models import AuditEntry
+        from app.models.assistant import AssistantMessage as AssistantMessageRow
+        from app.modules.assistant import router as assistant_router
+        from app.modules.assistant.schemas import AssistantPostRequest
+
+        from tests.test_assistant_pipeline import _UserStub
+
+        matter = _make_matter()
+        session = _AssistantSession(matter)
+        user = _UserStub()
+        user.id = matter.created_by_id
+
+        delta_seen = asyncio.Event()
+        client_gone = asyncio.Event()
+
+        class _HeldGateway:
+            """Streams a first delta, then holds the turn open until the
+            test has dropped the client, then finishes normally."""
+
+            async def call(self, *, on_delta=None, **kwargs) -> ModelResult:
+                text = json.dumps(_STREAMED_ENVELOPE)
+                if on_delta is not None:
+                    await on_delta(text[:24])
+                    delta_seen.set()
+                await client_gone.wait()
+                if on_delta is not None:
+                    await on_delta(text[24:])
+                return ModelResult(
+                    text=text,
+                    model_used="claude-opus-4-7",
+                    prompt_hash="ph",
+                    response_hash=hashlib.sha256(text.encode()).hexdigest(),
+                    token_count=63,
+                    latency_ms=5,
+                    provider="anthropic",
+                    tokens_in=42,
+                    tokens_out=21,
+                )
+
+        class _SessionFactory:
+            def __call__(self):
+                return self
+
+            async def __aenter__(self):
+                return session
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        request = _NS(app=_NS(state=_NS(session_factory=_SessionFactory())))
+
+        # Inject the held gateway through the real pipeline: the route does
+        # not take a gateway parameter, so wrap run_assistant_turn.
+        real_run = assistant_router.run_assistant_turn
+        gateway = _HeldGateway()
+
+        async def _run_with_held_gateway(**kwargs):
+            return await real_run(gateway=gateway, **kwargs)
+
+        with patch.object(
+            assistant_router, "run_assistant_turn", _run_with_held_gateway
+        ):
+            resp = await assistant_router.post_message_stream(
+                matter.slug,
+                AssistantPostRequest(content="When was Khan dismissed?"),
+                request,
+                user,
+            )
+            iterator = resp.body_iterator
+            saw_delta_frame = False
+            async for chunk in iterator:
+                frame = chunk if isinstance(chunk, str) else chunk.decode()
+                if "model.delta" in frame:
+                    saw_delta_frame = True
+                    break
+            assert saw_delta_frame, "stream never reached a model.delta frame"
+
+            # The client goes away mid-stream. Closing the relay generator
+            # is exactly what an ASGI disconnect does; the detached turn
+            # task must be untouched by it.
+            await iterator.aclose()
+            client_gone.set()
+
+            async def _wait_for_persisted_reply() -> None:
+                while not any(
+                    isinstance(o, AssistantMessageRow) and o.role == "assistant"
+                    for o in session.added
+                ):
+                    await asyncio.sleep(0.01)
+
+            await asyncio.wait_for(_wait_for_persisted_reply(), timeout=5)
+
+        assert delta_seen.is_set()
+        user_rows = [
+            o
+            for o in session.added
+            if isinstance(o, AssistantMessageRow) and o.role == "user"
+        ]
+        assistant_rows = [
+            o
+            for o in session.added
+            if isinstance(o, AssistantMessageRow) and o.role == "assistant"
+        ]
+        assert len(user_rows) == 1
+        assert len(assistant_rows) == 1
+        assert assistant_rows[0].content == _STREAMED_ENVELOPE["content"]
+        message_audits = [
+            o
+            for o in session.added
+            if isinstance(o, AuditEntry) and o.action == "module.assistant.message"
+        ]
+        assert len(message_audits) == 1

--- a/frontend/src/lib/api/assistant.ts
+++ b/frontend/src/lib/api/assistant.ts
@@ -52,7 +52,10 @@ export interface AssistantThread {
 }
 
 export type AssistantStreamEvent =
-  | { event: "turn.start"; data: { slug: string } }
+  // thread_id is present when the server resolved/created the thread —
+  // it lets a stopped turn refresh the right thread even when the turn
+  // opened a new one.
+  | { event: "turn.start"; data: { slug: string; thread_id?: string } }
   | {
       event: "context.loaded";
       data: {

--- a/frontend/src/matter/MessageBubble.tsx
+++ b/frontend/src/matter/MessageBubble.tsx
@@ -44,6 +44,10 @@ interface Props {
   // Save this reply as a draft output. Resolves to the artifact id.
   // Omitted on read-only surfaces (demo) — the action doesn't render.
   onSaveDraft?: (message: AssistantMessage) => Promise<string>;
+  // Resend the prompt that produced this reply as a new turn. The caller
+  // passes it only on the last assistant message and only when no turn
+  // is in flight — the earlier answer stays in the transcript.
+  onRegenerate?: () => void;
   // Open a saved draft (the artifact detail page).
   onOpenDraft?: (artifactId: string) => void;
   compact?: boolean;
@@ -60,6 +64,7 @@ export function MessageBubble({
   onVersions,
   onRecord,
   onSaveDraft,
+  onRegenerate,
   onOpenDraft,
   compact = false,
 }: Props) {
@@ -77,6 +82,7 @@ export function MessageBubble({
       onVersions={onVersions}
       onRecord={onRecord}
       onSaveDraft={onSaveDraft}
+      onRegenerate={onRegenerate}
       onOpenDraft={onOpenDraft}
       compact={compact}
     />
@@ -107,6 +113,7 @@ function AssistantMessageView({
   onVersions,
   onRecord,
   onSaveDraft,
+  onRegenerate,
   onOpenDraft,
   compact,
 }: Props) {
@@ -188,6 +195,7 @@ function AssistantMessageView({
           <MessageActions
             message={message}
             onSaveDraft={onSaveDraft}
+            onRegenerate={onRegenerate}
             onOpenDraft={onOpenDraft}
           />
         )}
@@ -208,10 +216,12 @@ type SaveState =
 function MessageActions({
   message,
   onSaveDraft,
+  onRegenerate,
   onOpenDraft,
 }: {
   message: AssistantMessage;
   onSaveDraft?: (message: AssistantMessage) => Promise<string>;
+  onRegenerate?: () => void;
   onOpenDraft?: (artifactId: string) => void;
 }) {
   const [copied, setCopied] = useState(false);
@@ -286,6 +296,16 @@ function MessageActions({
       )}
       {save.kind === "error" && (
         <span className="text-seal">Couldn't save — try again</span>
+      )}
+      {onRegenerate && (
+        <button
+          type="button"
+          onClick={onRegenerate}
+          className={linkCls}
+          data-testid="message-regenerate"
+        >
+          Regenerate
+        </button>
       )}
     </div>
   );

--- a/frontend/src/matter/tabs/AssistantTab.test.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.test.tsx
@@ -75,8 +75,8 @@ function mountChat(overrides?: {
       initialEntries: [`/matters/${matter.slug}/assistant`],
     }),
   });
-  render(<RouterProvider router={router} />);
-  return { setTabAndHash };
+  const { unmount } = render(<RouterProvider router={router} />);
+  return { setTabAndHash, unmount };
 }
 
 beforeEach(() => {
@@ -359,6 +359,7 @@ describe("AssistantTab — in-chat skill picker", () => {
     expect(api.postAssistantMessageStream).toHaveBeenCalledWith(
       matter.slug,
       { content: "Review the NDA", selected_document_ids: undefined },
+      expect.any(AbortSignal),
     );
   });
 
@@ -395,6 +396,7 @@ describe("AssistantTab — in-chat skill picker", () => {
             "Anonymise the selected document now.\n\nRequested from: Anonymise the witness statement",
           selected_document_ids: undefined,
         },
+        expect.any(AbortSignal),
       ),
     );
     expect(setTabAndHash).not.toHaveBeenCalled();
@@ -604,6 +606,7 @@ describe("AssistantTab — composer send keys", () => {
       expect(api.postAssistantMessageStream).toHaveBeenCalledWith(
         matter.slug,
         expect.objectContaining({ content: "First line" }),
+        expect.any(AbortSignal),
       ),
     );
   });
@@ -618,6 +621,7 @@ describe("AssistantTab — composer send keys", () => {
       expect(api.postAssistantMessageStream).toHaveBeenCalledWith(
         matter.slug,
         expect.objectContaining({ content: "Meta send" }),
+        expect.any(AbortSignal),
       ),
     );
   });
@@ -989,5 +993,303 @@ describe("AssistantTab — long-wait honesty line", () => {
     releaseResult();
     expect(await screen.findByText("Slow answer")).toBeInTheDocument();
     expect(screen.queryByTestId("chat-long-wait-note")).toBeNull();
+  });
+});
+
+// WI-1 (2026-07-06): chat turn control. Stop is client-side only — the
+// stream endpoint runs the turn in a detached task, so aborting the fetch
+// never cancels the turn; the persisted reply lands on the record and the
+// thread refresh swaps it in. Regenerate resends the last prompt as a
+// brand-new turn; the earlier answer stays (append-only record).
+describe("AssistantTab — Stop mid-stream", () => {
+  const heldStream = (onSignal?: (signal: AbortSignal | undefined) => void) =>
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* (_slug, _body, signal) {
+        onSignal?.(signal);
+        yield {
+          event: "turn.start",
+          data: { slug: matter.slug, thread_id: "t-1" },
+        } as never;
+        yield { event: "model.start", data: { stage: "assistant" } } as never;
+        yield { event: "model.delta", data: { text: "Khan was dis" } } as never;
+        // Hold the stream open until the client aborts, then fail the
+        // read the way fetch does.
+        await new Promise<never>((_, reject) => {
+          const fail = () =>
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          if (signal?.aborted) fail();
+          else signal?.addEventListener("abort", fail);
+        });
+      },
+    );
+
+  it(
+    "aborts the fetch, freezes the draft with a stopped line, then swaps in the persisted turn",
+    async () => {
+      let capturedSignal: AbortSignal | undefined;
+      heldStream((signal) => {
+        capturedSignal = signal;
+      });
+      vi.spyOn(api, "getThreadMessages").mockResolvedValue([
+        {
+          id: "u-p",
+          role: "user",
+          content: "When was Khan dismissed?",
+          suggested_actions: [],
+          created_at: "2026-07-07T10:00:00Z",
+        },
+        {
+          id: "a-p",
+          role: "assistant",
+          content: "Khan was dismissed on 10 March 2026.",
+          suggested_actions: [],
+          created_at: "2026-07-07T10:00:05Z",
+        },
+      ]);
+      mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+      const input = await screen.findByTestId("chat-composer-input");
+      fireEvent.change(input, { target: { value: "When was Khan dismissed?" } });
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+      // Stop replaces Send only once deltas are arriving.
+      fireEvent.click(await screen.findByTestId("chat-composer-stop"));
+
+      await waitFor(() => expect(capturedSignal?.aborted).toBe(true));
+      const frozen = await screen.findByTestId("chat-stopped-bubble");
+      expect(frozen).toHaveTextContent("Khan was dis");
+      expect(screen.getByTestId("chat-stopped-note")).toHaveTextContent(
+        "Stopped. The full answer is still being recorded.",
+      );
+      // A stop is not a failure: no error banner, prompt not restored.
+      expect(screen.queryByText(/Could not send message/i)).toBeNull();
+      expect(screen.getByTestId("chat-composer-send")).toBeInTheDocument();
+
+      // ~2s later the thread refresh replaces the frozen draft with the
+      // persisted turn.
+      await waitFor(
+        () => expect(screen.queryByTestId("chat-stopped-bubble")).toBeNull(),
+        { timeout: 4000 },
+      );
+      expect(
+        screen.getByText("Khan was dismissed on 10 March 2026."),
+      ).toBeInTheDocument();
+      expect(api.getThreadMessages).toHaveBeenCalledWith(matter.slug, "t-1");
+    },
+    10_000,
+  );
+
+  it("never offers Stop for a non-streaming turn", async () => {
+    let releaseResult!: () => void;
+    const resultGate = new Promise<void>((resolve) => {
+      releaseResult = resolve;
+    });
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* () {
+        yield { event: "model.start", data: { stage: "assistant" } } as never;
+        // No model.delta events — a keyless/stub turn.
+        await resultGate;
+        yield {
+          event: "result",
+          data: {
+            user: {
+              id: "u-1",
+              role: "user",
+              content: "Hello",
+              suggested_actions: [],
+              created_at: "",
+            },
+            assistant: {
+              id: "a-1",
+              role: "assistant",
+              content: "Stub answer",
+              suggested_actions: [],
+              created_at: "",
+            },
+          },
+        } as never;
+      },
+    );
+    mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText("Working...")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-composer-stop")).toBeNull();
+
+    releaseResult();
+    expect(await screen.findByText("Stub answer")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-composer-stop")).toBeNull();
+  });
+
+  it("aborts the in-flight stream on unmount without state warnings", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    heldStream((signal) => {
+      capturedSignal = signal;
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { unmount } = mountChat({ docs: [someDoc("doc-1", "note.txt")] });
+
+    const input = await screen.findByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "When was Khan dismissed?" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await screen.findByTestId("chat-composer-stop");
+
+    unmount();
+
+    await waitFor(() => expect(capturedSignal?.aborted).toBe(true));
+    // Give the rejected stream a beat to run its catch/finally paths.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const logged = errorSpy.mock.calls.flat().map(String).join(" ");
+    expect(logged).not.toMatch(/unmounted component|not wrapped in act/i);
+  });
+});
+
+describe("AssistantTab — Regenerate", () => {
+  const priorTurn: AssistantMessage[] = [
+    {
+      id: "u-1",
+      role: "user",
+      content: "When was Khan dismissed?",
+      suggested_actions: [],
+      created_at: "2026-07-07T09:00:00Z",
+    },
+    {
+      id: "a-1",
+      role: "assistant",
+      content: "First answer.",
+      suggested_actions: [],
+      created_at: "2026-07-07T09:00:05Z",
+    },
+  ];
+
+  it("resends the previous prompt as a new turn and keeps the earlier answer", async () => {
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* () {
+        yield {
+          event: "result",
+          data: {
+            user: {
+              id: "u-2",
+              role: "user",
+              content: "When was Khan dismissed?",
+              suggested_actions: [],
+              created_at: "2026-07-07T09:01:00Z",
+            },
+            assistant: {
+              id: "a-2",
+              role: "assistant",
+              content: "Second answer.",
+              suggested_actions: [],
+              created_at: "2026-07-07T09:01:05Z",
+            },
+          },
+        } as never;
+      },
+    );
+    mountChat({
+      docs: [someDoc("doc-1", "note.txt")],
+      initialMessages: priorTurn,
+    });
+
+    fireEvent.click(await screen.findByTestId("message-regenerate"));
+
+    await waitFor(() =>
+      expect(api.postAssistantMessageStream).toHaveBeenCalledWith(
+        matter.slug,
+        expect.objectContaining({ content: "When was Khan dismissed?" }),
+        expect.any(AbortSignal),
+      ),
+    );
+    // Append-only: the old answer stays in the transcript beside the new one.
+    expect(await screen.findByText("Second answer.")).toBeInTheDocument();
+    expect(screen.getByText("First answer.")).toBeInTheDocument();
+  });
+
+  it("renders only on the last assistant message and resends its prompt", async () => {
+    mountChat({
+      docs: [someDoc("doc-1", "note.txt")],
+      initialMessages: [
+        ...priorTurn,
+        {
+          id: "u-2",
+          role: "user",
+          content: "Draft a letter",
+          suggested_actions: [],
+          created_at: "2026-07-07T09:02:00Z",
+        },
+        {
+          id: "a-2",
+          role: "assistant",
+          content: "Here is a letter.",
+          suggested_actions: [],
+          created_at: "2026-07-07T09:02:05Z",
+        },
+      ],
+    });
+
+    await screen.findByText("Here is a letter.");
+    const actions = screen.getAllByTestId("message-regenerate");
+    expect(actions).toHaveLength(1);
+
+    fireEvent.click(actions[0]);
+    await waitFor(() =>
+      expect(api.postAssistantMessageStream).toHaveBeenCalledWith(
+        matter.slug,
+        expect.objectContaining({ content: "Draft a letter" }),
+        expect.any(AbortSignal),
+      ),
+    );
+  });
+
+  it("hides Regenerate while a turn is in flight", async () => {
+    let releaseResult!: () => void;
+    const resultGate = new Promise<void>((resolve) => {
+      releaseResult = resolve;
+    });
+    vi.spyOn(api, "postAssistantMessageStream").mockImplementation(
+      async function* () {
+        await resultGate;
+        yield {
+          event: "result",
+          data: {
+            user: {
+              id: "u-2",
+              role: "user",
+              content: "Another question",
+              suggested_actions: [],
+              created_at: "",
+            },
+            assistant: {
+              id: "a-2",
+              role: "assistant",
+              content: "Another answer.",
+              suggested_actions: [],
+              created_at: "",
+            },
+          },
+        } as never;
+      },
+    );
+    mountChat({
+      docs: [someDoc("doc-1", "note.txt")],
+      initialMessages: priorTurn,
+    });
+
+    expect(await screen.findByTestId("message-regenerate")).toBeInTheDocument();
+
+    const input = screen.getByTestId("chat-composer-input");
+    fireEvent.change(input, { target: { value: "Another question" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("message-regenerate")).toBeNull(),
+    );
+
+    releaseResult();
+    await screen.findByText("Another answer.");
+    expect(screen.getAllByTestId("message-regenerate")).toHaveLength(1);
   });
 });

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -158,6 +158,43 @@ export function AssistantTab({
   // fill this via model.delta events; the final message replaces it on
   // result. null = no draft (non-streaming providers never set it).
   const [draft, setDraft] = useState<string | null>(null);
+  // True only while model.delta events are arriving — the guard for the
+  // Stop affordance. Keyless/stub turns never stream, so Stop never
+  // appears for them ("stream active", not "request active").
+  const [streamActive, setStreamActive] = useState(false);
+  // A user-stopped turn: the frozen partial draft. The turn keeps running
+  // server-side (client disconnect never cancels it — the stream endpoint
+  // runs the turn in a detached task) and the persisted reply replaces
+  // this once the thread refresh finds it.
+  const [stopped, setStopped] = useState<{ text: string } | null>(null);
+  // One AbortController per in-flight streaming turn.
+  const abortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+  // Cancellation token for the post-stop thread poll: bumped by any new
+  // send, thread switch, or unmount so a stale poll never writes state.
+  const stopPollToken = useRef(0);
+  const stopPollTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Reset on mount, not just initialisation: StrictMode's dev
+    // mount/unmount/mount cycle runs the cleanup once, and the ref must
+    // come back true for the real mount.
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      stopPollToken.current += 1;
+      if (stopPollTimer.current !== null) window.clearTimeout(stopPollTimer.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const cancelStopPoll = () => {
+    stopPollToken.current += 1;
+    if (stopPollTimer.current !== null) {
+      window.clearTimeout(stopPollTimer.current);
+      stopPollTimer.current = null;
+    }
+  };
   // Fallback for non-streaming paths: after ~10s of a pending turn with no
   // draft text, one quiet honesty line appears under the step ticker.
   const [longWait, setLongWait] = useState(false);
@@ -251,6 +288,11 @@ export function AssistantTab({
 
   const switchThread = async (threadId: string) => {
     if (threadId === activeThreadId || pending) return;
+    // Belt and braces: pending guards mean no stream can be in flight
+    // here, but a stopped turn may still be polling for its reply.
+    abortRef.current?.abort();
+    cancelStopPoll();
+    setStopped(null);
     setActiveThreadId(threadId);
     setError(null);
     setKeyMissingProvider(null);
@@ -271,6 +313,9 @@ export function AssistantTab({
   // refresh the list.
   const startNewChat = () => {
     if (pending) return;
+    abortRef.current?.abort();
+    cancelStopPoll();
+    setStopped(null);
     setActiveThreadId(null);
     setMessages([]);
     setError(null);
@@ -395,9 +440,15 @@ export function AssistantTab({
     if (!content || pending || disabled) return;
     setError(null);
     setKeyMissingProvider(null);
+    cancelStopPoll();
+    setStopped(null);
     setPending(true);
     setThinking(true);
     setAgentSteps([{ label: "Starting turn", status: "running" }]);
+    // How many persisted messages the thread showed before this turn —
+    // the post-stop poll uses it to tell "reply landed" from "user row
+    // only" (both rows commit together at the end of the turn).
+    const baselineCount = messages.length;
     const optimistic: AssistantMessage = {
       id: `optimistic-${Date.now()}`,
       role: "user",
@@ -407,13 +458,26 @@ export function AssistantTab({
     };
     setMessages((prev) => [...prev, optimistic]);
     setInput("");
+    const controller = new AbortController();
+    abortRef.current = controller;
+    // Local mirror of the draft text: the catch block needs the partial
+    // answer at stop time, and reading React state there would be stale.
+    let draftText = "";
+    // The thread this turn runs in. turn.start carries the id even when
+    // the server opened a new thread, so a stopped turn can still be
+    // refreshed from the right thread.
+    let turnThreadId: string | null = activeThreadId;
     try {
       const wasNewThread = activeThreadId === null;
-      const stream = postAssistantMessageStream(matter.slug, {
-        content,
-        selected_document_ids: selectedIds.size > 0 ? Array.from(selectedIds) : undefined,
-        thread_id: activeThreadId ?? undefined,
-      });
+      const stream = postAssistantMessageStream(
+        matter.slug,
+        {
+          content,
+          selected_document_ids: selectedIds.size > 0 ? Array.from(selectedIds) : undefined,
+          thread_id: activeThreadId ?? undefined,
+        },
+        controller.signal,
+      );
       let sawResult = false;
       let newThreadId: string | null = null;
       let retrieval: { docs: number; chunks: number } | null = null;
@@ -422,14 +486,20 @@ export function AssistantTab({
           throw streamEventError(event);
         }
         setAgentSteps((prev) => nextAgentSteps(prev, event));
+        if (event.event === "turn.start" && event.data.thread_id) {
+          turnThreadId = event.data.thread_id;
+        }
         // Each model call starts a fresh draft (a tool turn writes twice);
         // deltas append the answer as it is written.
         if (event.event === "model.start") {
           setDraft(null);
+          draftText = "";
         }
         if (event.event === "model.delta") {
           const text = event.data.text;
           setDraft((prev) => (prev ?? "") + text);
+          draftText += text;
+          setStreamActive(true);
         }
         if (event.event === "context.loaded") {
           const docs = event.data.retrieved_document_count ?? 0;
@@ -465,29 +535,100 @@ export function AssistantTab({
         void refreshThreads();
       }
     } catch (err) {
-      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
-      // The optimistic message is gone — give the user their prompt back
-      // in the composer so a failed send never eats the text. Attached
-      // docs are untouched (selection only clears on explicit remove).
-      setInput(content);
-      if (err instanceof ProviderKeyMissingError) {
-        setKeyMissingProvider(err.provider);
+      if (controller.signal.aborted) {
+        // User Stop (or unmount/thread-switch abort). The turn keeps
+        // running server-side and persists atomically, so nothing is
+        // lost: keep the optimistic user message, freeze the partial
+        // draft, and poll the thread until the recorded reply lands.
+        if (mountedRef.current) {
+          setStopped({ text: draftText });
+          if (turnThreadId) {
+            schedulePostStopRefresh(turnThreadId, baselineCount);
+          }
+        }
       } else {
-        setError(formatError(err));
+        setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
+        // The optimistic message is gone — give the user their prompt back
+        // in the composer so a failed send never eats the text. Attached
+        // docs are untouched (selection only clears on explicit remove).
+        setInput(content);
+        if (err instanceof ProviderKeyMissingError) {
+          setKeyMissingProvider(err.provider);
+        } else {
+          setError(formatError(err));
+        }
       }
     } finally {
-      setPending(false);
-      setThinking(false);
-      setAgentSteps([]);
-      // A partial draft never persists as a message: the final message
-      // already replaced it on success, and a failed turn discards it.
-      setDraft(null);
+      if (mountedRef.current) {
+        setPending(false);
+        setThinking(false);
+        setAgentSteps([]);
+        setStreamActive(false);
+        // A partial draft never persists as a message: the final message
+        // already replaced it on success, a failed turn discards it, and
+        // a stopped turn froze its copy into `stopped` above.
+        setDraft(null);
+      }
     }
+  };
+
+  // After a user Stop, the turn is still finishing on the server. Refresh
+  // the thread after ~2s and keep checking until the persisted reply
+  // (user + assistant rows commit together) replaces the frozen draft.
+  const schedulePostStopRefresh = (threadId: string, baselineCount: number) => {
+    const token = stopPollToken.current;
+    let attempt = 0;
+    const tick = async () => {
+      if (!mountedRef.current || stopPollToken.current !== token) return;
+      try {
+        const msgs = await getThreadMessages(matter.slug, threadId);
+        if (!mountedRef.current || stopPollToken.current !== token) return;
+        const last = msgs[msgs.length - 1];
+        if (msgs.length >= baselineCount + 2 && last?.role === "assistant") {
+          setMessages(msgs);
+          setActiveThreadId((current) => current ?? threadId);
+          setStopped(null);
+          void refreshThreads();
+          return;
+        }
+      } catch {
+        // transient — try again on the next tick
+      }
+      attempt += 1;
+      if (attempt < 24) {
+        stopPollTimer.current = window.setTimeout(() => void tick(), 2500);
+      }
+    };
+    stopPollTimer.current = window.setTimeout(() => void tick(), 2000);
   };
 
   const onSend = async () => {
     await sendMessage(input);
   };
+
+  const onStop = () => {
+    abortRef.current?.abort();
+  };
+
+  // Regenerate: resend the last user prompt as a brand-new turn through
+  // the normal send path. The earlier answer stays in the transcript —
+  // the record is append-only and the UI matches. Only offered on the
+  // last assistant message, and only when no turn is in flight (a
+  // stopped turn is still finishing server-side, so it counts).
+  const lastAssistantIndex = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") return i;
+    }
+    return -1;
+  }, [messages]);
+  const regenerateContent = useMemo(() => {
+    for (let i = lastAssistantIndex - 1; i >= 0; i--) {
+      if (messages[i].role === "user") return messages[i].content;
+    }
+    return null;
+  }, [messages, lastAssistantIndex]);
+  const canRegenerate =
+    !disabled && !pending && stopped === null && regenerateContent !== null;
 
   // Enter sends; Shift+Enter inserts a newline (the universal chat
   // convention). ⌘/Ctrl+Enter still sends. The isComposing guard keeps
@@ -893,7 +1034,7 @@ export function AssistantTab({
             </div>
           </div>
         )}
-        {messages.map((m) => {
+        {messages.map((m, i) => {
           const note = m.role === "assistant" ? retrievalNotes.get(m.id) : undefined;
           return (
             <div key={m.id}>
@@ -901,6 +1042,11 @@ export function AssistantTab({
                 message={m}
                 docs={docs}
                 chronology={chronology}
+                onRegenerate={
+                  canRegenerate && i === lastAssistantIndex && regenerateContent
+                    ? () => void sendMessage(regenerateContent)
+                    : undefined
+                }
                 onDocChip={dispatchDocChip}
                 onChronChip={dispatchChronChip}
                 onAction={dispatchAction}
@@ -942,6 +1088,28 @@ export function AssistantTab({
             onClose={() => setActiveRunnerSkill(null)}
             compact
           />
+        )}
+        {stopped && (
+          // A user-stopped turn: the partial draft, frozen, with an honest
+          // line about what happens next. The persisted reply replaces
+          // this via the post-stop thread refresh.
+          <div className="flex justify-start" data-testid="chat-stopped-bubble">
+            <div className="flex w-full flex-col gap-2">
+              {stopped.text.length > 0 && (
+                <>
+                  <div className="tech-token text-[11px] text-muted">
+                    Assistant · stopped
+                  </div>
+                  <div className="whitespace-pre-wrap text-[15px] leading-relaxed text-ink">
+                    {stopped.text}
+                  </div>
+                </>
+              )}
+              <p className="text-xs text-muted" data-testid="chat-stopped-note">
+                Stopped. The full answer is still being recorded.
+              </p>
+            </div>
+          </div>
         )}
         {thinking && (
           <div className="flex flex-col gap-1.5">
@@ -1204,16 +1372,31 @@ export function AssistantTab({
               )}
             </div>
 
-            {/* Right: Send */}
+            {/* Right: Send, or Stop while an answer is streaming. Stop is
+                the same geometry as Send but bordered, not dark — a stop
+                is a small verdict, so seal text is allowed. It only
+                appears while model.delta events are arriving; keyless
+                turns never stream, so they never show it. */}
             <div className="flex items-center gap-3">
-              <button
-                onClick={onSend}
-                disabled={pending || !input.trim()}
-                data-testid="chat-composer-send"
-                className={primaryBtn + " px-4 py-1.5 text-[14px]"}
-              >
-                {pending ? "Sending…" : "Send"}
-              </button>
+              {streamActive ? (
+                <button
+                  type="button"
+                  onClick={onStop}
+                  data-testid="chat-composer-stop"
+                  className="rounded-item border border-ink bg-paper px-4 py-1.5 text-[14px] font-medium text-seal transition-colors hover:bg-paper-sunken min-h-[44px]"
+                >
+                  Stop
+                </button>
+              ) : (
+                <button
+                  onClick={onSend}
+                  disabled={pending || !input.trim()}
+                  data-testid="chat-composer-send"
+                  className={primaryBtn + " px-4 py-1.5 text-[14px]"}
+                >
+                  {pending ? "Sending…" : "Send"}
+                </button>
+              )}
             </div>
           </div>
           </div>


### PR DESCRIPTION
Closes the last first-class gap on the launch-critical chat surface (handover WI-1): a lawyer can stop a wrong answer mid-stream and re-roll a poor one without retyping.

**Case A confirmed:** the stream endpoint runs the turn in a detached `asyncio.create_task` with its own DB session, and persistence is one atomic commit at the end of the turn — client disconnect only closes the SSE relay, never the turn. Stop is therefore purely client-side; no backend runtime changes.

**Stop**
- One AbortController per streaming turn; signal wired through `postAssistantMessageStream` (already accepted it). Aborts on click, thread switch, and unmount.
- Stop replaces Send only while `model.delta` events are arriving — keyless/stub turns never show it.
- On Stop the partial draft freezes with "Stopped. The full answer is still being recorded." and the thread is refreshed from ~2s (bounded retries) until the persisted turn replaces the frozen bubble.

**Regenerate**
- New action in the last assistant message's actions row (same `linkCls`/`.hit` idiom), hidden while any turn is in flight. Resends the previous user prompt as a brand-new turn through the normal send path; the earlier answer stays (append-only record, UI matches).
- v1 caveat: attach/skill context is not carried on persisted user messages, so Regenerate resends plain content (plus whatever is currently attached), per the spec's accepted fallback.

**Tests**
- Backend: `TestStreamDisconnectPersistence` pins the Case A guarantee — drop the SSE client mid-stream, assistant message row + `module.assistant.message` audit row still land.
- Frontend: Stop aborts the fetch, freezes the draft, shows the stopped line, and the persisted turn swaps in; Stop never appears for non-streaming turns; abort on unmount without state warnings; Regenerate resends identical content as a new turn, keeps the old answer, renders only on the last assistant message, and hides while in flight.
- Full suites green (`tsc` + 383 vitest, 20+29 pytest in the assistant streaming/pipeline files). Live keyless walk on the local stack verified Regenerate end to end (caught and fixed a StrictMode double-mount ref bug in the process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Stop action for in-progress assistant replies, letting you cancel a streaming response and keep the partial draft visible.
  * Added a Regenerate action to resend the latest prompt and generate a new assistant reply.
  * Improved chat handling so streamed replies can recover and persist correctly after interruptions.

* **Bug Fixes**
  * Streaming turns now stay stable when a client disconnects mid-response.
  * Assistant threads now update more reliably across streaming and refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->