### PR TITLE
Contribution on-ramp: ladder, community catalogue, authoring guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Something in the running stack behaves differently from what the docs claim.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The house rule: a capability is only described as live if the code implements it.
+        If the docs claim something the code does not do, that is a bug even when the code is "working as written".
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got.
+      placeholder: Ran the chronology skill on the Khan sample matter, expected an audit row per model call, got none for the second call.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Steps from a fresh `docker compose up`. The Khan v Acme sample matter seeds automatically, so repros against it are ideal.
+      placeholder: |
+        1. docker compose -f infra/docker-compose.yml up --build
+        2. Sign up, open Khan v Acme
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: macOS 15 / Docker 27 / commit abc1234
+    validations:
+      required: false
+  - type: dropdown
+    id: provenance
+    attributes:
+      label: Where are you coming from? (optional)
+      description: Helps us see whose problems we are actually solving.
+      options:
+        - Practitioner (solicitor, paralegal, legal ops)
+        - Builder (developer, researcher)
+        - Firm (evaluating for an organisation)
+        - Prefer not to say
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/b1rdmania/legalise/blob/master/SECURITY.md
+    about: Please report vulnerabilities privately, not as public issues. Acknowledged within 48 hours.

--- a/.github/ISSUE_TEMPLATE/eval_case.yml
+++ b/.github/ISSUE_TEMPLATE/eval_case.yml
@@ -1,0 +1,39 @@
+name: Eval case proposal
+description: Propose a deterministic regression case for the agent-kit dataset. Data-only PRs are the fastest way to a first contribution.
+labels: ["evals", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The eval harness ([`evals/agent-kit/`](https://github.com/b1rdmania/legalise/blob/master/evals/agent-kit/README.md)) runs
+        deterministic cases against real production functions. A case is one JSONL row: an input, and judges that assert on the output.
+        If your case fits an existing adapter case (`posture_refusal`, `deterministic_summary`, `chain_intact`, `retrieval_grounding`),
+        you can PR the row directly. If it needs a new adapter case, propose it here first.
+  - type: textarea
+    id: invariant
+    attributes:
+      label: What invariant should hold?
+      description: The claim the case checks, in plain language.
+      placeholder: A matter with posture B_mixed must never route privileged document bodies to a hosted provider.
+    validations:
+      required: true
+  - type: dropdown
+    id: adapter-case
+    attributes:
+      label: Which adapter case?
+      options:
+        - posture_refusal
+        - deterministic_summary
+        - chain_intact
+        - retrieval_grounding
+        - Needs a new adapter case (describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: sketch
+    attributes:
+      label: Case sketch (optional)
+      description: A draft JSONL row if you have one. See existing rows in evals/agent-kit/dataset.jsonl for the shape.
+      render: json
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/practitioner_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/practitioner_feedback.yml
@@ -1,0 +1,34 @@
+name: Practitioner feedback
+description: You work in or around E&W legal practice and something here is wrong, missing, or would not survive contact with a real matter.
+labels: ["provenance:practitioner"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is the highest-value issue type this project receives. You do not need to read the code.
+        Corrections with authority attached (a statute, a CPR Part, an SRA position, an insurer requirement) are gold.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of feedback?
+      options:
+        - Correction (the docs or a skill assert something wrong)
+        - Coverage gap (a skill or safeguard real practice would need)
+        - Workflow mismatch (the loop does not match how matters actually run)
+        - Regulatory or insurance angle we have missed
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: The feedback
+      description: What is wrong or missing, and if you can, the authority that says so.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Your vantage point (optional)
+      description: Practice area, firm size, role. No names needed. Helps us weigh the feedback.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/skill_submission.yml
+++ b/.github/ISSUE_TEMPLATE/skill_submission.yml
@@ -1,0 +1,47 @@
+name: Skill submission
+description: Add your skill to the community catalogue. Your skill stays in your repo; the catalogue links to it at a pinned ref.
+labels: ["skill-catalogue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Skills live in your own repository and import into Legalise through the trust ceremony.
+        Getting listed is a one-row PR to [`docs/CATALOGUE.md`](https://github.com/b1rdmania/legalise/blob/master/docs/CATALOGUE.md).
+        This issue form is the pre-flight: we check the ground rules together before you open the PR.
+        Authoring guide: [`docs/BUILDING_SKILLS.md`](https://github.com/b1rdmania/legalise/blob/master/docs/BUILDING_SKILLS.md).
+  - type: input
+    id: repo
+    attributes:
+      label: Skill repository
+      description: Public GitHub repo containing a SKILL.md at the root (or a /tree/ URL to a subdirectory).
+      placeholder: https://github.com/you/your-skill
+    validations:
+      required: true
+  - type: textarea
+    id: what-it-does
+    attributes:
+      label: What it does
+      description: One or two sentences. What matter context does it read, what does it produce?
+    validations:
+      required: true
+  - type: checkboxes
+    id: ground-rules
+    attributes:
+      label: Ground rules
+      options:
+        - label: England & Wales jurisdiction. Every legal assertion cites authority (statutes by short title and section, rules by CPR Part, cases by neutral citation).
+          required: true
+        - label: The output is a draft for solicitor review, and the SKILL.md says so. Nothing softens the sign-off assumption.
+          required: true
+        - label: I verified every legal citation manually, including any drafted with AI assistance.
+          required: true
+        - label: The skill is prompt-runtime only. It declares what it reads and writes; it does not ask users to run scripts.
+          required: true
+  - type: textarea
+    id: test-notes
+    attributes:
+      label: Import test
+      description: Confirm you imported it into a local Legalise via GitHub import and walked the trust ceremony. Note anything the ceremony flagged.
+      placeholder: Imported at commit abc1234, 7-step inspection, no permission warnings.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- One conceptual change per PR. Why, not just what. -->
+
+## What and why
+
+## Checklist
+
+- [ ] Backend changes have tests; frontend type-checks and builds (`npm run build`)
+- [ ] Any legal assertion cites authority (statute short title + section, CPR Part, neutral citation), verified manually even if AI-drafted
+- [ ] New or changed model-calling paths write audit rows and respect `Matter.privilege_posture`
+- [ ] Voice check on touched chrome strings and docs: `rg -n "—|–" frontend/src/ README.md docs/*.md` returns nothing new
+- [ ] Catalogue rows only: skill repo is public, SKILL.md at the stated path, ground rules in `docs/CATALOGUE.md` met
+
+<!-- By submitting, you agree to the CLA terms in CONTRIBUTING.md. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,32 @@
 
 Thanks for considering a contribution.
 
+## Ways in, easiest first
+
+You do not need to touch the core to contribute. In rough order of
+effort:
+
+1. **Practitioner feedback.** You work in or around E&W practice and
+   something here is wrong, missing, or would not survive a real
+   matter. No code required.
+   [Open a feedback issue](https://github.com/b1rdmania/legalise/issues/new?template=practitioner_feedback.yml);
+   corrections with authority attached are the most valuable thing this
+   project receives.
+2. **Eval cases.** One JSONL row asserting an invariant against real
+   production functions. Data only, reviewable in minutes. See
+   [`evals/agent-kit/`](./evals/agent-kit/README.md) and the
+   [eval case template](https://github.com/b1rdmania/legalise/issues/new?template=eval_case.yml).
+3. **Skills.** Build a governed legal skill in your own repo (an
+   evening's work, mostly legal drafting) and list it with a one-row PR
+   to the catalogue. Guide: [`docs/BUILDING_SKILLS.md`](./docs/BUILDING_SKILLS.md).
+   Index: [`docs/CATALOGUE.md`](./docs/CATALOGUE.md).
+4. **Docs.** If a claim in the docs does not match the code, that is a
+   bug either way. PRs welcome.
+5. **Core code.** Backend and frontend changes, the highest bar: tests,
+   audit integration, posture respect. Look for
+   [`good first issue`](https://github.com/b1rdmania/legalise/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+   labels, or open an issue before building anything large.
+
 ## Ground rules
 
 1. **Solicitor-in-the-loop is the design assumption.** Every output is a draft. Don't soften this.

--- a/README.md
+++ b/README.md
@@ -241,8 +241,17 @@ Start with [`docs/`](./docs/):
 - [`docs/ROADMAP.md`](./docs/ROADMAP.md): shipped, deferred, parked
 - [`docs/ATTRIBUTIONS.md`](./docs/ATTRIBUTIONS.md): credits and licence notes
 
-Operator and contributor material is maintained outside this public repo. Open
-an issue if you're self-hosting and need something that isn't here.
+Operator material is maintained outside this public repo. Open an issue if
+you're self-hosting and need something that isn't here.
+
+## Contributing
+
+You don't need to touch the core. The easiest ways in: practitioner feedback
+(no code, corrections with authority attached), a one-row eval case, or a
+governed legal skill built in your own repo and listed in the
+[community catalogue](./docs/CATALOGUE.md) with a one-row PR. The ladder, the
+ground rules, and the dev setup are in [CONTRIBUTING.md](./CONTRIBUTING.md);
+skill authoring is in [`docs/BUILDING_SKILLS.md`](./docs/BUILDING_SKILLS.md).
 
 ## Caveat
 

--- a/docs/BUILDING_SKILLS.md
+++ b/docs/BUILDING_SKILLS.md
@@ -1,0 +1,87 @@
+# Building a skill
+
+A Legalise skill is a public GitHub repo with a `SKILL.md` at the root.
+You own the repo; Legalise imports it at a pinned commit, converts the
+frontmatter into a governed module draft, and walks it through the
+trust ceremony before anything runs. No code from your repo executes:
+imported skills are prompt-runtime, meaning your instructions become
+the system prompt inside the full governance seam (posture gate, read
+grants, advice boundary, invocation audit, provider call, model audit,
+write grants, artifact write, completion audit).
+
+An evening is enough. The work is legal, not infrastructural: a good
+skill is a well-scoped instruction set with verified citations.
+
+## 1. Write the SKILL.md
+
+Frontmatter first, instructions after:
+
+```markdown
+---
+name: limitation-checker
+description: Flags limitation issues in an E&W civil matter from the chronology and pleadings.
+metadata:
+  version: 0.1.0
+---
+
+You are preparing a limitation analysis for solicitor review...
+```
+
+`name` and `description` are what the importer reads; keep them exact.
+The body is your prompt. House rules that apply to the body:
+
+- England & Wales only. Statutes by short title and section
+  (Limitation Act 1980, s 11), rules by CPR Part, cases by neutral
+  citation.
+- The output must present itself as a draft for a named solicitor to
+  review and sign. Do not soften this.
+- Say what the skill reads (documents, chronology) and what it
+  produces, so the manifest draft declares honest capabilities.
+
+## 2. Import it locally
+
+Run the stack (`docker compose -f infra/docker-compose.yml up --build`,
+see [CONTRIBUTING.md](../CONTRIBUTING.md)), then import your repo by
+URL from the Skills surface. Accepted shapes:
+
+- `https://github.com/you/your-skill` (SKILL.md at the root)
+- `https://github.com/you/your-skill/tree/<ref>/<path>` (SKILL.md under a subdirectory)
+
+The importer pins the commit SHA for provenance and builds a
+manifest-v2 draft. It arrives as a draft, never installed.
+
+## 3. Walk the trust ceremony
+
+Enabling the draft runs the inspection: manifest, signature, publisher,
+permissions, data movement, gates, then trust and grant. Unsigned
+community skills take the full 7-step path by design. Read what it
+shows you; if the permission step surprises you, your frontmatter is
+claiming more than the skill needs.
+
+## 4. Test against the sample matter
+
+The Khan v Acme matter seeds on signup. Run your skill against it,
+read the output as if you were the supervising solicitor, and check the
+Activity tab shows the invocation and model audit rows.
+
+## 5. Verify every citation
+
+Manually. Every statute, rule, and case your prompt references or your
+output tends to produce. AI-assisted drafting is welcome;
+AI-fabricated authority is the one thing that gets a catalogue listing
+pulled without discussion.
+
+## 6. Get listed
+
+Open a [skill submission issue](https://github.com/b1rdmania/legalise/issues/new?template=skill_submission.yml),
+then PR one row to [`CATALOGUE.md`](./CATALOGUE.md). The maintainer
+imports your skill at the pinned ref and checks the ground rules before
+merging.
+
+## Native modules are different
+
+Skills are the community surface. Native Python modules
+(`backend/app/modules/`) are core substrate: they need tests, audit
+integration, and a discussion issue first. If your idea needs code
+rather than a prompt, start with an issue; `examples/modules/` shows
+the shape a native module takes.

--- a/docs/CATALOGUE.md
+++ b/docs/CATALOGUE.md
@@ -1,0 +1,45 @@
+# Community skill catalogue
+
+Skills for Legalise live in their authors' own repositories and import
+through the trust ceremony at a pinned commit. This file is the index.
+Listing here is a one-row PR; the skill itself never enters this repo.
+
+**A listing is not an endorsement.** Every import runs the full
+inspection ceremony regardless of what this file says, and every output
+is a draft for solicitor review. The maintainer checks that a listed
+skill imports cleanly and meets the ground rules below at the pinned
+ref, nothing more.
+
+## Ground rules for listing
+
+1. England & Wales. Every legal assertion cites authority: statutes by
+   short title and section, rules by CPR Part, cases by neutral
+   citation.
+2. The SKILL.md states plainly that output is a draft for solicitor
+   review. Nothing softens the sign-off assumption.
+3. Prompt-runtime only. The skill declares what it reads and writes in
+   its frontmatter; it does not ask users to run scripts.
+4. Citations verified manually by the author, including any drafted
+   with AI assistance. AI-fabricated authority gets a listing pulled.
+5. Public repo, importable at the stated ref via GitHub import.
+
+To use a listed skill: in the app, open Skill library, choose "Any
+public GitHub repo", and paste the skill's repo link. The import runs
+the full trust ceremony before anything can run.
+
+To list a skill: open a
+[skill submission issue](https://github.com/b1rdmania/legalise/issues/new?template=skill_submission.yml)
+for pre-flight, then PR a row to the table below. Authoring guide:
+[`BUILDING_SKILLS.md`](./BUILDING_SKILLS.md).
+
+## Skills
+
+| Skill | Author | What it does | Pinned ref |
+|---|---|---|---|
+| [pre-motion](https://github.com/b1rdmania/pre-motion) | [@b1rdmania](https://github.com/b1rdmania) | Adversarial premortem for E&W civil litigation: builds the strongest version of a case, then attacks it from four angles to find where it loses. | `main` (pin on import) |
+
+## Reference implementations (in-repo, not importable)
+
+[`examples/modules/`](../examples/modules/) holds Contract Review,
+Pre-Motion, and example-tab as reference implementations of the
+governance order. They show the shape; they are not installed modules.

--- a/docs/handovers/HANDOVER_OSS_CONTRIBUTION_2026-07-08.md
+++ b/docs/handovers/HANDOVER_OSS_CONTRIBUTION_2026-07-08.md
@@ -1,0 +1,101 @@
+# Handover: open-source contribution restructure (2026-07-08)
+
+Goal: make external contribution a designed surface, not an accident.
+The architecture already supported it (manifest v2 with `community`
+visibility, trust ceremony, prompt-runtime skill import, agent-kit
+evals). What was missing was the on-ramp. This work order adds it and
+lists the GitHub-side actions still to run.
+
+## Shipped in this change
+
+- `.github/ISSUE_TEMPLATE/` — bug report, skill submission, eval case
+  proposal, practitioner feedback (auto-applies `provenance:practitioner`),
+  config with private security-report link.
+- `.github/PULL_REQUEST_TEMPLATE.md` — house checklist (tests, citations,
+  audit/posture, voice check, catalogue rules).
+- `docs/CATALOGUE.md` — community skill index. Skills stay in authors'
+  repos; listing is a one-row PR. Seeded with `b1rdmania/pre-motion`.
+- `docs/BUILDING_SKILLS.md` — evening-sized authoring guide:
+  SKILL.md, local import, trust ceremony, sample-matter test,
+  citation verification, listing.
+- `CONTRIBUTING.md` — "Ways in, easiest first" ladder at the top
+  (feedback, eval cases, skills, docs, core).
+- `README.md` — Contributing section pointing at the ladder and
+  catalogue.
+
+## Design decisions
+
+- **Contribution unit = catalogue row + eval row, not core code.**
+  Users of a legal tool are practitioners, not PR authors; the ladder
+  gives them a no-code rung (feedback issues) and gives builders an
+  evening-sized rung (skills in their own repos, indexed here).
+- **Catalogue in-repo** so each listing is a merged PR from an external
+  contributor: community signal that accrues to this repo.
+- **A listing is not an endorsement**; the ceremony still runs on every
+  import. Stated in CATALOGUE.md.
+
+## Still to do (GitHub-side, needs maintainer)
+
+1. Create a `skill-catalogue` and an `evals` label (templates reference
+   both):
+   ```bash
+   gh label create skill-catalogue -R b1rdmania/legalise --color 5319e7 --description "Community skill catalogue listings"
+   gh label create evals -R b1rdmania/legalise --color 0e8a16 --description "agent-kit eval cases"
+   ```
+2. Seed good-first-issues (drafts below), label them
+   `good first issue` + `help wanted`.
+3. Pin the pre-motion catalogue row to a commit SHA.
+4. Enable GitHub Discussions if feedback volume warrants it (optional).
+5. Announce: the ladder gives the LinkedIn/X post a concrete CTA
+   ("PR one eval row" / "list your skill").
+
+## Good-first-issue drafts
+
+Review, edit, then create. Each is deliberately evening-sized or
+smaller.
+
+```bash
+gh issue create -R b1rdmania/legalise \
+  --title "Eval: B_mixed posture rows for posture_refusal" \
+  --label "evals,good first issue,help wanted" \
+  --body "dataset.jsonl covers C_paused (refuses), A_cleared (allows), and unknown-posture fail-closed. Add rows pinning the B_mixed contract of core/posture_gate._evaluate_posture so a future change to mixed-posture handling trips an eval, not a user. Data-only PR; shape of existing rows in evals/agent-kit/dataset.jsonl. See evals/agent-kit/README.md for how to run."
+
+gh issue create -R b1rdmania/legalise \
+  --title "Eval: retrieval_grounding negative case (no matching documents)" \
+  --label "evals,good first issue,help wanted" \
+  --body "Add a dataset.jsonl row for retrieval_grounding where the query matches nothing in the Khan sample matter, asserting source_count 0 and well_formed true. Pins the empty-result contract of core/retrieval.search_documents. Data-only PR."
+
+gh issue create -R b1rdmania/legalise \
+  --title "Skill wanted: limitation checker (Limitation Act 1980)" \
+  --label "skill-catalogue,good first issue,help wanted" \
+  --body "A prompt-runtime skill that reads the matter chronology and flags limitation issues: cause of action accrual, applicable period (Limitation Act 1980 ss 2, 5, 11, 14A), s 33 discretion factors where relevant. Output is a draft limitation analysis for solicitor review. Build it in your own repo per docs/BUILDING_SKILLS.md, then list it in docs/CATALOGUE.md. Legal drafting matters more than code here; practitioners especially welcome."
+
+gh issue create -R b1rdmania/legalise \
+  --title "Skill wanted: pre-action protocol compliance reviewer" \
+  --label "skill-catalogue,good first issue,help wanted" \
+  --body "A skill that reads correspondence in a matter and checks a letter of claim against the relevant Pre-Action Protocol (start with the Practice Direction on Pre-Action Conduct and the Debt Protocol): required content present, response windows stated correctly, proportionality of threatened steps. Draft output for solicitor review. docs/BUILDING_SKILLS.md has the authoring path."
+
+gh issue create -R b1rdmania/legalise \
+  --title "Skill wanted: witness statement compliance check (CPR 32 / PD 57AC)" \
+  --label "skill-catalogue,good first issue,help wanted" \
+  --body "A skill that reviews a draft witness statement for PD 57AC compliance in Business and Property Courts matters: statement of own knowledge vs belief, documents referred to, the required confirmations, opinion/argument creep. Output flags issues with rule citations for the supervising solicitor. Build in your own repo, list via docs/CATALOGUE.md."
+
+gh issue create -R b1rdmania/legalise \
+  --title "Docs: trust-ceremony walkthrough screenshots for BUILDING_SKILLS.md" \
+  --label "documentation,good first issue,help wanted" \
+  --body "docs/BUILDING_SKILLS.md describes the import and 7-step inspection in text. Add captioned screenshots (or a short GIF) of importing a skill by GitHub URL and walking the ceremony, using the example skill or pre-motion. Pure docs PR; run the stack per CONTRIBUTING.md."
+```
+
+Existing issues worth relabelling for visibility: #244 (DocumentDetail
+god-file split) as `help wanted`; #194 (refactor remainders) as
+`good first issue` if the E5/E7 helpers are genuinely self-contained.
+
+## Follow-up (added at review)
+
+Two catalogues now exist: the in-product Skill library (Lawve feed +
+GitHub import) and docs/CATALOGUE.md. Cross-links ship in this change
+(the library's GitHub-repo cell points at the community catalogue; the
+catalogue explains the in-app import path). The real convergence, when
+community listings grow: teach the product's catalogue endpoint to read
+docs/CATALOGUE.md as a source, so the repo file becomes the canonical
+community feed and the two surfaces cannot drift.

--- a/frontend/src/modules-v2/ModulesCatalog.tsx
+++ b/frontend/src/modules-v2/ModulesCatalog.tsx
@@ -532,7 +532,22 @@ export function ModulesCatalog() {
             />
             <SourceRoute
               name="Any public GitHub repo"
-              body="Needs a SKILL.md file at the top of the repo. We pin the exact version you imported."
+              body={
+                <>
+                  Needs a SKILL.md file at the top of the repo. We pin the
+                  exact version you imported. Community-built skills are
+                  indexed in the{" "}
+                  <a
+                    href="https://github.com/b1rdmania/legalise/blob/master/docs/CATALOGUE.md"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline underline-offset-4 decoration-rule hover:decoration-seal hover:text-seal"
+                  >
+                    community catalogue
+                  </a>
+                  .
+                </>
+              }
             />
             <SourceRoute
               name={
@@ -682,7 +697,7 @@ export function ModulesCatalog() {
 
 
 /** One admission route in the "Where skills come from" strip. */
-function SourceRoute({ name, body }: { name: ReactNode; body: string }) {
+function SourceRoute({ name, body }: { name: ReactNode; body: ReactNode }) {
   return (
     <div className="bg-paper p-4">
       <h3 className="text-sm font-semibold text-ink">{name}</h3>


### PR DESCRIPTION
Restructures the repo for external contribution: easiest-first ladder in CONTRIBUTING, community skill catalogue (skills stay in authors' repos; one-row listing PRs; ceremony gatekeeps at import), authoring guide, issue templates, README section, cross-links between the in-product Skill library and the catalogue. Seed issues + labels are ready-to-paste commands in the handover doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided issue and pull request templates to make bug reports, feedback, eval cases, and skill submissions easier to file.
  * Introduced a community skill catalogue with clearer contribution paths and listing guidance.
  * Updated the app’s catalogue help text to include a link to the community catalogue.

* **Documentation**
  * Expanded contribution docs with step-by-step paths for reporting, testing, and publishing skills.
  * Added setup and publishing guidance for community-contributed skills, plus a handover note for maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->