### PR TITLE
OpenRouter as a BYO-key provider, Sonnet 5 as reference model

### DIFF
--- a/backend/app/api/matters.py
+++ b/backend/app/api/matters.py
@@ -110,7 +110,8 @@ class MatterRead(BaseModel):
     pivot_fact: str | None
     privilege_posture: str
     default_model_id: str
-    # Keyed provider the default model needs ("anthropic"/"openai"), or
+    # Keyed provider the default model needs ("anthropic"/"openai"/
+    # "openrouter"), or
     # null for keyless models. Frontend reads this for run-readiness
     # instead of re-deriving model families.
     required_provider: str | None
@@ -140,7 +141,7 @@ class MatterModelPatch(BaseModel):
 class ModelCatalogEntryRead(BaseModel):
     id: str
     label: str
-    # "anthropic" | "openai" | "ollama" | "none"
+    # "anthropic" | "openai" | "openrouter" | "ollama" | "none"
     provider: str
     requires_key: bool
     note: str
@@ -273,7 +274,7 @@ async def list_models(
 
     Each entry is annotated with `key_configured` against THIS user's
     stored provider keys: keyless models (provider "ollama"/"none") are
-    always ready; keyed models (anthropic/openai) are ready only when the
+    always ready; keyed models (anthropic/openai/openrouter) are ready only when the
     user has a stored key for that provider.
     """
     rows = await session.scalars(

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -30,12 +30,16 @@ from app.models import User, UserApiKey
 router = APIRouter()
 
 
-SUPPORTED_PROVIDERS = ("anthropic", "openai")
-Provider = Literal["anthropic", "openai"]
+SUPPORTED_PROVIDERS = ("anthropic", "openai", "openrouter")
+Provider = Literal["anthropic", "openai", "openrouter"]
 
 # Providers verified with a live probe at save time. Keyless providers
 # (ollama, stub-echo) never reach this router and need no verification.
-_VERIFIABLE_PROVIDERS = {"anthropic", "openai"}
+_VERIFIABLE_PROVIDERS = {"anthropic", "openai", "openrouter"}
+
+# OpenRouter exposes a dedicated key endpoint — an authenticated GET is
+# the cheapest possible validity check (no tokens spent).
+_OPENROUTER_KEY_URL = "https://openrouter.ai/api/v1/key"
 
 
 async def _verify_provider_key(provider: str, api_key: str) -> None:
@@ -54,6 +58,28 @@ async def _verify_provider_key(provider: str, api_key: str) -> None:
         unreachable.
       - success -> return cleanly.
     """
+    if provider == "openrouter":
+        # Cheaper than a model call: GET /key with the candidate key is
+        # OpenRouter's own auth check and spends no tokens.
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    _OPENROUTER_KEY_URL,
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+        except httpx.HTTPError:
+            # Transient — don't block the save because OpenRouter is
+            # momentarily unreachable.
+            return
+        if resp.status_code in (401, 403):
+            raise HTTPException(
+                400,
+                f"the key was rejected by {provider}; check it and try again",
+            )
+        return
+
     if provider == "anthropic":
         from app.providers.anthropic_provider import AnthropicProvider
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
     # cost and latency than Opus, and it answers matter questions cleanly
     # (Opus 4.7 was the legacy default and tended to deflect). A user's own
     # default_model_id, then an explicit per-matter choice, override this.
-    default_model_id: str = "claude-sonnet-4-6"
+    default_model_id: str = "claude-sonnet-5"
 
     # Retrieval embedding backend. "fastembed" (default) runs a local,
     # keyless ONNX model (BAAI/bge-small-en-v1.5, 384-dim) so privileged

--- a/backend/app/core/model_catalog.py
+++ b/backend/app/core/model_catalog.py
@@ -10,14 +10,20 @@ Each entry carries:
     id            the model id stored on the matter (``default_model_id``)
     label         human-readable name for the picker
     provider      gateway provider name the id routes to —
-                  "anthropic" | "openai" | "ollama" | "none"
+                  "anthropic" | "openai" | "openrouter" | "ollama" | "none"
     requires_key  True if a per-user provider key must be configured
     note          short one-line hint shown beside the entry
 
 Provider values are kept consistent with
-``app.core.model_gateway.provider_for_model`` (claude-* -> anthropic,
-gpt-* -> openai, keyless otherwise). To add or retire a model, edit
-``_CATALOG`` below — nothing else needs to change.
+``app.core.model_gateway.provider_for_model`` (slash-form ids ->
+openrouter, claude-* -> anthropic, gpt-* -> openai, keyless otherwise).
+To add or retire a model, edit ``_CATALOG`` below — nothing else needs
+to change.
+
+Reference-model policy: Legalise is built and tested against Claude
+Sonnet 5. Other models run (via their own provider or an OpenRouter
+key) but are available, not endorsed — citation behaviour is verified
+on the reference model only.
 """
 
 from __future__ import annotations
@@ -39,6 +45,14 @@ class ModelEntry:
 _CATALOG: list[ModelEntry] = [
     # --- Anthropic (claude-* -> anthropic, requires a user key) ----------
     ModelEntry(
+        id="claude-sonnet-5",
+        label="Claude Sonnet 5 - reference model",
+        provider="anthropic",
+        requires_key=True,
+        note="Legalise is built and tested against Sonnet 5. Runs on your Anthropic key.",
+        recommended=True,
+    ),
+    ModelEntry(
         id="claude-opus-4-8",
         label="Claude Opus 4.8 — most capable",
         provider="anthropic",
@@ -50,8 +64,7 @@ _CATALOG: list[ModelEntry] = [
         label="Claude Sonnet 4.6 — balanced",
         provider="anthropic",
         requires_key=True,
-        note="Strong quality at lower cost and latency. Recommended default.",
-        recommended=True,
+        note="Previous default; superseded by Sonnet 5.",
     ),
     ModelEntry(
         id="claude-haiku-4-5",
@@ -83,6 +96,30 @@ _CATALOG: list[ModelEntry] = [
         provider="openai",
         requires_key=True,
         note="Cheaper, faster OpenAI tier.",
+    ),
+    # --- OpenRouter (slash-form ids -> openrouter, one key, many models).
+    # Curated, not exhaustive. Requests are privacy-pinned: routing only
+    # to endpoints that do not train on or retain prompts.
+    ModelEntry(
+        id="anthropic/claude-sonnet-5",
+        label="Claude Sonnet 5 (via OpenRouter)",
+        provider="openrouter",
+        requires_key=True,
+        note="The reference model on an OpenRouter key.",
+    ),
+    ModelEntry(
+        id="openai/gpt-5",
+        label="GPT-5 (via OpenRouter)",
+        provider="openrouter",
+        requires_key=True,
+        note="OpenAI flagship on an OpenRouter key.",
+    ),
+    ModelEntry(
+        id="deepseek/deepseek-r1",
+        label="DeepSeek R1 (via OpenRouter)",
+        provider="openrouter",
+        requires_key=True,
+        note="Strong open-weights reasoning model on an OpenRouter key.",
     ),
     # --- Local (Ollama, keyless, in-tenant) ------------------------------
     ModelEntry(

--- a/backend/app/core/model_gateway.py
+++ b/backend/app/core/model_gateway.py
@@ -1,4 +1,4 @@
-"""Model gateway — privilege-aware routing across Anthropic, OpenAI, Ollama.
+"""Model gateway — privilege-aware routing across Anthropic, OpenAI, OpenRouter, Ollama.
 
 Every call writes an `AuditEntry` row with prompt/response hashes, model used,
 token count and latency. Privilege posture gates which provider can serve the
@@ -39,7 +39,9 @@ from app.models import Matter
 
 # Providers that require a per-user (or server-fallback) API key. Ollama
 # and stub-echo run keyless; everything else routes through user_keys.
-_KEYED_PROVIDERS = {"anthropic", "openai"}
+# OpenRouter is BYO-key only: there is no server-side OpenRouter key,
+# not even as a dev fallback.
+_KEYED_PROVIDERS = {"anthropic", "openai", "openrouter"}
 _DEV_ENVIRONMENTS = {"development", "dev", "local"}
 
 
@@ -52,6 +54,11 @@ def provider_for_model(model_id: str | None) -> str | None:
     """
     if not model_id:
         return None
+    # Slash-form ids are OpenRouter model slugs ("anthropic/claude-sonnet-5",
+    # "openai/gpt-5"). Bare claude-*/gpt-* ids keep routing direct to the
+    # provider's own API, as before.
+    if "/" in model_id:
+        return "openrouter"
     if model_id.startswith("claude-"):
         return "anthropic"
     if model_id.startswith("gpt-"):
@@ -298,7 +305,12 @@ class ModelGateway:
             # probe reachability synchronously, so we trust the requested
             # model unless it's obviously frontier and a local exists.
             local = self._providers.get("ollama")
-            if local is not None and requested.startswith(("claude-", "gpt-")):
+            # Frontier ids: bare claude-*/gpt-* and OpenRouter slash-form
+            # slugs. All of them leave the tenant, so B_mixed prefers the
+            # local provider for the lot.
+            if local is not None and (
+                requested.startswith(("claude-", "gpt-")) or "/" in requested
+            ):
                 return local
         # Map a model id (e.g. claude-opus-4-7) onto a provider name
         # (anthropic). Without this, a Claude model id falls through to
@@ -395,7 +407,8 @@ class ModelGateway:
         requested = model or settings.default_model_id
         provider = self._select_provider(requested, effective_posture)
 
-        # Per-user key resolution for keyed providers (anthropic, openai).
+        # Per-user key resolution for keyed providers (anthropic, openai,
+        # openrouter).
         # Ollama/stub-echo are keyless. If the user has no key and the
         # dev-only server fallback isn't permitted, raise structured
         # ProviderKeyMissing — routers translate to 422 with a UI nudge.
@@ -420,6 +433,14 @@ class ModelGateway:
             or getattr(provider, "default_model", None)
             or provider.name
         )
