### PR TITLE
copy: claim the independence axis — register, not governance layer

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Legalise: open-source governance layer for UK legal AI</title>
-    <meta name="description" content="Open-source governance layer for UK legal AI: human sign-off and a tamper-evident audit trail for AI-assisted legal work. An evaluation release, not for live client matters." />
+    <title>Legalise: the independent register underneath the AI workspaces</title>
+    <meta name="description" content="Open source, England &amp; Wales. The independent register for AI-assisted legal work: every human review, edit, approval, and sign-off, recorded outside the tool that did the drafting. An evaluation release, not for live client matters." />
 
     <link rel="icon" type="image/svg+xml" href="/brandmark.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
@@ -12,14 +12,14 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
 
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Legalise: open-source governance layer for UK legal AI" />
-    <meta property="og:description" content="Human sign-off and a tamper-evident audit trail for AI-assisted legal work. An evaluation release, not for live client matters." />
+    <meta property="og:title" content="Legalise: the independent register underneath the AI workspaces" />
+    <meta property="og:description" content="Every human review, edit, approval, and sign-off, recorded outside the tool that did the drafting. An evaluation release, not for live client matters." />
     <meta property="og:image" content="https://legalise.dev/og-card-v2.png" />
     <meta property="og:url" content="https://legalise.dev" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Legalise: open-source governance layer for UK legal AI" />
-    <meta name="twitter:description" content="Human sign-off and a tamper-evident audit trail for AI-assisted legal work. An evaluation release, not for live client matters." />
+    <meta name="twitter:title" content="Legalise: the independent register underneath the AI workspaces" />
+    <meta name="twitter:description" content="Every human review, edit, approval, and sign-off, recorded outside the tool that did the drafting. An evaluation release, not for live client matters." />
     <meta name="twitter:image" content="https://legalise.dev/og-card-v2.png" />
 
     <!-- Redaction (Kaphar / Betts / Mickel — MCKL, SIL OFL). Primary typeface.

--- a/frontend/src/landing/Architecture.tsx
+++ b/frontend/src/landing/Architecture.tsx
@@ -633,7 +633,7 @@ export function Architecture() {
           </h1>
           <div className="mt-6 max-w-2xl text-base leading-relaxed text-prose">
             <p>
-              Legalise is an open-source governance layer for legal AI in
+              Legalise is an open-source, independent register for legal AI in
               England and Wales — an evaluation of the guardrails around it:
               supervision, human sign-off, and a tamper-evident record. It is
               not a finished product. This page documents how it is built: the

--- a/frontend/src/landing/Landing.tsx
+++ b/frontend/src/landing/Landing.tsx
@@ -41,6 +41,11 @@ export function Landing() {
             Legalise keeps AI work inside the matter file, with a record of
             every human review, edit, approval, and sign-off.
           </p>
+          <p className="mt-5 text-base text-muted max-w-2xl">
+            Courts have started sanctioning AI-drafted filings no one
+            reviewed. Built for the partner who signs, and the COLP who
+            answers for it.
+          </p>
           <p className="mt-5 text-base text-muted">
             Unfinished. Experimental. Come break it.
           </p>


### PR DESCRIPTION
Positioning pass on the public surface, run against LQ-AI's current README — their self-audit vocabulary (append-only audit log, citation ledger, fiduciary gates) is blurring the category from below. The axis that survives is independence, so the copy now claims it.

**Changed**
- `<title>`/OG/Twitter: "open-source governance layer for UK legal AI" → "the independent register underneath the AI workspaces"; descriptions now lead with the record being kept **outside the tool that did the drafting** (open source + England & Wales moved into the description).
- Hero: one added paragraph — the why-now (courts sanctioning unreviewed AI-drafted filings; general statement, no case names pinned to the homepage) and a named reader (the partner who signs, the COLP who answers for it).
- Architecture intro: "governance layer" → "independent register" for consistency.

**Untouched:** the h1, "Unfinished. Experimental. Come break it.", eyebrow, demo copy. Every new line is a capability or fact claim the product already keeps — nothing gated.

Full read: the positioning report artifact (private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the landing page messaging and preview text to better describe the product as an independent register for AI workspaces.
  * Added a new note highlighting that courts are increasingly accepting AI-drafted filings without human review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->