+        # OpenRouter reports which model (and which upstream provider)
+        # actually served the call in the response body. The provider
+        # fills this request-scoped out-param; after a successful call
+        # the reported values refine `served_model` and land in the
+        # audit payload as `upstream_provider`.
+        served_meta: dict = {}
+        if provider.name == "openrouter":
+            provider_kwargs["meta_out"] = served_meta
         if provider.name in _KEYED_PROVIDERS:
             user_key: str | None = None
             if actor_id is not None:
@@ -516,6 +537,13 @@ class ModelGateway:
         if provider.name in _KEYED_PROVIDERS and actor_id is not None and "api_key" in provider_kwargs:
             await mark_user_key_used(session, actor_id, provider.name)
 
+        # Served-model refinement (OpenRouter): trust the response body's
+        # `model` field over the requested slug — that is what audit rows
+        # must record. `requested_model` in the payload keeps the
+        # requested-vs-served distinction legible (PR #248).
+        if served_meta.get("served_model"):
+            served_model = served_meta["served_model"]
+
         result = ModelResult(
             text=response_text,
             model_used=served_model,
@@ -552,6 +580,14 @@ class ModelGateway:
                 "requested_model": requested,
                 "provider": provider.name,
                 "posture": effective_posture.value,
+                # Upstream provider that served the call via OpenRouter,
+                # when the response reported one. Lives in the payload
+                # JSON so no audit-schema change is needed.
+                **(
+                    {"upstream_provider": served_meta["upstream_provider"]}
+                    if served_meta.get("upstream_provider")
+                    else {}
+                ),
                 **(payload or {}),
             },
         )

--- a/backend/app/core/seed.py
+++ b/backend/app/core/seed.py
@@ -688,7 +688,7 @@ async def seed_demo_matter_for_user(session: AsyncSession, user: User) -> Matter
         pivot_fact=KHAN_PIVOT_FACT,
         privilege_posture=PRIVILEGE_MIXED,
         # Matches settings.default_model_id (Sonnet) — the recommended model.
-        default_model_id="claude-sonnet-4-6",
+        default_model_id="claude-sonnet-5",
         facts=KHAN_FACTS,
         opened_at=datetime(2026, 5, 12, 15, 45, 8, tzinfo=timezone.utc),
         retention_until=date(2032, 7, 3),

--- a/backend/app/models/matter.py
+++ b/backend/app/models/matter.py
@@ -51,7 +51,7 @@ class Matter(Base):
     pivot_fact: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     privilege_posture: Mapped[str] = mapped_column(String(32), nullable=False, default=PRIVILEGE_MIXED)
-    default_model_id: Mapped[str] = mapped_column(String(64), nullable=False, default="claude-sonnet-4-6")
+    default_model_id: Mapped[str] = mapped_column(String(64), nullable=False, default="claude-sonnet-5")
 
     # Free-form key/value bag for matter-type-specific fields (EDT, ACAS dates, etc.)
     facts: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)

--- a/backend/app/providers/__init__.py
+++ b/backend/app/providers/__init__.py
@@ -22,6 +22,7 @@ from app.core.model_gateway import ModelGateway
 from app.providers.anthropic_provider import AnthropicProvider
 from app.providers.ollama_provider import OllamaProvider
 from app.providers.openai_provider import OpenAIProvider
+from app.providers.openrouter_provider import OpenRouterProvider
 
 logger = structlog.get_logger()
 
@@ -75,6 +76,12 @@ async def register_providers(gateway: ModelGateway) -> list[str]:
     gateway.register(OpenAIProvider(api_key=settings.openai_api_key))
     registered.append("openai")
 
+    # OpenRouter is BYO-key only — constructed with no fallback key on
+    # purpose. There is no server-side OpenRouter key, not even the
+    # dev-only env fallback the other keyed providers get.
+    gateway.register(OpenRouterProvider(api_key=None))
+    registered.append("openrouter")
+
     if settings.ollama_url and await _probe_ollama(settings.ollama_url):
         gateway.register(OllamaProvider(base_url=settings.ollama_url))
         registered.append("ollama")
@@ -83,4 +90,10 @@ async def register_providers(gateway: ModelGateway) -> list[str]:
     return registered
 
 
-__all__ = ["register_providers", "AnthropicProvider", "OpenAIProvider", "OllamaProvider"]
+__all__ = [
+    "register_providers",
+    "AnthropicProvider",
+    "OpenAIProvider",
+    "OpenRouterProvider",
+    "OllamaProvider",
+]

--- a/backend/app/providers/openai_provider.py
+++ b/backend/app/providers/openai_provider.py
@@ -51,6 +51,38 @@ class OpenAIProvider:
         # when the caller didn't pass one.
         self.default_model = default_model
 
+    def _make_client(self, api_key: str) -> AsyncOpenAI:
+        """Build the SDK client. Subclasses (OpenRouter) override to set a
+        different base_url and attribution headers."""
+        return AsyncOpenAI(api_key=api_key)
+
+    def _request_extras(self) -> dict:
+        """Extra kwargs merged into every chat.completions.create call.
+
+        Subclasses use this to pin request-body fields the wire format
+        requires (OpenRouter's `provider.data_collection` routing pin).
+        """
+        return {}
+
+    @staticmethod
+    def _capture_meta(obj: object, meta: object) -> None:
+        """Record served-model metadata from a response (or stream chunk)
+        into the gateway-supplied `meta_out` dict, when one was passed.
+
+        `model` is the model that actually served the call; `provider`
+        (OpenRouter only) is the upstream provider name. Both are absent
+        on plain OpenAI responses' chunks sometimes, so only truthy
+        values are recorded.
+        """
+        if not isinstance(meta, dict):
+            return
+        served = getattr(obj, "model", None)
+        if served:
+            meta["served_model"] = served
+        upstream = getattr(obj, "provider", None)
+        if upstream and isinstance(upstream, str):
+            meta["upstream_provider"] = upstream
+
     async def call(
         self, prompt: str, *, system: str | None = None, **kwargs
     ) -> tuple[str, int, int]:
@@ -61,9 +93,12 @@ class OpenAIProvider:
         # The returned text is the concatenation of exactly those deltas;
         # finish_reason and usage arrive on the stream's final chunks.
         on_delta = kwargs.get("on_delta")
+        # Gateway-supplied out-param: filled with the served model (and,
+        # for OpenRouter, the upstream provider) read off the response.
+        meta_out = kwargs.get("meta_out")
         if not api_key:
-            raise RuntimeError("openai: no api_key supplied")
-        client = AsyncOpenAI(api_key=api_key)
+            raise RuntimeError(f"{self.name}: no api_key supplied")
+        client = self._make_client(api_key)
 
         messages: list[dict] = []
         if system:
@@ -76,11 +111,13 @@ class OpenAIProvider:
                     model=model,
                     max_tokens=max_tokens,
                     messages=messages,
+                    **self._request_extras(),
                 )
                 choice = response.choices[0]
                 finish_reason = getattr(choice, "finish_reason", None)
                 text = choice.message.content or ""
                 usage = response.usage
+                self._capture_meta(response, meta_out)
             else:
                 stream = await client.chat.completions.create(
                     model=model,
@@ -88,11 +125,13 @@ class OpenAIProvider:
                     messages=messages,
                     stream=True,
                     stream_options={"include_usage": True},
+                    **self._request_extras(),
                 )
                 parts: list[str] = []
                 finish_reason = None
                 usage = None
                 async for chunk in stream:
+                    self._capture_meta(chunk, meta_out)
                     if chunk.choices:
                         chunk_choice = chunk.choices[0]
                         delta = getattr(chunk_choice, "delta", None)
@@ -107,26 +146,26 @@ class OpenAIProvider:
                 text = "".join(parts)
         except APIStatusError as exc:
             logger.exception(
-                "legalise.provider.openai.error",
+                f"legalise.provider.{self.name}.error",
                 model=model,
                 upstream_status=exc.status_code,
             )
-            raise _translate_status_error("openai", exc) from exc
+            raise _translate_status_error(self.name, exc) from exc
         except APIConnectionError as exc:
-            logger.exception("legalise.provider.openai.connection_error", model=model)
+            logger.exception(f"legalise.provider.{self.name}.connection_error", model=model)
             raise ProviderUpstreamError(
-                provider="openai",
+                provider=self.name,
                 code="provider_error",
                 upstream_status=None,
-                message=f"openai: connection error: {exc}",
+                message=f"{self.name}: connection error: {exc}",
             ) from exc
         except Exception as exc:
-            logger.exception("legalise.provider.openai.error", model=model)
+            logger.exception(f"legalise.provider.{self.name}.error", model=model)
             raise ProviderUpstreamError(
-                provider="openai",
+                provider=self.name,
                 code="provider_error",
                 upstream_status=None,
-                message=f"openai: {type(exc).__name__}: {exc}",
+                message=f"{self.name}: {type(exc).__name__}: {exc}",
             ) from exc
 
         # A hard stop at the output cap means the response is incomplete —
@@ -134,12 +173,12 @@ class OpenAIProvider:
         # half-written body that fails its JSON-envelope parse downstream.
         if finish_reason == "length":
             logger.warning(
-                "legalise.provider.openai.truncated",
+                f"legalise.provider.{self.name}.truncated",
                 model=model,
                 max_tokens=max_tokens,
             )
             raise ProviderUpstreamError(
-                provider="openai",
+                provider=self.name,
                 code="provider_truncated",
                 upstream_status=None,
                 message=(

--- a/backend/app/providers/openrouter_provider.py
+++ b/backend/app/providers/openrouter_provider.py
@@ -1,0 +1,58 @@
+"""OpenRouter provider.
+
+OpenRouter speaks the OpenAI chat-completions wire format, so this is a
+thin parameterisation of `OpenAIProvider`: same SDK, different base_url,
+attribution headers, and one non-negotiable request-body pin.
+
+Privacy pin (governance default, not user-configurable in v1): every
+request body carries `"provider": {"data_collection": "deny"}`, which
+restricts OpenRouter's routing to upstream endpoints that do not train
+on or retain prompts. Matter content must never reach a
+training/retention endpoint.
+
+Model ids are OpenRouter's slash form ("anthropic/claude-sonnet-5").
+The response's `model` and `provider` fields (the model actually served
+and the upstream provider that served it) are captured through the
+shared `meta_out` mechanism so the gateway can stamp them onto the
+audit row.
+"""
+
+from __future__ import annotations
+
+from openai import AsyncOpenAI
+
+from app.providers.openai_provider import OpenAIProvider
+
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+DEFAULT_MODEL = "anthropic/claude-sonnet-5"
+
+# App attribution headers OpenRouter uses for rankings/analytics.
+ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://legalise.dev",
+    "X-Title": "Legalise",
+}
+
+# Routing pin: only serve from endpoints that neither train on nor
+# retain prompts. Sent on EVERY request; there is deliberately no code
+# path that omits it.
+PRIVACY_PIN = {"provider": {"data_collection": "deny"}}
+
+
+class OpenRouterProvider(OpenAIProvider):
+    name = "openrouter"
+
+    def __init__(self, api_key: str | None, default_model: str = DEFAULT_MODEL):
+        super().__init__(api_key, default_model=default_model)
+
+    def _make_client(self, api_key: str) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            api_key=api_key,
+            base_url=OPENROUTER_BASE_URL,
+            default_headers=dict(ATTRIBUTION_HEADERS),
+        )
+
+    def _request_extras(self) -> dict:
+        # `extra_body` is the OpenAI SDK's escape hatch for
+        # provider-specific body fields; it merges into the JSON body.
+        return {"extra_body": dict(PRIVACY_PIN)}

--- a/backend/tests/test_matter_required_provider.py
+++ b/backend/tests/test_matter_required_provider.py
@@ -17,6 +17,11 @@ def test_required_provider_property_matches_gateway() -> None:
     # Pure property — no DB. The mapping is the gateway's, not a copy.
     assert Matter(default_model_id="claude-opus-4-7").required_provider == "anthropic"
     assert Matter(default_model_id="gpt-4o").required_provider == "openai"
+    assert (
+        Matter(default_model_id="anthropic/claude-sonnet-5").required_provider
+        == "openrouter"
+    )
+    assert Matter(default_model_id="openai/gpt-5").required_provider == "openrouter"
     assert Matter(default_model_id="stub-echo").required_provider is None
     assert Matter(default_model_id="ollama-local").required_provider is None
 

--- a/backend/tests/test_openrouter_provider.py
+++ b/backend/tests/test_openrouter_provider.py
@@ -1,0 +1,461 @@
+"""OpenRouter provider + gateway routing.
+
+Pins the OpenRouter contract:
+
+  - client is built against the OpenRouter base_url with the app
+    attribution headers (HTTP-Referer / X-Title)
+  - EVERY request body carries the privacy pin
+    `"provider": {"data_collection": "deny"}` (governance default;
+    not user-disableable) - streaming and non-streaming alike
+  - the response's `model` (served model) and `provider` (upstream
+    provider) fields are captured into the gateway-supplied `meta_out`
+    so the audit row records what actually served the call
+  - finish_reason "length" -> provider_truncated, matching the OpenAI
+    provider contract
+  - slash-form model ids ("anthropic/claude-sonnet-5") route to the
+    "openrouter" provider; bare claude-*/gpt-* ids keep routing direct
+  - OpenRouter is BYO-key: no user key -> ProviderKeyMissing
+
+All network is mocked - there is no OpenRouter key in CI.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core import model_gateway as gw_module
+from app.core.model_catalog import model_catalog
+from app.core.model_gateway import ModelGateway, PrivilegePosture, provider_for_model
+from app.core.user_keys import ProviderKeyMissing, ProviderUpstreamError
+from app.providers.openrouter_provider import (
+    ATTRIBUTION_HEADERS,
+    OPENROUTER_BASE_URL,
+    OpenRouterProvider,
+)
+
+
+def _response(
+    content: str = "answer body",
+    finish_reason: str = "stop",
+    model: str | None = "anthropic/claude-sonnet-5",
+    provider: str | None = "Anthropic",
+):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason=finish_reason,
+                message=SimpleNamespace(content=content),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20),
+        model=model,
+        provider=provider,
+    )
+
+
+def _patched_client(response=None):
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response or _response())
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Provider unit tests - non-streaming
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterProvider:
+    @pytest.mark.asyncio
+    async def test_client_built_with_base_url_and_attribution_headers(self) -> None:
+        client = _patched_client()
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        with patch(
+            "app.providers.openrouter_provider.AsyncOpenAI", return_value=client
+        ) as ctor:
+            await provider.call("question")
+
+        ctor_kwargs = ctor.call_args.kwargs
+        assert ctor_kwargs["base_url"] == OPENROUTER_BASE_URL
+        assert ctor_kwargs["default_headers"] == ATTRIBUTION_HEADERS
+        assert ctor_kwargs["api_key"] == "sk-or-test"
+
+    @pytest.mark.asyncio
+    async def test_every_request_carries_data_collection_deny(self) -> None:
+        client = _patched_client()
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        with patch(
+            "app.providers.openrouter_provider.AsyncOpenAI", return_value=client
+        ):
+            await provider.call("question", model="anthropic/claude-sonnet-5")
+
+        create_kwargs = client.chat.completions.create.call_args.kwargs
+        assert create_kwargs["extra_body"] == {
+            "provider": {"data_collection": "deny"}
+        }
+        assert create_kwargs["model"] == "anthropic/claude-sonnet-5"
+
+    @pytest.mark.asyncio
+    async def test_served_model_and_upstream_provider_captured(self) -> None:
+        client = _patched_client(
+            _response(model="anthropic/claude-sonnet-5", provider="Google Vertex")
+        )
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        meta: dict = {}
+        with patch(
+            "app.providers.openrouter_provider.AsyncOpenAI", return_value=client
+        ):
+            text, tokens_in, tokens_out = await provider.call(
+                "question", meta_out=meta
+            )
+
+        assert text == "answer body"
+        assert (tokens_in, tokens_out) == (10, 20)
+        assert meta["served_model"] == "anthropic/claude-sonnet-5"
+        assert meta["upstream_provider"] == "Google Vertex"
+
+    @pytest.mark.asyncio
+    async def test_missing_meta_fields_are_omitted(self) -> None:
+        client = _patched_client(_response(model=None, provider=None))
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        meta: dict = {}
+        with patch(
+            "app.providers.openrouter_provider.AsyncOpenAI", return_value=client
+        ):
+            await provider.call("question", meta_out=meta)
+
+        assert "served_model" not in meta
+        assert "upstream_provider" not in meta
+
+    @pytest.mark.asyncio
+    async def test_truncation_raises_provider_truncated(self) -> None:
+        client = _patched_client(
+            _response(content="truncated body", finish_reason="length")
+        )
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        with patch(
+            "app.providers.openrouter_provider.AsyncOpenAI", return_value=client
+        ):
+            with pytest.raises(ProviderUpstreamError) as excinfo:
+                await provider.call("long question")
+
+        assert excinfo.value.code == "provider_truncated"
+        assert excinfo.value.provider == "openrouter"
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_raises(self) -> None:
+        provider = OpenRouterProvider(api_key=None)
+        with pytest.raises(RuntimeError, match="openrouter: no api_key supplied"):
+            await provider.call("question")
+
+
+# ---------------------------------------------------------------------------
+# Provider unit tests - streaming (mirrors TestOpenAIStreaming)
+# ---------------------------------------------------------------------------
+
+
+def _chunk(
+    content: str | None = None,
+    finish_reason: str | None = None,
+    usage=None,
+    model: str | None = None,
+    provider: str | None = None,
+):
+    choices = []
+    if content is not None or finish_reason is not None:
+        choices.append(
+            SimpleNamespace(
+                delta=SimpleNamespace(content=content),
+                finish_reason=finish_reason,
+            )
+        )
+    return SimpleNamespace(
+        choices=choices, usage=usage, model=model, provider=provider
+    )
+
+
+async def _stream(chunks):
+    for c in chunks:
+        yield c
+
+
+class TestOpenRouterStreaming:
+    @pytest.mark.asyncio
+    async def test_streams_deltas_and_captures_usage_and_meta(self) -> None:
+        chunks = [
+            _chunk("complete ", model="anthropic/claude-sonnet-5", provider="Anthropic"),
+            _chunk("body"),
+            _chunk(finish_reason="stop"),
+            _chunk(usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20)),
+        ]
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=_stream(chunks))
+        deltas: list[str] = []
+
+        async def _on_delta(text: str) -> None:
+            deltas.append(text)
+
+        meta: dict = {}
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        with patch(
+            "app.providers.openrouter_provider.AsyncOpenAI", return_value=client
+        ):
+            text, tokens_in, tokens_out = await provider.call(
+                "question", on_delta=_on_delta, meta_out=meta
+            )
+
+        assert deltas == ["complete ", "body"]
+        assert text == "complete body"
+        assert (tokens_in, tokens_out) == (10, 20)
+        assert meta["served_model"] == "anthropic/claude-sonnet-5"
+        assert meta["upstream_provider"] == "Anthropic"
+        create_kwargs = client.chat.completions.create.call_args.kwargs
+        assert create_kwargs["stream"] is True
+        assert create_kwargs["stream_options"] == {"include_usage": True}
+        # The privacy pin is on the streaming request too.
+        assert create_kwargs["extra_body"] == {
+            "provider": {"data_collection": "deny"}
+        }
+
+    @pytest.mark.asyncio
+    async def test_streaming_truncation_still_raises(self) -> None:
+        chunks = [
+            _chunk("truncated"),
+            _chunk(finish_reason="length"),
+            _chunk(usage=SimpleNamespace(prompt_tokens=10, completion_tokens=2048)),
+        ]
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=_stream(chunks))
+
+        async def _on_delta(_text: str) -> None:
+            return None
+
+        provider = OpenRouterProvider(api_key="sk-or-test")
+        with patch(
+            "app.providers.openrouter_provider.AsyncOpenAI", return_value=client
+        ):
+            with pytest.raises(ProviderUpstreamError) as excinfo:
+                await provider.call("long question", on_delta=_on_delta)
+
+        assert excinfo.value.code == "provider_truncated"
+        assert excinfo.value.provider == "openrouter"
+
+
+# ---------------------------------------------------------------------------
+# Gateway routing
+# ---------------------------------------------------------------------------
+
+
+class TestProviderForModelRouting:
+    def test_slash_ids_route_to_openrouter(self) -> None:
+        assert provider_for_model("anthropic/claude-sonnet-5") == "openrouter"
+        assert provider_for_model("openai/gpt-5") == "openrouter"
+        assert provider_for_model("deepseek/deepseek-r1") == "openrouter"
+
+    def test_direct_ids_unchanged(self) -> None:
+        assert provider_for_model("claude-sonnet-5") == "anthropic"
+        assert provider_for_model("claude-opus-4-8") == "anthropic"
+        assert provider_for_model("gpt-5") == "openai"
+        assert provider_for_model("stub-echo") is None
+        assert provider_for_model("ollama") is None
+
+    def test_catalog_providers_agree_with_gateway_routing(self) -> None:
+        """The catalog's explicit provider and provider_for_model must not
+        drift: for every keyed entry they agree; keyless entries map to
+        no keyed provider."""
+        keyed = {"anthropic", "openai", "openrouter"}
+        for entry in model_catalog():
+            routed = provider_for_model(entry.id)
+            if entry.provider in keyed:
+                assert routed == entry.provider, entry.id
+                assert entry.requires_key, entry.id
+            else:
+                assert routed is None, entry.id
+                assert not entry.requires_key, entry.id
+
+    def test_catalog_reference_model_policy(self) -> None:
+        by_id = {e.id: e for e in model_catalog()}
+        # Sonnet 5 is the single recommended reference model.
+        assert by_id["claude-sonnet-5"].recommended is True
+        recommended = [e for e in model_catalog() if e.recommended]
+        assert len(recommended) == 1
+        # The previous default stays selectable but demoted.
+        assert by_id["claude-sonnet-4-6"].recommended is False
+        assert "superseded by Sonnet 5" in by_id["claude-sonnet-4-6"].note
+        # Curated OpenRouter entries exist, including the reference model.
+        assert by_id["anthropic/claude-sonnet-5"].provider == "openrouter"
+        assert by_id["openai/gpt-5"].provider == "openrouter"
+        assert by_id["deepseek/deepseek-r1"].provider == "openrouter"
+
+
+class _OpenRouterStub:
+    """Stand-in with name='openrouter' so the KEYED_PROVIDERS check
+    fires. Fills meta_out the way the real provider does."""
+
+    name = "openrouter"
+    default_model = "anthropic/claude-sonnet-5"
+
+    def __init__(self, served_model=None, upstream=None) -> None:
+        self._served_model = served_model
+        self._upstream = upstream
+        self.last_kwargs: dict = {}
+
+    async def call(self, prompt: str, *, system=None, **kwargs):  # noqa: ANN001
+        self.last_kwargs = dict(kwargs)
+        meta = kwargs.get("meta_out")
+        if isinstance(meta, dict):
+            if self._served_model:
+                meta["served_model"] = self._served_model
+            if self._upstream:
+                meta["upstream_provider"] = self._upstream
+        return ("ok", 3, 2)
+
+
+class _StubSession:
+    bind = None
+
+    async def scalar(self, *args, **kwargs):  # noqa: ANN001, ANN002
+        return None
+
+    async def execute(self, *args, **kwargs):  # noqa: ANN001, ANN002
+        class _Row:
+            def first(self):
+                return None
+
+        return _Row()
+
+    def add(self, *args, **kwargs):  # noqa: ANN001, ANN002
+        pass
+
+
+class _CapturingAudit:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def log(self, session, action, **kwargs):  # noqa: ANN001
+        self.calls.append({"action": action, **kwargs})
+
+
+@pytest.fixture
+def actor_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+class TestGatewayOpenRouter:
+    @pytest.mark.asyncio
+    @patch.object(gw_module, "mark_user_key_used")
+    @patch.object(gw_module, "get_user_provider_key", return_value="sk-or-user")
+    async def test_slash_model_served_via_openrouter_and_audited(
+        self, _mock_lookup, _mock_mark, actor_id
+    ) -> None:
+        """A slash-form model id routes to the openrouter provider; the
+        audit row records the served model, that openrouter served it,
+        and the upstream provider name in the payload."""
+        import app.core.api as api_module
+
+        stub = _OpenRouterStub(
+            served_model="anthropic/claude-sonnet-5", upstream="Anthropic"
+        )
+        g = ModelGateway()
+        g.register(stub)
+        fake_audit = _CapturingAudit()
+
+        with patch.object(api_module, "audit", fake_audit):
+            result = await g.call(
+                session=_StubSession(),
+                matter_id=None,
+                actor_id=actor_id,
+                prompt="hi",
+                model="anthropic/claude-sonnet-5",
+                posture=PrivilegePosture.A_CLEARED,
+            )
+
+        assert stub.last_kwargs.get("api_key") == "sk-or-user"
+        assert stub.last_kwargs.get("model") == "anthropic/claude-sonnet-5"
+        assert result.provider == "openrouter"
+        assert result.model_used == "anthropic/claude-sonnet-5"
+
+        rows = [c for c in fake_audit.calls if c["action"] == "model.call"]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["model_used"] == "anthropic/claude-sonnet-5"
+        assert row["payload"]["provider"] == "openrouter"
+        assert row["payload"]["requested_model"] == "anthropic/claude-sonnet-5"
+        assert row["payload"]["upstream_provider"] == "Anthropic"
+
+    @pytest.mark.asyncio
+    @patch.object(gw_module, "mark_user_key_used")
+    @patch.object(gw_module, "get_user_provider_key", return_value="sk-or-user")
+    async def test_reported_served_model_wins_over_requested(
+        self, _mock_lookup, _mock_mark, actor_id
+    ) -> None:
+        """If OpenRouter reports a different served model, the result and
+        audit row record what actually ran; requested_model keeps the
+        request legible."""
+        import app.core.api as api_module
+
+        stub = _OpenRouterStub(served_model="anthropic/claude-sonnet-5-1")
+        g = ModelGateway()
+        g.register(stub)
+        fake_audit = _CapturingAudit()
+
+        with patch.object(api_module, "audit", fake_audit):
+            result = await g.call(
+                session=_StubSession(),
+                matter_id=None,
+                actor_id=actor_id,
+                prompt="hi",
+                model="anthropic/claude-sonnet-5",
+                posture=PrivilegePosture.A_CLEARED,
+            )
+
+        assert result.model_used == "anthropic/claude-sonnet-5-1"
+        row = [c for c in fake_audit.calls if c["action"] == "model.call"][0]
+        assert row["model_used"] == "anthropic/claude-sonnet-5-1"
+        assert row["payload"]["requested_model"] == "anthropic/claude-sonnet-5"
+
+    @pytest.mark.asyncio
+    @patch.object(gw_module, "get_user_provider_key", return_value=None)
+    async def test_no_user_key_raises_provider_key_missing(
+        self, _mock_lookup, actor_id
+    ) -> None:
+        stub = _OpenRouterStub()
+        g = ModelGateway()
+        g.register(stub)
+
+        with patch.object(gw_module.settings, "environment", "demo"), patch.object(
+            gw_module.settings, "allow_server_key_fallback", False
+        ):
+            with pytest.raises(ProviderKeyMissing) as excinfo:
+                await g.call(
+                    session=_StubSession(),
+                    matter_id=None,
+                    actor_id=actor_id,
+                    prompt="hi",
+                    model="anthropic/claude-sonnet-5",
+                    posture=PrivilegePosture.A_CLEARED,
+                )
+        assert excinfo.value.provider == "openrouter"
+
+    @pytest.mark.asyncio
+    async def test_b_mixed_prefers_local_for_openrouter_models(self) -> None:
+        """Privacy posture consistency: on a B_mixed matter with a local
+        provider registered, an OpenRouter frontier id is served locally,
+        exactly like bare claude-*/gpt-* ids."""
+
+        class _LocalStub:
+            name = "ollama"
+            default_model = "local-model"
+
+            async def call(self, prompt: str, *, system=None, **kwargs):  # noqa: ANN001
+                return ("local ok", 1, 1)
+
+        g = ModelGateway()
+        g.register(_LocalStub())
+        name = g.select_provider_name(
+            "anthropic/claude-sonnet-5", PrivilegePosture.B_MIXED
+        )
+        assert name == "ollama"

--- a/backend/tests/test_settings_key_verification.py
+++ b/backend/tests/test_settings_key_verification.py
@@ -110,6 +110,81 @@ async def test_auth_failure_rejects_and_does_not_persist(persisted):
     assert persisted["persisted"] is False
 
 
+def _openrouter_body(api_key: str = "sk-or-candidate-key") -> UserApiKeyUpsert:
+    return UserApiKeyUpsert(provider="openrouter", api_key=api_key)
+
+
+def _fake_httpx_client(status_code: int | None = 200, raise_exc: Exception | None = None):
+    """Async-context-manager httpx.AsyncClient stand-in whose `get` either
+    returns a response with `status_code` or raises `raise_exc`."""
+    import httpx  # noqa: F401 - mirrors the lazy import in the route
+
+    class _Resp:
+        def __init__(self, code: int) -> None:
+            self.status_code = code
+
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            self.last_url: str | None = None
+            self.last_headers: dict | None = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc) -> None:  # noqa: ANN002
+            return None
+
+        async def get(self, url, headers=None):  # noqa: ANN001
+            self.last_url = url
+            self.last_headers = headers
+            if raise_exc is not None:
+                raise raise_exc
+            return _Resp(status_code)
+
+    return _Client
+
+
+@pytest.mark.asyncio
+async def test_openrouter_valid_key_persists(persisted):
+    """The OpenRouter probe is a token-free GET /key; a 200 persists."""
+    with patch("httpx.AsyncClient", _fake_httpx_client(status_code=200)):
+        row = await upsert_key(
+            _openrouter_body(), session=_FakeSession(), user=_FakeUser()
+        )
+    assert persisted["persisted"] is True
+    assert row is not None
+
+
+@pytest.mark.asyncio
+async def test_openrouter_auth_failure_rejects_and_does_not_persist(persisted):
+    from fastapi import HTTPException
+
+    with patch("httpx.AsyncClient", _fake_httpx_client(status_code=401)):
+        with pytest.raises(HTTPException) as excinfo:
+            await upsert_key(
+                _openrouter_body(), session=_FakeSession(), user=_FakeUser()
+            )
+
+    assert excinfo.value.status_code == 400
+    assert "rejected" in excinfo.value.detail
+    assert persisted["persisted"] is False
+
+
+@pytest.mark.asyncio
+async def test_openrouter_transient_failure_still_persists(persisted):
+    import httpx
+
+    with patch(
+        "httpx.AsyncClient",
+        _fake_httpx_client(raise_exc=httpx.ConnectError("unreachable")),
+    ):
+        row = await upsert_key(
+            _openrouter_body(), session=_FakeSession(), user=_FakeUser()
+        )
+    assert persisted["persisted"] is True
+    assert row is not None
+
+
 @pytest.mark.asyncio
 async def test_transient_failure_still_persists(persisted):
     async def _transient(self, prompt, *, system=None, **kwargs):  # noqa: ANN001

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,8 +308,11 @@ All LLM traffic leaves through one chokepoint —
 directly; this is the only place matter content crosses to a third party
 (the single egress in `docs/THREAT_MODEL.md`).
 
-- **Providers:** Anthropic and OpenAI (keyed), Ollama (local, keyless),
-  plus a deterministic `stub-echo` provider for smoke tests and the demo.
+- **Providers:** Anthropic, OpenAI, and OpenRouter (keyed), Ollama
+  (local, keyless), plus a deterministic `stub-echo` provider for smoke
+  tests and the demo. OpenRouter (ADR-011) is BYO-key only, takes
+  slash-form model ids ("anthropic/claude-sonnet-5"), and pins
+  `provider.data_collection = "deny"` on every request.
 - **BYO key, no server-paid keys in prod.** User keys are stored encrypted
   per user (`backend/app/core/user_keys.py`, AES-256-GCM), decrypted for a
   single call. A server fallback key is used **only** in a dev environment
@@ -326,8 +329,8 @@ directly; this is the only place matter content crosses to a third party
   emit `model.call.error` via `audit_failure`.
 
 The matter default is the recommended Anthropic model (currently
-`claude-sonnet-4-6`, in `config.py` / `matter.py`) — per-matter,
-overridable, refreshed as model ids advance.
+`claude-sonnet-5`, the reference model, in `config.py` / `matter.py`) —
+per-matter, overridable, refreshed as model ids advance.
 
 ---
 

--- a/docs/adr/ADR-011-openrouter.md
+++ b/docs/adr/ADR-011-openrouter.md
@@ -1,0 +1,55 @@
+# ADR-011 - OpenRouter as a BYO-key provider
+
+**Status:** Accepted (2026-07).
+
+## Context
+
+Legalise is BYO-key (ADR-001) and single-egress (ADR-009). Users asked
+for model choice without holding one key per vendor. OpenRouter gives
+one key that unlocks many models over the OpenAI wire format, so it
+slots in as a thin parameterisation of the existing OpenAI provider
+rather than a new integration surface.
+
+## Decision
+
+- **OpenRouter is a supported keyed provider** (`openrouter`), BYO-key
+  only. There is no server-side OpenRouter key, not even the dev-only
+  env fallback the other keyed providers have.
+- **Routing:** slash-form model ids ("anthropic/claude-sonnet-5",
+  "openai/gpt-5") route to OpenRouter; bare `claude-*`/`gpt-*` ids keep
+  routing direct to Anthropic/OpenAI. The catalog carries the provider
+  explicitly and a test pins catalog-vs-gateway agreement.
+- **Privacy pin (not user-configurable in v1):** every request body
+  carries `"provider": {"data_collection": "deny"}`, restricting
+  OpenRouter's routing to upstream endpoints that neither train on nor
+  retain prompts. Matter content must never reach a training/retention
+  endpoint; this is the governance default, so there is no code path
+  that omits it.
+- **Reference-model policy:** Legalise is built and tested against
+  Claude Sonnet 5 (the recommended catalog entry). Other models -
+  including everything reachable through OpenRouter - run but are
+  available, not endorsed. The picker carries one caveat line:
+  citation behaviour is verified on the reference model only.
+- **Audit:** the audit row's `model_used` records the served model as
+  reported by OpenRouter's response body; the payload keeps
+  `requested_model`, `provider: "openrouter"`, and - when the response
+  reports one - `upstream_provider` (the vendor endpoint that actually
+  served the call). No audit schema change; the upstream provider lives
+  in the existing payload JSON.
+- **Posture:** on `B_mixed` matters a registered local provider is
+  preferred for OpenRouter ids exactly as for bare frontier ids.
+- **Key verification:** saving an OpenRouter key probes
+  `GET https://openrouter.ai/api/v1/key` (token-free auth check); auth
+  failure rejects the save, transient failure saves unverified - the
+  same contract as the other keyed providers.
+
+## Consequences
+
+- One key unlocks curated models (Sonnet 5, GPT-5, one open-weights
+  entry) without widening the egress surface: the gateway chokepoint,
+  posture gates, and audit stamping are unchanged.
+- The `data_collection: deny` pin can narrow OpenRouter's routing pool
+  and may occasionally make a model unavailable; that is the accepted
+  cost of the privacy default.
+- The catalog stays curated (no free-text model field in v1), so every
+  selectable id is one we have named and can reason about.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,3 +16,4 @@ claims verified against master as of 2026-07-05.
 - [ADR-008](./ADR-008-register-sidecar-provenance.md) — The register sidecar: three-grade provenance for external exports
 - [ADR-009](./ADR-009-model-gateway.md) — One model gateway: passthrough + audit-stamping contract
 - [ADR-010](./ADR-010-fail-closed-deletes.md) — Fail-closed deletes and the tombstone lifecycle
+- [ADR-011](./ADR-011-openrouter.md) — OpenRouter as a BYO-key provider

--- a/frontend/src/auth/Register.tsx
+++ b/frontend/src/auth/Register.tsx
@@ -53,7 +53,7 @@ export function Register() {
     <AuthCard
       eyebrow="The workspace"
       heading="Create an account"
-      intro="Evaluation access. Bring your own Anthropic / OpenAI key, or use the keyless demo model. Not for live client matters."
+      intro="Evaluation access. Bring your own Anthropic, OpenAI, or OpenRouter key, or use the keyless demo model. Not for live client matters."
     >
       <form className="flex flex-col gap-6" onSubmit={submit}>
         <LedgerField label="Name" htmlFor="reg-name">

--- a/frontend/src/auth/Settings.test.tsx
+++ b/frontend/src/auth/Settings.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Settings keys tab — OpenRouter as a first-class BYO-key provider.
+ *
+ * Pins:
+ *   - the provider select offers OpenRouter alongside Anthropic/OpenAI
+ *   - a stored OpenRouter key renders as a row with the remove affordance
+ *   - the default-model picker renders the catalog's OpenRouter entries
+ *     plus the single reference-model caveat line (once, not per entry)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { Settings } from "./Settings";
+import { AuthProvider } from "./AuthProvider";
+import * as api from "../lib/api";
+import type { CurrentUser, ModelOption, UserApiKeyRead } from "../lib/api";
+
+const USER: CurrentUser = {
+  id: "u-1",
+  email: "user@example.com",
+  name: "Test User",
+  role: "user",
+  plan: "eval",
+  default_model_id: null,
+  default_privilege_posture: null,
+  is_active: true,
+  is_verified: true,
+  is_superuser: false,
+};
+
+const MODELS: ModelOption[] = [
+  {
+    id: "claude-sonnet-5",
+    label: "Claude Sonnet 5 - reference model",
+    provider: "anthropic",
+    requires_key: true,
+    note: "Legalise is built and tested against Sonnet 5. Runs on your Anthropic key.",
+    recommended: true,
+    key_configured: false,
+  },
+  {
+    id: "anthropic/claude-sonnet-5",
+    label: "Claude Sonnet 5 (via OpenRouter)",
+    provider: "openrouter",
+    requires_key: true,
+    note: "The reference model on an OpenRouter key.",
+    recommended: false,
+    key_configured: true,
+  },
+  {
+    id: "deepseek/deepseek-r1",
+    label: "DeepSeek R1 (via OpenRouter)",
+    provider: "openrouter",
+    requires_key: true,
+    note: "Strong open-weights reasoning model on an OpenRouter key.",
+    recommended: false,
+    key_configured: true,
+  },
+];
+
+const OPENROUTER_KEY: UserApiKeyRead = {
+  provider: "openrouter",
+  last_used_at: null,
+  created_at: "2026-07-08T09:00:00Z",
+};
+
+function mountKeysTab() {
+  return render(
+    <AuthProvider>
+      <Settings tab="keys" />
+    </AuthProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(api, "getCurrentUser").mockResolvedValue(USER);
+  vi.spyOn(api, "listModels").mockResolvedValue(MODELS);
+  vi.spyOn(api, "listApiKeys").mockResolvedValue([]);
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe("Settings keys — OpenRouter provider", () => {
+  it("offers OpenRouter in the add-key provider select", async () => {
+    mountKeysTab();
+
+    const option = await screen.findByRole("option", {
+      name: /openrouter - one key, many models/i,
+    });
+    expect((option as HTMLOptionElement).value).toBe("openrouter");
+    // The existing providers are still there.
+    expect(
+      screen.getByRole("option", { name: /anthropic/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /openai/i })).toBeInTheDocument();
+  });
+
+  it("renders a stored OpenRouter key as a row with Remove", async () => {
+    vi.spyOn(api, "listApiKeys").mockResolvedValue([OPENROUTER_KEY]);
+    mountKeysTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("openrouter")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/many models, one key/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /remove/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders OpenRouter catalog entries and the caveat line once", async () => {
+    mountKeysTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Claude Sonnet 5 (via OpenRouter)"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("DeepSeek R1 (via OpenRouter)")).toBeInTheDocument();
+    // Sonnet 5 direct entry is marked recommended.
+    expect(
+      screen.getByText("Claude Sonnet 5 - reference model"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/recommended/i)).toBeInTheDocument();
+    // The honest caveat renders exactly once for the whole list.
+    const caveats = screen.getAllByText(
+      /Citation behaviour is verified on the reference model only/i,
+    );
+    expect(caveats).toHaveLength(1);
+  });
+});

--- a/frontend/src/auth/Settings.tsx
+++ b/frontend/src/auth/Settings.tsx
@@ -293,7 +293,7 @@ function SettingsProfile({
               type="text"
               value={defaultModel}
               onChange={(e: ChangeEvent<HTMLInputElement>) => setDefaultModel(e.target.value)}
-              placeholder="claude-sonnet-4-6"
+              placeholder="claude-sonnet-5"
               className={inputCls + " tech-token"}
             />
           )}
@@ -474,6 +474,12 @@ function DefaultModelPicker() {
               </button>
             );
           })}
+          {models.some((m) => m.provider === "openrouter") && (
+            <p className="mt-1 text-xs text-muted">
+              Other models run through OpenRouter. Citation behaviour is
+              verified on the reference model only.
+            </p>
+          )}
         </div>
       )}
     </div>
@@ -482,7 +488,7 @@ function DefaultModelPicker() {
 
 function SettingsKeys() {
   const [keys, setKeys] = useState<UserApiKeyRead[] | null>(null);
-  const [provider, setProvider] = useState<"anthropic" | "openai">("anthropic");
+  const [provider, setProvider] = useState<"anthropic" | "openai" | "openrouter">("anthropic");
   const [apiKey, setApiKey] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -541,9 +547,9 @@ function SettingsKeys() {
         <SectionRule label="Provider keys" />
         <p className="prose-p mb-0 mt-3">
         The hosted site has no shared production model key. To run real
-        model calls, bring your own Anthropic or OpenAI key. Keys are
-        encrypted and used only for your requests — Legalise does not
-        resell model access.
+        model calls, bring your own Anthropic, OpenAI, or OpenRouter key.
+        Keys are encrypted and used only for your requests — Legalise does
+        not resell model access.
         </p>
       </div>
 
@@ -574,7 +580,9 @@ function SettingsKeys() {
                       ? "Claude models"
                       : k.provider === "openai"
                         ? "GPT models"
-                        : "model calls"}
+                        : k.provider === "openrouter"
+                          ? "many models, one key"
+                          : "model calls"}
                   </span>
                 </span>
                 <span className="text-muted">{k.created_at.slice(0, 10)}</span>
@@ -602,15 +610,16 @@ function SettingsKeys() {
         </p>
         <Field
           label="Provider"
-          hint="Anthropic key is used by Claude models; OpenAI key by GPT models"
+          hint="Anthropic key is used by Claude models; OpenAI key by GPT models; an OpenRouter key runs the (via OpenRouter) models"
         >
           <select
             value={provider}
-            onChange={(e: ChangeEvent<HTMLSelectElement>) => setProvider(e.target.value as "anthropic" | "openai")}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setProvider(e.target.value as "anthropic" | "openai" | "openrouter")}
             className={inputCls}
           >
             <option value="anthropic">Anthropic — used by Claude models</option>
             <option value="openai">OpenAI — used by GPT models</option>
+            <option value="openrouter">OpenRouter - one key, many models</option>
           </select>
         </Field>
         <Field label="API key" hint="stored encrypted; the full key is never shown after submission">

--- a/frontend/src/lib/api/_core.ts
+++ b/frontend/src/lib/api/_core.ts
@@ -133,11 +133,19 @@ export async function jsonOrThrow<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+// Human-readable provider name for UI copy. Covers the brand spellings
+// naive capitalisation gets wrong (OpenAI, OpenRouter).
+export function providerLabel(provider: string): string {
+  if (provider === "openai") return "OpenAI";
+  if (provider === "openrouter") return "OpenRouter";
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
 // Translate a `ProviderUpstreamError` code into a human readable banner
 // string. `{provider}` is substituted with the actual provider name so
-// the same map serves Anthropic, OpenAI, and Ollama.
+// the same map serves Anthropic, OpenAI, OpenRouter, and Ollama.
 export function providerUpstreamMessage(err: ProviderUpstreamError): string {
-  const provider = err.provider.charAt(0).toUpperCase() + err.provider.slice(1);
+  const provider = providerLabel(err.provider);
   switch (err.code) {
     case "provider_invalid_key":
       return `${provider} rejected the API key. Re-check it in Settings.`;

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -12,7 +12,7 @@ export interface UserApiKeyRead {
 export const listApiKeys = () =>
   apiFetch(`${API}/settings/keys`).then((r) => jsonOrThrow<UserApiKeyRead[]>(r));
 
-export const upsertApiKey = (provider: "anthropic" | "openai", apiKey: string) =>
+export const upsertApiKey = (provider: "anthropic" | "openai" | "openrouter", apiKey: string) =>
   apiFetch(`${API}/settings/keys`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/frontend/src/matter/GrantsPanel.tsx
+++ b/frontend/src/matter/GrantsPanel.tsx
@@ -28,6 +28,7 @@ import {
   listInstalledModules,
   ModuleDisabledError,
   ModuleNotInstalledError,
+  providerLabel as sharedProviderLabel,
   revokeGrant,
   type GrantRow,
   type InstalledModule,
@@ -170,7 +171,7 @@ function readinessFor(opts: {
     };
   }
 
-  const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
+  const providerLabel = sharedProviderLabel(provider);
   if (opts.keyQuery.status === "loading") {
     return {
       disabled: true,

--- a/frontend/src/matter/NewMatter.tsx
+++ b/frontend/src/matter/NewMatter.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { FormEvent } from "react";
-import { createMatter, listModels, type ModelOption } from "../lib/api";
+import { createMatter, listModels, providerLabel, type ModelOption } from "../lib/api";
 import { useAuth } from "../auth/AuthProvider";
 import { navigate } from "../lib/route";
 import type { ReactNode } from "react";
@@ -30,7 +30,7 @@ const CAUSE_PREFILL: Record<string, string> = {
 // Aligned with the catalog's recommended default. Only used until
 // /api/models responds (or if it never does); once the list arrives the
 // recommended/usable model wins.
-const FALLBACK_MODEL_ID = "claude-sonnet-4-6";
+const FALLBACK_MODEL_ID = "claude-sonnet-5";
 
 // Ledger-label form field (DESIGN.md P27): labels carry the 0.18em
 // clerk's-ledger tier rather than the generic eyebrow-sm.
@@ -215,9 +215,7 @@ export function NewMatter() {
             >
               {models.map((m) => {
                 const needsKey = m.requires_key && !m.key_configured;
-                const provider = m.provider
-                  ? m.provider.charAt(0).toUpperCase() + m.provider.slice(1)
-                  : "";
+                const provider = m.provider ? providerLabel(m.provider) : "";
                 return (
                   <option key={m.id} value={m.id} disabled={needsKey}>
                     {m.label}
@@ -226,6 +224,12 @@ export function NewMatter() {
                 );
               })}
             </select>
+          )}
+          {models !== null && models.some((m) => m.provider === "openrouter") && (
+            <p className="text-xs text-muted">
+              Other models run through OpenRouter. Citation behaviour is
+              verified on the reference model only.
+            </p>
           )}
           {selectedNeedsKey && (
             <p className="text-xs text-muted">

--- a/frontend/src/matter/tabs/AssistantTab.tsx
+++ b/frontend/src/matter/tabs/AssistantTab.tsx
@@ -14,6 +14,7 @@ import {
   ProviderKeyMissingError,
   ProviderUpstreamError,
   providerKeyMissingFromBody,
+  providerLabel,
   providerUpstreamMessage,
   tryParseProviderUpstream,
   type AssistantMessage,
@@ -2042,10 +2043,6 @@ function RailPanel({
       <div className="mt-3">{children}</div>
     </section>
   );
-}
-
-function providerLabel(provider: string): string {
-  return provider.charAt(0).toUpperCase() + provider.slice(1);
 }
 
 function formatError(err: unknown): string {

--- a/frontend/src/ui/primitives.tsx
+++ b/frontend/src/ui/primitives.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { providerLabel } from "../lib/api/_core";
 
 export const inputCls =
   "bg-paper border border-rule rounded-item px-4 py-3 text-[16px] sm:text-[17px] focus:border-ink focus:outline-none transition-colors min-h-[44px] font-sans text-ink w-full";
@@ -11,7 +12,7 @@ export const primaryBtn =
 // link to `/settings/keys` is what makes this a one-click resolution
 // instead of a dead-end blob.
 export function ProviderKeyMissingBanner({ provider }: { provider: string }) {
-  const label = provider.charAt(0).toUpperCase() + provider.slice(1);
+  const label = providerLabel(provider);
   return (
     <div className="border border-ink p-3 my-3 text-sm">
       <div className="font-semibold text-ink mb-1">{label} API key required</div>


### PR DESCRIPTION
## What

OpenRouter becomes a supported BYO-key provider: one key unlocks many models. Claude Sonnet 5 is the reference model - the catalog says Legalise is built and tested against it; other models run but are available, not endorsed.

## How

- **Provider** (`backend/app/providers/openrouter_provider.py`): parameterises `OpenAIProvider` (same wire format) with the OpenRouter base_url, `HTTP-Referer: https://legalise.dev` + `X-Title: Legalise` headers, and a privacy pin on EVERY request body: `"provider": {"data_collection": "deny"}` - routes only to endpoints that do not train on or retain prompts. Governance default, not user-disableable. Streaming reuses the existing on_delta path; `finish_reason: length` -> `provider_truncated` as per #257/#248.
- **Gateway**: `"openrouter"` added to keyed providers; slash-form ids (`anthropic/claude-sonnet-5`) route to it, bare `claude-*`/`gpt-*` ids route direct as today. The served model from the response body lands on `model_used`; the upstream provider (when reported) lands in the audit payload JSON - no audit schema change, canonical fields untouched. Requested-vs-served stamping from #248 preserved. `B_mixed` prefers a registered local provider for OpenRouter ids exactly like bare frontier ids.
- **Keys**: `openrouter` provider kind end-to-end. Save-time verification probes `GET https://openrouter.ai/api/v1/key` (token-free): auth failure rejects the save, transient failure saves unverified - same contract as anthropic/openai. No server-side OpenRouter key exists, not even the dev fallback.
- **Catalog**: `claude-sonnet-5` recommended ("reference model"); `claude-sonnet-4-6` demoted to "Previous default; superseded by Sonnet 5" (in-code defaults moved to `claude-sonnet-5` so that note is true); three curated OpenRouter entries: Sonnet 5, GPT-5, DeepSeek R1 (open-weights). Ollama/keyless unchanged. Pickers render one caveat line: "Other models run through OpenRouter. Citation behaviour is verified on the reference model only."
- **Copy**: shared `providerLabel` helper (OpenAI/OpenRouter brand spellings) now backs the key-hint strings; Settings + Register intro copy mention OpenRouter.
- **Docs**: `docs/adr/ADR-011-openrouter.md` + provider line in `docs/ARCHITECTURE.md`.

## Tests

Backend (`test_openrouter_provider.py` + extensions):
- headers/base_url, data_collection=deny on non-streaming AND streaming bodies, served-model + upstream-provider capture, truncation, streaming deltas/usage (mirrors the OpenAI streaming tests)
- gateway: slash ids -> openrouter, direct ids unchanged, catalog-vs-gateway agreement pinned both ways, audit payload carries `upstream_provider`, no-key -> `ProviderKeyMissing("openrouter")`, B_mixed local preference
- `test_settings_key_verification.py`: OpenRouter probe persist/reject/transient
- `test_matter_required_provider.py`: slash ids -> `required_provider == "openrouter"`

Frontend (`Settings.test.tsx`, new): OpenRouter option in the add-key select, stored-key row with Remove, catalog entries + caveat line rendered exactly once.

Full suites green locally (backend: 5 pre-existing `test_runtime`/`test_sandbox` env failures also fail on clean master; frontend: 386/386 + tsc clean).

## Not live-verified

There is no OpenRouter key in this environment - all verification is mocked/unit level. 5-minute live checklist:

1. Settings -> Provider keys -> add your OpenRouter key (a bad key should be rejected at save).
2. New matter (or existing matter Overview) -> pick "Claude Sonnet 5 (via OpenRouter)".
3. Send one chat turn; confirm tokens stream.
4. Matter Activity/audit: the `model.call` row shows `model_used: anthropic/claude-sonnet-5`, payload `provider: openrouter` and `upstream_provider` set.
5. Optional: OpenRouter dashboard shows the request attributed to Legalise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as a supported provider for model access and API key management.
  * Added OpenRouter-backed models to the model picker and related UI labels.
  * Updated the default model to Claude Sonnet 5.

* **Bug Fixes**
  * Improved provider key handling so invalid OpenRouter keys are rejected, while temporary connection issues won’t block saving.
  * Better displays provider names consistently across notices and error messages.

* **Tests**
  * Expanded coverage for OpenRouter routing, key verification, and settings behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->